### PR TITLE
[crowdstrike] add date parsing for BiosReleaseDate field

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.5"
+  changes:
+    - description: Add date parsing for BiosReleaseDate field.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2867
 - version: "1.2.4"
   changes:
     - description: Add missing field mapping for several event and host fields.

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
@@ -1,117 +1,161 @@
 {
     "expected": [
         {
+            "@timestamp": "2021-07-07T17:05:21.137Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "RGID": "501",
+                "RUID": "501",
+                "SVGID": "20",
+                "SVUID": "501",
+                "SessionProcessId": "363970027584976556",
+                "SourceProcessId": "362225661973273550",
+                "SourceThreadId": "0",
+                "SyntheticPR2Flags": "8",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "SyntheticProcessRollup2MacV3"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "SyntheticProcessRollup2",
+                "category": [
+                    "process"
+                ],
+                "created": "2021-07-07T17:05:21.162Z",
+                "id": "ffffffff-1111-11eb-8dd4-061759968cdf",
+                "ingested": "2022-03-22T18:19:46.426427700Z",
+                "kind": "event",
+                "original": "{\"ParentProcessId\":\"362225661973273550\",\"SourceProcessId\":\"362225661973273550\",\"aip\":\"67.43.156.14\",\"SessionProcessId\":\"363970027584976556\",\"SyntheticPR2Flags\":\"8\",\"event_platform\":\"Mac\",\"SVUID\":\"501\",\"id\":\"ffffffff-1111-11eb-8dd4-061759968cdf\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677521162\",\"ProcessGroupId\":\"363970027584976556\",\"event_simpleName\":\"SyntheticProcessRollup2\",\"RawProcessId\":\"9505\",\"ContextTimeStamp\":\"1625677521.137\",\"GID\":\"20\",\"ConfigStateHash\":\"1620585913\",\"SVGID\":\"20\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"501\",\"CommandLine\":\"/bin/sh -s unix:cmd\",\"TargetProcessId\":\"363970027584976556\",\"ImageFileName\":\"/bin/sh\",\"RGID\":\"501\",\"SourceThreadId\":\"0\",\"Entitlements\":\"15\",\"name\":\"SyntheticProcessRollup2MacV3\",\"RUID\":\"501\",\"aid\":\"ffffffffa63e404bba4bff7465ab3afb\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffa63e404bba4bff7465ab3afb",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "args": [
                     "/bin/sh",
                     "-s",
                     "unix:cmd"
                 ],
+                "args_count": 3,
+                "command_line": "/bin/sh -s unix:cmd",
+                "entity_id": "363970027584976556",
+                "executable": "/bin/sh",
                 "parent": {
                     "entity_id": "362225661973273550"
                 },
                 "pgid": 363970027584976556,
-                "pid": 9505,
-                "args_count": 3,
-                "entity_id": "363970027584976556",
-                "command_line": "/bin/sh -s unix:cmd",
-                "executable": "/bin/sh"
-            },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffa63e404bba4bff7465ab3afb",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:21.137Z",
-            "ecs": {
-                "version": "8.0.0"
+                "pid": 9505
             },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561676842Z",
-                "original": "{\"ParentProcessId\":\"362225661973273550\",\"SourceProcessId\":\"362225661973273550\",\"aip\":\"67.43.156.14\",\"SessionProcessId\":\"363970027584976556\",\"SyntheticPR2Flags\":\"8\",\"event_platform\":\"Mac\",\"SVUID\":\"501\",\"id\":\"ffffffff-1111-11eb-8dd4-061759968cdf\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677521162\",\"ProcessGroupId\":\"363970027584976556\",\"event_simpleName\":\"SyntheticProcessRollup2\",\"RawProcessId\":\"9505\",\"ContextTimeStamp\":\"1625677521.137\",\"GID\":\"20\",\"ConfigStateHash\":\"1620585913\",\"SVGID\":\"20\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"501\",\"CommandLine\":\"/bin/sh -s unix:cmd\",\"TargetProcessId\":\"363970027584976556\",\"ImageFileName\":\"/bin/sh\",\"RGID\":\"501\",\"SourceThreadId\":\"0\",\"Entitlements\":\"15\",\"name\":\"SyntheticProcessRollup2MacV3\",\"RUID\":\"501\",\"aid\":\"ffffffffa63e404bba4bff7465ab3afb\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:21.162Z",
-                "kind": "event",
-                "action": "SyntheticProcessRollup2",
-                "id": "ffffffff-1111-11eb-8dd4-061759968cdf",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "1620585913",
-                "SVGID": "20",
-                "SourceProcessId": "362225661973273550",
-                "SessionProcessId": "363970027584976556",
-                "SyntheticPR2Flags": "8",
-                "SVUID": "501",
-                "RGID": "501",
-                "SourceThreadId": "0",
-                "Entitlements": "15",
-                "name": "SyntheticProcessRollup2MacV3",
-                "RUID": "501",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "id": "501",
                 "group": {
                     "id": "20"
-                }
+                },
+                "id": "501"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:23.068Z",
+            "crowdstrike": {
+                "AsepWrittenCount": 0,
+                "ConfigStateHash": "3090255842",
+                "ContextProcessId": "365053603452626914",
+                "DirectoryCreatedCount": 0,
+                "DnsRequestCount": 0,
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "ExecutableDeletedCount": 0,
+                "FileDeletedCount": 0,
+                "NetworkBindCount": 0,
+                "NetworkCapableAsepWriteCount": 0,
+                "NetworkCloseCount": 0,
+                "NetworkConnectCount": 0,
+                "NetworkListenCount": 0,
+                "NetworkRecvAcceptCount": 0,
+                "NewExecutableWrittenCount": 0,
+                "SuspectStackCount": 0,
+                "SuspiciousDnsRequestCount": 0,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "EndOfProcessMacV15"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "EndOfProcess",
+                "category": [
+                    "process"
+                ],
+                "created": "2021-07-07T17:05:24.102Z",
+                "id": "ffffffff-1111-11eb-9d75-02bcf3ade03b",
+                "ingested": "2022-03-22T18:19:46.426438800Z",
+                "kind": "event",
+                "original": "{\"FileDeletedCount\":\"0\",\"DirectoryCreatedCount\":\"0\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"NetworkConnectCount\":\"0\",\"NetworkListenCount\":\"0\",\"event_platform\":\"Mac\",\"NetworkBindCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"id\":\"ffffffff-1111-11eb-9d75-02bcf3ade03b\",\"NewExecutableWrittenCount\":\"0\",\"NetworkCloseCount\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"SuspectStackCount\":\"0\",\"timestamp\":\"1625677524102\",\"event_simpleName\":\"EndOfProcess\",\"RawProcessId\":\"33454\",\"ContextTimeStamp\":\"1625677523.068\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365053603452626914\",\"AsepWrittenCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"NetworkCapableAsepWriteCount\":\"0\",\"ExecutableDeletedCount\":\"0\",\"TargetProcessId\":\"365053603452626914\",\"DnsRequestCount\":\"0\",\"Entitlements\":\"15\",\"name\":\"EndOfProcessMacV15\",\"aid\":\"ffffffff3c0846978560dbc0048d6555\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
                 "serial_number": "ffffffff3c0846978560dbc0048d6555",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
             },
             "process": {
                 "entity_id": "365053603452626914",
@@ -120,176 +164,180 @@
                     "id": 0
                 }
             },
-            "@timestamp": "2021-07-07T17:05:23.068Z",
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561680542Z",
-                "original": "{\"FileDeletedCount\":\"0\",\"DirectoryCreatedCount\":\"0\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"NetworkConnectCount\":\"0\",\"NetworkListenCount\":\"0\",\"event_platform\":\"Mac\",\"NetworkBindCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"id\":\"ffffffff-1111-11eb-9d75-02bcf3ade03b\",\"NewExecutableWrittenCount\":\"0\",\"NetworkCloseCount\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"SuspectStackCount\":\"0\",\"timestamp\":\"1625677524102\",\"event_simpleName\":\"EndOfProcess\",\"RawProcessId\":\"33454\",\"ContextTimeStamp\":\"1625677523.068\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365053603452626914\",\"AsepWrittenCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"NetworkCapableAsepWriteCount\":\"0\",\"ExecutableDeletedCount\":\"0\",\"TargetProcessId\":\"365053603452626914\",\"DnsRequestCount\":\"0\",\"Entitlements\":\"15\",\"name\":\"EndOfProcessMacV15\",\"aid\":\"ffffffff3c0846978560dbc0048d6555\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:24.102Z",
-                "kind": "event",
-                "action": "EndOfProcess",
-                "id": "ffffffff-1111-11eb-9d75-02bcf3ade03b",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "FileDeletedCount": 0,
-                "ConfigStateHash": "3090255842",
-                "ContextProcessId": "365053603452626914",
-                "DirectoryCreatedCount": 0,
-                "AsepWrittenCount": 0,
-                "SuspiciousDnsRequestCount": 0,
-                "NetworkConnectCount": 0,
-                "NetworkListenCount": 0,
-                "NetworkCapableAsepWriteCount": 0,
-                "ExecutableDeletedCount": 0,
-                "NetworkBindCount": 0,
-                "DnsRequestCount": 0,
-                "Entitlements": "15",
-                "name": "EndOfProcessMacV15",
-                "NetworkRecvAcceptCount": 0,
-                "NewExecutableWrittenCount": 0,
-                "NetworkCloseCount": 0,
-                "EffectiveTransmissionClass": "3",
-                "SuspectStackCount": 0,
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "process": {
-                "entity_id": "365042236081053654"
-            },
-            "os": {
-                "type": "macos"
-            },
-            "destination": {
-                "geo": {
-                    "continent_name": "Europe",
-                    "country_name": "Norway",
-                    "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
-                },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "port": 546,
-                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Europe",
-                    "country_name": "Norway",
-                    "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
-                },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "port": 547,
-                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "community_id": "1:ZmJm1KFUrdmL4/rYSRwMQ18GXnk=",
-                "transport": "udp",
-                "iana_number": "17",
-                "direction": "unknown"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffc59c473aa7fcbbe7438082cb",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
             "@timestamp": "2021-07-07T17:04:48.594Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "RawBindIP6MacV10"
+            },
+            "destination": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "port": 546
+            },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "RawBindIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:04:48.615Z",
+                "id": "ffffffff-1111-11eb-ad8d-064c77be2fd1",
+                "ingested": "2022-03-22T18:19:46.426446700Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"RawBindIP6\",\"ContextTimeStamp\":\"1625677488.594\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"RemoteAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"1620585913\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"365042236081053654\",\"RemotePort\":\"546\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"547\",\"Entitlements\":\"15\",\"name\":\"RawBindIP6MacV10\",\"id\":\"ffffffff-1111-11eb-ad8d-064c77be2fd1\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffffc59c473aa7fcbbe7438082cb\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677488615\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
+            "network": {
+                "community_id": "1:ZmJm1KFUrdmL4/rYSRwMQ18GXnk=",
+                "direction": "unknown",
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffc59c473aa7fcbbe7438082cb",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "process": {
+                "entity_id": "365042236081053654"
+            },
             "related": {
+                "hash": [
+                    "1620585913"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ],
-                "hash": [
-                    "1620585913"
                 ],
                 "ip": [
                     "67.43.156.14",
                     "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561681559Z",
-                "original": "{\"event_simpleName\":\"RawBindIP6\",\"ContextTimeStamp\":\"1625677488.594\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"RemoteAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"1620585913\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"365042236081053654\",\"RemotePort\":\"546\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"547\",\"Entitlements\":\"15\",\"name\":\"RawBindIP6MacV10\",\"id\":\"ffffffff-1111-11eb-ad8d-064c77be2fd1\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffffc59c473aa7fcbbe7438082cb\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677488615\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:48.615Z",
-                "kind": "event",
-                "action": "RawBindIP6",
-                "id": "ffffffff-1111-11eb-ad8d-064c77be2fd1",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "success"
+            "source": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "port": 547
             },
-            "crowdstrike": {
-                "ConfigStateHash": "1620585913",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "RawBindIP6MacV10",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:04.527Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "ProcessCount": 4,
+                "Timeout": 600,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ProcessRollup2StatsMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2Stats",
+                "category": [
+                    "process"
+                ],
+                "created": "2021-07-07T17:05:04.527Z",
+                "id": "ffffffff-1111-11eb-822b-06081a3f0f45",
+                "ingested": "2022-03-22T18:19:46.426454500Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"ProcessRollup2Stats\",\"ConfigStateHash\":\"1620585913\",\"Timeout\":\"600\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"f8bd34d4ac025f862c6fe8f3fd3f170072f94f1f2ec9dc6cb2d7925422b77018\",\"ProcessCount\":\"4\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"502\",\"event_platform\":\"Mac\",\"CommandLine\":\"ruby --disable-gems sorbet/feature_dependency_plugin.rb --class EmergingAlbertsonsPickupBannerDiscount --method feature_dependency --source feature_dependency Domain::FeatureDependencies::RouletteUserFeature.new(\\n        feature_name: FEATURE_NAME,\\n        variants: [FEATURE_VARIANT],\\n      )\",\"Entitlements\":\"15\",\"name\":\"ProcessRollup2StatsMacV1\",\"id\":\"ffffffff-1111-11eb-822b-06081a3f0f45\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff59fe460783ea45d59e417d6f\",\"timestamp\":\"1625677504527\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff59fe460783ea45d59e417d6f",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "args": [
                     "ruby",
@@ -314,509 +362,475 @@
                     "sha256": "f8bd34d4ac025f862c6fe8f3fd3f170072f94f1f2ec9dc6cb2d7925422b77018"
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff59fe460783ea45d59e417d6f",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:04.527Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "f8bd34d4ac025f862c6fe8f3fd3f170072f94f1f2ec9dc6cb2d7925422b77018",
                     "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561682552Z",
-                "original": "{\"event_simpleName\":\"ProcessRollup2Stats\",\"ConfigStateHash\":\"1620585913\",\"Timeout\":\"600\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"f8bd34d4ac025f862c6fe8f3fd3f170072f94f1f2ec9dc6cb2d7925422b77018\",\"ProcessCount\":\"4\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"502\",\"event_platform\":\"Mac\",\"CommandLine\":\"ruby --disable-gems sorbet/feature_dependency_plugin.rb --class EmergingAlbertsonsPickupBannerDiscount --method feature_dependency --source feature_dependency Domain::FeatureDependencies::RouletteUserFeature.new(\\n        feature_name: FEATURE_NAME,\\n        variants: [FEATURE_VARIANT],\\n      )\",\"Entitlements\":\"15\",\"name\":\"ProcessRollup2StatsMacV1\",\"id\":\"ffffffff-1111-11eb-822b-06081a3f0f45\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff59fe460783ea45d59e417d6f\",\"timestamp\":\"1625677504527\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:04.527Z",
-                "kind": "state",
-                "action": "ProcessRollup2Stats",
-                "id": "ffffffff-1111-11eb-822b-06081a3f0f45",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "unknown"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "1620585913",
-                "Timeout": 600,
-                "Entitlements": "15",
-                "name": "ProcessRollup2StatsMacV1",
-                "EffectiveTransmissionClass": "2",
-                "ProcessCount": 4,
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "id": "502"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffe1ad47b6b5b44ae9151a6cf3",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:05:14.783Z",
+            "crowdstrike": {
+                "ConfigIDBase": "65994753",
+                "ConfigIDBuild": "13701",
+                "ConfigIDPlatform": "4",
+                "ConfigStateHash": "3090255842",
+                "ConfigurationVersion": "10",
+                "EffectiveTransmissionClass": "0",
+                "Entitlements": "15",
+                "NetworkContainmentState": "0",
+                "ProvisionState": "1",
+                "SensorStateBitMap": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "SensorHeartbeatMacV4"
+            },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
+            "event": {
+                "action": "SensorHeartbeat",
+                "category": [
+                    "package"
                 ],
+                "created": "2021-07-07T17:05:14.783Z",
+                "id": "ffffffff-1111-11eb-97c6-02fd02aca859",
+                "ingested": "2022-03-22T18:19:46.426462200Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"SensorHeartbeat\",\"ConfigStateHash\":\"3090255842\",\"NetworkContainmentState\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigIDBase\":\"65994753\",\"SensorStateBitMap\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"ConfigurationVersion\":\"10\",\"Entitlements\":\"15\",\"name\":\"SensorHeartbeatMacV4\",\"ConfigIDPlatform\":\"4\",\"id\":\"ffffffff-1111-11eb-97c6-02fd02aca859\",\"ConfigIDBuild\":\"13701\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffffe1ad47b6b5b44ae9151a6cf3\",\"ProvisionState\":\"1\",\"timestamp\":\"1625677514783\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffe1ad47b6b5b44ae9151a6cf3",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
                 "hash": [
                     "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:02.500Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "MachOSubType": "1",
+                "RGID": "0",
+                "RUID": "0",
+                "SVGID": "0",
+                "SVUID": "0",
+                "SessionProcessId": "362213307092004097",
+                "SourceProcessId": "362213307092004097",
+                "SourceThreadId": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ProcessRollup2MacV5"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2",
+                "category": [
+                    "process"
+                ],
+                "created": "2021-07-07T17:05:02.500Z",
+                "id": "ffffffff-1111-11eb-a9ce-02e9216bdbcb",
+                "ingested": "2022-03-22T18:19:46.426469800Z",
+                "kind": "event",
+                "original": "{\"MachOSubType\":\"1\",\"ParentProcessId\":\"362213307092004097\",\"SourceProcessId\":\"362213307092004097\",\"aip\":\"67.43.156.14\",\"SessionProcessId\":\"362213307092004097\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"event_platform\":\"Mac\",\"ProcessEndTime\":\"\",\"SVUID\":\"0\",\"ParentBaseFileName\":\"launchd\",\"id\":\"ffffffff-1111-11eb-a9ce-02e9216bdbcb\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677502500\",\"ProcessGroupId\":\"362213307092004097\",\"event_simpleName\":\"ProcessRollup2\",\"RawProcessId\":\"56254\",\"GID\":\"0\",\"ConfigStateHash\":\"1620585913\",\"SVGID\":\"0\",\"MD5HashData\":\"88922d50263b059696c2af5a99906562\",\"SHA256HashData\":\"d4ff1c438e330777002332a305fcf965cfaa7d0dbeb899293d347298cbf6d4b6\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"0\",\"CommandLine\":\"xpcproxy com.apple.mdworker.shared.01000000-0600-0000-0000-000000000000\",\"TargetProcessId\":\"363276350115996101\",\"ImageFileName\":\"/usr/libexec/xpcproxy\",\"RGID\":\"0\",\"SourceThreadId\":\"0\",\"Entitlements\":\"15\",\"name\":\"ProcessRollup2MacV5\",\"RUID\":\"0\",\"ProcessStartTime\":\"1625677502.233\",\"aid\":\"ffffffff8be84591864008eb2e484920\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff8be84591864008eb2e484920",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
             "os": {
                 "type": "macos"
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561683490Z",
-                "original": "{\"event_simpleName\":\"SensorHeartbeat\",\"ConfigStateHash\":\"3090255842\",\"NetworkContainmentState\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigIDBase\":\"65994753\",\"SensorStateBitMap\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"ConfigurationVersion\":\"10\",\"Entitlements\":\"15\",\"name\":\"SensorHeartbeatMacV4\",\"ConfigIDPlatform\":\"4\",\"id\":\"ffffffff-1111-11eb-97c6-02fd02aca859\",\"ConfigIDBuild\":\"13701\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffffe1ad47b6b5b44ae9151a6cf3\",\"ProvisionState\":\"1\",\"timestamp\":\"1625677514783\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:14.783Z",
-                "kind": "event",
-                "action": "SensorHeartbeat",
-                "id": "ffffffff-1111-11eb-97c6-02fd02aca859",
-                "category": [
-                    "package"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3090255842",
-                "ConfigurationVersion": "10",
-                "NetworkContainmentState": "0",
-                "Entitlements": "15",
-                "name": "SensorHeartbeatMacV4",
-                "ConfigIDPlatform": "4",
-                "ConfigIDBase": "65994753",
-                "SensorStateBitMap": "0",
-                "ConfigIDBuild": "13701",
-                "EffectiveTransmissionClass": "0",
-                "ProvisionState": "1",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
             "process": {
                 "args": [
                     "xpcproxy",
                     "com.apple.mdworker.shared.01000000-0600-0000-0000-000000000000"
                 ],
-                "parent": {
-                    "name": "launchd",
-                    "entity_id": "362213307092004097"
-                },
-                "pgid": 362213307092004097,
-                "start": "2021-07-07T17:05:02.233Z",
-                "pid": 56254,
                 "args_count": 2,
-                "entity_id": "363276350115996101",
                 "command_line": "xpcproxy com.apple.mdworker.shared.01000000-0600-0000-0000-000000000000",
+                "entity_id": "363276350115996101",
                 "executable": "/usr/libexec/xpcproxy",
                 "hash": {
-                    "sha256": "d4ff1c438e330777002332a305fcf965cfaa7d0dbeb899293d347298cbf6d4b6",
-                    "md5": "88922d50263b059696c2af5a99906562"
-                }
-            },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                    "md5": "88922d50263b059696c2af5a99906562",
+                    "sha256": "d4ff1c438e330777002332a305fcf965cfaa7d0dbeb899293d347298cbf6d4b6"
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff8be84591864008eb2e484920",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:02.500Z",
-            "ecs": {
-                "version": "8.0.0"
+                "parent": {
+                    "entity_id": "362213307092004097",
+                    "name": "launchd"
+                },
+                "pgid": 362213307092004097,
+                "pid": 56254,
+                "start": "2021-07-07T17:05:02.233Z"
             },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "88922d50263b059696c2af5a99906562",
                     "d4ff1c438e330777002332a305fcf965cfaa7d0dbeb899293d347298cbf6d4b6",
                     "1620585913"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561684515Z",
-                "original": "{\"MachOSubType\":\"1\",\"ParentProcessId\":\"362213307092004097\",\"SourceProcessId\":\"362213307092004097\",\"aip\":\"67.43.156.14\",\"SessionProcessId\":\"362213307092004097\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"event_platform\":\"Mac\",\"ProcessEndTime\":\"\",\"SVUID\":\"0\",\"ParentBaseFileName\":\"launchd\",\"id\":\"ffffffff-1111-11eb-a9ce-02e9216bdbcb\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677502500\",\"ProcessGroupId\":\"362213307092004097\",\"event_simpleName\":\"ProcessRollup2\",\"RawProcessId\":\"56254\",\"GID\":\"0\",\"ConfigStateHash\":\"1620585913\",\"SVGID\":\"0\",\"MD5HashData\":\"88922d50263b059696c2af5a99906562\",\"SHA256HashData\":\"d4ff1c438e330777002332a305fcf965cfaa7d0dbeb899293d347298cbf6d4b6\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"0\",\"CommandLine\":\"xpcproxy com.apple.mdworker.shared.01000000-0600-0000-0000-000000000000\",\"TargetProcessId\":\"363276350115996101\",\"ImageFileName\":\"/usr/libexec/xpcproxy\",\"RGID\":\"0\",\"SourceThreadId\":\"0\",\"Entitlements\":\"15\",\"name\":\"ProcessRollup2MacV5\",\"RUID\":\"0\",\"ProcessStartTime\":\"1625677502.233\",\"aid\":\"ffffffff8be84591864008eb2e484920\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:02.500Z",
-                "kind": "event",
-                "action": "ProcessRollup2",
-                "id": "ffffffff-1111-11eb-a9ce-02e9216bdbcb",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "1620585913",
-                "MachOSubType": "1",
-                "SVGID": "0",
-                "SourceProcessId": "362213307092004097",
-                "SessionProcessId": "362213307092004097",
-                "SVUID": "0",
-                "RGID": "0",
-                "SourceThreadId": "0",
-                "Entitlements": "15",
-                "name": "ProcessRollup2MacV5",
-                "RUID": "0",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "user": {
-                "id": "0",
-                "group": {
-                    "id": "0"
-                }
-            }
-        },
-        {
-            "process": {
-                "entity_id": "17307488247882"
-            },
-            "os": {
-                "type": "linux"
-            },
-            "destination": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 53,
-                "ip": "67.43.156.14"
-            },
-            "source": {
-                "port": 39920,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "url": {
-                "scheme": "http"
-            },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "community_id": "1:urvmigA14TUbvxTimPg744QEiSA=",
-                "transport": "udp",
-                "iana_number": "17",
-                "direction": "inbound"
+            "url": {
+                "scheme": "http"
             },
-            "observer": {
+            "user": {
+                "group": {
+                    "id": "0"
+                },
+                "id": "0"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:04.982Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1701000200",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkReceiveAcceptIP4LinV5"
+            },
+            "destination": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
-                "serial_number": "ffffffff5a2e420c99f6b6d3a5d9de9b",
-                "type": "agent",
-                "version": "1007.8.0011308.1"
+                "port": 53
             },
-            "@timestamp": "2021-07-07T17:05:04.982Z",
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14",
-                    "0.0.0.0"
-                ],
-                "hash": [
-                    "1701000200"
-                ],
-                "ip": [
-                    "67.43.156.14",
-                    "0.0.0.0"
-                ]
-            },
             "event": {
-                "ingested": "2021-12-30T05:11:46.561685465Z",
-                "original": "{\"LocalAddressIP4\":\"0.0.0.0\",\"event_simpleName\":\"NetworkReceiveAcceptIP4\",\"ContextTimeStamp\":\"1625677504.982\",\"ConfigStateHash\":\"1701000200\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"17307488247882\",\"RemotePort\":\"53\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"39920\",\"Entitlements\":\"15\",\"name\":\"NetworkReceiveAcceptIP4LinV5\",\"id\":\"ffffffff-1111-11eb-9d7c-02e8a46f51a5\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff5a2e420c99f6b6d3a5d9de9b\",\"RemoteAddressIP4\":\"67.43.156.14\",\"ConnectionDirection\":\"1\",\"InContext\":\"0\",\"timestamp\":\"1625677505511\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:05.511Z",
-                "kind": "event",
                 "action": "NetworkReceiveAcceptIP4",
-                "id": "ffffffff-1111-11eb-9d7c-02e8a46f51a5",
                 "category": [
                     "network"
                 ],
+                "created": "2021-07-07T17:05:05.511Z",
+                "id": "ffffffff-1111-11eb-9d7c-02e8a46f51a5",
+                "ingested": "2022-03-22T18:19:46.426477500Z",
+                "kind": "event",
+                "original": "{\"LocalAddressIP4\":\"0.0.0.0\",\"event_simpleName\":\"NetworkReceiveAcceptIP4\",\"ContextTimeStamp\":\"1625677504.982\",\"ConfigStateHash\":\"1701000200\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"17307488247882\",\"RemotePort\":\"53\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"39920\",\"Entitlements\":\"15\",\"name\":\"NetworkReceiveAcceptIP4LinV5\",\"id\":\"ffffffff-1111-11eb-9d7c-02e8a46f51a5\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff5a2e420c99f6b6d3a5d9de9b\",\"RemoteAddressIP4\":\"67.43.156.14\",\"ConnectionDirection\":\"1\",\"InContext\":\"0\",\"timestamp\":\"1625677505511\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
                 "type": [
                     "allowed",
                     "access",
                     "connection"
-                ],
-                "outcome": "unknown"
+                ]
             },
-            "crowdstrike": {
-                "ConfigStateHash": "1701000200",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkReceiveAcceptIP4LinV5",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            }
-        },
-        {
-            "process": {
-                "entity_id": "362579458925546303"
+            "network": {
+                "community_id": "1:urvmigA14TUbvxTimPg744QEiSA=",
+                "direction": "inbound",
+                "iana_number": "17",
+                "transport": "udp"
             },
-            "os": {
-                "type": "macos"
-            },
-            "destination": {
-                "port": 0,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "source": {
+            "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 53,
-                "ip": "67.43.156.14"
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff5a2e420c99f6b6d3a5d9de9b",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011308.1"
             },
-            "url": {
-                "scheme": "http"
+            "os": {
+                "type": "linux"
+            },
+            "process": {
+                "entity_id": "17307488247882"
+            },
+            "related": {
+                "hash": [
+                    "1701000200"
+                ],
+                "hosts": [
+                    "67.43.156.14",
+                    "0.0.0.0"
+                ],
+                "ip": [
+                    "67.43.156.14",
+                    "0.0.0.0"
+                ]
+            },
+            "source": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 39920
             },
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:21.866Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "RawBindIP4MacV10"
+            },
+            "destination": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "RawBindIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:05:22.009Z",
+                "id": "ffffffff-1111-11eb-81d4-0282ad9ac82d",
+                "ingested": "2022-03-22T18:19:46.426485200Z",
+                "kind": "event",
+                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"RawBindIP4\",\"ContextTimeStamp\":\"1625677521.866\",\"ConfigStateHash\":\"3090255842\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"362579458925546303\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"53\",\"Entitlements\":\"15\",\"name\":\"RawBindIP4MacV10\",\"id\":\"ffffffff-1111-11eb-81d4-0282ad9ac82d\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff01fc49949cf06bf0bce3c010\",\"RemoteAddressIP4\":\"0.0.0.0\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677522009\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
             "network": {
+                "direction": "unknown",
                 "iana_number": "17",
-                "transport": "udp",
-                "direction": "unknown"
+                "transport": "udp"
             },
             "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
                 "serial_number": "ffffffff01fc49949cf06bf0bce3c010",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:21.866Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14",
-                    "0.0.0.0"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.14",
-                    "0.0.0.0"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561686382Z",
-                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"RawBindIP4\",\"ContextTimeStamp\":\"1625677521.866\",\"ConfigStateHash\":\"3090255842\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"362579458925546303\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"53\",\"Entitlements\":\"15\",\"name\":\"RawBindIP4MacV10\",\"id\":\"ffffffff-1111-11eb-81d4-0282ad9ac82d\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff01fc49949cf06bf0bce3c010\",\"RemoteAddressIP4\":\"0.0.0.0\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677522009\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:22.009Z",
-                "kind": "event",
-                "action": "RawBindIP4",
-                "id": "ffffffff-1111-11eb-81d4-0282ad9ac82d",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3090255842",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "RawBindIP4MacV10",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            }
-        },
-        {
-            "process": {
-                "entity_id": "364783686797112486"
             },
             "os": {
                 "type": "macos"
             },
-            "destination": {
-                "port": 50626,
-                "address": "127.0.0.1",
-                "ip": "127.0.0.1"
+            "process": {
+                "entity_id": "362579458925546303"
+            },
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14",
+                    "0.0.0.0"
+                ],
+                "ip": [
+                    "67.43.156.14",
+                    "0.0.0.0"
+                ]
             },
             "source": {
-                "port": 0,
-                "address": "0:0:0:0:0:0:0:0",
-                "ip": "0:0:0:0:0:0:0:0"
-            },
-            "url": {
-                "scheme": "http"
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "port": 53
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "outbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff083845f68a7de3d95cb34361",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
             "@timestamp": "2021-07-07T17:05:23.901Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkConnectIP6MacV10"
+            },
+            "destination": {
+                "address": "127.0.0.1",
+                "ip": "127.0.0.1",
+                "port": 50626
+            },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "NetworkConnectIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:05:24.048Z",
+                "id": "ffffffff-1111-11eb-97c6-02fd02aca859",
+                "ingested": "2022-03-22T18:19:46.426492800Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"NetworkConnectIP6\",\"ContextTimeStamp\":\"1625677523.901\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:0\",\"RemoteAddressIP4\":\"127.0.0.1\",\"ConfigStateHash\":\"3090255842\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"364783686797112486\",\"RemotePort\":\"50626\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"0\",\"Entitlements\":\"15\",\"name\":\"NetworkConnectIP6MacV10\",\"id\":\"ffffffff-1111-11eb-97c6-02fd02aca859\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff083845f68a7de3d95cb34361\",\"ConnectionDirection\":\"0\",\"InContext\":\"0\",\"timestamp\":\"1625677524048\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff083845f68a7de3d95cb34361",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "process": {
+                "entity_id": "364783686797112486"
+            },
             "related": {
+                "hash": [
+                    "3090255842"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "0:0:0:0:0:0:0:0",
                     "127.0.0.1"
-                ],
-                "hash": [
-                    "3090255842"
                 ],
                 "ip": [
                     "67.43.156.14",
@@ -824,33 +838,72 @@
                     "127.0.0.1"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561687334Z",
-                "original": "{\"event_simpleName\":\"NetworkConnectIP6\",\"ContextTimeStamp\":\"1625677523.901\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:0\",\"RemoteAddressIP4\":\"127.0.0.1\",\"ConfigStateHash\":\"3090255842\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"364783686797112486\",\"RemotePort\":\"50626\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"0\",\"Entitlements\":\"15\",\"name\":\"NetworkConnectIP6MacV10\",\"id\":\"ffffffff-1111-11eb-97c6-02fd02aca859\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff083845f68a7de3d95cb34361\",\"ConnectionDirection\":\"0\",\"InContext\":\"0\",\"timestamp\":\"1625677524048\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:24.048Z",
-                "kind": "event",
-                "action": "NetworkConnectIP6",
-                "id": "ffffffff-1111-11eb-97c6-02fd02aca859",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "unknown"
+            "source": {
+                "address": "0:0:0:0:0:0:0:0",
+                "ip": "0:0:0:0:0:0:0:0",
+                "port": 0
             },
-            "crowdstrike": {
-                "ConfigStateHash": "3090255842",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkConnectIP6MacV10",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:35.482Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1284133626",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "RGID": "119",
+                "RUID": "114",
+                "SVGID": "119",
+                "SVUID": "114",
+                "SessionProcessId": "38911772846634",
+                "SourceProcessId": "38911774195823",
+                "SourceThreadId": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ProcessRollup2LinV6"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2",
+                "category": [
+                    "process"
+                ],
+                "created": "2021-07-07T17:05:35.482Z",
+                "id": "ffffffff-1111-11eb-bad4-02690d039c6b",
+                "ingested": "2022-03-22T18:19:46.426500500Z",
+                "kind": "event",
+                "original": "{\"ParentProcessId\":\"38911774195823\",\"SourceProcessId\":\"38911774195823\",\"aip\":\"67.43.156.14\",\"SessionProcessId\":\"38911772846634\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"event_platform\":\"Lin\",\"ProcessEndTime\":\"1625677535.102\",\"SVUID\":\"114\",\"ParentBaseFileName\":\"bash\",\"id\":\"ffffffff-1111-11eb-bad4-02690d039c6b\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677535482\",\"ProcessGroupId\":\"9277112078\",\"event_simpleName\":\"ProcessRollup2\",\"RawProcessId\":\"73249\",\"GID\":\"119\",\"ConfigStateHash\":\"1284133626\",\"SVGID\":\"119\",\"MD5HashData\":\"29037cef466fa57f03bd1b2a092c47a4\",\"SHA256HashData\":\"a4f11f04df7aa3ac611dcbdb3e3d934a8f0523ea17b0a41a1809c380efd2d112\",\"ConfigBuild\":\"1007.8.0010912.1\",\"UID\":\"114\",\"CommandLine\":\"pgbackrest --stanza\\u003dmain archive-get 000000020004D51F0000009F pg_wal/RECOVERYXLOG\",\"TargetProcessId\":\"38911778380590\",\"ImageFileName\":\"/usr/bin/pgbackrest\",\"RGID\":\"119\",\"SourceThreadId\":\"0\",\"Entitlements\":\"15\",\"name\":\"ProcessRollup2LinV6\",\"RUID\":\"114\",\"ProcessStartTime\":\"1625677535.068\",\"aid\":\"ffffffffcf45409f87ed463b40c368ec\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffcf45409f87ed463b40c368ec",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0010912.1"
+            },
+            "os": {
+                "type": "linux"
+            },
             "process": {
                 "args": [
                     "pgbackrest",
@@ -859,1030 +912,999 @@
                     "000000020004D51F0000009F",
                     "pg_wal/RECOVERYXLOG"
                 ],
-                "parent": {
-                    "name": "bash",
-                    "entity_id": "38911774195823"
-                },
-                "pgid": 9277112078,
-                "start": "2021-07-07T17:05:35.068Z",
-                "end": "2021-07-07T17:05:35.102Z",
-                "pid": 73249,
                 "args_count": 5,
-                "entity_id": "38911778380590",
                 "command_line": "pgbackrest --stanza=main archive-get 000000020004D51F0000009F pg_wal/RECOVERYXLOG",
+                "end": "2021-07-07T17:05:35.102Z",
+                "entity_id": "38911778380590",
                 "executable": "/usr/bin/pgbackrest",
                 "hash": {
-                    "sha256": "a4f11f04df7aa3ac611dcbdb3e3d934a8f0523ea17b0a41a1809c380efd2d112",
-                    "md5": "29037cef466fa57f03bd1b2a092c47a4"
+                    "md5": "29037cef466fa57f03bd1b2a092c47a4",
+                    "sha256": "a4f11f04df7aa3ac611dcbdb3e3d934a8f0523ea17b0a41a1809c380efd2d112"
                 },
+                "parent": {
+                    "entity_id": "38911774195823",
+                    "name": "bash"
+                },
+                "pgid": 9277112078,
+                "pid": 73249,
+                "start": "2021-07-07T17:05:35.068Z",
                 "uptime": 0
             },
-            "os": {
-                "type": "linux"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffcf45409f87ed463b40c368ec",
-                "type": "agent",
-                "version": "1007.8.0010912.1"
-            },
-            "@timestamp": "2021-07-07T17:05:35.482Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "29037cef466fa57f03bd1b2a092c47a4",
                     "a4f11f04df7aa3ac611dcbdb3e3d934a8f0523ea17b0a41a1809c380efd2d112",
                     "1284133626"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561688260Z",
-                "original": "{\"ParentProcessId\":\"38911774195823\",\"SourceProcessId\":\"38911774195823\",\"aip\":\"67.43.156.14\",\"SessionProcessId\":\"38911772846634\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"event_platform\":\"Lin\",\"ProcessEndTime\":\"1625677535.102\",\"SVUID\":\"114\",\"ParentBaseFileName\":\"bash\",\"id\":\"ffffffff-1111-11eb-bad4-02690d039c6b\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677535482\",\"ProcessGroupId\":\"9277112078\",\"event_simpleName\":\"ProcessRollup2\",\"RawProcessId\":\"73249\",\"GID\":\"119\",\"ConfigStateHash\":\"1284133626\",\"SVGID\":\"119\",\"MD5HashData\":\"29037cef466fa57f03bd1b2a092c47a4\",\"SHA256HashData\":\"a4f11f04df7aa3ac611dcbdb3e3d934a8f0523ea17b0a41a1809c380efd2d112\",\"ConfigBuild\":\"1007.8.0010912.1\",\"UID\":\"114\",\"CommandLine\":\"pgbackrest --stanza\\u003dmain archive-get 000000020004D51F0000009F pg_wal/RECOVERYXLOG\",\"TargetProcessId\":\"38911778380590\",\"ImageFileName\":\"/usr/bin/pgbackrest\",\"RGID\":\"119\",\"SourceThreadId\":\"0\",\"Entitlements\":\"15\",\"name\":\"ProcessRollup2LinV6\",\"RUID\":\"114\",\"ProcessStartTime\":\"1625677535.068\",\"aid\":\"ffffffffcf45409f87ed463b40c368ec\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:35.482Z",
-                "kind": "event",
-                "action": "ProcessRollup2",
-                "id": "ffffffff-1111-11eb-bad4-02690d039c6b",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "1284133626",
-                "SVUID": "114",
-                "SVGID": "119",
-                "RGID": "119",
-                "SourceThreadId": "0",
-                "Entitlements": "15",
-                "SourceProcessId": "38911774195823",
-                "name": "ProcessRollup2LinV6",
-                "RUID": "114",
-                "SessionProcessId": "38911772846634",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "id": "114",
                 "group": {
                     "id": "119"
-                }
+                },
+                "id": "114"
             }
         },
         {
-            "process": {
-                "entity_id": "17307455014463"
+            "@timestamp": "2021-07-07T17:05:03.713Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1701000200",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkConnectIP6LinV5"
+            },
+            "destination": {
+                "address": "0:0:0:0:0:0:0:1",
+                "ip": "0:0:0:0:0:0:0:1",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkConnectIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:05:03.947Z",
+                "id": "ffffffff-1111-11eb-9d7c-02e8a46f51a5",
+                "ingested": "2022-03-22T18:19:46.426508200Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"NetworkConnectIP6\",\"ContextTimeStamp\":\"1625677503.713\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:1\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:1\",\"ConfigStateHash\":\"1701000200\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"17307455014463\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"41952\",\"Entitlements\":\"15\",\"name\":\"NetworkConnectIP6LinV5\",\"id\":\"ffffffff-1111-11eb-9d7c-02e8a46f51a5\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff5a2e420c99f6b6d3a5d9de9b\",\"ConnectionDirection\":\"0\",\"InContext\":\"0\",\"timestamp\":\"1625677503947\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff5a2e420c99f6b6d3a5d9de9b",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011308.1"
             },
             "os": {
                 "type": "linux"
             },
-            "destination": {
-                "port": 0,
-                "address": "0:0:0:0:0:0:0:1",
-                "ip": "0:0:0:0:0:0:0:1"
-            },
-            "source": {
-                "port": 41952,
-                "address": "0:0:0:0:0:0:0:1",
-                "ip": "0:0:0:0:0:0:0:1"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "iana_number": "17",
-                "transport": "udp",
-                "direction": "outbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff5a2e420c99f6b6d3a5d9de9b",
-                "type": "agent",
-                "version": "1007.8.0011308.1"
-            },
-            "@timestamp": "2021-07-07T17:05:03.713Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "17307455014463"
             },
             "related": {
+                "hash": [
+                    "1701000200"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "0:0:0:0:0:0:0:1"
-                ],
-                "hash": [
-                    "1701000200"
                 ],
                 "ip": [
                     "67.43.156.14",
                     "0:0:0:0:0:0:0:1"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561689258Z",
-                "original": "{\"event_simpleName\":\"NetworkConnectIP6\",\"ContextTimeStamp\":\"1625677503.713\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:1\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:1\",\"ConfigStateHash\":\"1701000200\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"17307455014463\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"41952\",\"Entitlements\":\"15\",\"name\":\"NetworkConnectIP6LinV5\",\"id\":\"ffffffff-1111-11eb-9d7c-02e8a46f51a5\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff5a2e420c99f6b6d3a5d9de9b\",\"ConnectionDirection\":\"0\",\"InContext\":\"0\",\"timestamp\":\"1625677503947\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:03.947Z",
-                "kind": "event",
-                "action": "NetworkConnectIP6",
-                "id": "ffffffff-1111-11eb-9d7c-02e8a46f51a5",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "unknown"
+            "source": {
+                "address": "0:0:0:0:0:0:0:1",
+                "ip": "0:0:0:0:0:0:0:1",
+                "port": 41952
             },
-            "crowdstrike": {
-                "ConfigStateHash": "1701000200",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkConnectIP6LinV5",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:20.973Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "OoxmlFileWrittenMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "OoxmlFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:05:21.081Z",
+                "id": "ffffffff-1111-11eb-8ad1-02cfdadef55f",
+                "ingested": "2022-03-22T18:19:46.426516200Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"OoxmlFileWritten\",\"ContextTimeStamp\":\"1625677520.973\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365044948432500700\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"0500000100000000000000000000000021b0260000000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"OoxmlFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-8ad1-02cfdadef55f\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff20bd481a98a3d1f6191047ff\",\"timestamp\":\"1625677521081\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user1/Library/Application Support/Google/DriveFS/110588730849638631570/content_cache/d23/d44/432508\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/Users/user1/Library/Application Support/Google/DriveFS/110588730849638631570/content_cache/d23/d44",
+                "inode": "0500000100000000000000000000000021b0260000000000",
+                "name": "432508",
+                "path": "/Users/user1/Library/Application Support/Google/DriveFS/110588730849638631570/content_cache/d23/d44/432508",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff20bd481a98a3d1f6191047ff",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "365044948432500700",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff20bd481a98a3d1f6191047ff",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:20.973Z",
-            "file": {
-                "inode": "0500000100000000000000000000000021b0260000000000",
-                "name": "432508",
-                "path": "/Users/user1/Library/Application Support/Google/DriveFS/110588730849638631570/content_cache/d23/d44/432508",
-                "type": "file",
-                "directory": "/Users/user1/Library/Application Support/Google/DriveFS/110588730849638631570/content_cache/d23/d44"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561690385Z",
-                "original": "{\"event_simpleName\":\"OoxmlFileWritten\",\"ContextTimeStamp\":\"1625677520.973\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365044948432500700\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"0500000100000000000000000000000021b0260000000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"OoxmlFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-8ad1-02cfdadef55f\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff20bd481a98a3d1f6191047ff\",\"timestamp\":\"1625677521081\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user1/Library/Application Support/Google/DriveFS/110588730849638631570/content_cache/d23/d44/432508\"}",
-                "created": "2021-07-07T17:05:21.081Z",
-                "kind": "event",
-                "action": "OoxmlFileWritten",
-                "id": "ffffffff-1111-11eb-8ad1-02cfdadef55f",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "OoxmlFileWrittenMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            }
-        },
-        {
-            "process": {
-                "entity_id": "12227094573885"
-            },
-            "os": {
-                "type": "linux"
-            },
-            "destination": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 80,
-                "ip": "67.43.156.14"
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 59926,
-                "ip": "67.43.156.14"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "community_id": "1:XUmTKB40anItSVy47MPGAZ+mJWM=",
-                "transport": "tcp",
-                "iana_number": "6",
-                "direction": "outbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffffbd064538b214ab0dce8e82c3",
-                "type": "agent",
-                "version": "1007.8.0011308.1"
-            },
-            "@timestamp": "2021-07-07T17:05:30.308Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13",
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3469235958"
-                ],
-                "ip": [
-                    "67.43.156.13",
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561691336Z",
-                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"NetworkConnectIP4\",\"ContextTimeStamp\":\"1625677530.308\",\"ConfigStateHash\":\"3469235958\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"12227094573885\",\"RemotePort\":\"80\",\"aip\":\"67.43.156.13\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"59926\",\"Entitlements\":\"15\",\"name\":\"NetworkConnectIP4LinV5\",\"id\":\"ffffffff-1111-11eb-b727-028bbe41f38d\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffffbd064538b214ab0dce8e82c3\",\"RemoteAddressIP4\":\"67.43.156.14\",\"ConnectionDirection\":\"0\",\"InContext\":\"0\",\"timestamp\":\"1625677530841\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:30.841Z",
-                "kind": "event",
-                "action": "NetworkConnectIP4",
-                "id": "ffffffff-1111-11eb-b727-028bbe41f38d",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "unknown"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3469235958",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkConnectIP4LinV5",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
+            "@timestamp": "2021-07-07T17:05:30.308Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3469235958",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkConnectIP4LinV5"
+            },
+            "destination": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
-                "serial_number": "ffffffff25b14d4aa96de99e24bad2fa",
-                "type": "agent",
-                "version": "1007.8.0011611.1"
+                "port": 80
             },
-            "@timestamp": "2021-07-07T17:04:53.974Z",
             "ecs": {
                 "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "1156120155"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "os": {
-                "type": "linux"
             },
             "event": {
-                "action": "ChannelVersionRequired",
-                "ingested": "2021-12-30T05:11:46.561692256Z",
-                "original": "{\"ChannelVersion\":\"0\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"1156120155\",\"ChannelDiffStatus\":\"1\",\"aip\":\"67.43.156.14\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"12\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"name\":\"ChannelVersionRequiredLinV2\",\"id\":\"ffffffff-1111-11eb-b7e0-02332cdcc16d\",\"ErrorCode\":\"0\",\"aid\":\"ffffffff25b14d4aa96de99e24bad2fa\",\"timestamp\":\"1625677493974\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "id": "ffffffff-1111-11eb-b7e0-02332cdcc16d",
-                "created": "2021-07-07T17:04:53.974Z"
+                "action": "NetworkConnectIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:05:30.841Z",
+                "id": "ffffffff-1111-11eb-b727-028bbe41f38d",
+                "ingested": "2022-03-22T18:19:46.426576Z",
+                "kind": "event",
+                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"NetworkConnectIP4\",\"ContextTimeStamp\":\"1625677530.308\",\"ConfigStateHash\":\"3469235958\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"12227094573885\",\"RemotePort\":\"80\",\"aip\":\"67.43.156.13\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"59926\",\"Entitlements\":\"15\",\"name\":\"NetworkConnectIP4LinV5\",\"id\":\"ffffffff-1111-11eb-b727-028bbe41f38d\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffffbd064538b214ab0dce8e82c3\",\"RemoteAddressIP4\":\"67.43.156.14\",\"ConnectionDirection\":\"0\",\"InContext\":\"0\",\"timestamp\":\"1625677530841\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "start",
+                    "connection"
+                ]
             },
-            "crowdstrike": {
-                "ChannelVersion": "0",
-                "ConfigStateHash": "1156120155",
-                "ChannelDiffStatus": "1",
-                "name": "ChannelVersionRequiredLinV2",
-                "ChannelVersionRequired": "0",
-                "ErrorCode": "0",
-                "ChannelId": "12",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "network": {
+                "community_id": "1:XUmTKB40anItSVy47MPGAZ+mJWM=",
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
             },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
             "observer": {
+                "address": "67.43.156.13",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffc9114c1898e79604708955a6",
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffffbd064538b214ab0dce8e82c3",
                 "type": "agent",
-                "version": "1007.8.0011611.1"
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011308.1"
             },
-            "@timestamp": "2021-07-07T17:05:21.218Z",
             "os": {
                 "type": "linux"
             },
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "12227094573885"
             },
             "related": {
-                "hosts": [
-                    "67.43.156.14",
-                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ],
                 "hash": [
-                    "1156120155"
+                    "3469235958"
+                ],
+                "hosts": [
+                    "67.43.156.13",
+                    "67.43.156.14"
                 ],
                 "ip": [
-                    "67.43.156.14",
-                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                    "67.43.156.13",
+                    "67.43.156.14"
                 ]
             },
             "source": {
-                "geo": {
-                    "continent_name": "Europe",
-                    "country_name": "Norway",
-                    "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
                 },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "mac": "6e-9e-e0-1f-6d-7d",
-                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "port": 59926
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:04:53.974Z",
+            "crowdstrike": {
+                "ChannelDiffStatus": "1",
+                "ChannelId": "12",
+                "ChannelVersion": "0",
+                "ChannelVersionRequired": "0",
+                "ConfigStateHash": "1156120155",
+                "ErrorCode": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ChannelVersionRequiredLinV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
             },
             "event": {
-                "ingested": "2021-12-30T05:11:46.561693282Z",
-                "original": "{\"event_simpleName\":\"LocalIpAddressIP6\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"1156120155\",\"CreationTimeStamp\":\"1625677520.686\",\"aip\":\"67.43.156.14\",\"PhysicalAddress\":\"6e-9e-e0-1f-6d-7d\",\"InterfaceAlias\":\"vethdeb0243\",\"InterfaceIndex\":\"3736\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"InterfaceType\":\"1\",\"name\":\"LocalIpAddressIP6LinV1\",\"id\":\"ffffffff-1111-11eb-92d2-0286f570f8e1\",\"PhysicalAddressLength\":\"6\",\"aid\":\"ffffffffc9114c1898e79604708955a6\",\"timestamp\":\"1625677521218\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:21.218Z",
-                "kind": "state",
+                "action": "ChannelVersionRequired",
+                "created": "2021-07-07T17:04:53.974Z",
+                "id": "ffffffff-1111-11eb-b7e0-02332cdcc16d",
+                "ingested": "2022-03-22T18:19:46.426581100Z",
+                "original": "{\"ChannelVersion\":\"0\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"1156120155\",\"ChannelDiffStatus\":\"1\",\"aip\":\"67.43.156.14\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"12\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"name\":\"ChannelVersionRequiredLinV2\",\"id\":\"ffffffff-1111-11eb-b7e0-02332cdcc16d\",\"ErrorCode\":\"0\",\"aid\":\"ffffffff25b14d4aa96de99e24bad2fa\",\"timestamp\":\"1625677493974\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff25b14d4aa96de99e24bad2fa",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011611.1"
+            },
+            "os": {
+                "type": "linux"
+            },
+            "related": {
+                "hash": [
+                    "1156120155"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:21.218Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1156120155",
+                "InterfaceAlias": "vethdeb0243",
+                "InterfaceIndex": 3736,
+                "InterfaceType": "1",
+                "PhysicalAddressLength": 6,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LocalIpAddressIP6LinV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
                 "action": "LocalIpAddressIP6",
-                "id": "ffffffff-1111-11eb-92d2-0286f570f8e1",
                 "category": [
                     "configuration",
                     "host"
                 ],
+                "created": "2021-07-07T17:05:21.218Z",
+                "id": "ffffffff-1111-11eb-92d2-0286f570f8e1",
+                "ingested": "2022-03-22T18:19:46.426587400Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"LocalIpAddressIP6\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"1156120155\",\"CreationTimeStamp\":\"1625677520.686\",\"aip\":\"67.43.156.14\",\"PhysicalAddress\":\"6e-9e-e0-1f-6d-7d\",\"InterfaceAlias\":\"vethdeb0243\",\"InterfaceIndex\":\"3736\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"InterfaceType\":\"1\",\"name\":\"LocalIpAddressIP6LinV1\",\"id\":\"ffffffff-1111-11eb-92d2-0286f570f8e1\",\"PhysicalAddressLength\":\"6\",\"aid\":\"ffffffffc9114c1898e79604708955a6\",\"timestamp\":\"1625677521218\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
                 "type": [
                     "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "InterfaceIndex": 3736,
-                "InterfaceType": "1",
-                "ConfigStateHash": "1156120155",
-                "name": "LocalIpAddressIP6LinV1",
-                "PhysicalAddressLength": 6,
-                "InterfaceAlias": "vethdeb0243",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff2d7b4778a73b2cf58d327e42",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:40.455Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
-                "hash": [
-                    "1620585913"
-                ],
-                "ip": [
-                    "67.43.156.13"
                 ]
             },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "action": "ChannelVersionRequired",
-                "ingested": "2021-12-30T05:11:46.561694305Z",
-                "original": "{\"ChannelVersion\":\"0\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"1620585913\",\"ChannelDiffStatus\":\"1\",\"aip\":\"67.43.156.13\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"210\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ChannelVersionRequiredMacV2\",\"id\":\"ffffffff-1111-11eb-8cc5-02c6fb049dd3\",\"ErrorCode\":\"0\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff2d7b4778a73b2cf58d327e42\",\"timestamp\":\"1625677480455\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "id": "ffffffff-1111-11eb-8cc5-02c6fb049dd3",
-                "created": "2021-07-07T17:04:40.455Z"
-            },
-            "crowdstrike": {
-                "ChannelVersion": "0",
-                "ConfigStateHash": "1620585913",
-                "ChannelDiffStatus": "1",
-                "Entitlements": "15",
-                "name": "ChannelVersionRequiredMacV2",
-                "ChannelVersionRequired": "0",
-                "ErrorCode": "0",
-                "ChannelId": "210",
-                "EffectiveTransmissionClass": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
             "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
                 "address": "67.43.156.14",
-                "vendor": "crowdstrike",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
                 "ip": "67.43.156.14",
-                "serial_number": "fffffffff6e146908cbf31d72b94b626",
+                "serial_number": "ffffffffc9114c1898e79604708955a6",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "@timestamp": "2021-07-07T17:05:40.292Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "1156120155"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
             },
             "os": {
                 "type": "linux"
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561695390Z",
-                "original": "{\"event_simpleName\":\"SensorHeartbeat\",\"ConfigStateHash\":\"1156120155\",\"NetworkContainmentState\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigIDBase\":\"65994753\",\"SensorStateBitMap\":\"2\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"ConfigurationVersion\":\"10\",\"name\":\"SensorHeartbeatLinV4\",\"ConfigIDPlatform\":\"8\",\"id\":\"ffffffff-1111-11eb-993f-02b8dc387eb5\",\"ConfigIDBuild\":\"11611\",\"aid\":\"fffffffff6e146908cbf31d72b94b626\",\"timestamp\":\"1625677540292\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:40.292Z",
-                "kind": "event",
-                "action": "SensorHeartbeat",
-                "id": "ffffffff-1111-11eb-993f-02b8dc387eb5",
-                "category": [
-                    "package"
+            "related": {
+                "hash": [
+                    "1156120155"
                 ],
-                "type": [
-                    "info"
+                "hosts": [
+                    "67.43.156.14",
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
                 ],
-                "outcome": "success"
+                "ip": [
+                    "67.43.156.14",
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                ]
             },
-            "crowdstrike": {
-                "ConfigStateHash": "1156120155",
-                "ConfigurationVersion": "10",
-                "NetworkContainmentState": "0",
-                "name": "SensorHeartbeatLinV4",
-                "ConfigIDPlatform": "8",
-                "ConfigIDBase": "65994753",
-                "SensorStateBitMap": "2",
-                "ConfigIDBuild": "11611",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
+            "source": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "mac": "6e-9e-e0-1f-6d-7d"
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:04:40.455Z",
+            "crowdstrike": {
+                "ChannelDiffStatus": "1",
+                "ChannelId": "210",
+                "ChannelVersion": "0",
+                "ChannelVersionRequired": "0",
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "0",
+                "Entitlements": "15",
+                "ErrorCode": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ChannelVersionRequiredMacV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ChannelVersionRequired",
+                "created": "2021-07-07T17:04:40.455Z",
+                "id": "ffffffff-1111-11eb-8cc5-02c6fb049dd3",
+                "ingested": "2022-03-22T18:19:46.426592400Z",
+                "original": "{\"ChannelVersion\":\"0\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"1620585913\",\"ChannelDiffStatus\":\"1\",\"aip\":\"67.43.156.13\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"210\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ChannelVersionRequiredMacV2\",\"id\":\"ffffffff-1111-11eb-8cc5-02c6fb049dd3\",\"ErrorCode\":\"0\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff2d7b4778a73b2cf58d327e42\",\"timestamp\":\"1625677480455\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff2d7b4778a73b2cf58d327e42",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
+                "ip": [
+                    "67.43.156.13"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:40.292Z",
+            "crowdstrike": {
+                "ConfigIDBase": "65994753",
+                "ConfigIDBuild": "11611",
+                "ConfigIDPlatform": "8",
+                "ConfigStateHash": "1156120155",
+                "ConfigurationVersion": "10",
+                "NetworkContainmentState": "0",
+                "SensorStateBitMap": "2",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "SensorHeartbeatLinV4"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "SensorHeartbeat",
+                "category": [
+                    "package"
+                ],
+                "created": "2021-07-07T17:05:40.292Z",
+                "id": "ffffffff-1111-11eb-993f-02b8dc387eb5",
+                "ingested": "2022-03-22T18:19:46.426598600Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"SensorHeartbeat\",\"ConfigStateHash\":\"1156120155\",\"NetworkContainmentState\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigIDBase\":\"65994753\",\"SensorStateBitMap\":\"2\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"ConfigurationVersion\":\"10\",\"name\":\"SensorHeartbeatLinV4\",\"ConfigIDPlatform\":\"8\",\"id\":\"ffffffff-1111-11eb-993f-02b8dc387eb5\",\"ConfigIDBuild\":\"11611\",\"aid\":\"fffffffff6e146908cbf31d72b94b626\",\"timestamp\":\"1625677540292\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "fffffffff6e146908cbf31d72b94b626",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011611.1"
+            },
+            "os": {
+                "type": "linux"
+            },
+            "related": {
+                "hash": [
+                    "1156120155"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:28.570Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "JavaClassFileWrittenMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "JavaClassFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:05:28.717Z",
+                "id": "ffffffff-1111-11eb-97c6-02fd02aca859",
+                "ingested": "2022-03-22T18:19:46.426605700Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"JavaClassFileWritten\",\"ContextTimeStamp\":\"1625677528.570\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364783686797112486\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"04000001000000000000000000000000986b480e00000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"JavaClassFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-97c6-02fd02aca859\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff083845f68a7de3d95cb34361\",\"timestamp\":\"1625677528717\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user2/shopper-one/tooling/teams-plugin/build/classes/kotlin/main/com/instacart/shopper/tooling/TeamsPlugin$apply$$inlined$configure$1.class\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/Users/user2/shopper-one/tooling/teams-plugin/build/classes/kotlin/main/com/instacart/shopper/tooling",
+                "extension": "class",
+                "inode": "04000001000000000000000000000000986b480e00000000",
+                "name": "TeamsPlugin$apply$$inlined$configure$1.class",
+                "path": "/Users/user2/shopper-one/tooling/teams-plugin/build/classes/kotlin/main/com/instacart/shopper/tooling/TeamsPlugin$apply$$inlined$configure$1.class",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff083845f68a7de3d95cb34361",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "364783686797112486",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff083845f68a7de3d95cb34361",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:28.570Z",
-            "file": {
-                "inode": "04000001000000000000000000000000986b480e00000000",
-                "name": "TeamsPlugin$apply$$inlined$configure$1.class",
-                "path": "/Users/user2/shopper-one/tooling/teams-plugin/build/classes/kotlin/main/com/instacart/shopper/tooling/TeamsPlugin$apply$$inlined$configure$1.class",
-                "extension": "class",
-                "type": "file",
-                "directory": "/Users/user2/shopper-one/tooling/teams-plugin/build/classes/kotlin/main/com/instacart/shopper/tooling"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561696466Z",
-                "original": "{\"event_simpleName\":\"JavaClassFileWritten\",\"ContextTimeStamp\":\"1625677528.570\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364783686797112486\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"04000001000000000000000000000000986b480e00000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"JavaClassFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-97c6-02fd02aca859\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff083845f68a7de3d95cb34361\",\"timestamp\":\"1625677528717\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user2/shopper-one/tooling/teams-plugin/build/classes/kotlin/main/com/instacart/shopper/tooling/TeamsPlugin$apply$$inlined$configure$1.class\"}",
-                "created": "2021-07-07T17:05:28.717Z",
-                "kind": "event",
-                "action": "JavaClassFileWritten",
-                "id": "ffffffff-1111-11eb-97c6-02fd02aca859",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "JavaClassFileWrittenMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "process": {
-                "entity_id": "364796317497854624"
+            "@timestamp": "2021-07-07T17:05:12.700Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkConnectIP4MacV10"
+            },
+            "destination": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkConnectIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:05:12.892Z",
+                "id": "ffffffff-1111-11eb-9c94-0222a21bbb27",
+                "ingested": "2022-03-22T18:19:46.426612500Z",
+                "kind": "event",
+                "original": "{\"LocalAddressIP4\":\"0.0.0.0\",\"event_simpleName\":\"NetworkConnectIP4\",\"ContextTimeStamp\":\"1625677512.700\",\"ConfigStateHash\":\"1620585913\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"364796317497854624\",\"RemotePort\":\"443\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"0\",\"Entitlements\":\"15\",\"name\":\"NetworkConnectIP4MacV10\",\"id\":\"ffffffff-1111-11eb-9c94-0222a21bbb27\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff96f142f6b2475f3c584ddd80\",\"RemoteAddressIP4\":\"67.43.156.14\",\"ConnectionDirection\":\"0\",\"InContext\":\"0\",\"timestamp\":\"1625677512892\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff96f142f6b2475f3c584ddd80",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
             },
             "os": {
                 "type": "macos"
             },
-            "destination": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 443,
-                "ip": "67.43.156.14"
-            },
-            "source": {
-                "port": 0,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "outbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff96f142f6b2475f3c584ddd80",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:12.700Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "364796317497854624"
             },
             "related": {
+                "hash": [
+                    "1620585913"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "0.0.0.0"
-                ],
-                "hash": [
-                    "1620585913"
                 ],
                 "ip": [
                     "67.43.156.14",
                     "0.0.0.0"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561697387Z",
-                "original": "{\"LocalAddressIP4\":\"0.0.0.0\",\"event_simpleName\":\"NetworkConnectIP4\",\"ContextTimeStamp\":\"1625677512.700\",\"ConfigStateHash\":\"1620585913\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"364796317497854624\",\"RemotePort\":\"443\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"0\",\"Entitlements\":\"15\",\"name\":\"NetworkConnectIP4MacV10\",\"id\":\"ffffffff-1111-11eb-9c94-0222a21bbb27\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff96f142f6b2475f3c584ddd80\",\"RemoteAddressIP4\":\"67.43.156.14\",\"ConnectionDirection\":\"0\",\"InContext\":\"0\",\"timestamp\":\"1625677512892\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:12.892Z",
-                "kind": "event",
-                "action": "NetworkConnectIP4",
-                "id": "ffffffff-1111-11eb-9c94-0222a21bbb27",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "unknown"
+            "source": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 0
             },
-            "crowdstrike": {
-                "ConfigStateHash": "1620585913",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkConnectIP4MacV10",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:04:35.806Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "DnsRequestMacV1"
+            },
+            "dns": {
+                "question": {
+                    "name": "jss.dom1.com",
+                    "registered_domain": "dom1.com",
+                    "subdomain": "jss",
+                    "top_level_domain": "com",
+                    "type": "AAAA"
+                },
+                "type": "query"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "DnsRequest",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:04:36.111Z",
+                "id": "ffffffff-1111-11eb-9644-060415b1fd87",
+                "ingested": "2022-03-22T18:19:46.426620300Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"DnsRequest\",\"ContextTimeStamp\":\"1625677475.806\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"364977197365370629\",\"DomainName\":\"jss.dom1.com\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"DnsRequestMacV1\",\"id\":\"ffffffff-1111-11eb-9644-060415b1fd87\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff7ecf4e61bba14ca5ac5d17b1\",\"timestamp\":\"1625677476111\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"RequestType\":\"28\"}",
+                "outcome": "success",
+                "type": [
+                    "protocol"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff7ecf4e61bba14ca5ac5d17b1",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "364977197365370629",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "dns": {
-                "question": {
-                    "name": "jss.dom1.com",
-                    "subdomain": "jss",
-                    "registered_domain": "dom1.com",
-                    "type": "AAAA",
-                    "top_level_domain": "com"
-                },
-                "type": "query"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff7ecf4e61bba14ca5ac5d17b1",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:35.806Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561698352Z",
-                "original": "{\"event_simpleName\":\"DnsRequest\",\"ContextTimeStamp\":\"1625677475.806\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"364977197365370629\",\"DomainName\":\"jss.dom1.com\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"DnsRequestMacV1\",\"id\":\"ffffffff-1111-11eb-9644-060415b1fd87\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff7ecf4e61bba14ca5ac5d17b1\",\"timestamp\":\"1625677476111\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"RequestType\":\"28\"}",
-                "created": "2021-07-07T17:04:36.111Z",
-                "kind": "event",
-                "action": "DnsRequest",
-                "id": "ffffffff-1111-11eb-9644-060415b1fd87",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "protocol"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "DnsRequestMacV1",
-                "ConfigStateHash": "1620585913",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:04.770Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NewScriptWrittenMacV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NewScriptWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:05:40.055Z",
+                "id": "ffffffff-1111-11eb-b3de-06a53f021cc9",
+                "ingested": "2022-03-22T18:19:46.426628100Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"NewScriptWritten\",\"ContextTimeStamp\":\"1625677504.770\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"365053504406857894\",\"Size\":\"0\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"2d9a331f045a9c6b13d45eabe948b5c7dfdc25e1251bff6756fa306581087da9\",\"FileIdentifier\":\"05000001000000000000000000000000b588050000000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"NewScriptWrittenMacV2\",\"id\":\"ffffffff-1111-11eb-b3de-06a53f021cc9\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffbea440b9aad8b5bf222d303f\",\"timestamp\":\"1625677540055\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Applications/BitBar/countdown_timer.1s.py\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/Applications/BitBar",
+                "extension": "py",
+                "inode": "05000001000000000000000000000000b588050000000000",
+                "name": "countdown_timer.1s.py",
+                "path": "/Applications/BitBar/countdown_timer.1s.py",
+                "size": 0,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffbea440b9aad8b5bf222d303f",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "365053504406857894",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffbea440b9aad8b5bf222d303f",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:04.770Z",
-            "file": {
-                "inode": "05000001000000000000000000000000b588050000000000",
-                "path": "/Applications/BitBar/countdown_timer.1s.py",
-                "extension": "py",
-                "size": 0,
-                "name": "countdown_timer.1s.py",
-                "type": "file",
-                "directory": "/Applications/BitBar"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "2d9a331f045a9c6b13d45eabe948b5c7dfdc25e1251bff6756fa306581087da9",
                     "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561699269Z",
-                "original": "{\"event_simpleName\":\"NewScriptWritten\",\"ContextTimeStamp\":\"1625677504.770\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"365053504406857894\",\"Size\":\"0\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"2d9a331f045a9c6b13d45eabe948b5c7dfdc25e1251bff6756fa306581087da9\",\"FileIdentifier\":\"05000001000000000000000000000000b588050000000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"NewScriptWrittenMacV2\",\"id\":\"ffffffff-1111-11eb-b3de-06a53f021cc9\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffbea440b9aad8b5bf222d303f\",\"timestamp\":\"1625677540055\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Applications/BitBar/countdown_timer.1s.py\"}",
-                "created": "2021-07-07T17:05:40.055Z",
-                "kind": "event",
-                "action": "NewScriptWritten",
-                "id": "ffffffff-1111-11eb-b3de-06a53f021cc9",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "NewScriptWrittenMacV2",
-                "ConfigStateHash": "1620585913",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffbfbf4ff5aa56a26ad3c1a942",
-                "type": "agent",
-                "version": "1007.8.0011611.1"
-            },
             "@timestamp": "2021-07-07T17:05:26.386Z",
-            "os": {
-                "type": "linux"
+            "crowdstrike": {
+                "ConfigStateHash": "1156120155",
+                "InterfaceIndex": 186,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LocalIpAddressRemovedIP6LinV1"
             },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "LocalIpAddressRemovedIP6",
+                "category": [
+                    "configuration",
+                    "host"
+                ],
+                "created": "2021-07-07T17:05:26.386Z",
+                "id": "ffffffff-1111-11eb-b3c1-02ff598b7945",
+                "ingested": "2022-03-22T18:19:46.426635800Z",
+                "kind": "state",
+                "original": "{\"InterfaceIndex\":\"186\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_simpleName\":\"LocalIpAddressRemovedIP6\",\"event_platform\":\"Lin\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"1156120155\",\"name\":\"LocalIpAddressRemovedIP6LinV1\",\"aip\":\"67.43.156.14\",\"id\":\"ffffffff-1111-11eb-b3c1-02ff598b7945\",\"aid\":\"ffffffffbfbf4ff5aa56a26ad3c1a942\",\"timestamp\":\"1625677526386\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffbfbf4ff5aa56a26ad3c1a942",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011611.1"
+            },
+            "os": {
+                "type": "linux"
+            },
             "related": {
+                "hash": [
+                    "1156120155"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ],
-                "hash": [
-                    "1156120155"
                 ],
                 "ip": [
                     "67.43.156.14",
@@ -1890,263 +1912,298 @@
                 ]
             },
             "source": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
                 "geo": {
                     "continent_name": "Europe",
+                    "country_iso_code": "NO",
                     "country_name": "Norway",
                     "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
                 },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
                 "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561700176Z",
-                "original": "{\"InterfaceIndex\":\"186\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_simpleName\":\"LocalIpAddressRemovedIP6\",\"event_platform\":\"Lin\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"1156120155\",\"name\":\"LocalIpAddressRemovedIP6LinV1\",\"aip\":\"67.43.156.14\",\"id\":\"ffffffff-1111-11eb-b3c1-02ff598b7945\",\"aid\":\"ffffffffbfbf4ff5aa56a26ad3c1a942\",\"timestamp\":\"1625677526386\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:26.386Z",
-                "kind": "state",
-                "action": "LocalIpAddressRemovedIP6",
-                "id": "ffffffff-1111-11eb-b3c1-02ff598b7945",
-                "category": [
-                    "configuration",
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "InterfaceIndex": 186,
-                "name": "LocalIpAddressRemovedIP6LinV1",
-                "ConfigStateHash": "1156120155",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:04:59.994Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "Flags": "0",
+                "UnixMode": "0",
+                "VnodeType": "2",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "DirectoryCreateMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "DirectoryCreate",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:05:00.089Z",
+                "id": "ffffffff-1111-11eb-92d2-0286f570f8e1",
+                "ingested": "2022-03-22T18:19:46.426643700Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"DirectoryCreate\",\"ContextTimeStamp\":\"1625677499.994\",\"GID\":\"0\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365053555029062046\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"Flags\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"0\",\"event_platform\":\"Mac\",\"UnixMode\":\"0\",\"Entitlements\":\"15\",\"name\":\"DirectoryCreateMacV1\",\"id\":\"ffffffff-1111-11eb-92d2-0286f570f8e1\",\"VnodeType\":\"2\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff24db47799d1a85aae61dc7bc\",\"TargetDirectoryName\":\"/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS/2F71C2D4-D215-453E-BF4C-D6C037502871\",\"timestamp\":\"1625677500089\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS/2F71C2D4-D215-453E-BF4C-D6C037502871\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS",
+                "name": "2F71C2D4-D215-453E-BF4C-D6C037502871",
+                "path": "/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS/2F71C2D4-D215-453E-BF4C-D6C037502871",
+                "type": "dir"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff24db47799d1a85aae61dc7bc",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "365053555029062046",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff24db47799d1a85aae61dc7bc",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:59.994Z",
-            "file": {
-                "name": "2F71C2D4-D215-453E-BF4C-D6C037502871",
-                "path": "/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS/2F71C2D4-D215-453E-BF4C-D6C037502871",
-                "type": "dir",
-                "directory": "/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561701102Z",
-                "original": "{\"event_simpleName\":\"DirectoryCreate\",\"ContextTimeStamp\":\"1625677499.994\",\"GID\":\"0\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365053555029062046\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"Flags\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"0\",\"event_platform\":\"Mac\",\"UnixMode\":\"0\",\"Entitlements\":\"15\",\"name\":\"DirectoryCreateMacV1\",\"id\":\"ffffffff-1111-11eb-92d2-0286f570f8e1\",\"VnodeType\":\"2\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff24db47799d1a85aae61dc7bc\",\"TargetDirectoryName\":\"/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS/2F71C2D4-D215-453E-BF4C-D6C037502871\",\"timestamp\":\"1625677500089\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS/2F71C2D4-D215-453E-BF4C-D6C037502871\"}",
-                "created": "2021-07-07T17:05:00.089Z",
-                "kind": "event",
-                "action": "DirectoryCreate",
-                "id": "ffffffff-1111-11eb-92d2-0286f570f8e1",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3090255842",
-                "UnixMode": "0",
-                "Entitlements": "15",
-                "name": "DirectoryCreateMacV1",
-                "Flags": "0",
-                "VnodeType": "2",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "id": "0",
                 "group": {
                     "id": "0"
-                }
+                },
+                "id": "0"
             }
         },
         {
-            "process": {
-                "entity_id": "84424232977619"
+            "@timestamp": "2021-07-07T17:05:17.658Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1479784503",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkCloseIP4LinV6"
+            },
+            "destination": {
+                "address": "67.43.156.13",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkCloseIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:05:17.986Z",
+                "id": "ffffffff-1111-11eb-9015-02e89cda7d5f",
+                "ingested": "2022-03-22T18:19:46.426651600Z",
+                "kind": "event",
+                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"NetworkCloseIP4\",\"ContextTimeStamp\":\"1625677517.658\",\"ConfigStateHash\":\"1479784503\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"84424232977619\",\"RemotePort\":\"443\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"40394\",\"Entitlements\":\"15\",\"name\":\"NetworkCloseIP4LinV6\",\"id\":\"ffffffff-1111-11eb-9015-02e89cda7d5f\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff58de4e748d9f64c85a9b49e6\",\"RemoteAddressIP4\":\"67.43.156.13\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677517986\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "end",
+                    "connection"
+                ]
+            },
+            "network": {
+                "community_id": "1:UVftVVD3gVlBx8wJQBdaiJYrD6A=",
+                "direction": "unknown",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff58de4e748d9f64c85a9b49e6",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011308.1"
             },
             "os": {
                 "type": "linux"
             },
-            "destination": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.13",
-                "port": 443,
-                "ip": "67.43.156.13"
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 40394,
-                "ip": "67.43.156.14"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:UVftVVD3gVlBx8wJQBdaiJYrD6A=",
-                "transport": "tcp",
-                "iana_number": "6",
-                "direction": "unknown"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff58de4e748d9f64c85a9b49e6",
-                "type": "agent",
-                "version": "1007.8.0011308.1"
-            },
-            "@timestamp": "2021-07-07T17:05:17.658Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "84424232977619"
             },
             "related": {
+                "hash": [
+                    "1479784503"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "67.43.156.13"
-                ],
-                "hash": [
-                    "1479784503"
                 ],
                 "ip": [
                     "67.43.156.14",
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561702139Z",
-                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"NetworkCloseIP4\",\"ContextTimeStamp\":\"1625677517.658\",\"ConfigStateHash\":\"1479784503\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"84424232977619\",\"RemotePort\":\"443\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"40394\",\"Entitlements\":\"15\",\"name\":\"NetworkCloseIP4LinV6\",\"id\":\"ffffffff-1111-11eb-9015-02e89cda7d5f\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff58de4e748d9f64c85a9b49e6\",\"RemoteAddressIP4\":\"67.43.156.13\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677517986\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:17.986Z",
-                "kind": "event",
-                "action": "NetworkCloseIP4",
-                "id": "ffffffff-1111-11eb-9015-02e89cda7d5f",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "end",
-                    "connection"
-                ],
-                "outcome": "unknown"
+            "source": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "port": 40394
             },
-            "crowdstrike": {
-                "ConfigStateHash": "1479784503",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkCloseIP4LinV6",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:04:56.750Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "VolumeAppearanceTime": "1625677422.647",
+                "VolumeBusName": "IONVMeController",
+                "VolumeBusPath": "IODeviceTree:/PCI0@0/RP01@1C/SSD0@0/IONVMeController",
+                "VolumeDeviceInternal": "1",
+                "VolumeDeviceModel": "APPLE SSD SM0256L",
+                "VolumeDevicePath": "IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP01@1C/IOPP/SSD0@0/IONVMeController/IONVMeBlockStorageDevice@1",
+                "VolumeDeviceProtocol": "PCI-Express",
+                "VolumeDeviceRevision": "CXS4LA0Q",
+                "VolumeFileSystemDriver": "apfs",
+                "VolumeIsNetwork": "0",
+                "VolumeMediaBSDMajor": "1",
+                "VolumeMediaBSDMinor": "8",
+                "VolumeMediaBSDName": "disk1s3",
+                "VolumeMediaBSDUnit": "1",
+                "VolumeMediaContent": "41504653-0000-11AA-AA11-00306543ECAC",
+                "VolumeMediaEjectable": "0",
+                "VolumeMediaName": "AppleAPFSMedia",
+                "VolumeMediaPath": "IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP01@1C/IOPP/SSD0@0/IONVMeController/IONVMeBlockStorageDevice@1/IOBlockStorageDriver/APPLE SSD SM0256L Media/IOGUIDPartitionScheme/NoName@2/AppleAPFSContainerScheme/AppleAPFSMedia/AppleAPFSContainer/Recovery@3",
+                "VolumeMediaRemovable": "0",
+                "VolumeMediaSize": "250685575168",
+                "VolumeMediaUUID": "AD0F4085-F901-4204-8C5D-441F365D4909",
+                "VolumeMediaWhole": "0",
+                "VolumeMediaWritable": "1",
+                "VolumeMountPoint": "/Volumes/Recovery",
+                "VolumeName": "Recovery",
+                "VolumeSectorSize": "4096",
+                "VolumeType": "APFS",
+                "VolumeUUID": "85400FAD-01F9-0442-8C5D-441F365D4909",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "FsVolumeMountedMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "FsVolumeMounted",
+                "category": [
+                    "host"
+                ],
+                "created": "2021-07-07T17:04:56.804Z",
+                "id": "ffffffff-1111-11eb-956a-02748d01bd3d",
+                "ingested": "2022-03-22T18:19:46.426659400Z",
+                "kind": "event",
+                "original": "{\"VolumeMediaName\":\"AppleAPFSMedia\",\"VolumeDeviceProtocol\":\"PCI-Express\",\"VolumeDeviceVendor\":\"\",\"ContextThreadId\":\"0\",\"VolumeMediaContent\":\"41504653-0000-11AA-AA11-00306543ECAC\",\"VolumeMediaEjectable\":\"0\",\"aip\":\"67.43.156.14\",\"VolumeAppearanceTime\":\"1625677422.647\",\"VolumeDeviceModel\":\"APPLE SSD SM0256L\",\"VolumeMediaBSDName\":\"disk1s3\",\"VolumeMountPoint\":\"/Volumes/Recovery\",\"event_platform\":\"Mac\",\"VolumeType\":\"APFS\",\"VolumeMediaRemovable\":\"0\",\"VolumeMediaBSDUnit\":\"1\",\"VolumeFileSystemDriver\":\"apfs\",\"id\":\"ffffffff-1111-11eb-956a-02748d01bd3d\",\"VolumeMediaSize\":\"250685575168\",\"EffectiveTransmissionClass\":\"2\",\"VolumeBusName\":\"IONVMeController\",\"timestamp\":\"1625677496804\",\"VolumeMediaBSDMinor\":\"8\",\"VolumeMediaWritable\":\"1\",\"event_simpleName\":\"FsVolumeMounted\",\"VolumeDevicePath\":\"IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP01@1C/IOPP/SSD0@0/IONVMeController/IONVMeBlockStorageDevice@1\",\"VolumeName\":\"Recovery\",\"ContextTimeStamp\":\"1625677496.750\",\"VolumeSectorSize\":\"4096\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365053546767850587\",\"VolumeBusPath\":\"IODeviceTree:/PCI0@0/RP01@1C/SSD0@0/IONVMeController\",\"VolumeDeviceInternal\":\"1\",\"ConfigBuild\":\"1007.4.0013701.1\",\"VolumeUUID\":\"85400FAD-01F9-0442-8C5D-441F365D4909\",\"VolumeDeviceRevision\":\"CXS4LA0Q\",\"Entitlements\":\"15\",\"name\":\"FsVolumeMountedMacV1\",\"VolumeMediaBSDMajor\":\"1\",\"VolumeMediaPath\":\"IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP01@1C/IOPP/SSD0@0/IONVMeController/IONVMeBlockStorageDevice@1/IOBlockStorageDriver/APPLE SSD SM0256L Media/IOGUIDPartitionScheme/NoName@2/AppleAPFSContainerScheme/AppleAPFSMedia/AppleAPFSContainer/Recovery@3\",\"aid\":\"ffffffff8eca418b7a861be9c5f7de1d\",\"VolumeMediaUUID\":\"AD0F4085-F901-4204-8C5D-441F365D4909\",\"VolumeMediaWhole\":\"0\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"VolumeIsNetwork\":\"0\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
                 "serial_number": "ffffffff8eca418b7a861be9c5f7de1d",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
             },
             "process": {
                 "entity_id": "365053546767850587",
@@ -2154,666 +2211,639 @@
                     "id": 0
                 }
             },
-            "@timestamp": "2021-07-07T17:04:56.750Z",
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
                 ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561703140Z",
-                "original": "{\"VolumeMediaName\":\"AppleAPFSMedia\",\"VolumeDeviceProtocol\":\"PCI-Express\",\"VolumeDeviceVendor\":\"\",\"ContextThreadId\":\"0\",\"VolumeMediaContent\":\"41504653-0000-11AA-AA11-00306543ECAC\",\"VolumeMediaEjectable\":\"0\",\"aip\":\"67.43.156.14\",\"VolumeAppearanceTime\":\"1625677422.647\",\"VolumeDeviceModel\":\"APPLE SSD SM0256L\",\"VolumeMediaBSDName\":\"disk1s3\",\"VolumeMountPoint\":\"/Volumes/Recovery\",\"event_platform\":\"Mac\",\"VolumeType\":\"APFS\",\"VolumeMediaRemovable\":\"0\",\"VolumeMediaBSDUnit\":\"1\",\"VolumeFileSystemDriver\":\"apfs\",\"id\":\"ffffffff-1111-11eb-956a-02748d01bd3d\",\"VolumeMediaSize\":\"250685575168\",\"EffectiveTransmissionClass\":\"2\",\"VolumeBusName\":\"IONVMeController\",\"timestamp\":\"1625677496804\",\"VolumeMediaBSDMinor\":\"8\",\"VolumeMediaWritable\":\"1\",\"event_simpleName\":\"FsVolumeMounted\",\"VolumeDevicePath\":\"IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP01@1C/IOPP/SSD0@0/IONVMeController/IONVMeBlockStorageDevice@1\",\"VolumeName\":\"Recovery\",\"ContextTimeStamp\":\"1625677496.750\",\"VolumeSectorSize\":\"4096\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365053546767850587\",\"VolumeBusPath\":\"IODeviceTree:/PCI0@0/RP01@1C/SSD0@0/IONVMeController\",\"VolumeDeviceInternal\":\"1\",\"ConfigBuild\":\"1007.4.0013701.1\",\"VolumeUUID\":\"85400FAD-01F9-0442-8C5D-441F365D4909\",\"VolumeDeviceRevision\":\"CXS4LA0Q\",\"Entitlements\":\"15\",\"name\":\"FsVolumeMountedMacV1\",\"VolumeMediaBSDMajor\":\"1\",\"VolumeMediaPath\":\"IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP01@1C/IOPP/SSD0@0/IONVMeController/IONVMeBlockStorageDevice@1/IOBlockStorageDriver/APPLE SSD SM0256L Media/IOGUIDPartitionScheme/NoName@2/AppleAPFSContainerScheme/AppleAPFSMedia/AppleAPFSContainer/Recovery@3\",\"aid\":\"ffffffff8eca418b7a861be9c5f7de1d\",\"VolumeMediaUUID\":\"AD0F4085-F901-4204-8C5D-441F365D4909\",\"VolumeMediaWhole\":\"0\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"VolumeIsNetwork\":\"0\"}",
-                "created": "2021-07-07T17:04:56.804Z",
-                "kind": "event",
-                "action": "FsVolumeMounted",
-                "id": "ffffffff-1111-11eb-956a-02748d01bd3d",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "VolumeMediaName": "AppleAPFSMedia",
-                "VolumeDeviceProtocol": "PCI-Express",
-                "VolumeMediaContent": "41504653-0000-11AA-AA11-00306543ECAC",
-                "VolumeMediaEjectable": "0",
-                "VolumeAppearanceTime": "1625677422.647",
-                "VolumeDeviceModel": "APPLE SSD SM0256L",
-                "VolumeMediaBSDName": "disk1s3",
-                "VolumeMountPoint": "/Volumes/Recovery",
-                "VolumeType": "APFS",
-                "VolumeMediaRemovable": "0",
-                "VolumeMediaBSDUnit": "1",
-                "VolumeFileSystemDriver": "apfs",
-                "VolumeMediaSize": "250685575168",
-                "EffectiveTransmissionClass": "2",
-                "VolumeBusName": "IONVMeController",
-                "VolumeMediaBSDMinor": "8",
-                "VolumeMediaWritable": "1",
-                "VolumeDevicePath": "IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP01@1C/IOPP/SSD0@0/IONVMeController/IONVMeBlockStorageDevice@1",
-                "VolumeName": "Recovery",
-                "VolumeSectorSize": "4096",
-                "ConfigStateHash": "3090255842",
-                "VolumeBusPath": "IODeviceTree:/PCI0@0/RP01@1C/SSD0@0/IONVMeController",
-                "VolumeDeviceInternal": "1",
-                "VolumeUUID": "85400FAD-01F9-0442-8C5D-441F365D4909",
-                "VolumeDeviceRevision": "CXS4LA0Q",
-                "Entitlements": "15",
-                "name": "FsVolumeMountedMacV1",
-                "VolumeMediaBSDMajor": "1",
-                "VolumeMediaPath": "IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP01@1C/IOPP/SSD0@0/IONVMeController/IONVMeBlockStorageDevice@1/IOBlockStorageDriver/APPLE SSD SM0256L Media/IOGUIDPartitionScheme/NoName@2/AppleAPFSContainerScheme/AppleAPFSMedia/AppleAPFSContainer/Recovery@3",
-                "VolumeMediaUUID": "AD0F4085-F901-4204-8C5D-441F365D4909",
-                "VolumeMediaWhole": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
-                "VolumeIsNetwork": "0"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff190e436aaebc3892bcda5beb",
-                "type": "agent",
-                "version": "1007.8.0011611.1"
-            },
-            "@timestamp": "2021-07-07T17:05:14.374Z",
-            "os": {
-                "type": "linux"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
                 "hosts": [
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "1156120155"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "mac": "0e-d6-ff-ff-ff-63",
-                "ip": "67.43.156.14"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561704138Z",
-                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"LocalIpAddressIP4\",\"ConfigStateHash\":\"1156120155\",\"CreationTimeStamp\":\"1625677513.841\",\"aip\":\"67.43.156.14\",\"PhysicalAddress\":\"0e-d6-ff-ff-ff-63\",\"InterfaceAlias\":\"eth0\",\"InterfaceIndex\":\"2\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"InterfaceType\":\"1\",\"name\":\"LocalIpAddressIP4LinV1\",\"id\":\"ffffffff-1111-11eb-9c94-0222a21bbb27\",\"PhysicalAddressLength\":\"6\",\"aid\":\"ffffffff190e436aaebc3892bcda5beb\",\"timestamp\":\"1625677514374\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:14.374Z",
-                "kind": "state",
-                "action": "LocalIpAddressIP4",
-                "id": "ffffffff-1111-11eb-9c94-0222a21bbb27",
-                "category": [
-                    "configuration",
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "InterfaceIndex": 2,
-                "InterfaceType": "1",
-                "ConfigStateHash": "1156120155",
-                "name": "LocalIpAddressIP4LinV1",
-                "PhysicalAddressLength": 6,
-                "InterfaceAlias": "eth0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:40.056Z",
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13",
-                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ],
-                "hash": [
-                    "3967242894"
-                ],
-                "ip": [
-                    "67.43.156.13",
-                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ]
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Europe",
-                    "country_name": "Norway",
-                    "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
-                },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561705055Z",
-                "original": "{\"event_simpleName\":\"LocalIpAddressRemovedIP6\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"InterfaceIndex\":\"8\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"NetLuidIndex\":\"0\",\"Entitlements\":\"15\",\"name\":\"LocalIpAddressRemovedIP6MacV1\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"timestamp\":\"1625677480056\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:40.056Z",
-                "kind": "state",
-                "action": "LocalIpAddressRemovedIP6",
-                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
-                "category": [
-                    "configuration",
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "InterfaceIndex": 8,
-                "ConfigStateHash": "3967242894",
-                "NetLuidIndex": 0,
-                "Entitlements": "15",
-                "name": "LocalIpAddressRemovedIP6MacV1",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff0ad7494e8e817b3903f4eebb",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:21.723Z",
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14",
-                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ],
-                "hash": [
-                    "1620585913"
-                ],
-                "ip": [
-                    "67.43.156.14",
-                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ]
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Europe",
-                    "country_name": "Norway",
-                    "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
-                },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "mac": "c2-27-b0-27-83-0f",
-                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561705972Z",
-                "original": "{\"OutOctets\":\"0\",\"CreationTimeStamp\":\"\",\"aip\":\"67.43.156.14\",\"OutMulticastPkts\":\"0\",\"InErrors\":\"0\",\"InterfaceAlias\":\"llw0\",\"InDiscards\":\"0\",\"InterfaceIndex\":\"8\",\"event_platform\":\"Mac\",\"InterfaceType\":\"6\",\"id\":\"ffffffff-1111-11eb-b88d-06b7cb0d7bd7\",\"PhysicalAddressLength\":\"6\",\"InUcastPkts\":\"0\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677521723\",\"event_simpleName\":\"LocalIpAddressIP6\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"1620585913\",\"PhysicalAddress\":\"c2-27-b0-27-83-0f\",\"OutErrors\":\"0\",\"InUnknownProtos\":\"0\",\"OutUcastPkts\":\"0\",\"InMulticastPkts\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"InOctets\":\"0\",\"NetLuidIndex\":\"0\",\"Entitlements\":\"15\",\"name\":\"LocalIpAddressIP6MacV1\",\"aid\":\"ffffffff0ad7494e8e817b3903f4eebb\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:21.723Z",
-                "kind": "state",
-                "action": "LocalIpAddressIP6",
-                "id": "ffffffff-1111-11eb-b88d-06b7cb0d7bd7",
-                "category": [
-                    "configuration",
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "OutOctets": "0",
-                "ConfigStateHash": "1620585913",
-                "OutMulticastPkts": "0",
-                "InErrors": "0",
-                "OutErrors": "0",
-                "InUnknownProtos": "0",
-                "OutUcastPkts": "0",
-                "InterfaceAlias": "llw0",
-                "InDiscards": "0",
-                "InMulticastPkts": "0",
-                "InterfaceIndex": 8,
-                "InterfaceType": "6",
-                "InOctets": "0",
-                "NetLuidIndex": 0,
-                "Entitlements": "15",
-                "name": "LocalIpAddressIP6MacV1",
-                "PhysicalAddressLength": 6,
-                "InUcastPkts": "0",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "process": {
-                "entity_id": "364432308748445743"
-            },
-            "os": {
-                "type": "macos"
-            },
-            "destination": {
-                "port": 0,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "source": {
-                "port": 50647,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "unknown"
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:14.374Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1156120155",
+                "InterfaceAlias": "eth0",
+                "InterfaceIndex": 2,
+                "InterfaceType": "1",
+                "PhysicalAddressLength": 6,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LocalIpAddressIP4LinV1"
             },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff23d24c4193ffa6f270775ee5",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:07.037Z",
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "LocalIpAddressIP4",
+                "category": [
+                    "configuration",
+                    "host"
+                ],
+                "created": "2021-07-07T17:05:14.374Z",
+                "id": "ffffffff-1111-11eb-9c94-0222a21bbb27",
+                "ingested": "2022-03-22T18:19:46.426667100Z",
+                "kind": "state",
+                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"LocalIpAddressIP4\",\"ConfigStateHash\":\"1156120155\",\"CreationTimeStamp\":\"1625677513.841\",\"aip\":\"67.43.156.14\",\"PhysicalAddress\":\"0e-d6-ff-ff-ff-63\",\"InterfaceAlias\":\"eth0\",\"InterfaceIndex\":\"2\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"InterfaceType\":\"1\",\"name\":\"LocalIpAddressIP4LinV1\",\"id\":\"ffffffff-1111-11eb-9c94-0222a21bbb27\",\"PhysicalAddressLength\":\"6\",\"aid\":\"ffffffff190e436aaebc3892bcda5beb\",\"timestamp\":\"1625677514374\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff190e436aaebc3892bcda5beb",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011611.1"
+            },
+            "os": {
+                "type": "linux"
+            },
             "related": {
+                "hash": [
+                    "1156120155"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "source": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "mac": "0e-d6-ff-ff-ff-63"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:04:40.056Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3967242894",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "InterfaceIndex": 8,
+                "NetLuidIndex": 0,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LocalIpAddressRemovedIP6MacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "LocalIpAddressRemovedIP6",
+                "category": [
+                    "configuration",
+                    "host"
+                ],
+                "created": "2021-07-07T17:04:40.056Z",
+                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
+                "ingested": "2022-03-22T18:19:46.426674900Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"LocalIpAddressRemovedIP6\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"InterfaceIndex\":\"8\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"NetLuidIndex\":\"0\",\"Entitlements\":\"15\",\"name\":\"LocalIpAddressRemovedIP6MacV1\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"timestamp\":\"1625677480056\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "3967242894"
+                ],
+                "hosts": [
+                    "67.43.156.13",
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                ],
+                "ip": [
+                    "67.43.156.13",
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                ]
+            },
+            "source": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:21.723Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "InDiscards": "0",
+                "InErrors": "0",
+                "InMulticastPkts": "0",
+                "InOctets": "0",
+                "InUcastPkts": "0",
+                "InUnknownProtos": "0",
+                "InterfaceAlias": "llw0",
+                "InterfaceIndex": 8,
+                "InterfaceType": "6",
+                "NetLuidIndex": 0,
+                "OutErrors": "0",
+                "OutMulticastPkts": "0",
+                "OutOctets": "0",
+                "OutUcastPkts": "0",
+                "PhysicalAddressLength": 6,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LocalIpAddressIP6MacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "LocalIpAddressIP6",
+                "category": [
+                    "configuration",
+                    "host"
+                ],
+                "created": "2021-07-07T17:05:21.723Z",
+                "id": "ffffffff-1111-11eb-b88d-06b7cb0d7bd7",
+                "ingested": "2022-03-22T18:19:46.426682500Z",
+                "kind": "state",
+                "original": "{\"OutOctets\":\"0\",\"CreationTimeStamp\":\"\",\"aip\":\"67.43.156.14\",\"OutMulticastPkts\":\"0\",\"InErrors\":\"0\",\"InterfaceAlias\":\"llw0\",\"InDiscards\":\"0\",\"InterfaceIndex\":\"8\",\"event_platform\":\"Mac\",\"InterfaceType\":\"6\",\"id\":\"ffffffff-1111-11eb-b88d-06b7cb0d7bd7\",\"PhysicalAddressLength\":\"6\",\"InUcastPkts\":\"0\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677521723\",\"event_simpleName\":\"LocalIpAddressIP6\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"ConfigStateHash\":\"1620585913\",\"PhysicalAddress\":\"c2-27-b0-27-83-0f\",\"OutErrors\":\"0\",\"InUnknownProtos\":\"0\",\"OutUcastPkts\":\"0\",\"InMulticastPkts\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"InOctets\":\"0\",\"NetLuidIndex\":\"0\",\"Entitlements\":\"15\",\"name\":\"LocalIpAddressIP6MacV1\",\"aid\":\"ffffffff0ad7494e8e817b3903f4eebb\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff0ad7494e8e817b3903f4eebb",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.14",
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                ],
+                "ip": [
+                    "67.43.156.14",
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                ]
+            },
+            "source": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "mac": "c2-27-b0-27-83-0f"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:07.037Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkListenIP4MacV10"
+            },
+            "destination": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkListenIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:05:07.086Z",
+                "id": "ffffffff-1111-11eb-8b36-06a8af5164a9",
+                "ingested": "2022-03-22T18:19:46.426690200Z",
+                "kind": "event",
+                "original": "{\"LocalAddressIP4\":\"0.0.0.0\",\"event_simpleName\":\"NetworkListenIP4\",\"ContextTimeStamp\":\"1625677507.037\",\"ConfigStateHash\":\"3090255842\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"364432308748445743\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"50647\",\"Entitlements\":\"15\",\"name\":\"NetworkListenIP4MacV10\",\"id\":\"ffffffff-1111-11eb-8b36-06a8af5164a9\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff23d24c4193ffa6f270775ee5\",\"RemoteAddressIP4\":\"0.0.0.0\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677507086\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "network": {
+                "direction": "unknown",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff23d24c4193ffa6f270775ee5",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "process": {
+                "entity_id": "364432308748445743"
+            },
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "0.0.0.0"
-                ],
-                "hash": [
-                    "3090255842"
                 ],
                 "ip": [
                     "67.43.156.14",
                     "0.0.0.0"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561707005Z",
-                "original": "{\"LocalAddressIP4\":\"0.0.0.0\",\"event_simpleName\":\"NetworkListenIP4\",\"ContextTimeStamp\":\"1625677507.037\",\"ConfigStateHash\":\"3090255842\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"364432308748445743\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"50647\",\"Entitlements\":\"15\",\"name\":\"NetworkListenIP4MacV10\",\"id\":\"ffffffff-1111-11eb-8b36-06a8af5164a9\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff23d24c4193ffa6f270775ee5\",\"RemoteAddressIP4\":\"0.0.0.0\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677507086\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:07.086Z",
-                "kind": "event",
-                "action": "NetworkListenIP4",
-                "id": "ffffffff-1111-11eb-8b36-06a8af5164a9",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
+            "source": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 50647
             },
-            "crowdstrike": {
-                "ConfigStateHash": "3090255842",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkListenIP4MacV10",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:36.729Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ExecutableDeletedMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ExecutableDeleted",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:05:36.784Z",
+                "id": "ffffffff-1111-11eb-8ca0-0231588e8cbb",
+                "ingested": "2022-03-22T18:19:46.426697900Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"ExecutableDeleted\",\"ContextTimeStamp\":\"1625677536.729\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364994904864288322\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ExecutableDeletedMacV1\",\"id\":\"ffffffff-1111-11eb-8ca0-0231588e8cbb\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffa7bf46da689501ce58bd6987\",\"timestamp\":\"1625677536784\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user3/Library/Caches/com.tinyspeck.slackmacgap.ShipIt/update.FXKsmFO/Slack.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt\"}",
+                "outcome": "success",
+                "type": [
+                    "deletion"
+                ]
+            },
+            "file": {
+                "directory": "/Users/user3/Library/Caches/com.tinyspeck.slackmacgap.ShipIt/update.FXKsmFO/Slack.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources",
+                "name": "ShipIt",
+                "path": "/Users/user3/Library/Caches/com.tinyspeck.slackmacgap.ShipIt/update.FXKsmFO/Slack.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffa7bf46da689501ce58bd6987",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "364994904864288322",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffa7bf46da689501ce58bd6987",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:36.729Z",
-            "file": {
-                "name": "ShipIt",
-                "path": "/Users/user3/Library/Caches/com.tinyspeck.slackmacgap.ShipIt/update.FXKsmFO/Slack.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt",
-                "type": "file",
-                "directory": "/Users/user3/Library/Caches/com.tinyspeck.slackmacgap.ShipIt/update.FXKsmFO/Slack.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561708127Z",
-                "original": "{\"event_simpleName\":\"ExecutableDeleted\",\"ContextTimeStamp\":\"1625677536.729\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364994904864288322\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ExecutableDeletedMacV1\",\"id\":\"ffffffff-1111-11eb-8ca0-0231588e8cbb\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffa7bf46da689501ce58bd6987\",\"timestamp\":\"1625677536784\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user3/Library/Caches/com.tinyspeck.slackmacgap.ShipIt/update.FXKsmFO/Slack.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt\"}",
-                "created": "2021-07-07T17:05:36.784Z",
-                "kind": "event",
-                "action": "ExecutableDeleted",
-                "id": "ffffffff-1111-11eb-8ca0-0231588e8cbb",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "deletion"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "ExecutableDeletedMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:04.542Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "GzipFileWrittenMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "GzipFileWritten",
+                "created": "2021-07-07T17:05:04.614Z",
+                "id": "ffffffff-1111-11eb-9320-06d410e6f705",
+                "ingested": "2022-03-22T18:19:46.426705600Z",
+                "original": "{\"event_simpleName\":\"GzipFileWritten\",\"ContextTimeStamp\":\"1625677504.542\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"362897421906895953\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"04000001000000000000000000000000501f510700000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"GzipFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-9320-06d410e6f705\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"fffffffffc2c4e4fa9c08e1a8388e5f9\",\"timestamp\":\"1625677504614\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/db/powerlog/Library/BatteryLife/Archives/powerlog_2021-07-05_CC5F9FC1.PLSQL.gz\"}"
+            },
+            "file": {
+                "directory": "/private/var/db/powerlog/Library/BatteryLife/Archives",
+                "extension": "gz",
+                "inode": "04000001000000000000000000000000501f510700000000",
+                "name": "powerlog_2021-07-05_CC5F9FC1.PLSQL.gz",
+                "path": "/private/var/db/powerlog/Library/BatteryLife/Archives/powerlog_2021-07-05_CC5F9FC1.PLSQL.gz",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "fffffffffc2c4e4fa9c08e1a8388e5f9",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "362897421906895953",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "fffffffffc2c4e4fa9c08e1a8388e5f9",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:04.542Z",
-            "file": {
-                "inode": "04000001000000000000000000000000501f510700000000",
-                "name": "powerlog_2021-07-05_CC5F9FC1.PLSQL.gz",
-                "path": "/private/var/db/powerlog/Library/BatteryLife/Archives/powerlog_2021-07-05_CC5F9FC1.PLSQL.gz",
-                "extension": "gz",
-                "type": "file",
-                "directory": "/private/var/db/powerlog/Library/BatteryLife/Archives"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "action": "GzipFileWritten",
-                "ingested": "2021-12-30T05:11:46.561709141Z",
-                "original": "{\"event_simpleName\":\"GzipFileWritten\",\"ContextTimeStamp\":\"1625677504.542\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"362897421906895953\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"04000001000000000000000000000000501f510700000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"GzipFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-9320-06d410e6f705\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"fffffffffc2c4e4fa9c08e1a8388e5f9\",\"timestamp\":\"1625677504614\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/db/powerlog/Library/BatteryLife/Archives/powerlog_2021-07-05_CC5F9FC1.PLSQL.gz\"}",
-                "id": "ffffffff-1111-11eb-9320-06d410e6f705",
-                "created": "2021-07-07T17:05:04.614Z"
-            },
-            "crowdstrike": {
-                "name": "GzipFileWrittenMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T01:52:50.595Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3967242894",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "IOServiceClass": "IOUSBDevice:IOUSBNub:IOService:IORegistryEntry:OSObject",
+                "IOServiceName": "Touch Bar Backlight",
+                "IOServicePath": "IOService:/IOResources/AppleUSBHostResources/AppleUSBLegacyRoot/AppleUSBVHCIBCE@80000000/Touch Bar Backlight@80700000",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "IOServiceRegisterMacV1"
+            },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
+            "event": {
+                "action": "IOServiceRegister",
+                "category": [
+                    "package"
                 ],
-                "hash": [
-                    "3967242894"
-                ],
-                "ip": [
-                    "67.43.156.13"
+                "created": "2021-07-07T17:04:40.056Z",
+                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
+                "ingested": "2022-03-22T18:19:46.426713400Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"IOServiceRegister\",\"ContextTimeStamp\":\"1625622770.595\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"IOServiceClass\":\"IOUSBDevice:IOUSBNub:IOService:IORegistryEntry:OSObject\",\"ConfigBuild\":\"1007.4.0013701.1\",\"IOServicePath\":\"IOService:/IOResources/AppleUSBHostResources/AppleUSBLegacyRoot/AppleUSBVHCIBCE@80000000/Touch Bar Backlight@80700000\",\"event_platform\":\"Mac\",\"IOServiceProperties\":\"\",\"Entitlements\":\"15\",\"name\":\"IOServiceRegisterMacV1\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"IOServiceName\":\"Touch Bar Backlight\",\"timestamp\":\"1625677480056\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
                 ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
             },
             "os": {
                 "type": "macos"
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561710230Z",
-                "original": "{\"event_simpleName\":\"IOServiceRegister\",\"ContextTimeStamp\":\"1625622770.595\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"IOServiceClass\":\"IOUSBDevice:IOUSBNub:IOService:IORegistryEntry:OSObject\",\"ConfigBuild\":\"1007.4.0013701.1\",\"IOServicePath\":\"IOService:/IOResources/AppleUSBHostResources/AppleUSBLegacyRoot/AppleUSBVHCIBCE@80000000/Touch Bar Backlight@80700000\",\"event_platform\":\"Mac\",\"IOServiceProperties\":\"\",\"Entitlements\":\"15\",\"name\":\"IOServiceRegisterMacV1\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"IOServiceName\":\"Touch Bar Backlight\",\"timestamp\":\"1625677480056\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:40.056Z",
-                "kind": "event",
-                "action": "IOServiceRegister",
-                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
-                "category": [
-                    "package"
+            "related": {
+                "hash": [
+                    "3967242894"
                 ],
-                "type": [
-                    "change"
+                "hosts": [
+                    "67.43.156.13"
                 ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "IOServicePath": "IOService:/IOResources/AppleUSBHostResources/AppleUSBLegacyRoot/AppleUSBVHCIBCE@80000000/Touch Bar Backlight@80700000",
-                "ConfigStateHash": "3967242894",
-                "Entitlements": "15",
-                "name": "IOServiceRegisterMacV1",
-                "IOServiceClass": "IOUSBDevice:IOUSBNub:IOService:IORegistryEntry:OSObject",
-                "EffectiveTransmissionClass": "2",
-                "IOServiceName": "Touch Bar Backlight",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
+                "ip": [
+                    "67.43.156.13"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T01:50:02.031Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3967242894",
+                "DeviceId": "251658248",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "PtyCreatedMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "PtyCreated",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:04:38.739Z",
+                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
+                "ingested": "2022-03-22T18:19:46.426721Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"PtyCreated\",\"ContextTimeStamp\":\"1625622602.031\",\"ConfigStateHash\":\"3967242894\",\"ContextProcessId\":\"364938416497226937\",\"DeviceId\":\"251658248\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.13\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"PtyCreatedMacV1\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"timestamp\":\"1625677478739\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.13",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.13",
                 "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
             },
             "process": {
                 "entity_id": "364938416497226937",
@@ -2821,281 +2851,200 @@
                     "id": 0
                 }
             },
-            "@timestamp": "2021-07-07T01:50:02.031Z",
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "3967242894"
                 ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
                 "ip": [
                     "67.43.156.13"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561711192Z",
-                "original": "{\"event_simpleName\":\"PtyCreated\",\"ContextTimeStamp\":\"1625622602.031\",\"ConfigStateHash\":\"3967242894\",\"ContextProcessId\":\"364938416497226937\",\"DeviceId\":\"251658248\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.13\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"PtyCreatedMacV1\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"timestamp\":\"1625677478739\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:38.739Z",
-                "kind": "event",
-                "action": "PtyCreated",
-                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "PtyCreatedMacV1",
-                "ConfigStateHash": "3967242894",
-                "EffectiveTransmissionClass": "2",
-                "DeviceId": "251658248",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff5ae3449ab33a1809fe6c5ce2",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:35.967Z",
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "1803419442"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "ip": "67.43.156.14"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561712117Z",
-                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"LocalIpAddressRemovedIP4\",\"ConfigStateHash\":\"1803419442\",\"aip\":\"67.43.156.14\",\"InterfaceIndex\":\"18\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"NetLuidIndex\":\"2\",\"Entitlements\":\"15\",\"name\":\"LocalIpAddressRemovedIP4MacV1\",\"id\":\"ffffffff-1111-11eb-b7b7-066cc89bcebf\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff5ae3449ab33a1809fe6c5ce2\",\"timestamp\":\"1625677475967\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:35.967Z",
-                "kind": "state",
-                "action": "LocalIpAddressRemovedIP4",
-                "id": "ffffffff-1111-11eb-b7b7-066cc89bcebf",
-                "category": [
-                    "configuration",
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "InterfaceIndex": 18,
-                "ConfigStateHash": "1803419442",
-                "NetLuidIndex": 2,
-                "Entitlements": "15",
-                "name": "LocalIpAddressRemovedIP4MacV1",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "process": {
-                "entity_id": "12241681491990"
-            },
-            "os": {
-                "type": "linux"
-            },
-            "destination": {
-                "port": 9,
-                "address": "0:0:0:0:0:0:0:1",
-                "ip": "0:0:0:0:0:0:0:1"
-            },
-            "source": {
-                "port": 59999,
-                "address": "0:0:0:0:0:0:0:1",
-                "ip": "0:0:0:0:0:0:0:1"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "community_id": "1:3WneLMsNfPNapoUBcHO8QHx99mg=",
-                "transport": "udp",
-                "iana_number": "17",
-                "direction": "unknown"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff335f47ca89cad6a19f203bbd",
-                "type": "agent",
-                "version": "1007.8.0011308.1"
-            },
-            "@timestamp": "2021-07-07T17:04:34.875Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13",
-                    "0:0:0:0:0:0:0:1"
-                ],
-                "hash": [
-                    "1701000200"
-                ],
-                "ip": [
-                    "67.43.156.13",
-                    "0:0:0:0:0:0:0:1"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561713220Z",
-                "original": "{\"event_simpleName\":\"NetworkCloseIP6\",\"ContextTimeStamp\":\"1625677474.875\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:1\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:1\",\"ConfigStateHash\":\"1701000200\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"12241681491990\",\"RemotePort\":\"9\",\"aip\":\"67.43.156.13\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"59999\",\"Entitlements\":\"15\",\"name\":\"NetworkCloseIP6LinV6\",\"id\":\"ffffffff-1111-11eb-8130-02cde7751097\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff335f47ca89cad6a19f203bbd\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677475413\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:35.413Z",
-                "kind": "event",
-                "action": "NetworkCloseIP6",
-                "id": "ffffffff-1111-11eb-8130-02cde7751097",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "end",
-                    "connection"
-                ],
-                "outcome": "unknown"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "1701000200",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkCloseIP6LinV6",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffa74a4c89b9984a3a7124bb9d",
-                "type": "agent",
-                "version": "1007.8.0011611.1"
+            "@timestamp": "2021-07-07T17:04:35.967Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1803419442",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "InterfaceIndex": 18,
+                "NetLuidIndex": 2,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LocalIpAddressRemovedIP4MacV1"
             },
-            "@timestamp": "2021-07-07T17:04:50.580Z",
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "LocalIpAddressRemovedIP4",
+                "category": [
+                    "configuration",
+                    "host"
+                ],
+                "created": "2021-07-07T17:04:35.967Z",
+                "id": "ffffffff-1111-11eb-b7b7-066cc89bcebf",
+                "ingested": "2022-03-22T18:19:46.426728800Z",
+                "kind": "state",
+                "original": "{\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"LocalIpAddressRemovedIP4\",\"ConfigStateHash\":\"1803419442\",\"aip\":\"67.43.156.14\",\"InterfaceIndex\":\"18\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"NetLuidIndex\":\"2\",\"Entitlements\":\"15\",\"name\":\"LocalIpAddressRemovedIP4MacV1\",\"id\":\"ffffffff-1111-11eb-b7b7-066cc89bcebf\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff5ae3449ab33a1809fe6c5ce2\",\"timestamp\":\"1625677475967\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff5ae3449ab33a1809fe6c5ce2",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "related": {
+                "hash": [
+                    "1803419442"
+                ],
                 "hosts": [
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "1156120155"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
+            },
+            "source": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:04:34.875Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1701000200",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkCloseIP6LinV6"
+            },
+            "destination": {
+                "address": "0:0:0:0:0:0:0:1",
+                "ip": "0:0:0:0:0:0:0:1",
+                "port": 9
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkCloseIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:04:35.413Z",
+                "id": "ffffffff-1111-11eb-8130-02cde7751097",
+                "ingested": "2022-03-22T18:19:46.426736700Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"NetworkCloseIP6\",\"ContextTimeStamp\":\"1625677474.875\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:1\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:1\",\"ConfigStateHash\":\"1701000200\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"12241681491990\",\"RemotePort\":\"9\",\"aip\":\"67.43.156.13\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"59999\",\"Entitlements\":\"15\",\"name\":\"NetworkCloseIP6LinV6\",\"id\":\"ffffffff-1111-11eb-8130-02cde7751097\",\"Protocol\":\"17\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff335f47ca89cad6a19f203bbd\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677475413\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "end",
+                    "connection"
+                ]
+            },
+            "network": {
+                "community_id": "1:3WneLMsNfPNapoUBcHO8QHx99mg=",
+                "direction": "unknown",
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff335f47ca89cad6a19f203bbd",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011308.1"
             },
             "os": {
                 "type": "linux"
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561714150Z",
-                "original": "{\"ConfigBuild\":\"1007.8.0011611.1\",\"event_simpleName\":\"ConfigStateUpdate\",\"event_platform\":\"Lin\",\"ConfigStateHash\":\"1156120155\",\"ConfigStateData\":\"0,0,1007.8.0011611.1|1,c,0|1,22,6|1,59,2d|2,0,a8000000032,140000000085,18000000004c,18000000004f,180000000054,18000000022a,180000000248,180000000279,18000000027a,1800000002b4,180400000079,180400000225,180c00000133,180c00000285,181000000128,181000000180,18100000021f,181000000220,181000000280,1c0400000205|\",\"name\":\"ConfigStateUpdateLinV2\",\"aip\":\"67.43.156.14\",\"id\":\"ffffffff-1111-11eb-af89-06c111484f9f\",\"aid\":\"ffffffffa74a4c89b9984a3a7124bb9d\",\"timestamp\":\"1625677490580\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:50.580Z",
-                "kind": "event",
-                "action": "ConfigStateUpdate",
-                "id": "ffffffff-1111-11eb-af89-06c111484f9f",
-                "category": [
-                    "configuration"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
+            "process": {
+                "entity_id": "12241681491990"
             },
+            "related": {
+                "hash": [
+                    "1701000200"
+                ],
+                "hosts": [
+                    "67.43.156.13",
+                    "0:0:0:0:0:0:0:1"
+                ],
+                "ip": [
+                    "67.43.156.13",
+                    "0:0:0:0:0:0:0:1"
+                ]
+            },
+            "source": {
+                "address": "0:0:0:0:0:0:0:1",
+                "ip": "0:0:0:0:0:0:0:1",
+                "port": 59999
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:04:50.580Z",
             "crowdstrike": {
-                "name": "ConfigStateUpdateLinV2",
-                "ConfigStateHash": "1156120155",
                 "ConfigStateData": [
                     "0,0,1007.8.0011611.1",
                     "1,c,0",
@@ -3103,32 +3052,114 @@
                     "1,59,2d",
                     "2,0,a8000000032,140000000085,18000000004c,18000000004f,180000000054,18000000022a,180000000248,180000000279,18000000027a,1800000002b4,180400000079,180400000225,180c00000133,180c00000285,181000000128,181000000180,18100000021f,181000000220,181000000280,1c0400000205"
                 ],
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "ConfigStateHash": "1156120155",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ConfigStateUpdateLinV2"
             },
-            "url": {
-                "scheme": "http"
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ConfigStateUpdate",
+                "category": [
+                    "configuration"
+                ],
+                "created": "2021-07-07T17:04:50.580Z",
+                "id": "ffffffff-1111-11eb-af89-06c111484f9f",
+                "ingested": "2022-03-22T18:19:46.426744500Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.8.0011611.1\",\"event_simpleName\":\"ConfigStateUpdate\",\"event_platform\":\"Lin\",\"ConfigStateHash\":\"1156120155\",\"ConfigStateData\":\"0,0,1007.8.0011611.1|1,c,0|1,22,6|1,59,2d|2,0,a8000000032,140000000085,18000000004c,18000000004f,180000000054,18000000022a,180000000248,180000000279,18000000027a,1800000002b4,180400000079,180400000225,180c00000133,180c00000285,181000000128,181000000180,18100000021f,181000000220,181000000280,1c0400000205|\",\"name\":\"ConfigStateUpdateLinV2\",\"aip\":\"67.43.156.14\",\"id\":\"ffffffff-1111-11eb-af89-06c111484f9f\",\"aid\":\"ffffffffa74a4c89b9984a3a7124bb9d\",\"timestamp\":\"1625677490580\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffa74a4c89b9984a3a7124bb9d",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011611.1"
+            },
+            "os": {
+                "type": "linux"
+            },
+            "related": {
+                "hash": [
+                    "1156120155"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:04:53.531Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "RequestType": "1",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "SuspiciousDnsRequestMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "SuspiciousDnsRequest",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:04:53.756Z",
+                "id": "ffffffff-1111-11eb-a4a3-02cbdfb8f529",
+                "ingested": "2022-03-22T18:19:46.426752100Z",
+                "kind": "alert",
+                "original": "{\"event_simpleName\":\"SuspiciousDnsRequest\",\"ContextTimeStamp\":\"1625677493.531\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364839648316192383\",\"DomainName\":\"hg-t2.dotice.me\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"SuspiciousDnsRequestMacV1\",\"id\":\"ffffffff-1111-11eb-a4a3-02cbdfb8f529\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff0cd64fb78626ab1b6c65ac8c\",\"timestamp\":\"1625677493756\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"RequestType\":\"1\"}",
+                "outcome": "success",
+                "type": [
+                    "start",
+                    "protocol"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
                 "serial_number": "ffffffff0cd64fb78626ab1b6c65ac8c",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
             },
             "process": {
                 "entity_id": "364839648316192383",
@@ -3136,180 +3167,97 @@
                     "id": 0
                 }
             },
-            "@timestamp": "2021-07-07T17:04:53.531Z",
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
                 ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561715093Z",
-                "original": "{\"event_simpleName\":\"SuspiciousDnsRequest\",\"ContextTimeStamp\":\"1625677493.531\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364839648316192383\",\"DomainName\":\"hg-t2.dotice.me\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"SuspiciousDnsRequestMacV1\",\"id\":\"ffffffff-1111-11eb-a4a3-02cbdfb8f529\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff0cd64fb78626ab1b6c65ac8c\",\"timestamp\":\"1625677493756\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"RequestType\":\"1\"}",
-                "created": "2021-07-07T17:04:53.756Z",
-                "kind": "alert",
-                "action": "SuspiciousDnsRequest",
-                "id": "ffffffff-1111-11eb-a4a3-02cbdfb8f529",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "protocol"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "SuspiciousDnsRequestMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
-                "RequestType": "1"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffabd047b1a86c1fcd8ef22b59",
-                "type": "agent",
-                "version": "1007.8.0011611.1"
-            },
-            "@timestamp": "2021-07-07T17:05:30.922Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
                 "hosts": [
                     "67.43.156.14"
                 ],
-                "hash": [
-                    "1156120155"
-                ],
                 "ip": [
                     "67.43.156.14"
                 ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:30.922Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1156120155",
+                "ErrorStatus": "3759276032",
+                "Facility": "16778240",
+                "File": "0",
+                "Line": "96",
+                "Parameter1": "18446744072635810412",
+                "Parameter2": "0",
+                "Parameter3": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ErrorEventLinV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ErrorEvent",
+                "category": [
+                    "package"
+                ],
+                "created": "2021-07-07T17:05:30.922Z",
+                "id": "ffffffff-1111-11eb-bdd3-0681aa29cecb",
+                "ingested": "2022-03-22T18:19:46.426759700Z",
+                "kind": "alert",
+                "original": "{\"Parameter2\":\"0\",\"event_simpleName\":\"ErrorEvent\",\"Parameter1\":\"18446744072635810412\",\"Parameter3\":\"0\",\"ConfigStateHash\":\"1156120155\",\"aip\":\"67.43.156.14\",\"Line\":\"96\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"ErrorStatus\":\"3759276032\",\"name\":\"ErrorEventLinV1\",\"id\":\"ffffffff-1111-11eb-bdd3-0681aa29cecb\",\"Facility\":\"16778240\",\"aid\":\"ffffffffabd047b1a86c1fcd8ef22b59\",\"File\":\"0\",\"timestamp\":\"1625677530922\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "failure",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffabd047b1a86c1fcd8ef22b59",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011611.1"
             },
             "os": {
                 "type": "linux"
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561716007Z",
-                "original": "{\"Parameter2\":\"0\",\"event_simpleName\":\"ErrorEvent\",\"Parameter1\":\"18446744072635810412\",\"Parameter3\":\"0\",\"ConfigStateHash\":\"1156120155\",\"aip\":\"67.43.156.14\",\"Line\":\"96\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"ErrorStatus\":\"3759276032\",\"name\":\"ErrorEventLinV1\",\"id\":\"ffffffff-1111-11eb-bdd3-0681aa29cecb\",\"Facility\":\"16778240\",\"aid\":\"ffffffffabd047b1a86c1fcd8ef22b59\",\"File\":\"0\",\"timestamp\":\"1625677530922\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:30.922Z",
-                "kind": "alert",
-                "action": "ErrorEvent",
-                "id": "ffffffff-1111-11eb-bdd3-0681aa29cecb",
-                "category": [
-                    "package"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "failure"
-            },
-            "crowdstrike": {
-                "Parameter2": "0",
-                "Line": "96",
-                "Parameter1": "18446744072635810412",
-                "Parameter3": "0",
-                "ConfigStateHash": "1156120155",
-                "ErrorStatus": "3759276032",
-                "name": "ErrorEventLinV1",
-                "Facility": "16778240",
-                "File": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffa15a452190ae454f7d33e07e",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:30.590Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
+                "hash": [
+                    "1156120155"
+                ],
                 "hosts": [
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561717009Z",
-                "original": "{\"event_simpleName\":\"ConfigStateUpdate\",\"ConfigStateHash\":\"3090255842\",\"ConfigStateData\":\"0,0,1007.4.0013701.1|1,2,1|1,4,a|1,6,0|1,8,46|1,a,1|1,c,0|1,17,1f|1,18,18|1,19,0|1,1e,407|1,21,3d2|1,27,1|1,53,18b|1,56,0|1,d0,16d|1,d1,0|1,d2,0|1,df,4c|1,e0,6|1,f6,1|1,1f5,1|1,1f7,1|1,1fd,1|1,200,0|2,0,138,a8000000032,140000000085,140000000153,18000000004c,18000000004f,180000000050,180000000051,180000000054,1800000000e1,1800000000e7,180000000144,18000000014e,18000000015a,18000000020e,180000000226,180000000227,180400000079,18040000009b,18040000009c,1804000000ff,180400000117,180400000118,180400000142,180400000163,180400000164,180400000166,180400000167,1804000001b2,1804000001f2,1804000001f3,180400000225,1804000002be,1804000002bf,1804000002ca,1804000002cb,1808000000c9,1808000000ee,1808000000fc,1808000000fd,1808000000fe,180c0000016b,180c0000016c,180c0000016d,180c0000016e,180c0000016f,180c00000170,180c000001b6,180c000001b7,180c000001b8,180c000001b9,180c000001f6,180c000001f7,180c000001f8,180c000002c2,180c000002c3,180c000002c4,180c000002ce,180c000002cf,180c000002d0,18100000011e,18100000011f,181000000120,181000000121,181000000122,181000000123,181000000124,181000000125,181000000126,181000000128,181000000169,18100000016a,181000000180,1810000001b1,1810000001c3,18100000021f,181000000220,18100000024e,18100000025b,181000000280,1810000002ad,1810000002d6,1810000002d7,1810000002f3,1c04000000a1,1c04000000a2,1c04000000a3,1c04000000a4,1c04000000a5,1c04000000a6,1c040000011a,1c040000011b,1c040000011c,1c0400000268,1c0400000269,1c040000026a,1c040000026c,1c040000026d,1c040000026e,1c0400000271,1c0400000272,1c0400000273,1c0400000275,1c0400000276,1c0400000277,1c040000028f,1c0400000290,1c0400000291,1c0400000293,1c0400000294,1c0400000295,1c0400000297,1c0400000298,1c0400000299,1c040000029b,1c040000029c,1c040000029d,1c040000029f,1c04000002a0|3,0,65|\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ConfigStateUpdateMacV2\",\"id\":\"ffffffff-1111-11eb-8dc4-0234c12f9875\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffffa15a452190ae454f7d33e07e\",\"timestamp\":\"1625677530590\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:30.590Z",
-                "kind": "event",
-                "action": "ConfigStateUpdate",
-                "id": "ffffffff-1111-11eb-8dc4-0234c12f9875",
-                "category": [
-                    "configuration"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:30.590Z",
             "crowdstrike": {
-                "name": "ConfigStateUpdateMacV2",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "0",
                 "ConfigStateData": [
                     "0,0,1007.4.0013701.1",
                     "1,2,1",
@@ -3339,33 +3287,115 @@
                     "2,0,138,a8000000032,140000000085,140000000153,18000000004c,18000000004f,180000000050,180000000051,180000000054,1800000000e1,1800000000e7,180000000144,18000000014e,18000000015a,18000000020e,180000000226,180000000227,180400000079,18040000009b,18040000009c,1804000000ff,180400000117,180400000118,180400000142,180400000163,180400000164,180400000166,180400000167,1804000001b2,1804000001f2,1804000001f3,180400000225,1804000002be,1804000002bf,1804000002ca,1804000002cb,1808000000c9,1808000000ee,1808000000fc,1808000000fd,1808000000fe,180c0000016b,180c0000016c,180c0000016d,180c0000016e,180c0000016f,180c00000170,180c000001b6,180c000001b7,180c000001b8,180c000001b9,180c000001f6,180c000001f7,180c000001f8,180c000002c2,180c000002c3,180c000002c4,180c000002ce,180c000002cf,180c000002d0,18100000011e,18100000011f,181000000120,181000000121,181000000122,181000000123,181000000124,181000000125,181000000126,181000000128,181000000169,18100000016a,181000000180,1810000001b1,1810000001c3,18100000021f,181000000220,18100000024e,18100000025b,181000000280,1810000002ad,1810000002d6,1810000002d7,1810000002f3,1c04000000a1,1c04000000a2,1c04000000a3,1c04000000a4,1c04000000a5,1c04000000a6,1c040000011a,1c040000011b,1c040000011c,1c0400000268,1c0400000269,1c040000026a,1c040000026c,1c040000026d,1c040000026e,1c0400000271,1c0400000272,1c0400000273,1c0400000275,1c0400000276,1c0400000277,1c040000028f,1c0400000290,1c0400000291,1c0400000293,1c0400000294,1c0400000295,1c0400000297,1c0400000298,1c0400000299,1c040000029b,1c040000029c,1c040000029d,1c040000029f,1c04000002a0",
                     "3,0,65"
                 ],
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "0",
                 "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ConfigStateUpdateMacV2"
             },
-            "url": {
-                "scheme": "http"
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ConfigStateUpdate",
+                "category": [
+                    "configuration"
+                ],
+                "created": "2021-07-07T17:05:30.590Z",
+                "id": "ffffffff-1111-11eb-8dc4-0234c12f9875",
+                "ingested": "2022-03-22T18:19:46.426767400Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"ConfigStateUpdate\",\"ConfigStateHash\":\"3090255842\",\"ConfigStateData\":\"0,0,1007.4.0013701.1|1,2,1|1,4,a|1,6,0|1,8,46|1,a,1|1,c,0|1,17,1f|1,18,18|1,19,0|1,1e,407|1,21,3d2|1,27,1|1,53,18b|1,56,0|1,d0,16d|1,d1,0|1,d2,0|1,df,4c|1,e0,6|1,f6,1|1,1f5,1|1,1f7,1|1,1fd,1|1,200,0|2,0,138,a8000000032,140000000085,140000000153,18000000004c,18000000004f,180000000050,180000000051,180000000054,1800000000e1,1800000000e7,180000000144,18000000014e,18000000015a,18000000020e,180000000226,180000000227,180400000079,18040000009b,18040000009c,1804000000ff,180400000117,180400000118,180400000142,180400000163,180400000164,180400000166,180400000167,1804000001b2,1804000001f2,1804000001f3,180400000225,1804000002be,1804000002bf,1804000002ca,1804000002cb,1808000000c9,1808000000ee,1808000000fc,1808000000fd,1808000000fe,180c0000016b,180c0000016c,180c0000016d,180c0000016e,180c0000016f,180c00000170,180c000001b6,180c000001b7,180c000001b8,180c000001b9,180c000001f6,180c000001f7,180c000001f8,180c000002c2,180c000002c3,180c000002c4,180c000002ce,180c000002cf,180c000002d0,18100000011e,18100000011f,181000000120,181000000121,181000000122,181000000123,181000000124,181000000125,181000000126,181000000128,181000000169,18100000016a,181000000180,1810000001b1,1810000001c3,18100000021f,181000000220,18100000024e,18100000025b,181000000280,1810000002ad,1810000002d6,1810000002d7,1810000002f3,1c04000000a1,1c04000000a2,1c04000000a3,1c04000000a4,1c04000000a5,1c04000000a6,1c040000011a,1c040000011b,1c040000011c,1c0400000268,1c0400000269,1c040000026a,1c040000026c,1c040000026d,1c040000026e,1c0400000271,1c0400000272,1c0400000273,1c0400000275,1c0400000276,1c0400000277,1c040000028f,1c0400000290,1c0400000291,1c0400000293,1c0400000294,1c0400000295,1c0400000297,1c0400000298,1c0400000299,1c040000029b,1c040000029c,1c040000029d,1c040000029f,1c04000002a0|3,0,65|\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ConfigStateUpdateMacV2\",\"id\":\"ffffffff-1111-11eb-8dc4-0234c12f9875\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffffa15a452190ae454f7d33e07e\",\"timestamp\":\"1625677530590\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffa15a452190ae454f7d33e07e",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:05:09.064Z",
+            "crowdstrike": {
+                "BundleID": "com.apple.driver.AudioAUUC",
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "KextLoadMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "KextLoad",
+                "category": [
+                    "driver"
+                ],
+                "created": "2021-07-07T17:05:09.069Z",
+                "id": "ffffffff-1111-11eb-a2ae-028f6bf89be7",
+                "ingested": "2022-03-22T18:19:46.426775200Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"KextLoad\",\"ContextTimeStamp\":\"1625677509.064\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"364867547408058681\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"BundleID\":\"com.apple.driver.AudioAUUC\",\"Entitlements\":\"15\",\"name\":\"KextLoadMacV1\",\"id\":\"ffffffff-1111-11eb-a2ae-028f6bf89be7\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffaa0e47a1b009aef151d6179d\",\"timestamp\":\"1625677509069\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
                 "serial_number": "ffffffffaa0e47a1b009aef151d6179d",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
             },
             "process": {
                 "entity_id": "364867547408058681",
@@ -3373,113 +3403,133 @@
                     "id": 0
                 }
             },
-            "@timestamp": "2021-07-07T17:05:09.064Z",
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "1620585913"
                 ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561717942Z",
-                "original": "{\"event_simpleName\":\"KextLoad\",\"ContextTimeStamp\":\"1625677509.064\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"364867547408058681\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"BundleID\":\"com.apple.driver.AudioAUUC\",\"Entitlements\":\"15\",\"name\":\"KextLoadMacV1\",\"id\":\"ffffffff-1111-11eb-a2ae-028f6bf89be7\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffaa0e47a1b009aef151d6179d\",\"timestamp\":\"1625677509069\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:09.069Z",
-                "kind": "event",
-                "action": "KextLoad",
-                "id": "ffffffff-1111-11eb-a2ae-028f6bf89be7",
-                "category": [
-                    "driver"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "KextLoadMacV1",
-                "BundleID": "com.apple.driver.AudioAUUC",
-                "ConfigStateHash": "1620585913",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff67d54f7daf3d998ffc74d48e",
-                "type": "agent",
-                "version": "1007.8.0011110.1"
-            },
-            "@timestamp": "2021-07-07T17:05:07.901Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
                 "hosts": [
                     "67.43.156.14"
                 ],
-                "hash": [
-                    "3155796140"
-                ],
                 "ip": [
                     "67.43.156.14"
                 ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:07.901Z",
+            "crowdstrike": {
+                "ChannelId": "20",
+                "ChannelVersion": "25",
+                "ChannelVersionRequired": "0",
+                "ConfigStateHash": "3155796140",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ChannelVersionRequiredLinV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ChannelVersionRequired",
+                "created": "2021-07-07T17:05:07.901Z",
+                "id": "ffffffff-1111-11eb-b411-06baeacb7a63",
+                "ingested": "2022-03-22T18:19:46.426782900Z",
+                "original": "{\"ChannelVersion\":\"25\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"3155796140\",\"aip\":\"67.43.156.14\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"20\",\"ConfigBuild\":\"1007.8.0011110.1\",\"event_platform\":\"Lin\",\"name\":\"ChannelVersionRequiredLinV1\",\"id\":\"ffffffff-1111-11eb-b411-06baeacb7a63\",\"aid\":\"ffffffff67d54f7daf3d998ffc74d48e\",\"timestamp\":\"1625677507901\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff67d54f7daf3d998ffc74d48e",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011110.1"
             },
             "os": {
                 "type": "linux"
             },
-            "event": {
-                "action": "ChannelVersionRequired",
-                "ingested": "2021-12-30T05:11:46.561718857Z",
-                "original": "{\"ChannelVersion\":\"25\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"3155796140\",\"aip\":\"67.43.156.14\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"20\",\"ConfigBuild\":\"1007.8.0011110.1\",\"event_platform\":\"Lin\",\"name\":\"ChannelVersionRequiredLinV1\",\"id\":\"ffffffff-1111-11eb-b411-06baeacb7a63\",\"aid\":\"ffffffff67d54f7daf3d998ffc74d48e\",\"timestamp\":\"1625677507901\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "id": "ffffffff-1111-11eb-b411-06baeacb7a63",
-                "created": "2021-07-07T17:05:07.901Z"
-            },
-            "crowdstrike": {
-                "ChannelVersion": "25",
-                "name": "ChannelVersionRequiredLinV1",
-                "ChannelVersionRequired": "0",
-                "ConfigStateHash": "3155796140",
-                "ChannelId": "20",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
+            "related": {
+                "hash": [
+                    "3155796140"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:05:11.754Z",
+            "crowdstrike": {
+                "BoundedCount": 57,
+                "ConfigStateHash": "2037712541",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "ProcessCount": 60,
+                "SuppressType": "3",
+                "Timeout": 60,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ProcessRollup2StatsLinV3"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2Stats",
+                "category": [
+                    "process"
+                ],
+                "created": "2021-07-07T17:05:11.754Z",
+                "id": "ffffffff-1111-11eb-b34e-063f4cefccb3",
+                "ingested": "2022-03-22T18:19:46.426790700Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"ProcessRollup2Stats\",\"ConfigStateHash\":\"2037712541\",\"Timeout\":\"60\",\"ParentProcessId\":\"0\",\"aip\":\"67.43.156.14\",\"SuppressType\":\"3\",\"SHA256HashData\":\"64e48365207d0c19008ba7d53d75c0de3fcd5a1590e4c40fc69c677663fedc20\",\"ProcessCount\":\"60\",\"BoundedCount\":\"57\",\"ConfigBuild\":\"1007.8.0011308.1\",\"UID\":\"115\",\"event_platform\":\"Lin\",\"CommandLine\":\"sh -c \\\"/usr/lib/erlang/erts-11.1.3/bin/epmd\\\" -daemon\",\"Entitlements\":\"15\",\"name\":\"ProcessRollup2StatsLinV3\",\"id\":\"ffffffff-1111-11eb-b34e-063f4cefccb3\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffe22549479fbe8293b6747a68\",\"timestamp\":\"1625677511754\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffe22549479fbe8293b6747a68",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011308.1"
+            },
+            "os": {
+                "type": "linux"
+            },
             "process": {
                 "args": [
                     "sh",
@@ -3487,236 +3537,238 @@
                     "/usr/lib/erlang/erts-11.1.3/bin/epmd",
                     "-daemon"
                 ],
-                "parent": {
-                    "entity_id": "0"
-                },
                 "args_count": 4,
                 "command_line": "sh -c \"/usr/lib/erlang/erts-11.1.3/bin/epmd\" -daemon",
                 "hash": {
                     "sha256": "64e48365207d0c19008ba7d53d75c0de3fcd5a1590e4c40fc69c677663fedc20"
+                },
+                "parent": {
+                    "entity_id": "0"
                 }
             },
-            "os": {
-                "type": "linux"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffe22549479fbe8293b6747a68",
-                "type": "agent",
-                "version": "1007.8.0011308.1"
-            },
-            "@timestamp": "2021-07-07T17:05:11.754Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "64e48365207d0c19008ba7d53d75c0de3fcd5a1590e4c40fc69c677663fedc20",
                     "2037712541"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561719892Z",
-                "original": "{\"event_simpleName\":\"ProcessRollup2Stats\",\"ConfigStateHash\":\"2037712541\",\"Timeout\":\"60\",\"ParentProcessId\":\"0\",\"aip\":\"67.43.156.14\",\"SuppressType\":\"3\",\"SHA256HashData\":\"64e48365207d0c19008ba7d53d75c0de3fcd5a1590e4c40fc69c677663fedc20\",\"ProcessCount\":\"60\",\"BoundedCount\":\"57\",\"ConfigBuild\":\"1007.8.0011308.1\",\"UID\":\"115\",\"event_platform\":\"Lin\",\"CommandLine\":\"sh -c \\\"/usr/lib/erlang/erts-11.1.3/bin/epmd\\\" -daemon\",\"Entitlements\":\"15\",\"name\":\"ProcessRollup2StatsLinV3\",\"id\":\"ffffffff-1111-11eb-b34e-063f4cefccb3\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffe22549479fbe8293b6747a68\",\"timestamp\":\"1625677511754\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:11.754Z",
-                "kind": "state",
-                "action": "ProcessRollup2Stats",
-                "id": "ffffffff-1111-11eb-b34e-063f4cefccb3",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "unknown"
-            },
-            "crowdstrike": {
-                "BoundedCount": 57,
-                "ConfigStateHash": "2037712541",
-                "Timeout": 60,
-                "Entitlements": "15",
-                "name": "ProcessRollup2StatsLinV3",
-                "SuppressType": "3",
-                "EffectiveTransmissionClass": "2",
-                "ProcessCount": 60,
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "id": "115"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:04:38.122Z",
-            "os": {
-                "type": "macos"
+            "crowdstrike": {
+                "AuthenticationId": "265",
+                "AuthenticationUuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109",
+                "AuthenticationUuidAsString": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109",
+                "ConfigStateHash": "3967242894",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "LoginSessionId": "1138166333440",
+                "UserSid": "S-1-5-21-3852557355-3178143607-2040168074-1530",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "UserIdentityMacV4"
             },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "user": [
-                    "user1"
-                ],
-                "hosts": [
-                    "67.43.156.13"
-                ],
-                "hash": [
-                    "3967242894"
-                ],
-                "ip": [
-                    "67.43.156.13"
-                ]
-            },
             "event": {
-                "ingested": "2021-12-30T05:11:46.561720867Z",
-                "original": "{\"event_simpleName\":\"UserIdentity\",\"LoginSessionId\":\"1138166333440\",\"AuthenticationUuidAsString\":\"FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109\",\"UserName\":\"user1\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"AuthenticationId\":\"265\",\"UserPrincipal\":\"user1@dom1\",\"UserSid\":\"S-1-5-21-3852557355-3178143607-2040168074-1530\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"265\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"UserIdentityMacV4\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"AuthenticationUuid\":\"FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109\",\"timestamp\":\"1625677478122\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:38.122Z",
-                "kind": "event",
                 "action": "UserIdentity",
-                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
                 "category": [
                     "authentication",
                     "iam"
                 ],
+                "created": "2021-07-07T17:04:38.122Z",
+                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
+                "ingested": "2022-03-22T18:19:46.426798500Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"UserIdentity\",\"LoginSessionId\":\"1138166333440\",\"AuthenticationUuidAsString\":\"FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109\",\"UserName\":\"user1\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"AuthenticationId\":\"265\",\"UserPrincipal\":\"user1@dom1\",\"UserSid\":\"S-1-5-21-3852557355-3178143607-2040168074-1530\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"265\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"UserIdentityMacV4\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"AuthenticationUuid\":\"FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109\",\"timestamp\":\"1625677478122\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
                 "type": [
                     "info",
                     "user"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "3967242894"
                 ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "UserSid": "S-1-5-21-3852557355-3178143607-2040168074-1530",
-                "LoginSessionId": "1138166333440",
-                "AuthenticationUuidAsString": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109",
-                "ConfigStateHash": "3967242894",
-                "Entitlements": "15",
-                "name": "UserIdentityMacV4",
-                "EffectiveTransmissionClass": "2",
-                "AuthenticationUuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109",
-                "AuthenticationId": "265",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "user": {
-                "name": "user1",
-                "full_name": "user1",
-                "id": "265",
-                "email": "user1@dom1",
-                "domain": "dom1"
-            },
-            "url": {
-                "scheme": "http"
+                "hosts": [
+                    "67.43.156.13"
+                ],
+                "ip": [
+                    "67.43.156.13"
+                ],
+                "user": [
+                    "user1"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            },
+            "user": {
+                "domain": "dom1",
+                "email": "user1@dom1",
+                "full_name": "user1",
+                "id": "265",
+                "name": "user1"
+            }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff45d647e6ae0ba8764a4bd570",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:04:49.052Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "1",
+                "Entitlements": "15",
+                "FXFileSize": "502032",
+                "FeatureExtractionVersion": "2",
+                "FeatureVector": "000000527b2276223a22312e30222c226e223a352c226c223a3235362c2265223a7b2261223a5b31363737373232332c31363737373232332c31363737373232332c31363737373232332c31363737373232335d7d7d3f48793e3f6837b53f276c8b3ef8d4fe3f036e2f3fdb404f3e361134404d8c7e3df27bb33ef837b53faa57a83e752546402e6b513eb8e2193f5e63203e1446743f295e9e401fb7e93fe010623f90be0e3f6f837b3e7333333f3951833f33afb83e3f62b73e1893753f1b851f3ea752543e9333333ed446743f045a1d40889ba64065d2f2ad9a1b883f573eab3dd773193ed254613f3f3b643eedab9f3f579a6b4082b5dd3f92d42c3e8809d54040fcf83f90a71e40d717593e832ca53e19e83e3b4b295f3f64c2f83f8a9d1f3f27fcb93f088ce73e7333333de944673e81d7dc3f2db22d3e90cb293e2ca57a3e22b6ae3e843fe63f44fdf43f0573eb3ecbc6a83c648e8a3ceb1c433d16c6153c0d4fdf3d0529353e08ce703c2d81ae3f0809d53b69a2c63b7b43d93ded91683ba90cd43e2f9db23b6e28673d646499bb84406c3c0bd6623ea809d53edfb15b3dcc73acbc188d2a3c20cae63d390eaa3d148fda398cfb263b872b023d4d2b2c3a19c60fbc58ec963af9b13139f75bed3f687fcc3f105bc0ae9de3cf3cfb15b53a5dcccfbc2398203c9f40a3ba91e2153d0ec95c3f7e00d23dd048173c13b7d83f3404ea3ef06f69400392643c4dc8753b1f9485bb875d573cdebd903e1a9fbe3be83a113b1528f23c9279143c40053e3b62089e3d06ec183d16e58aba9c7ffe3b30c0273c3cbe623cc9eecc3b1e55c1ba25558f35192b55bcba493d357b1f123422c77e35700fd4349540073385f5c53562b199363180c1bbb5f5f133702cb134553ec134453f1234dfedcabba8e2e3bc4df26734da8f6636e51c133592f7ea34116278be173eabbc11ea79bbb3d4ae3574e4c733a4bbc53046530d34fd74ee330432f8bcf212d7bbaf3e47bc46690534a8a19335420670af1ab38734cdff54338e0e59bd23ad1934a8bd10bd2bb44e3433be90390220d73590265c3481ec3abb7701543b3e1eb437841ede333ede4c31d582ecbc195ee13510b6ab35ab6563b85ae696bcc582563510d9083490265c319cda2abc8327673428415ebba593a3347763df2f713b9cbd14a4d33486ea69bca3ec033d58ec963dc523f63dba7daa3cab9f563d5c67e03e8425af3cdaf8df3f47381d3bab606b3d174e663e6b1c433c4710cb3f04d0143c9691a73e0a233a3bde2ac33d0240b83ee339c13f139c0f3e2fec573df34d6a3d00e6b03df1a9fc3d9fb3fa3b6629953c4100e73d89fe873c0811b23d2d2dcb3ce5de163d0a1dfc3fac816f3f5096bc2e0d65af3df559b43b38ae323cf6555c3d93c3613d78a0903de872b03eb439583e27ef9e3c1689443f7c8b443eb06f694010ce703cff822c3c2d81ae3b0e68e43db5e2043e6b367a3d355ef23d1b089a3c5898b33bd373b03c41d29e3decbfb13d8a0e413bd9dfdb3c2dab9f3d1fddec3dcdd2f23cd10f523ce9ccb83f4b2fec3f7119ce3f276c8b3ee831273f036e2f3fe58adb3e361134404d8c7e3df972473ef837b53faab3683e7f1412402f34d73eb8e2193f62339c3e1446743f2041894013e0df3fe010623f90be0e3f6f837b3e7333333f449ba63f30a3d73e3f62b73e1893753f1b851f3ee240b83e9333333ed446743f03d07d40889ba64065d2f2ad8f49d23f4fd8ae3dd14e3c3edde69b3f3e147b3ee5bc023f579a6b409780343f92d42c3e8809d540435f703f90a71e40d717593e832ca53e19b3d03cc13fd13f6374bc3f8a9d1f3f27fcb93f1cd35b3e7333333de388663e884b5e3f29999a3e90cb293e2305533e2147ae3e843fe63f4d013b3f056d5d3ebe28243c6703b03cf084623d14a4d33c093b7e3d05a7093e087fcc3c304ab63f08c7e33b6ad0c43b8893b83dec22683ba8e2e33e2c56d63b6cd8dc3d637de9bb849cb23c08e79b3ea6dc5d3ee00d1b3dcb923abc1fd36f3c1cf56f3d385c683d134acb398c098e3b872b023d4e075f3a108bd4bc564d7f3b029cfe399cd0863f6958103f10b780ae9e16793cf601793a58523cbc231e7e3c9eecc0ba8398a63d0fba883f7d63883dd254613c14c4483f349ba63ef0b0f24003aa263c49afe23b23d70abb875d573cde3fbc3e1a9fbe3bebcc6c3b19d0203c92641b3c402f303b62d1f23d0366513d1797ccba9f40a33b32c83f3c39a1773ccfe9b83b2276b8ba786f1235192b55bcb890d63573a8ab34a531f734c11ccb3495400732a151a8369df96936179953bbbc1f00340207b734553ec134b523e7352bd356bba8e2e3bc4df26733a7cdeb36e51c1335421b0e3515c299be173eabbc11e647bbb3d4ae328448f533aa5c213046530d357f25dd330432f8bcf290acbbae9ee4bc4669053496f7d534ede333af1ab38733a03ec7346522f2bd23ad19353fd9cfbd2bb44e3392336039250bbe34bb34f73618f0ecbb7701543c50e560356884d0330f9fab31d582ecbc19f5e03510b6ab34e35d66b85ac660bcc582563510d9083490265c3399a707bc84a0e43474d02abba593a3342f209630b98ae7bd11fb4033605e7dbc9e59f33d5f11733dc922533db943183ca5a46a3d5b42463e83bcd33cdd2f1b3f47fcb93bae3a3b3d1ceaf23e6978d53c4836653f03a29c3c9afe1e3e096bba3bde76423cfd4bf13ee1e4f73f1418933e2ee6323df1a9fc3cfe1da83df0d8453d9e7ea63b69f6a93c4083123d8a7c5b3c0266773d2e147b3ce978d53d08ce703facf41f3f510cb32e0d9dfa3df2b0213b2bd5dc3cf77af63d94ee393d782d383de978d53eb404ea3e288ce73c2209ab3f7c91d13eb0d8454010e2193cfc65413c2e53653b0ede553db674d13e6ae7d53d361bb03d1c23b83c579d0a3bd3176a3c4447c33dea161e3d8a67623bd477bc3c2f4f0e3d1e6eeb3dd07c853cd4e8fb3cded2893f42de013f6d4fdf3f276c8b3ee1e4f73f036e2f3fe58adb3e361134404d8c7e3df837b53ef18fc53faa57a83e781d7e402d53263eb8e2193f62339c3e1b089a3f204189400eb9f53fe010623f9395813f6a233a3e81ff2e3f41a9fc3f3013a93e2666663e17dbf53f1b851f3ec666663e9333333ed446743f0e560440889ba64065d2f2ad9a1b883f573eab3dd7a7873edde69b3f3f3b643eed42c43f6a30554087f62b3f92d42c3e83958140435f703f90a71e40d717593e832ca53e19ce073cd0917d3f6374bc3f8a9d1f3f26e9793f088ce73e7333333df34d6a3e8710cb3f34f7663ea20c4a3e1a02753e23bcd33e843fe63f3a36e33f0573eb3ec84b5e3c6685db3cef0ae53d17acc53c0b32cf3d05681f3e0831273c2ff6d33f0a29c73b6a9e6f3b88c60d3deecbfb3baa53fc3e2d91683b6c636b3d66d9bebb8533b13c0a0d353ea91d153ee275253dcc9d9dbc159e623c1d27c43d3ad18d3d145b6c3982b47b3b88051d3d4fe9b83a12e7cfbc579d0a3af0a5f0390a9f2b3f69db233f10b780ae9e5a073cfc26573a5a6b1bbc247ed03c9d7343ba9bb6aa3d0f66a53f7d49523dd35a863c151c5c3f35b5743ef1d14e40047f243c4d9e843b24095fbb87b99d3cdd82fd3e1c28f63beeae9f3b14812c3c91a75d3c40ad043b613f4b3d033c603d195033ba9d8c6d3b307d0b3c3d12453cd234ec3b25375dba904f6e35181195bcba493d35a2674934a531f7352bda363522229033be54dc337b157336151dabbbb5f5f1340207b7345d30d93421b49d34c2b91cbba8e2e3bc4df26733a7cdeb369116e13592f7ea34116278be173eabbc11e647bbb3d4ae328448f533b7f4153046530d359e3e2233d006d8bcf2cf96bbad9ad8bc466905351da01436249e38af17834033a03ec7346522f2bd1ddc1e35d36497bd2bb44e33bf0a47390220d734c2822235531fdebb73ba773c1888f8356884d0330f9fab31d533c2bc195ee135adf23935ab6563b85b06ccbcc84b5e3510d9083490265c33e590e6bc81450f33ce498bbba593a334d1f8602f713b9cbd1930be33605e7dbca3ec033d5d249e3dc85b183dbc115e3ca858793d5c33723e83afb83cdcc63f3f4916873bab47413d1cb6853e6b9f563c49320e3f03eab33c9afe1e3e0aa64c3bdfd6953cfac1d33ee3e4263f14af4f3e2f69443df3b6463cfeda663df2b0213d9faebc3b50678c3c4250723d8c00543c0151a43d2d0e563ce4f7663d0701113fad2bd43f5075f72e0e19d33df5f6fd3b2eb80f3cf487fd3d92e72e3d7842313de944673eb50b0f3e295e9e3c1fd36f3f7d6a163eb15b57401159b43d000a7c3c2d2dcb3b0ecd8e3db4e11e3e6c3c9f3d3adc0a3d1bb0603c52dcb13bd338f83c4100e73de9e1b13d8b53503bd6ece13c2cd9e83d201cd63dd1b7173cda12303cdc725c3f48793e3f6ded293f276c8b3f036e2f3f036e2f3fea0f913e361134404d8c7e3e0189373ef837b53fabc3613e7f62b7403012063eb79a6b3f5e63203e0d4fdf3f204189400de9e23fe010623f90be0e3f6a233a3e81ff2e3f3951833f30902e3e4275253e18793e3f1b851f3ee0f9093e9333333ed446743f045a1d40889ba64065d2f2ad9d19253f573eab3dc692f73ece21963f3f3b643eee2eb23f579a6b407e76c93f92d42c3e83958140435f703f90a71e40d717593e832ca53e25aee63cb7e9103f64c2f83f8a9d1f3f27fcb93f06a7f03e676c8b3de147ae3e884b5e3f27bb303e90cb293e3295ea3e21e4f73e81205c3f3fec573f0573eb3ebec56d3c633eff3cf1800a3d1389b53c0ac1903d0587943e06dc5d3c2efb2b3f095e9e3b67ddca3b80303c3dec8b443ba782903e30068e3b6bcc6c3d619b91bb836eb53c0bf7f03ea60aa63ee00d1b3dcc447cbc28c1553c1d55e73d36e2eb3d132b56399063903b8776813d4d7f0f3a15a1bdbc55cfab3b06f04a39c25a833f68f5c33f107c85ae9e10d83cf9335d3a594a8abc2276b83c9f16b1ba66e57d3d0e0c9e3f7dbf483dd1b7173c1435ad3f34bc6a3ef096bc4003689d3c49afe23b22fcf0bb87a8d63cde939f3e1aee633bedbb5a3b14f69d3c91e6473c402f303b64217d3d06cca33d183516ba9fe8683b33d4ae3c38f9b13cced9173b288f00ba5a42d7356eda97bcb9628d356e0c6f341b95cf341f3c6534ad5b0a32a151a8337b157335b2c72cbbb2852334900adf34553ec1346e5ee5347ab7febba8e2e3bc4df26733a7cdeb35cf19143592f7ea34c9a612be173eabbc11e647bbb3d4ae35219fff33b7f4153046530d348b7aa434677fadbcf290acbbaf2d80bc46690535a6b2cc3206f2a8af17834033a03ec7338e0e59bd1e83e435857ac3bd2bb44e33043df73927249d34bb34f735906b14bb780dc33c50e560361e0a98336f92c2320a0eb4bc19b2c435adf23935ab6563b85a4586bcc56d5d3510d9083490265c3399a707bc811b1e34cde3d7bba593a334aec0612fb676c6bd13be2333605e7dbca3ec033d59be4d3dc9667b3db83cf33ca7ef9e3d5c09813e8361133cdba0a53f485f073ba023213d191bc53e69fbe73c4059213f04dd2f3c9835163e0865953be38a7e3d0385c63ee1b08a3f142c3d3e2f9db23df0068e3cff6d333df06f693d9e7ea63b68fb013c4250723d8a4d2b3c0b007a3d2e924f3cea209b3d094c443faccccd3f50ded32e0d9dfa3df41f213b2dab9f3cf95d4f3d94a4d33d7991bc3de809d53eb532613e28db8c3c1afe1e3f7cd9e83eb0ff974010f0d83cfc3b4f3c2e53653b0ede553db6c3763e6bb98c3d35f1bf3d1a95423c53d85a3bcedd483c46bce83ded5cfb3d8ac0833bd0edc43c319a413d1e30013dd07c853cdcf0303ce243573f4ded293f69c77a3f13d70a3f036e2f3f036e2f3feaa3053e361134404d8c7e3df5c28f3ef02de03faa57a83e70d845402f5dcc3eb8e2193f62339c3df0068e3f204189400de9e23fe010623f90be0e3f6a233a3e7333333f4a85883f3318fc3e4000003e063f143f1b851f3ecb5dcc3e9333333ed446743f0e560440889ba64065d2f2ad8f49d23f573eab3dbeff193ed7f62b3f3f3b643eedab9f3f57d567409780343f9292a33e8395814041158c3f90a71e40d717593e832ca53e1a511a3c74c6e73f64c2f83f832cf93f26e9793f03a92a3e6872b03df34d6a3e884b5e3f3381d83ea20c4a3e1a02753e2353f83e825aee3f4d013b3f041f213ec240b83c6a4a8c3cf3a14d3d15b5743c091e213d059c8d3e08ce703c2f78ff3f0837b53b6a7ce13b815e393ded91683ba9cdc43e2d42c43b73dc053d6147aebb8438093c0a61173ea72b023edf559b3dcaff6dbc1bd4063c21fd153d39ffd63d128e0d398d4bad3b894c443d4f18013a195aafbc5773193af57f7339ce41413f6851ec3f0fec57ae9dfa533cfa58f73a5a0d27bc21943a3ca1dfb9ba5471063d0e56043f7dd2f23dd1b7173c14b3813f33dd983ef013a9400347d83c4ca2db3b245d42bb8733663ce243573e1b22d13bf47b673b0f32383c928e0d3c4059213b6304473d05143c3d176ddbba9aed573b3220793c3c6a7f3ccc4ef93b267621ba298e0334f8d6f4bcba493d35461af9342ca85e34c11ccb352222903385f5c5368e9b3935b2c72cbbb75ea6344cfa3134553ec134b523e734c2b91cbba8e2e3bc4df26734d636243705eeb9351ad56535332082be173eabbc11ea79bbb3d4ae35a82cc133a943c13046530d34fd74ee34677fadbcf27bb3bbad8a11bc4669053496f7d53580f4d6af1848493405e546338e0e59bd23ad193400bddcbd2bb44e33bf0a473927249d34c2822235531fdebb73ba773c626d4836cf4407330f9fab31d582ecbc1a027535b8af0035d13ed5b85ad11cbcc582563573cb0735d499d3319cda2abc8548aa3474d02abba593a3351ccb0c2f713b9cbd14a4d333605e7dbca3ec033d6108c43dc9e4503dba34443ca454de3d5a511a3e84816f3cdc09813f4773193bac3a863d1945b73e6b1c433c48de2b3f03e4263c9a415f3e08b4393bd8ba413d0073583ee1cac13f13a92a3e2e48e93df318fc3d0216c63df212d73d9d7dbf3b627e0f3c44ef893d8ba1f53c03e8573d2c9afe3ce5f30e3d0846203fac710d3f50c49c2e0d4f2a3df487fd3b306c443cf837b53d96ffc13d795d4f3de8db8c3eb4bc6a3e28a71e3c1fba453f7c56d63eb07c854010c63f3cfeb0753c3170503b0e68e43db977853e6bb98c3d3c7f783d19a4163c55f99c3bd1e96c3c4669053debb98c3d8a6ca03bde43ee3c2efb2b3d2007dd3dce075f3cdbb59e3ce75793b01aa501",
+                "MLModelVersion": "4",
+                "Malicious": "0",
+                "ModelPrediction": "1436899696705536",
+                "PupAdwareConfidence": "0",
+                "PupAdwareDecisionValue": "12384657383358464",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "DeliverLocalFXToCloudMacV4"
+            },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "DeliverLocalFXToCloud",
+                "created": "2021-07-07T17:04:49.052Z",
+                "id": "ffffffff-1111-11eb-b44e-069a02b0ad6b",
+                "ingested": "2022-03-22T18:19:46.426806400Z",
+                "original": "{\"FeatureVector\":\"000000527b2276223a22312e30222c226e223a352c226c223a3235362c2265223a7b2261223a5b31363737373232332c31363737373232332c31363737373232332c31363737373232332c31363737373232335d7d7d3f48793e3f6837b53f276c8b3ef8d4fe3f036e2f3fdb404f3e361134404d8c7e3df27bb33ef837b53faa57a83e752546402e6b513eb8e2193f5e63203e1446743f295e9e401fb7e93fe010623f90be0e3f6f837b3e7333333f3951833f33afb83e3f62b73e1893753f1b851f3ea752543e9333333ed446743f045a1d40889ba64065d2f2ad9a1b883f573eab3dd773193ed254613f3f3b643eedab9f3f579a6b4082b5dd3f92d42c3e8809d54040fcf83f90a71e40d717593e832ca53e19e83e3b4b295f3f64c2f83f8a9d1f3f27fcb93f088ce73e7333333de944673e81d7dc3f2db22d3e90cb293e2ca57a3e22b6ae3e843fe63f44fdf43f0573eb3ecbc6a83c648e8a3ceb1c433d16c6153c0d4fdf3d0529353e08ce703c2d81ae3f0809d53b69a2c63b7b43d93ded91683ba90cd43e2f9db23b6e28673d646499bb84406c3c0bd6623ea809d53edfb15b3dcc73acbc188d2a3c20cae63d390eaa3d148fda398cfb263b872b023d4d2b2c3a19c60fbc58ec963af9b13139f75bed3f687fcc3f105bc0ae9de3cf3cfb15b53a5dcccfbc2398203c9f40a3ba91e2153d0ec95c3f7e00d23dd048173c13b7d83f3404ea3ef06f69400392643c4dc8753b1f9485bb875d573cdebd903e1a9fbe3be83a113b1528f23c9279143c40053e3b62089e3d06ec183d16e58aba9c7ffe3b30c0273c3cbe623cc9eecc3b1e55c1ba25558f35192b55bcba493d357b1f123422c77e35700fd4349540073385f5c53562b199363180c1bbb5f5f133702cb134553ec134453f1234dfedcabba8e2e3bc4df26734da8f6636e51c133592f7ea34116278be173eabbc11ea79bbb3d4ae3574e4c733a4bbc53046530d34fd74ee330432f8bcf212d7bbaf3e47bc46690534a8a19335420670af1ab38734cdff54338e0e59bd23ad1934a8bd10bd2bb44e3433be90390220d73590265c3481ec3abb7701543b3e1eb437841ede333ede4c31d582ecbc195ee13510b6ab35ab6563b85ae696bcc582563510d9083490265c319cda2abc8327673428415ebba593a3347763df2f713b9cbd14a4d33486ea69bca3ec033d58ec963dc523f63dba7daa3cab9f563d5c67e03e8425af3cdaf8df3f47381d3bab606b3d174e663e6b1c433c4710cb3f04d0143c9691a73e0a233a3bde2ac33d0240b83ee339c13f139c0f3e2fec573df34d6a3d00e6b03df1a9fc3d9fb3fa3b6629953c4100e73d89fe873c0811b23d2d2dcb3ce5de163d0a1dfc3fac816f3f5096bc2e0d65af3df559b43b38ae323cf6555c3d93c3613d78a0903de872b03eb439583e27ef9e3c1689443f7c8b443eb06f694010ce703cff822c3c2d81ae3b0e68e43db5e2043e6b367a3d355ef23d1b089a3c5898b33bd373b03c41d29e3decbfb13d8a0e413bd9dfdb3c2dab9f3d1fddec3dcdd2f23cd10f523ce9ccb83f4b2fec3f7119ce3f276c8b3ee831273f036e2f3fe58adb3e361134404d8c7e3df972473ef837b53faab3683e7f1412402f34d73eb8e2193f62339c3e1446743f2041894013e0df3fe010623f90be0e3f6f837b3e7333333f449ba63f30a3d73e3f62b73e1893753f1b851f3ee240b83e9333333ed446743f03d07d40889ba64065d2f2ad8f49d23f4fd8ae3dd14e3c3edde69b3f3e147b3ee5bc023f579a6b409780343f92d42c3e8809d540435f703f90a71e40d717593e832ca53e19b3d03cc13fd13f6374bc3f8a9d1f3f27fcb93f1cd35b3e7333333de388663e884b5e3f29999a3e90cb293e2305533e2147ae3e843fe63f4d013b3f056d5d3ebe28243c6703b03cf084623d14a4d33c093b7e3d05a7093e087fcc3c304ab63f08c7e33b6ad0c43b8893b83dec22683ba8e2e33e2c56d63b6cd8dc3d637de9bb849cb23c08e79b3ea6dc5d3ee00d1b3dcb923abc1fd36f3c1cf56f3d385c683d134acb398c098e3b872b023d4e075f3a108bd4bc564d7f3b029cfe399cd0863f6958103f10b780ae9e16793cf601793a58523cbc231e7e3c9eecc0ba8398a63d0fba883f7d63883dd254613c14c4483f349ba63ef0b0f24003aa263c49afe23b23d70abb875d573cde3fbc3e1a9fbe3bebcc6c3b19d0203c92641b3c402f303b62d1f23d0366513d1797ccba9f40a33b32c83f3c39a1773ccfe9b83b2276b8ba786f1235192b55bcb890d63573a8ab34a531f734c11ccb3495400732a151a8369df96936179953bbbc1f00340207b734553ec134b523e7352bd356bba8e2e3bc4df26733a7cdeb36e51c1335421b0e3515c299be173eabbc11e647bbb3d4ae328448f533aa5c213046530d357f25dd330432f8bcf290acbbae9ee4bc4669053496f7d534ede333af1ab38733a03ec7346522f2bd23ad19353fd9cfbd2bb44e3392336039250bbe34bb34f73618f0ecbb7701543c50e560356884d0330f9fab31d582ecbc19f5e03510b6ab34e35d66b85ac660bcc582563510d9083490265c3399a707bc84a0e43474d02abba593a3342f209630b98ae7bd11fb4033605e7dbc9e59f33d5f11733dc922533db943183ca5a46a3d5b42463e83bcd33cdd2f1b3f47fcb93bae3a3b3d1ceaf23e6978d53c4836653f03a29c3c9afe1e3e096bba3bde76423cfd4bf13ee1e4f73f1418933e2ee6323df1a9fc3cfe1da83df0d8453d9e7ea63b69f6a93c4083123d8a7c5b3c0266773d2e147b3ce978d53d08ce703facf41f3f510cb32e0d9dfa3df2b0213b2bd5dc3cf77af63d94ee393d782d383de978d53eb404ea3e288ce73c2209ab3f7c91d13eb0d8454010e2193cfc65413c2e53653b0ede553db674d13e6ae7d53d361bb03d1c23b83c579d0a3bd3176a3c4447c33dea161e3d8a67623bd477bc3c2f4f0e3d1e6eeb3dd07c853cd4e8fb3cded2893f42de013f6d4fdf3f276c8b3ee1e4f73f036e2f3fe58adb3e361134404d8c7e3df837b53ef18fc53faa57a83e781d7e402d53263eb8e2193f62339c3e1b089a3f204189400eb9f53fe010623f9395813f6a233a3e81ff2e3f41a9fc3f3013a93e2666663e17dbf53f1b851f3ec666663e9333333ed446743f0e560440889ba64065d2f2ad9a1b883f573eab3dd7a7873edde69b3f3f3b643eed42c43f6a30554087f62b3f92d42c3e83958140435f703f90a71e40d717593e832ca53e19ce073cd0917d3f6374bc3f8a9d1f3f26e9793f088ce73e7333333df34d6a3e8710cb3f34f7663ea20c4a3e1a02753e23bcd33e843fe63f3a36e33f0573eb3ec84b5e3c6685db3cef0ae53d17acc53c0b32cf3d05681f3e0831273c2ff6d33f0a29c73b6a9e6f3b88c60d3deecbfb3baa53fc3e2d91683b6c636b3d66d9bebb8533b13c0a0d353ea91d153ee275253dcc9d9dbc159e623c1d27c43d3ad18d3d145b6c3982b47b3b88051d3d4fe9b83a12e7cfbc579d0a3af0a5f0390a9f2b3f69db233f10b780ae9e5a073cfc26573a5a6b1bbc247ed03c9d7343ba9bb6aa3d0f66a53f7d49523dd35a863c151c5c3f35b5743ef1d14e40047f243c4d9e843b24095fbb87b99d3cdd82fd3e1c28f63beeae9f3b14812c3c91a75d3c40ad043b613f4b3d033c603d195033ba9d8c6d3b307d0b3c3d12453cd234ec3b25375dba904f6e35181195bcba493d35a2674934a531f7352bda363522229033be54dc337b157336151dabbbb5f5f1340207b7345d30d93421b49d34c2b91cbba8e2e3bc4df26733a7cdeb369116e13592f7ea34116278be173eabbc11e647bbb3d4ae328448f533b7f4153046530d359e3e2233d006d8bcf2cf96bbad9ad8bc466905351da01436249e38af17834033a03ec7346522f2bd1ddc1e35d36497bd2bb44e33bf0a47390220d734c2822235531fdebb73ba773c1888f8356884d0330f9fab31d533c2bc195ee135adf23935ab6563b85b06ccbcc84b5e3510d9083490265c33e590e6bc81450f33ce498bbba593a334d1f8602f713b9cbd1930be33605e7dbca3ec033d5d249e3dc85b183dbc115e3ca858793d5c33723e83afb83cdcc63f3f4916873bab47413d1cb6853e6b9f563c49320e3f03eab33c9afe1e3e0aa64c3bdfd6953cfac1d33ee3e4263f14af4f3e2f69443df3b6463cfeda663df2b0213d9faebc3b50678c3c4250723d8c00543c0151a43d2d0e563ce4f7663d0701113fad2bd43f5075f72e0e19d33df5f6fd3b2eb80f3cf487fd3d92e72e3d7842313de944673eb50b0f3e295e9e3c1fd36f3f7d6a163eb15b57401159b43d000a7c3c2d2dcb3b0ecd8e3db4e11e3e6c3c9f3d3adc0a3d1bb0603c52dcb13bd338f83c4100e73de9e1b13d8b53503bd6ece13c2cd9e83d201cd63dd1b7173cda12303cdc725c3f48793e3f6ded293f276c8b3f036e2f3f036e2f3fea0f913e361134404d8c7e3e0189373ef837b53fabc3613e7f62b7403012063eb79a6b3f5e63203e0d4fdf3f204189400de9e23fe010623f90be0e3f6a233a3e81ff2e3f3951833f30902e3e4275253e18793e3f1b851f3ee0f9093e9333333ed446743f045a1d40889ba64065d2f2ad9d19253f573eab3dc692f73ece21963f3f3b643eee2eb23f579a6b407e76c93f92d42c3e83958140435f703f90a71e40d717593e832ca53e25aee63cb7e9103f64c2f83f8a9d1f3f27fcb93f06a7f03e676c8b3de147ae3e884b5e3f27bb303e90cb293e3295ea3e21e4f73e81205c3f3fec573f0573eb3ebec56d3c633eff3cf1800a3d1389b53c0ac1903d0587943e06dc5d3c2efb2b3f095e9e3b67ddca3b80303c3dec8b443ba782903e30068e3b6bcc6c3d619b91bb836eb53c0bf7f03ea60aa63ee00d1b3dcc447cbc28c1553c1d55e73d36e2eb3d132b56399063903b8776813d4d7f0f3a15a1bdbc55cfab3b06f04a39c25a833f68f5c33f107c85ae9e10d83cf9335d3a594a8abc2276b83c9f16b1ba66e57d3d0e0c9e3f7dbf483dd1b7173c1435ad3f34bc6a3ef096bc4003689d3c49afe23b22fcf0bb87a8d63cde939f3e1aee633bedbb5a3b14f69d3c91e6473c402f303b64217d3d06cca33d183516ba9fe8683b33d4ae3c38f9b13cced9173b288f00ba5a42d7356eda97bcb9628d356e0c6f341b95cf341f3c6534ad5b0a32a151a8337b157335b2c72cbbb2852334900adf34553ec1346e5ee5347ab7febba8e2e3bc4df26733a7cdeb35cf19143592f7ea34c9a612be173eabbc11e647bbb3d4ae35219fff33b7f4153046530d348b7aa434677fadbcf290acbbaf2d80bc46690535a6b2cc3206f2a8af17834033a03ec7338e0e59bd1e83e435857ac3bd2bb44e33043df73927249d34bb34f735906b14bb780dc33c50e560361e0a98336f92c2320a0eb4bc19b2c435adf23935ab6563b85a4586bcc56d5d3510d9083490265c3399a707bc811b1e34cde3d7bba593a334aec0612fb676c6bd13be2333605e7dbca3ec033d59be4d3dc9667b3db83cf33ca7ef9e3d5c09813e8361133cdba0a53f485f073ba023213d191bc53e69fbe73c4059213f04dd2f3c9835163e0865953be38a7e3d0385c63ee1b08a3f142c3d3e2f9db23df0068e3cff6d333df06f693d9e7ea63b68fb013c4250723d8a4d2b3c0b007a3d2e924f3cea209b3d094c443faccccd3f50ded32e0d9dfa3df41f213b2dab9f3cf95d4f3d94a4d33d7991bc3de809d53eb532613e28db8c3c1afe1e3f7cd9e83eb0ff974010f0d83cfc3b4f3c2e53653b0ede553db6c3763e6bb98c3d35f1bf3d1a95423c53d85a3bcedd483c46bce83ded5cfb3d8ac0833bd0edc43c319a413d1e30013dd07c853cdcf0303ce243573f4ded293f69c77a3f13d70a3f036e2f3f036e2f3feaa3053e361134404d8c7e3df5c28f3ef02de03faa57a83e70d845402f5dcc3eb8e2193f62339c3df0068e3f204189400de9e23fe010623f90be0e3f6a233a3e7333333f4a85883f3318fc3e4000003e063f143f1b851f3ecb5dcc3e9333333ed446743f0e560440889ba64065d2f2ad8f49d23f573eab3dbeff193ed7f62b3f3f3b643eedab9f3f57d567409780343f9292a33e8395814041158c3f90a71e40d717593e832ca53e1a511a3c74c6e73f64c2f83f832cf93f26e9793f03a92a3e6872b03df34d6a3e884b5e3f3381d83ea20c4a3e1a02753e2353f83e825aee3f4d013b3f041f213ec240b83c6a4a8c3cf3a14d3d15b5743c091e213d059c8d3e08ce703c2f78ff3f0837b53b6a7ce13b815e393ded91683ba9cdc43e2d42c43b73dc053d6147aebb8438093c0a61173ea72b023edf559b3dcaff6dbc1bd4063c21fd153d39ffd63d128e0d398d4bad3b894c443d4f18013a195aafbc5773193af57f7339ce41413f6851ec3f0fec57ae9dfa533cfa58f73a5a0d27bc21943a3ca1dfb9ba5471063d0e56043f7dd2f23dd1b7173c14b3813f33dd983ef013a9400347d83c4ca2db3b245d42bb8733663ce243573e1b22d13bf47b673b0f32383c928e0d3c4059213b6304473d05143c3d176ddbba9aed573b3220793c3c6a7f3ccc4ef93b267621ba298e0334f8d6f4bcba493d35461af9342ca85e34c11ccb352222903385f5c5368e9b3935b2c72cbbb75ea6344cfa3134553ec134b523e734c2b91cbba8e2e3bc4df26734d636243705eeb9351ad56535332082be173eabbc11ea79bbb3d4ae35a82cc133a943c13046530d34fd74ee34677fadbcf27bb3bbad8a11bc4669053496f7d53580f4d6af1848493405e546338e0e59bd23ad193400bddcbd2bb44e33bf0a473927249d34c2822235531fdebb73ba773c626d4836cf4407330f9fab31d582ecbc1a027535b8af0035d13ed5b85ad11cbcc582563573cb0735d499d3319cda2abc8548aa3474d02abba593a3351ccb0c2f713b9cbd14a4d333605e7dbca3ec033d6108c43dc9e4503dba34443ca454de3d5a511a3e84816f3cdc09813f4773193bac3a863d1945b73e6b1c433c48de2b3f03e4263c9a415f3e08b4393bd8ba413d0073583ee1cac13f13a92a3e2e48e93df318fc3d0216c63df212d73d9d7dbf3b627e0f3c44ef893d8ba1f53c03e8573d2c9afe3ce5f30e3d0846203fac710d3f50c49c2e0d4f2a3df487fd3b306c443cf837b53d96ffc13d795d4f3de8db8c3eb4bc6a3e28a71e3c1fba453f7c56d63eb07c854010c63f3cfeb0753c3170503b0e68e43db977853e6bb98c3d3c7f783d19a4163c55f99c3bd1e96c3c4669053debb98c3d8a6ca03bde43ee3c2efb2b3d2007dd3dce075f3cdbb59e3ce75793b01aa501\",\"event_simpleName\":\"DeliverLocalFXToCloud\",\"ConfigStateHash\":\"1620585913\",\"aip\":\"67.43.156.14\",\"ModelPrediction\":\"1436899696705536\",\"SHA256HashData\":\"c89caf538788e6524bf4ae93194051f3389eecbc71e4793f12a2dc0368211cc2\",\"Malicious\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"FeatureExtractionVersion\":\"2\",\"event_platform\":\"Mac\",\"FXFileSize\":\"502032\",\"Entitlements\":\"15\",\"name\":\"DeliverLocalFXToCloudMacV4\",\"PupAdwareDecisionValue\":\"12384657383358464\",\"id\":\"ffffffff-1111-11eb-b44e-069a02b0ad6b\",\"PupAdwareConfidence\":\"0\",\"EffectiveTransmissionClass\":\"1\",\"aid\":\"ffffffff45d647e6ae0ba8764a4bd570\",\"MLModelVersion\":\"4\",\"timestamp\":\"1625677489052\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff45d647e6ae0ba8764a4bd570",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "c89caf538788e6524bf4ae93194051f3389eecbc71e4793f12a2dc0368211cc2",
                     "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:05:24.929Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "CreateProcessArgsMac"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "CreateProcessArgs",
+                "category": [
+                    "process"
+                ],
+                "created": "2021-07-07T17:05:25.128Z",
+                "id": "ffffffff-1111-11eb-8332-020506b18db5",
+                "ingested": "2022-03-22T18:19:46.426814100Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"CreateProcessArgs\",\"ContextTimeStamp\":\"1625677524.929\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365035560818271291\",\"ContextThreadId\":\"365035560818271291\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"CommandLine\":\"t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationActionView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationAddressView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationErrorView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationHeaderView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationLoadingView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationPostalCodeView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationViewController.o -index-store-path /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Index/DataStore -index-system-modules\",\"Entitlements\":\"15\",\"name\":\"CreateProcessArgsMac\",\"id\":\"ffffffff-1111-11eb-8332-020506b18db5\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffb3a3442585c05abc61e290fc\",\"timestamp\":\"1625677525128\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "file": {
+                "directory": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin",
+                "name": "swift-frontend",
+                "path": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffb3a3442585c05abc61e290fc",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
             "os": {
                 "type": "macos"
             },
-            "event": {
-                "action": "DeliverLocalFXToCloud",
-                "ingested": "2021-12-30T05:11:46.561721908Z",
-                "original": "{\"FeatureVector\":\"000000527b2276223a22312e30222c226e223a352c226c223a3235362c2265223a7b2261223a5b31363737373232332c31363737373232332c31363737373232332c31363737373232332c31363737373232335d7d7d3f48793e3f6837b53f276c8b3ef8d4fe3f036e2f3fdb404f3e361134404d8c7e3df27bb33ef837b53faa57a83e752546402e6b513eb8e2193f5e63203e1446743f295e9e401fb7e93fe010623f90be0e3f6f837b3e7333333f3951833f33afb83e3f62b73e1893753f1b851f3ea752543e9333333ed446743f045a1d40889ba64065d2f2ad9a1b883f573eab3dd773193ed254613f3f3b643eedab9f3f579a6b4082b5dd3f92d42c3e8809d54040fcf83f90a71e40d717593e832ca53e19e83e3b4b295f3f64c2f83f8a9d1f3f27fcb93f088ce73e7333333de944673e81d7dc3f2db22d3e90cb293e2ca57a3e22b6ae3e843fe63f44fdf43f0573eb3ecbc6a83c648e8a3ceb1c433d16c6153c0d4fdf3d0529353e08ce703c2d81ae3f0809d53b69a2c63b7b43d93ded91683ba90cd43e2f9db23b6e28673d646499bb84406c3c0bd6623ea809d53edfb15b3dcc73acbc188d2a3c20cae63d390eaa3d148fda398cfb263b872b023d4d2b2c3a19c60fbc58ec963af9b13139f75bed3f687fcc3f105bc0ae9de3cf3cfb15b53a5dcccfbc2398203c9f40a3ba91e2153d0ec95c3f7e00d23dd048173c13b7d83f3404ea3ef06f69400392643c4dc8753b1f9485bb875d573cdebd903e1a9fbe3be83a113b1528f23c9279143c40053e3b62089e3d06ec183d16e58aba9c7ffe3b30c0273c3cbe623cc9eecc3b1e55c1ba25558f35192b55bcba493d357b1f123422c77e35700fd4349540073385f5c53562b199363180c1bbb5f5f133702cb134553ec134453f1234dfedcabba8e2e3bc4df26734da8f6636e51c133592f7ea34116278be173eabbc11ea79bbb3d4ae3574e4c733a4bbc53046530d34fd74ee330432f8bcf212d7bbaf3e47bc46690534a8a19335420670af1ab38734cdff54338e0e59bd23ad1934a8bd10bd2bb44e3433be90390220d73590265c3481ec3abb7701543b3e1eb437841ede333ede4c31d582ecbc195ee13510b6ab35ab6563b85ae696bcc582563510d9083490265c319cda2abc8327673428415ebba593a3347763df2f713b9cbd14a4d33486ea69bca3ec033d58ec963dc523f63dba7daa3cab9f563d5c67e03e8425af3cdaf8df3f47381d3bab606b3d174e663e6b1c433c4710cb3f04d0143c9691a73e0a233a3bde2ac33d0240b83ee339c13f139c0f3e2fec573df34d6a3d00e6b03df1a9fc3d9fb3fa3b6629953c4100e73d89fe873c0811b23d2d2dcb3ce5de163d0a1dfc3fac816f3f5096bc2e0d65af3df559b43b38ae323cf6555c3d93c3613d78a0903de872b03eb439583e27ef9e3c1689443f7c8b443eb06f694010ce703cff822c3c2d81ae3b0e68e43db5e2043e6b367a3d355ef23d1b089a3c5898b33bd373b03c41d29e3decbfb13d8a0e413bd9dfdb3c2dab9f3d1fddec3dcdd2f23cd10f523ce9ccb83f4b2fec3f7119ce3f276c8b3ee831273f036e2f3fe58adb3e361134404d8c7e3df972473ef837b53faab3683e7f1412402f34d73eb8e2193f62339c3e1446743f2041894013e0df3fe010623f90be0e3f6f837b3e7333333f449ba63f30a3d73e3f62b73e1893753f1b851f3ee240b83e9333333ed446743f03d07d40889ba64065d2f2ad8f49d23f4fd8ae3dd14e3c3edde69b3f3e147b3ee5bc023f579a6b409780343f92d42c3e8809d540435f703f90a71e40d717593e832ca53e19b3d03cc13fd13f6374bc3f8a9d1f3f27fcb93f1cd35b3e7333333de388663e884b5e3f29999a3e90cb293e2305533e2147ae3e843fe63f4d013b3f056d5d3ebe28243c6703b03cf084623d14a4d33c093b7e3d05a7093e087fcc3c304ab63f08c7e33b6ad0c43b8893b83dec22683ba8e2e33e2c56d63b6cd8dc3d637de9bb849cb23c08e79b3ea6dc5d3ee00d1b3dcb923abc1fd36f3c1cf56f3d385c683d134acb398c098e3b872b023d4e075f3a108bd4bc564d7f3b029cfe399cd0863f6958103f10b780ae9e16793cf601793a58523cbc231e7e3c9eecc0ba8398a63d0fba883f7d63883dd254613c14c4483f349ba63ef0b0f24003aa263c49afe23b23d70abb875d573cde3fbc3e1a9fbe3bebcc6c3b19d0203c92641b3c402f303b62d1f23d0366513d1797ccba9f40a33b32c83f3c39a1773ccfe9b83b2276b8ba786f1235192b55bcb890d63573a8ab34a531f734c11ccb3495400732a151a8369df96936179953bbbc1f00340207b734553ec134b523e7352bd356bba8e2e3bc4df26733a7cdeb36e51c1335421b0e3515c299be173eabbc11e647bbb3d4ae328448f533aa5c213046530d357f25dd330432f8bcf290acbbae9ee4bc4669053496f7d534ede333af1ab38733a03ec7346522f2bd23ad19353fd9cfbd2bb44e3392336039250bbe34bb34f73618f0ecbb7701543c50e560356884d0330f9fab31d582ecbc19f5e03510b6ab34e35d66b85ac660bcc582563510d9083490265c3399a707bc84a0e43474d02abba593a3342f209630b98ae7bd11fb4033605e7dbc9e59f33d5f11733dc922533db943183ca5a46a3d5b42463e83bcd33cdd2f1b3f47fcb93bae3a3b3d1ceaf23e6978d53c4836653f03a29c3c9afe1e3e096bba3bde76423cfd4bf13ee1e4f73f1418933e2ee6323df1a9fc3cfe1da83df0d8453d9e7ea63b69f6a93c4083123d8a7c5b3c0266773d2e147b3ce978d53d08ce703facf41f3f510cb32e0d9dfa3df2b0213b2bd5dc3cf77af63d94ee393d782d383de978d53eb404ea3e288ce73c2209ab3f7c91d13eb0d8454010e2193cfc65413c2e53653b0ede553db674d13e6ae7d53d361bb03d1c23b83c579d0a3bd3176a3c4447c33dea161e3d8a67623bd477bc3c2f4f0e3d1e6eeb3dd07c853cd4e8fb3cded2893f42de013f6d4fdf3f276c8b3ee1e4f73f036e2f3fe58adb3e361134404d8c7e3df837b53ef18fc53faa57a83e781d7e402d53263eb8e2193f62339c3e1b089a3f204189400eb9f53fe010623f9395813f6a233a3e81ff2e3f41a9fc3f3013a93e2666663e17dbf53f1b851f3ec666663e9333333ed446743f0e560440889ba64065d2f2ad9a1b883f573eab3dd7a7873edde69b3f3f3b643eed42c43f6a30554087f62b3f92d42c3e83958140435f703f90a71e40d717593e832ca53e19ce073cd0917d3f6374bc3f8a9d1f3f26e9793f088ce73e7333333df34d6a3e8710cb3f34f7663ea20c4a3e1a02753e23bcd33e843fe63f3a36e33f0573eb3ec84b5e3c6685db3cef0ae53d17acc53c0b32cf3d05681f3e0831273c2ff6d33f0a29c73b6a9e6f3b88c60d3deecbfb3baa53fc3e2d91683b6c636b3d66d9bebb8533b13c0a0d353ea91d153ee275253dcc9d9dbc159e623c1d27c43d3ad18d3d145b6c3982b47b3b88051d3d4fe9b83a12e7cfbc579d0a3af0a5f0390a9f2b3f69db233f10b780ae9e5a073cfc26573a5a6b1bbc247ed03c9d7343ba9bb6aa3d0f66a53f7d49523dd35a863c151c5c3f35b5743ef1d14e40047f243c4d9e843b24095fbb87b99d3cdd82fd3e1c28f63beeae9f3b14812c3c91a75d3c40ad043b613f4b3d033c603d195033ba9d8c6d3b307d0b3c3d12453cd234ec3b25375dba904f6e35181195bcba493d35a2674934a531f7352bda363522229033be54dc337b157336151dabbbb5f5f1340207b7345d30d93421b49d34c2b91cbba8e2e3bc4df26733a7cdeb369116e13592f7ea34116278be173eabbc11e647bbb3d4ae328448f533b7f4153046530d359e3e2233d006d8bcf2cf96bbad9ad8bc466905351da01436249e38af17834033a03ec7346522f2bd1ddc1e35d36497bd2bb44e33bf0a47390220d734c2822235531fdebb73ba773c1888f8356884d0330f9fab31d533c2bc195ee135adf23935ab6563b85b06ccbcc84b5e3510d9083490265c33e590e6bc81450f33ce498bbba593a334d1f8602f713b9cbd1930be33605e7dbca3ec033d5d249e3dc85b183dbc115e3ca858793d5c33723e83afb83cdcc63f3f4916873bab47413d1cb6853e6b9f563c49320e3f03eab33c9afe1e3e0aa64c3bdfd6953cfac1d33ee3e4263f14af4f3e2f69443df3b6463cfeda663df2b0213d9faebc3b50678c3c4250723d8c00543c0151a43d2d0e563ce4f7663d0701113fad2bd43f5075f72e0e19d33df5f6fd3b2eb80f3cf487fd3d92e72e3d7842313de944673eb50b0f3e295e9e3c1fd36f3f7d6a163eb15b57401159b43d000a7c3c2d2dcb3b0ecd8e3db4e11e3e6c3c9f3d3adc0a3d1bb0603c52dcb13bd338f83c4100e73de9e1b13d8b53503bd6ece13c2cd9e83d201cd63dd1b7173cda12303cdc725c3f48793e3f6ded293f276c8b3f036e2f3f036e2f3fea0f913e361134404d8c7e3e0189373ef837b53fabc3613e7f62b7403012063eb79a6b3f5e63203e0d4fdf3f204189400de9e23fe010623f90be0e3f6a233a3e81ff2e3f3951833f30902e3e4275253e18793e3f1b851f3ee0f9093e9333333ed446743f045a1d40889ba64065d2f2ad9d19253f573eab3dc692f73ece21963f3f3b643eee2eb23f579a6b407e76c93f92d42c3e83958140435f703f90a71e40d717593e832ca53e25aee63cb7e9103f64c2f83f8a9d1f3f27fcb93f06a7f03e676c8b3de147ae3e884b5e3f27bb303e90cb293e3295ea3e21e4f73e81205c3f3fec573f0573eb3ebec56d3c633eff3cf1800a3d1389b53c0ac1903d0587943e06dc5d3c2efb2b3f095e9e3b67ddca3b80303c3dec8b443ba782903e30068e3b6bcc6c3d619b91bb836eb53c0bf7f03ea60aa63ee00d1b3dcc447cbc28c1553c1d55e73d36e2eb3d132b56399063903b8776813d4d7f0f3a15a1bdbc55cfab3b06f04a39c25a833f68f5c33f107c85ae9e10d83cf9335d3a594a8abc2276b83c9f16b1ba66e57d3d0e0c9e3f7dbf483dd1b7173c1435ad3f34bc6a3ef096bc4003689d3c49afe23b22fcf0bb87a8d63cde939f3e1aee633bedbb5a3b14f69d3c91e6473c402f303b64217d3d06cca33d183516ba9fe8683b33d4ae3c38f9b13cced9173b288f00ba5a42d7356eda97bcb9628d356e0c6f341b95cf341f3c6534ad5b0a32a151a8337b157335b2c72cbbb2852334900adf34553ec1346e5ee5347ab7febba8e2e3bc4df26733a7cdeb35cf19143592f7ea34c9a612be173eabbc11e647bbb3d4ae35219fff33b7f4153046530d348b7aa434677fadbcf290acbbaf2d80bc46690535a6b2cc3206f2a8af17834033a03ec7338e0e59bd1e83e435857ac3bd2bb44e33043df73927249d34bb34f735906b14bb780dc33c50e560361e0a98336f92c2320a0eb4bc19b2c435adf23935ab6563b85a4586bcc56d5d3510d9083490265c3399a707bc811b1e34cde3d7bba593a334aec0612fb676c6bd13be2333605e7dbca3ec033d59be4d3dc9667b3db83cf33ca7ef9e3d5c09813e8361133cdba0a53f485f073ba023213d191bc53e69fbe73c4059213f04dd2f3c9835163e0865953be38a7e3d0385c63ee1b08a3f142c3d3e2f9db23df0068e3cff6d333df06f693d9e7ea63b68fb013c4250723d8a4d2b3c0b007a3d2e924f3cea209b3d094c443faccccd3f50ded32e0d9dfa3df41f213b2dab9f3cf95d4f3d94a4d33d7991bc3de809d53eb532613e28db8c3c1afe1e3f7cd9e83eb0ff974010f0d83cfc3b4f3c2e53653b0ede553db6c3763e6bb98c3d35f1bf3d1a95423c53d85a3bcedd483c46bce83ded5cfb3d8ac0833bd0edc43c319a413d1e30013dd07c853cdcf0303ce243573f4ded293f69c77a3f13d70a3f036e2f3f036e2f3feaa3053e361134404d8c7e3df5c28f3ef02de03faa57a83e70d845402f5dcc3eb8e2193f62339c3df0068e3f204189400de9e23fe010623f90be0e3f6a233a3e7333333f4a85883f3318fc3e4000003e063f143f1b851f3ecb5dcc3e9333333ed446743f0e560440889ba64065d2f2ad8f49d23f573eab3dbeff193ed7f62b3f3f3b643eedab9f3f57d567409780343f9292a33e8395814041158c3f90a71e40d717593e832ca53e1a511a3c74c6e73f64c2f83f832cf93f26e9793f03a92a3e6872b03df34d6a3e884b5e3f3381d83ea20c4a3e1a02753e2353f83e825aee3f4d013b3f041f213ec240b83c6a4a8c3cf3a14d3d15b5743c091e213d059c8d3e08ce703c2f78ff3f0837b53b6a7ce13b815e393ded91683ba9cdc43e2d42c43b73dc053d6147aebb8438093c0a61173ea72b023edf559b3dcaff6dbc1bd4063c21fd153d39ffd63d128e0d398d4bad3b894c443d4f18013a195aafbc5773193af57f7339ce41413f6851ec3f0fec57ae9dfa533cfa58f73a5a0d27bc21943a3ca1dfb9ba5471063d0e56043f7dd2f23dd1b7173c14b3813f33dd983ef013a9400347d83c4ca2db3b245d42bb8733663ce243573e1b22d13bf47b673b0f32383c928e0d3c4059213b6304473d05143c3d176ddbba9aed573b3220793c3c6a7f3ccc4ef93b267621ba298e0334f8d6f4bcba493d35461af9342ca85e34c11ccb352222903385f5c5368e9b3935b2c72cbbb75ea6344cfa3134553ec134b523e734c2b91cbba8e2e3bc4df26734d636243705eeb9351ad56535332082be173eabbc11ea79bbb3d4ae35a82cc133a943c13046530d34fd74ee34677fadbcf27bb3bbad8a11bc4669053496f7d53580f4d6af1848493405e546338e0e59bd23ad193400bddcbd2bb44e33bf0a473927249d34c2822235531fdebb73ba773c626d4836cf4407330f9fab31d582ecbc1a027535b8af0035d13ed5b85ad11cbcc582563573cb0735d499d3319cda2abc8548aa3474d02abba593a3351ccb0c2f713b9cbd14a4d333605e7dbca3ec033d6108c43dc9e4503dba34443ca454de3d5a511a3e84816f3cdc09813f4773193bac3a863d1945b73e6b1c433c48de2b3f03e4263c9a415f3e08b4393bd8ba413d0073583ee1cac13f13a92a3e2e48e93df318fc3d0216c63df212d73d9d7dbf3b627e0f3c44ef893d8ba1f53c03e8573d2c9afe3ce5f30e3d0846203fac710d3f50c49c2e0d4f2a3df487fd3b306c443cf837b53d96ffc13d795d4f3de8db8c3eb4bc6a3e28a71e3c1fba453f7c56d63eb07c854010c63f3cfeb0753c3170503b0e68e43db977853e6bb98c3d3c7f783d19a4163c55f99c3bd1e96c3c4669053debb98c3d8a6ca03bde43ee3c2efb2b3d2007dd3dce075f3cdbb59e3ce75793b01aa501\",\"event_simpleName\":\"DeliverLocalFXToCloud\",\"ConfigStateHash\":\"1620585913\",\"aip\":\"67.43.156.14\",\"ModelPrediction\":\"1436899696705536\",\"SHA256HashData\":\"c89caf538788e6524bf4ae93194051f3389eecbc71e4793f12a2dc0368211cc2\",\"Malicious\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"FeatureExtractionVersion\":\"2\",\"event_platform\":\"Mac\",\"FXFileSize\":\"502032\",\"Entitlements\":\"15\",\"name\":\"DeliverLocalFXToCloudMacV4\",\"PupAdwareDecisionValue\":\"12384657383358464\",\"id\":\"ffffffff-1111-11eb-b44e-069a02b0ad6b\",\"PupAdwareConfidence\":\"0\",\"EffectiveTransmissionClass\":\"1\",\"aid\":\"ffffffff45d647e6ae0ba8764a4bd570\",\"MLModelVersion\":\"4\",\"timestamp\":\"1625677489052\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "id": "ffffffff-1111-11eb-b44e-069a02b0ad6b",
-                "created": "2021-07-07T17:04:49.052Z"
-            },
-            "crowdstrike": {
-                "FeatureVector": "000000527b2276223a22312e30222c226e223a352c226c223a3235362c2265223a7b2261223a5b31363737373232332c31363737373232332c31363737373232332c31363737373232332c31363737373232335d7d7d3f48793e3f6837b53f276c8b3ef8d4fe3f036e2f3fdb404f3e361134404d8c7e3df27bb33ef837b53faa57a83e752546402e6b513eb8e2193f5e63203e1446743f295e9e401fb7e93fe010623f90be0e3f6f837b3e7333333f3951833f33afb83e3f62b73e1893753f1b851f3ea752543e9333333ed446743f045a1d40889ba64065d2f2ad9a1b883f573eab3dd773193ed254613f3f3b643eedab9f3f579a6b4082b5dd3f92d42c3e8809d54040fcf83f90a71e40d717593e832ca53e19e83e3b4b295f3f64c2f83f8a9d1f3f27fcb93f088ce73e7333333de944673e81d7dc3f2db22d3e90cb293e2ca57a3e22b6ae3e843fe63f44fdf43f0573eb3ecbc6a83c648e8a3ceb1c433d16c6153c0d4fdf3d0529353e08ce703c2d81ae3f0809d53b69a2c63b7b43d93ded91683ba90cd43e2f9db23b6e28673d646499bb84406c3c0bd6623ea809d53edfb15b3dcc73acbc188d2a3c20cae63d390eaa3d148fda398cfb263b872b023d4d2b2c3a19c60fbc58ec963af9b13139f75bed3f687fcc3f105bc0ae9de3cf3cfb15b53a5dcccfbc2398203c9f40a3ba91e2153d0ec95c3f7e00d23dd048173c13b7d83f3404ea3ef06f69400392643c4dc8753b1f9485bb875d573cdebd903e1a9fbe3be83a113b1528f23c9279143c40053e3b62089e3d06ec183d16e58aba9c7ffe3b30c0273c3cbe623cc9eecc3b1e55c1ba25558f35192b55bcba493d357b1f123422c77e35700fd4349540073385f5c53562b199363180c1bbb5f5f133702cb134553ec134453f1234dfedcabba8e2e3bc4df26734da8f6636e51c133592f7ea34116278be173eabbc11ea79bbb3d4ae3574e4c733a4bbc53046530d34fd74ee330432f8bcf212d7bbaf3e47bc46690534a8a19335420670af1ab38734cdff54338e0e59bd23ad1934a8bd10bd2bb44e3433be90390220d73590265c3481ec3abb7701543b3e1eb437841ede333ede4c31d582ecbc195ee13510b6ab35ab6563b85ae696bcc582563510d9083490265c319cda2abc8327673428415ebba593a3347763df2f713b9cbd14a4d33486ea69bca3ec033d58ec963dc523f63dba7daa3cab9f563d5c67e03e8425af3cdaf8df3f47381d3bab606b3d174e663e6b1c433c4710cb3f04d0143c9691a73e0a233a3bde2ac33d0240b83ee339c13f139c0f3e2fec573df34d6a3d00e6b03df1a9fc3d9fb3fa3b6629953c4100e73d89fe873c0811b23d2d2dcb3ce5de163d0a1dfc3fac816f3f5096bc2e0d65af3df559b43b38ae323cf6555c3d93c3613d78a0903de872b03eb439583e27ef9e3c1689443f7c8b443eb06f694010ce703cff822c3c2d81ae3b0e68e43db5e2043e6b367a3d355ef23d1b089a3c5898b33bd373b03c41d29e3decbfb13d8a0e413bd9dfdb3c2dab9f3d1fddec3dcdd2f23cd10f523ce9ccb83f4b2fec3f7119ce3f276c8b3ee831273f036e2f3fe58adb3e361134404d8c7e3df972473ef837b53faab3683e7f1412402f34d73eb8e2193f62339c3e1446743f2041894013e0df3fe010623f90be0e3f6f837b3e7333333f449ba63f30a3d73e3f62b73e1893753f1b851f3ee240b83e9333333ed446743f03d07d40889ba64065d2f2ad8f49d23f4fd8ae3dd14e3c3edde69b3f3e147b3ee5bc023f579a6b409780343f92d42c3e8809d540435f703f90a71e40d717593e832ca53e19b3d03cc13fd13f6374bc3f8a9d1f3f27fcb93f1cd35b3e7333333de388663e884b5e3f29999a3e90cb293e2305533e2147ae3e843fe63f4d013b3f056d5d3ebe28243c6703b03cf084623d14a4d33c093b7e3d05a7093e087fcc3c304ab63f08c7e33b6ad0c43b8893b83dec22683ba8e2e33e2c56d63b6cd8dc3d637de9bb849cb23c08e79b3ea6dc5d3ee00d1b3dcb923abc1fd36f3c1cf56f3d385c683d134acb398c098e3b872b023d4e075f3a108bd4bc564d7f3b029cfe399cd0863f6958103f10b780ae9e16793cf601793a58523cbc231e7e3c9eecc0ba8398a63d0fba883f7d63883dd254613c14c4483f349ba63ef0b0f24003aa263c49afe23b23d70abb875d573cde3fbc3e1a9fbe3bebcc6c3b19d0203c92641b3c402f303b62d1f23d0366513d1797ccba9f40a33b32c83f3c39a1773ccfe9b83b2276b8ba786f1235192b55bcb890d63573a8ab34a531f734c11ccb3495400732a151a8369df96936179953bbbc1f00340207b734553ec134b523e7352bd356bba8e2e3bc4df26733a7cdeb36e51c1335421b0e3515c299be173eabbc11e647bbb3d4ae328448f533aa5c213046530d357f25dd330432f8bcf290acbbae9ee4bc4669053496f7d534ede333af1ab38733a03ec7346522f2bd23ad19353fd9cfbd2bb44e3392336039250bbe34bb34f73618f0ecbb7701543c50e560356884d0330f9fab31d582ecbc19f5e03510b6ab34e35d66b85ac660bcc582563510d9083490265c3399a707bc84a0e43474d02abba593a3342f209630b98ae7bd11fb4033605e7dbc9e59f33d5f11733dc922533db943183ca5a46a3d5b42463e83bcd33cdd2f1b3f47fcb93bae3a3b3d1ceaf23e6978d53c4836653f03a29c3c9afe1e3e096bba3bde76423cfd4bf13ee1e4f73f1418933e2ee6323df1a9fc3cfe1da83df0d8453d9e7ea63b69f6a93c4083123d8a7c5b3c0266773d2e147b3ce978d53d08ce703facf41f3f510cb32e0d9dfa3df2b0213b2bd5dc3cf77af63d94ee393d782d383de978d53eb404ea3e288ce73c2209ab3f7c91d13eb0d8454010e2193cfc65413c2e53653b0ede553db674d13e6ae7d53d361bb03d1c23b83c579d0a3bd3176a3c4447c33dea161e3d8a67623bd477bc3c2f4f0e3d1e6eeb3dd07c853cd4e8fb3cded2893f42de013f6d4fdf3f276c8b3ee1e4f73f036e2f3fe58adb3e361134404d8c7e3df837b53ef18fc53faa57a83e781d7e402d53263eb8e2193f62339c3e1b089a3f204189400eb9f53fe010623f9395813f6a233a3e81ff2e3f41a9fc3f3013a93e2666663e17dbf53f1b851f3ec666663e9333333ed446743f0e560440889ba64065d2f2ad9a1b883f573eab3dd7a7873edde69b3f3f3b643eed42c43f6a30554087f62b3f92d42c3e83958140435f703f90a71e40d717593e832ca53e19ce073cd0917d3f6374bc3f8a9d1f3f26e9793f088ce73e7333333df34d6a3e8710cb3f34f7663ea20c4a3e1a02753e23bcd33e843fe63f3a36e33f0573eb3ec84b5e3c6685db3cef0ae53d17acc53c0b32cf3d05681f3e0831273c2ff6d33f0a29c73b6a9e6f3b88c60d3deecbfb3baa53fc3e2d91683b6c636b3d66d9bebb8533b13c0a0d353ea91d153ee275253dcc9d9dbc159e623c1d27c43d3ad18d3d145b6c3982b47b3b88051d3d4fe9b83a12e7cfbc579d0a3af0a5f0390a9f2b3f69db233f10b780ae9e5a073cfc26573a5a6b1bbc247ed03c9d7343ba9bb6aa3d0f66a53f7d49523dd35a863c151c5c3f35b5743ef1d14e40047f243c4d9e843b24095fbb87b99d3cdd82fd3e1c28f63beeae9f3b14812c3c91a75d3c40ad043b613f4b3d033c603d195033ba9d8c6d3b307d0b3c3d12453cd234ec3b25375dba904f6e35181195bcba493d35a2674934a531f7352bda363522229033be54dc337b157336151dabbbb5f5f1340207b7345d30d93421b49d34c2b91cbba8e2e3bc4df26733a7cdeb369116e13592f7ea34116278be173eabbc11e647bbb3d4ae328448f533b7f4153046530d359e3e2233d006d8bcf2cf96bbad9ad8bc466905351da01436249e38af17834033a03ec7346522f2bd1ddc1e35d36497bd2bb44e33bf0a47390220d734c2822235531fdebb73ba773c1888f8356884d0330f9fab31d533c2bc195ee135adf23935ab6563b85b06ccbcc84b5e3510d9083490265c33e590e6bc81450f33ce498bbba593a334d1f8602f713b9cbd1930be33605e7dbca3ec033d5d249e3dc85b183dbc115e3ca858793d5c33723e83afb83cdcc63f3f4916873bab47413d1cb6853e6b9f563c49320e3f03eab33c9afe1e3e0aa64c3bdfd6953cfac1d33ee3e4263f14af4f3e2f69443df3b6463cfeda663df2b0213d9faebc3b50678c3c4250723d8c00543c0151a43d2d0e563ce4f7663d0701113fad2bd43f5075f72e0e19d33df5f6fd3b2eb80f3cf487fd3d92e72e3d7842313de944673eb50b0f3e295e9e3c1fd36f3f7d6a163eb15b57401159b43d000a7c3c2d2dcb3b0ecd8e3db4e11e3e6c3c9f3d3adc0a3d1bb0603c52dcb13bd338f83c4100e73de9e1b13d8b53503bd6ece13c2cd9e83d201cd63dd1b7173cda12303cdc725c3f48793e3f6ded293f276c8b3f036e2f3f036e2f3fea0f913e361134404d8c7e3e0189373ef837b53fabc3613e7f62b7403012063eb79a6b3f5e63203e0d4fdf3f204189400de9e23fe010623f90be0e3f6a233a3e81ff2e3f3951833f30902e3e4275253e18793e3f1b851f3ee0f9093e9333333ed446743f045a1d40889ba64065d2f2ad9d19253f573eab3dc692f73ece21963f3f3b643eee2eb23f579a6b407e76c93f92d42c3e83958140435f703f90a71e40d717593e832ca53e25aee63cb7e9103f64c2f83f8a9d1f3f27fcb93f06a7f03e676c8b3de147ae3e884b5e3f27bb303e90cb293e3295ea3e21e4f73e81205c3f3fec573f0573eb3ebec56d3c633eff3cf1800a3d1389b53c0ac1903d0587943e06dc5d3c2efb2b3f095e9e3b67ddca3b80303c3dec8b443ba782903e30068e3b6bcc6c3d619b91bb836eb53c0bf7f03ea60aa63ee00d1b3dcc447cbc28c1553c1d55e73d36e2eb3d132b56399063903b8776813d4d7f0f3a15a1bdbc55cfab3b06f04a39c25a833f68f5c33f107c85ae9e10d83cf9335d3a594a8abc2276b83c9f16b1ba66e57d3d0e0c9e3f7dbf483dd1b7173c1435ad3f34bc6a3ef096bc4003689d3c49afe23b22fcf0bb87a8d63cde939f3e1aee633bedbb5a3b14f69d3c91e6473c402f303b64217d3d06cca33d183516ba9fe8683b33d4ae3c38f9b13cced9173b288f00ba5a42d7356eda97bcb9628d356e0c6f341b95cf341f3c6534ad5b0a32a151a8337b157335b2c72cbbb2852334900adf34553ec1346e5ee5347ab7febba8e2e3bc4df26733a7cdeb35cf19143592f7ea34c9a612be173eabbc11e647bbb3d4ae35219fff33b7f4153046530d348b7aa434677fadbcf290acbbaf2d80bc46690535a6b2cc3206f2a8af17834033a03ec7338e0e59bd1e83e435857ac3bd2bb44e33043df73927249d34bb34f735906b14bb780dc33c50e560361e0a98336f92c2320a0eb4bc19b2c435adf23935ab6563b85a4586bcc56d5d3510d9083490265c3399a707bc811b1e34cde3d7bba593a334aec0612fb676c6bd13be2333605e7dbca3ec033d59be4d3dc9667b3db83cf33ca7ef9e3d5c09813e8361133cdba0a53f485f073ba023213d191bc53e69fbe73c4059213f04dd2f3c9835163e0865953be38a7e3d0385c63ee1b08a3f142c3d3e2f9db23df0068e3cff6d333df06f693d9e7ea63b68fb013c4250723d8a4d2b3c0b007a3d2e924f3cea209b3d094c443faccccd3f50ded32e0d9dfa3df41f213b2dab9f3cf95d4f3d94a4d33d7991bc3de809d53eb532613e28db8c3c1afe1e3f7cd9e83eb0ff974010f0d83cfc3b4f3c2e53653b0ede553db6c3763e6bb98c3d35f1bf3d1a95423c53d85a3bcedd483c46bce83ded5cfb3d8ac0833bd0edc43c319a413d1e30013dd07c853cdcf0303ce243573f4ded293f69c77a3f13d70a3f036e2f3f036e2f3feaa3053e361134404d8c7e3df5c28f3ef02de03faa57a83e70d845402f5dcc3eb8e2193f62339c3df0068e3f204189400de9e23fe010623f90be0e3f6a233a3e7333333f4a85883f3318fc3e4000003e063f143f1b851f3ecb5dcc3e9333333ed446743f0e560440889ba64065d2f2ad8f49d23f573eab3dbeff193ed7f62b3f3f3b643eedab9f3f57d567409780343f9292a33e8395814041158c3f90a71e40d717593e832ca53e1a511a3c74c6e73f64c2f83f832cf93f26e9793f03a92a3e6872b03df34d6a3e884b5e3f3381d83ea20c4a3e1a02753e2353f83e825aee3f4d013b3f041f213ec240b83c6a4a8c3cf3a14d3d15b5743c091e213d059c8d3e08ce703c2f78ff3f0837b53b6a7ce13b815e393ded91683ba9cdc43e2d42c43b73dc053d6147aebb8438093c0a61173ea72b023edf559b3dcaff6dbc1bd4063c21fd153d39ffd63d128e0d398d4bad3b894c443d4f18013a195aafbc5773193af57f7339ce41413f6851ec3f0fec57ae9dfa533cfa58f73a5a0d27bc21943a3ca1dfb9ba5471063d0e56043f7dd2f23dd1b7173c14b3813f33dd983ef013a9400347d83c4ca2db3b245d42bb8733663ce243573e1b22d13bf47b673b0f32383c928e0d3c4059213b6304473d05143c3d176ddbba9aed573b3220793c3c6a7f3ccc4ef93b267621ba298e0334f8d6f4bcba493d35461af9342ca85e34c11ccb352222903385f5c5368e9b3935b2c72cbbb75ea6344cfa3134553ec134b523e734c2b91cbba8e2e3bc4df26734d636243705eeb9351ad56535332082be173eabbc11ea79bbb3d4ae35a82cc133a943c13046530d34fd74ee34677fadbcf27bb3bbad8a11bc4669053496f7d53580f4d6af1848493405e546338e0e59bd23ad193400bddcbd2bb44e33bf0a473927249d34c2822235531fdebb73ba773c626d4836cf4407330f9fab31d582ecbc1a027535b8af0035d13ed5b85ad11cbcc582563573cb0735d499d3319cda2abc8548aa3474d02abba593a3351ccb0c2f713b9cbd14a4d333605e7dbca3ec033d6108c43dc9e4503dba34443ca454de3d5a511a3e84816f3cdc09813f4773193bac3a863d1945b73e6b1c433c48de2b3f03e4263c9a415f3e08b4393bd8ba413d0073583ee1cac13f13a92a3e2e48e93df318fc3d0216c63df212d73d9d7dbf3b627e0f3c44ef893d8ba1f53c03e8573d2c9afe3ce5f30e3d0846203fac710d3f50c49c2e0d4f2a3df487fd3b306c443cf837b53d96ffc13d795d4f3de8db8c3eb4bc6a3e28a71e3c1fba453f7c56d63eb07c854010c63f3cfeb0753c3170503b0e68e43db977853e6bb98c3d3c7f783d19a4163c55f99c3bd1e96c3c4669053debb98c3d8a6ca03bde43ee3c2efb2b3d2007dd3dce075f3cdbb59e3ce75793b01aa501",
-                "ConfigStateHash": "1620585913",
-                "ModelPrediction": "1436899696705536",
-                "Malicious": "0",
-                "FeatureExtractionVersion": "2",
-                "FXFileSize": "502032",
-                "Entitlements": "15",
-                "name": "DeliverLocalFXToCloudMacV4",
-                "PupAdwareDecisionValue": "12384657383358464",
-                "PupAdwareConfidence": "0",
-                "EffectiveTransmissionClass": "1",
-                "MLModelVersion": "4",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
             "process": {
                 "args": [
                     "t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o",
@@ -3739,461 +3791,359 @@
                     "-index-system-modules"
                 ],
                 "args_count": 18,
+                "command_line": "t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationActionView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationAddressView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationErrorView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationHeaderView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationLoadingView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationPostalCodeView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationViewController.o -index-store-path /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Index/DataStore -index-system-modules",
+                "entity_id": "365035560818271291",
                 "thread": {
                     "id": 365035560818271291
-                },
-                "entity_id": "365035560818271291",
-                "command_line": "t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationActionView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationAddressView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationErrorView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationHeaderView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationLoadingView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationPostalCodeView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationViewController.o -index-store-path /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Index/DataStore -index-system-modules"
-            },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffb3a3442585c05abc61e290fc",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:24.929Z",
-            "file": {
-                "name": "swift-frontend",
-                "path": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend",
-                "type": "file",
-                "directory": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-            },
-            "ecs": {
-                "version": "8.0.0"
+                }
             },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561722844Z",
-                "original": "{\"event_simpleName\":\"CreateProcessArgs\",\"ContextTimeStamp\":\"1625677524.929\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365035560818271291\",\"ContextThreadId\":\"365035560818271291\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"CommandLine\":\"t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationActionView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationAddressView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationErrorView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationHeaderView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationLoadingView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationPostalCodeView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationViewController.o -index-store-path /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Index/DataStore -index-system-modules\",\"Entitlements\":\"15\",\"name\":\"CreateProcessArgsMac\",\"id\":\"ffffffff-1111-11eb-8332-020506b18db5\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffb3a3442585c05abc61e290fc\",\"timestamp\":\"1625677525128\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend\"}",
-                "created": "2021-07-07T17:05:25.128Z",
-                "kind": "state",
-                "action": "CreateProcessArgs",
-                "id": "ffffffff-1111-11eb-8332-020506b18db5",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "CreateProcessArgsMac",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:04:48.523Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "PdfFileWrittenMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "PdfFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:04:48.576Z",
+                "id": "ffffffff-1111-11eb-8903-022a1941b91f",
+                "ingested": "2022-03-22T18:19:46.426821800Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"PdfFileWritten\",\"ContextTimeStamp\":\"1625677488.523\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364156540965623394\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.13\",\"FileIdentifier\":\"05000001000000000000000000000000f1321d0000000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"PdfFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-8903-022a1941b91f\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffc4044541995bffd84b9df003\",\"timestamp\":\"1625677488576\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/pt/s9pzbbwd07q_0fxqvfhc513r0000gp/T/com.microsoft.Excel/Content.MSO/mso6ACABA95\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/private/var/folders/pt/s9pzbbwd07q_0fxqvfhc513r0000gp/T/com.microsoft.Excel/Content.MSO",
+                "inode": "05000001000000000000000000000000f1321d0000000000",
+                "name": "mso6ACABA95",
+                "path": "/private/var/folders/pt/s9pzbbwd07q_0fxqvfhc513r0000gp/T/com.microsoft.Excel/Content.MSO/mso6ACABA95",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffffc4044541995bffd84b9df003",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "364156540965623394",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
+                "ip": [
+                    "67.43.156.13"
+                ]
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffffc4044541995bffd84b9df003",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:48.523Z",
-            "file": {
-                "inode": "05000001000000000000000000000000f1321d0000000000",
-                "name": "mso6ACABA95",
-                "path": "/private/var/folders/pt/s9pzbbwd07q_0fxqvfhc513r0000gp/T/com.microsoft.Excel/Content.MSO/mso6ACABA95",
-                "type": "file",
-                "directory": "/private/var/folders/pt/s9pzbbwd07q_0fxqvfhc513r0000gp/T/com.microsoft.Excel/Content.MSO"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.13"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561723768Z",
-                "original": "{\"event_simpleName\":\"PdfFileWritten\",\"ContextTimeStamp\":\"1625677488.523\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364156540965623394\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.13\",\"FileIdentifier\":\"05000001000000000000000000000000f1321d0000000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"PdfFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-8903-022a1941b91f\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffc4044541995bffd84b9df003\",\"timestamp\":\"1625677488576\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/pt/s9pzbbwd07q_0fxqvfhc513r0000gp/T/com.microsoft.Excel/Content.MSO/mso6ACABA95\"}",
-                "created": "2021-07-07T17:04:48.576Z",
-                "kind": "event",
-                "action": "PdfFileWritten",
-                "id": "ffffffff-1111-11eb-8903-022a1941b91f",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "PdfFileWrittenMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:04:38.379Z",
-            "os": {
-                "type": "macos"
+            "crowdstrike": {
+                "AuthenticationId": "1119489580471877843",
+                "AuthenticationUuid": "ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2",
+                "AuthenticationUuidAsString": "ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2",
+                "ConfigStateHash": "3967242894",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "GroupIdentityMacV2"
             },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "GroupIdentity",
+                "created": "2021-07-07T17:04:38.379Z",
+                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
+                "ingested": "2022-03-22T18:19:46.426826300Z",
+                "original": "{\"event_simpleName\":\"GroupIdentity\",\"GID\":\"242\",\"AuthenticationUuidAsString\":\"ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"AuthenticationId\":\"1119489580471877843\",\"UserPrincipal\":\"user2@dom1\",\"UserSid\":\"S-1-5-21-3852557355-3178143607-2040168074-1485\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"GroupIdentityMacV2\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"AuthenticationUuid\":\"ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2\",\"timestamp\":\"1625677478379\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "related": {
-                "user": [
-                    "user2"
+                "hash": [
+                    "3967242894"
                 ],
                 "hosts": [
                     "67.43.156.13"
                 ],
-                "hash": [
-                    "3967242894"
-                ],
                 "ip": [
                     "67.43.156.13"
+                ],
+                "user": [
+                    "user2"
                 ]
-            },
-            "event": {
-                "action": "GroupIdentity",
-                "ingested": "2021-12-30T05:11:46.561724734Z",
-                "original": "{\"event_simpleName\":\"GroupIdentity\",\"GID\":\"242\",\"AuthenticationUuidAsString\":\"ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"AuthenticationId\":\"1119489580471877843\",\"UserPrincipal\":\"user2@dom1\",\"UserSid\":\"S-1-5-21-3852557355-3178143607-2040168074-1485\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"GroupIdentityMacV2\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"AuthenticationUuid\":\"ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2\",\"timestamp\":\"1625677478379\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
-                "created": "2021-07-07T17:04:38.379Z"
-            },
-            "crowdstrike": {
-                "AuthenticationUuidAsString": "ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2",
-                "ConfigStateHash": "3967242894",
-                "Entitlements": "15",
-                "name": "GroupIdentityMacV2",
-                "EffectiveTransmissionClass": "2",
-                "AuthenticationUuid": "ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2",
-                "AuthenticationId": "1119489580471877843",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "user": {
-                "full_name": "user2",
-                "id": "S-1-5-21-3852557355-3178143607-2040168074-1485",
-                "email": "user2@dom1",
-                "domain": "dom1",
-                "group": {
-                    "id": "242"
-                }
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            },
+            "user": {
+                "domain": "dom1",
+                "email": "user2@dom1",
+                "full_name": "user2",
+                "group": {
+                    "id": "242"
+                },
+                "id": "S-1-5-21-3852557355-3178143607-2040168074-1485"
+            }
         },
         {
+            "@timestamp": "2021-07-07T01:50:11.845Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3967242894",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "MachOSubType": "3",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "MachOFileWrittenMacV3"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "MachOFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:04:39.336Z",
+                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
+                "ingested": "2022-03-22T18:19:46.426832Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"MachOFileWritten\",\"ContextTimeStamp\":\"1625622611.845\",\"ConfigStateHash\":\"3967242894\",\"MachOSubType\":\"3\",\"ContextProcessId\":\"364938429384226082\",\"Size\":\"0\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.13\",\"SHA256HashData\":\"c0f50d27fe9fb31e33d1ce6577eeb4d4e17639095ad20575da018d1fcf955198\",\"FileIdentifier\":\"04000001000000000000000000000000ac41270400000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"MachOFileWrittenMacV3\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"timestamp\":\"1625677479336\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/bf/dwpvdj3d1tq00l8fgs5rd7x00000gn/T/.net.example.desktop.ev80yl\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "file": {
+                "directory": "/private/var/folders/bf/dwpvdj3d1tq00l8fgs5rd7x00000gn/T",
+                "extension": "ev80yl",
+                "hash": {
+                    "sha256": "c0f50d27fe9fb31e33d1ce6577eeb4d4e17639095ad20575da018d1fcf955198"
+                },
+                "inode": "04000001000000000000000000000000ac41270400000000",
+                "name": ".net.example.desktop.ev80yl",
+                "path": "/private/var/folders/bf/dwpvdj3d1tq00l8fgs5rd7x00000gn/T/.net.example.desktop.ev80yl",
+                "size": 0,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "364938429384226082",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T01:50:11.845Z",
-            "file": {
-                "inode": "04000001000000000000000000000000ac41270400000000",
-                "path": "/private/var/folders/bf/dwpvdj3d1tq00l8fgs5rd7x00000gn/T/.net.example.desktop.ev80yl",
-                "extension": "ev80yl",
-                "size": 0,
-                "name": ".net.example.desktop.ev80yl",
-                "type": "file",
-                "directory": "/private/var/folders/bf/dwpvdj3d1tq00l8fgs5rd7x00000gn/T",
-                "hash": {
-                    "sha256": "c0f50d27fe9fb31e33d1ce6577eeb4d4e17639095ad20575da018d1fcf955198"
-                }
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "c0f50d27fe9fb31e33d1ce6577eeb4d4e17639095ad20575da018d1fcf955198",
                     "3967242894"
                 ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561725644Z",
-                "original": "{\"event_simpleName\":\"MachOFileWritten\",\"ContextTimeStamp\":\"1625622611.845\",\"ConfigStateHash\":\"3967242894\",\"MachOSubType\":\"3\",\"ContextProcessId\":\"364938429384226082\",\"Size\":\"0\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.13\",\"SHA256HashData\":\"c0f50d27fe9fb31e33d1ce6577eeb4d4e17639095ad20575da018d1fcf955198\",\"FileIdentifier\":\"04000001000000000000000000000000ac41270400000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"MachOFileWrittenMacV3\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"timestamp\":\"1625677479336\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/bf/dwpvdj3d1tq00l8fgs5rd7x00000gn/T/.net.example.desktop.ev80yl\"}",
-                "created": "2021-07-07T17:04:39.336Z",
-                "kind": "event",
-                "action": "MachOFileWritten",
-                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "MachOFileWrittenMacV3",
-                "ConfigStateHash": "3967242894",
-                "MachOSubType": "3",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "process": {
-                "entity_id": "364938390018585510"
+            "@timestamp": "2021-07-07T01:50:08.014Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3967242894",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkListenIP6MacV10"
+            },
+            "destination": {
+                "address": "0:0:0:0:0:0:0:0",
+                "ip": "0:0:0:0:0:0:0:0",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkListenIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:04:38.929Z",
+                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
+                "ingested": "2022-03-22T18:19:46.426838300Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"NetworkListenIP6\",\"ContextTimeStamp\":\"1625622608.014\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:0\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:0\",\"ConfigStateHash\":\"3967242894\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"364938390018585510\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.13\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"8770\",\"Entitlements\":\"15\",\"name\":\"NetworkListenIP6MacV10\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677478929\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "network": {
+                "direction": "unknown",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
             },
             "os": {
                 "type": "macos"
             },
-            "destination": {
-                "port": 0,
-                "address": "0:0:0:0:0:0:0:0",
-                "ip": "0:0:0:0:0:0:0:0"
+            "process": {
+                "entity_id": "364938390018585510"
+            },
+            "related": {
+                "hash": [
+                    "3967242894"
+                ],
+                "hosts": [
+                    "67.43.156.13",
+                    "0:0:0:0:0:0:0:0"
+                ],
+                "ip": [
+                    "67.43.156.13",
+                    "0:0:0:0:0:0:0:0"
+                ]
             },
             "source": {
-                "port": 8770,
                 "address": "0:0:0:0:0:0:0:0",
-                "ip": "0:0:0:0:0:0:0:0"
-            },
-            "url": {
-                "scheme": "http"
+                "ip": "0:0:0:0:0:0:0:0",
+                "port": 8770
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "unknown"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff44564c2f8d76394cb25c31ab",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T01:50:08.014Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13",
-                    "0:0:0:0:0:0:0:0"
-                ],
-                "hash": [
-                    "3967242894"
-                ],
-                "ip": [
-                    "67.43.156.13",
-                    "0:0:0:0:0:0:0:0"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561726684Z",
-                "original": "{\"event_simpleName\":\"NetworkListenIP6\",\"ContextTimeStamp\":\"1625622608.014\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:0\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:0\",\"ConfigStateHash\":\"3967242894\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"364938390018585510\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.13\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LocalPort\":\"8770\",\"Entitlements\":\"15\",\"name\":\"NetworkListenIP6MacV10\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677478929\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:38.929Z",
-                "kind": "event",
-                "action": "NetworkListenIP6",
-                "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3967242894",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkListenIP6MacV10",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff62714a708030d494ca0a7e60",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:05:02.693Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561727680Z",
-                "original": "{\"event_simpleName\":\"CurrentSystemTags\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"SystemTableIndex\":\"0\",\"Entitlements\":\"15\",\"name\":\"CurrentSystemTagsMacV1\",\"id\":\"ffffffff-1111-11eb-b88d-06b7cb0d7bd7\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff62714a708030d494ca0a7e60\",\"Tags\":\"312, 11544872091698, 21990232555653, 21990232555859, 26388279066700, 26388279066703, 26388279066704, 26388279066705, 26388279066708, 26388279066849, 26388279066855, 26388279066948, 26388279066958, 26388279066970, 26388279067150, 26388279067174, 26388279067175, 26405458935929, 26405458935963, 26405458935964, 26405458936063, 26405458936087, 26405458936088, 26405458936130, 26405458936163, 26405458936164, 26405458936166, 26405458936167, 26405458936242, 26405458936306, 26405458936307, 26405458936357, 26405458936510, 26405458936511, 26405458936522, 26405458936523, 26422638805193, 26422638805230, 26422638805244, 26422638805245, 26422638805246, 26439818674539, 26439818674540, 26439818674541, 26439818674542, 26439818674543, 26439818674544, 26439818674614, 26439818674615, 26439818674616, 26439818674617, 26439818674678, 26439818674679, 26439818674680, 26439818674882, 26439818674883, 26439818674884, 26439818674894, 26439818674895, 26439818674896, 26456998543646, 26456998543647, 26456998543648, 26456998543649, 26456998543650, 26456998543651, 26456998543652, 26456998543653, 26456998543654, 26456998543656, 26456998543721, 26456998543722, 26456998543744, 26456998543793, 26456998543811, 26456998543903, 26456998543904, 26456998543950, 26456998543963, 26456998544000, 26456998544045, 26456998544086, 26456998544087, 26456998544115, 30803505447073, 30803505447074, 30803505447075, 30803505447076, 30803505447077, 30803505447078, 30803505447194, 30803505447195, 30803505447196, 30803505447528, 30803505447529, 30803505447530, 30803505447532, 30803505447533, 30803505447534, 30803505447537, 30803505447538, 30803505447539, 30803505447541, 30803505447542, 30803505447543, 30803505447567, 30803505447568, 30803505447569, 30803505447571, 30803505447572, 30803505447573, 30803505447575, 30803505447576, 30803505447577, 30803505447579, 30803505447580, 30803505447581, 30803505447583, 30803505447584\",\"timestamp\":\"1625677502693\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:02.693Z",
-                "kind": "state",
-                "action": "CurrentSystemTags",
-                "id": "ffffffff-1111-11eb-b88d-06b7cb0d7bd7",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "success"
-            },
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
-                "SystemTableIndex": 0,
-                "Entitlements": "15",
-                "name": "CurrentSystemTagsMacV1",
                 "EffectiveTransmissionClass": "0",
+                "Entitlements": "15",
+                "SystemTableIndex": 0,
                 "Tags": [
                     "312",
                     "11544872091698",
@@ -4315,165 +4265,156 @@
                     "30803505447583",
                     "30803505447584"
                 ],
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "CurrentSystemTagsMacV1"
             },
-            "url": {
-                "scheme": "http"
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "CurrentSystemTags",
+                "category": [
+                    "host"
+                ],
+                "created": "2021-07-07T17:05:02.693Z",
+                "id": "ffffffff-1111-11eb-b88d-06b7cb0d7bd7",
+                "ingested": "2022-03-22T18:19:46.426844800Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"CurrentSystemTags\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"SystemTableIndex\":\"0\",\"Entitlements\":\"15\",\"name\":\"CurrentSystemTagsMacV1\",\"id\":\"ffffffff-1111-11eb-b88d-06b7cb0d7bd7\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff62714a708030d494ca0a7e60\",\"Tags\":\"312, 11544872091698, 21990232555653, 21990232555859, 26388279066700, 26388279066703, 26388279066704, 26388279066705, 26388279066708, 26388279066849, 26388279066855, 26388279066948, 26388279066958, 26388279066970, 26388279067150, 26388279067174, 26388279067175, 26405458935929, 26405458935963, 26405458935964, 26405458936063, 26405458936087, 26405458936088, 26405458936130, 26405458936163, 26405458936164, 26405458936166, 26405458936167, 26405458936242, 26405458936306, 26405458936307, 26405458936357, 26405458936510, 26405458936511, 26405458936522, 26405458936523, 26422638805193, 26422638805230, 26422638805244, 26422638805245, 26422638805246, 26439818674539, 26439818674540, 26439818674541, 26439818674542, 26439818674543, 26439818674544, 26439818674614, 26439818674615, 26439818674616, 26439818674617, 26439818674678, 26439818674679, 26439818674680, 26439818674882, 26439818674883, 26439818674884, 26439818674894, 26439818674895, 26439818674896, 26456998543646, 26456998543647, 26456998543648, 26456998543649, 26456998543650, 26456998543651, 26456998543652, 26456998543653, 26456998543654, 26456998543656, 26456998543721, 26456998543722, 26456998543744, 26456998543793, 26456998543811, 26456998543903, 26456998543904, 26456998543950, 26456998543963, 26456998544000, 26456998544045, 26456998544086, 26456998544087, 26456998544115, 30803505447073, 30803505447074, 30803505447075, 30803505447076, 30803505447077, 30803505447078, 30803505447194, 30803505447195, 30803505447196, 30803505447528, 30803505447529, 30803505447530, 30803505447532, 30803505447533, 30803505447534, 30803505447537, 30803505447538, 30803505447539, 30803505447541, 30803505447542, 30803505447543, 30803505447567, 30803505447568, 30803505447569, 30803505447571, 30803505447572, 30803505447573, 30803505447575, 30803505447576, 30803505447577, 30803505447579, 30803505447580, 30803505447581, 30803505447583, 30803505447584\",\"timestamp\":\"1625677502693\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff62714a708030d494ca0a7e60",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:05:33.027Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "VnodeModificationType": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NewExecutableWrittenMacV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NewExecutableWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:05:33.060Z",
+                "id": "ffffffff-1111-11eb-985c-02152dd35bc1",
+                "ingested": "2022-03-22T18:19:46.426849200Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"NewExecutableWritten\",\"ContextTimeStamp\":\"1625677533.027\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"362208380891022165\",\"Size\":\"596224\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"70a06a11057efb22285a7200a53e5b6bae001fe0a98d4b23d0f6a31ad818a005\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"NewExecutableWrittenMacV2\",\"id\":\"ffffffff-1111-11eb-985c-02152dd35bc1\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff28414c2293e35c360213e723\",\"timestamp\":\"1625677533060\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.CVG7Ya/Zoom.app/Contents/MacOS/app_mode_loader\",\"VnodeModificationType\":\"0\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.CVG7Ya/Zoom.app/Contents/MacOS",
+                "hash": {
+                    "sha256": "70a06a11057efb22285a7200a53e5b6bae001fe0a98d4b23d0f6a31ad818a005"
+                },
+                "name": "app_mode_loader",
+                "path": "/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.CVG7Ya/Zoom.app/Contents/MacOS/app_mode_loader",
+                "size": 596224,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff28414c2293e35c360213e723",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "362208380891022165",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff28414c2293e35c360213e723",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:33.027Z",
-            "file": {
-                "name": "app_mode_loader",
-                "path": "/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.CVG7Ya/Zoom.app/Contents/MacOS/app_mode_loader",
-                "size": 596224,
-                "type": "file",
-                "directory": "/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.CVG7Ya/Zoom.app/Contents/MacOS",
-                "hash": {
-                    "sha256": "70a06a11057efb22285a7200a53e5b6bae001fe0a98d4b23d0f6a31ad818a005"
-                }
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "70a06a11057efb22285a7200a53e5b6bae001fe0a98d4b23d0f6a31ad818a005",
                     "1620585913"
                 ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561728816Z",
-                "original": "{\"event_simpleName\":\"NewExecutableWritten\",\"ContextTimeStamp\":\"1625677533.027\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"362208380891022165\",\"Size\":\"596224\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"70a06a11057efb22285a7200a53e5b6bae001fe0a98d4b23d0f6a31ad818a005\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"NewExecutableWrittenMacV2\",\"id\":\"ffffffff-1111-11eb-985c-02152dd35bc1\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff28414c2293e35c360213e723\",\"timestamp\":\"1625677533060\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.CVG7Ya/Zoom.app/Contents/MacOS/app_mode_loader\",\"VnodeModificationType\":\"0\"}",
-                "created": "2021-07-07T17:05:33.060Z",
-                "kind": "event",
-                "action": "NewExecutableWritten",
-                "id": "ffffffff-1111-11eb-985c-02152dd35bc1",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "NewExecutableWrittenMacV2",
-                "ConfigStateHash": "1620585913",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
-                "VnodeModificationType": "0"
-            }
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "fffffffffbea48169985c2c2bae89d1d",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:03:48.827Z",
-            "file": {
-                "name": "ruby",
-                "path": "/Users/user5/.rbenv/versions/2.6.5/bin/ruby",
-                "size": 3876424,
-                "type": "file",
-                "directory": "/Users/user5/.rbenv/versions/2.6.5/bin"
-            },
-            "os": {
-                "type": "macos"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
                 "hosts": [
                     "67.43.156.14"
                 ],
-                "hash": [
-                    "d7b56e2a06304ecd343985a1aaedff2eb32ee1151bba0e152aff97c778b7562a",
-                    "3090255842"
-                ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561729734Z",
-                "original": "{\"event_simpleName\":\"LfoUploadDataComplete\",\"LfoUploadFlags\":\"4\",\"AttemptNumber\":\"0\",\"ConfigStateHash\":\"3090255842\",\"SourceFileName\":\"/Users/user5/.rbenv/versions/2.6.5/bin/ruby\",\"Size\":\"3876424\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"d7b56e2a06304ecd343985a1aaedff2eb32ee1151bba0e152aff97c778b7562a\",\"UploadId\":\"8023668629276690295\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"LfoUploadDataCompleteMacV3\",\"id\":\"ffffffff-1111-11eb-a2ab-024aafff599f\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"fffffffffbea48169985c2c2bae89d1d\",\"Tags\":\"312, 11544872091698, 21990232555653, 21990232555859, 26388279066700, 26388279066703, 26388279066704, 26388279066705, 26388279066708, 26388279066849, 26388279066855, 26388279066948, 26388279066958, 26388279066970, 26388279067150, 26388279067174, 26388279067175, 26405458935929, 26405458935963, 26405458935964, 26405458936063, 26405458936087, 26405458936088, 26405458936130, 26405458936163, 26405458936164, 26405458936166, 26405458936167, 26405458936242, 26405458936306, 26405458936307, 26405458936357, 26405458936510, 26405458936511, 26405458936522, 26405458936523, 26422638805193, 26422638805230, 26422638805244, 26422638805245, 26422638805246, 26439818674539, 26439818674540, 26439818674541, 26439818674542, 26439818674543, 26439818674544, 26439818674614, 26439818674615, 26439818674616, 26439818674617, 26439818674678, 26439818674679, 26439818674680, 26439818674882, 26439818674883, 26439818674884, 26439818674894, 26439818674895, 26439818674896, 26456998543646, 26456998543647, 26456998543648, 26456998543649, 26456998543650, 26456998543651, 26456998543652, 26456998543653, 26456998543654, 26456998543656, 26456998543721, 26456998543722, 26456998543744, 26456998543793, 26456998543811, 26456998543903, 26456998543904, 26456998543950, 26456998543963, 26456998544000, 26456998544045, 26456998544086, 26456998544087, 26456998544115, 30803505447073, 30803505447074, 30803505447075, 30803505447076, 30803505447077, 30803505447078, 30803505447194, 30803505447195, 30803505447196, 30803505447528, 30803505447529, 30803505447530, 30803505447532, 30803505447533, 30803505447534, 30803505447537, 30803505447538, 30803505447539, 30803505447541, 30803505447542, 30803505447543, 30803505447567, 30803505447568, 30803505447569, 30803505447571, 30803505447572, 30803505447573, 30803505447575, 30803505447576, 30803505447577, 30803505447579, 30803505447580, 30803505447581, 30803505447583, 30803505447584\",\"timestamp\":\"1625677428827\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:03:48.827Z",
-                "kind": "event",
-                "action": "LfoUploadDataComplete",
-                "id": "ffffffff-1111-11eb-a2ab-024aafff599f",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:03:48.827Z",
             "crowdstrike": {
-                "LfoUploadFlags": "4",
                 "AttemptNumber": 0,
                 "ConfigStateHash": "3090255842",
-                "Entitlements": "15",
-                "name": "LfoUploadDataCompleteMacV3",
                 "EffectiveTransmissionClass": "2",
-                "UploadId": "8023668629276690295",
+                "Entitlements": "15",
+                "LfoUploadFlags": "4",
                 "Tags": [
                     "312",
                     "11544872091698",
@@ -4595,128 +4536,139 @@
                     "30803505447583",
                     "30803505447584"
                 ],
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "UploadId": "8023668629276690295",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LfoUploadDataCompleteMacV3"
             },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffd452449b8d1eb7d85b146650",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:13.146Z",
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "LfoUploadDataComplete",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:03:48.827Z",
+                "id": "ffffffff-1111-11eb-a2ab-024aafff599f",
+                "ingested": "2022-03-22T18:19:46.426854900Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"LfoUploadDataComplete\",\"LfoUploadFlags\":\"4\",\"AttemptNumber\":\"0\",\"ConfigStateHash\":\"3090255842\",\"SourceFileName\":\"/Users/user5/.rbenv/versions/2.6.5/bin/ruby\",\"Size\":\"3876424\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"d7b56e2a06304ecd343985a1aaedff2eb32ee1151bba0e152aff97c778b7562a\",\"UploadId\":\"8023668629276690295\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"LfoUploadDataCompleteMacV3\",\"id\":\"ffffffff-1111-11eb-a2ab-024aafff599f\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"fffffffffbea48169985c2c2bae89d1d\",\"Tags\":\"312, 11544872091698, 21990232555653, 21990232555859, 26388279066700, 26388279066703, 26388279066704, 26388279066705, 26388279066708, 26388279066849, 26388279066855, 26388279066948, 26388279066958, 26388279066970, 26388279067150, 26388279067174, 26388279067175, 26405458935929, 26405458935963, 26405458935964, 26405458936063, 26405458936087, 26405458936088, 26405458936130, 26405458936163, 26405458936164, 26405458936166, 26405458936167, 26405458936242, 26405458936306, 26405458936307, 26405458936357, 26405458936510, 26405458936511, 26405458936522, 26405458936523, 26422638805193, 26422638805230, 26422638805244, 26422638805245, 26422638805246, 26439818674539, 26439818674540, 26439818674541, 26439818674542, 26439818674543, 26439818674544, 26439818674614, 26439818674615, 26439818674616, 26439818674617, 26439818674678, 26439818674679, 26439818674680, 26439818674882, 26439818674883, 26439818674884, 26439818674894, 26439818674895, 26439818674896, 26456998543646, 26456998543647, 26456998543648, 26456998543649, 26456998543650, 26456998543651, 26456998543652, 26456998543653, 26456998543654, 26456998543656, 26456998543721, 26456998543722, 26456998543744, 26456998543793, 26456998543811, 26456998543903, 26456998543904, 26456998543950, 26456998543963, 26456998544000, 26456998544045, 26456998544086, 26456998544087, 26456998544115, 30803505447073, 30803505447074, 30803505447075, 30803505447076, 30803505447077, 30803505447078, 30803505447194, 30803505447195, 30803505447196, 30803505447528, 30803505447529, 30803505447530, 30803505447532, 30803505447533, 30803505447534, 30803505447537, 30803505447538, 30803505447539, 30803505447541, 30803505447542, 30803505447543, 30803505447567, 30803505447568, 30803505447569, 30803505447571, 30803505447572, 30803505447573, 30803505447575, 30803505447576, 30803505447577, 30803505447579, 30803505447580, 30803505447581, 30803505447583, 30803505447584\",\"timestamp\":\"1625677428827\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "file": {
+                "directory": "/Users/user5/.rbenv/versions/2.6.5/bin",
+                "name": "ruby",
+                "path": "/Users/user5/.rbenv/versions/2.6.5/bin/ruby",
+                "size": 3876424,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "fffffffffbea48169985c2c2bae89d1d",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "related": {
+                "hash": [
+                    "d7b56e2a06304ecd343985a1aaedff2eb32ee1151bba0e152aff97c778b7562a",
+                    "3090255842"
+                ],
                 "hosts": [
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "action": "LightningLatencyInfo",
-                "ingested": "2021-12-30T05:11:46.561730710Z",
-                "original": "{\"event_simpleName\":\"LightningLatencyInfo\",\"LightningLatencyState\":\"3\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"LightningLatencyInfoMacV1\",\"id\":\"ffffffff-1111-11eb-b44e-069a02b0ad6b\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffffd452449b8d1eb7d85b146650\",\"timestamp\":\"1625677453146\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "id": "ffffffff-1111-11eb-b44e-069a02b0ad6b",
-                "created": "2021-07-07T17:04:13.146Z"
-            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:04:13.146Z",
             "crowdstrike": {
-                "name": "LightningLatencyInfoMacV1",
-                "LightningLatencyState": "3",
                 "ConfigStateHash": "3090255842",
                 "EffectiveTransmissionClass": "0",
                 "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "LightningLatencyState": "3",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LightningLatencyInfoMacV1"
             },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff8eb649cf8d82be1e65629a0e",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:10.083Z",
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "LightningLatencyInfo",
+                "created": "2021-07-07T17:04:13.146Z",
+                "id": "ffffffff-1111-11eb-b44e-069a02b0ad6b",
+                "ingested": "2022-03-22T18:19:46.426862700Z",
+                "original": "{\"event_simpleName\":\"LightningLatencyInfo\",\"LightningLatencyState\":\"3\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"LightningLatencyInfoMacV1\",\"id\":\"ffffffff-1111-11eb-b44e-069a02b0ad6b\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffffd452449b8d1eb7d85b146650\",\"timestamp\":\"1625677453146\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffd452449b8d1eb7d85b146650",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "related": {
+                "hash": [
+                    "3090255842"
+                ],
                 "hosts": [
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "1620585913"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561731646Z",
-                "original": "{\"event_simpleName\":\"NeighborListIP4\",\"ConfigStateHash\":\"1620585913\",\"NeighborList\":\"40-C7-29-FF-FF-FF|192.168.2.1|1|64-9A-BE-FF-FF-FF|192.168.2.10|0|F0-FF-FF-FF-A0-14|192.168.2.43|0|DE-58-FF-FF-5D-3B|192.168.2.113|0|5E-AA-FF-FF-FF-20|192.168.2.128|0|44-FF-FF-FF-03-DD|192.168.2.136|0|EE-74-EE-EE-FF-0D|192.168.2.137|0|3A-FF-FF-FF-03-26|192.168.2.144|0|DE-79-FF-FF-FF-D4|192.168.2.145|0|0E-24-FF-EE-EE-87|192.168.2.152|0|CC-D9-AC-AF-66-F8|192.168.2.153|0|\",\"aip\":\"67.43.156.14\",\"InterfaceIndex\":\"6\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"NeighborListIP4MacV1\",\"id\":\"ffffffff-1111-11eb-9dc0-06c6f5278873\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff8eb649cf8d82be1e65629a0e\",\"timestamp\":\"1625677450083\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:10.083Z",
-                "kind": "state",
-                "action": "NeighborListIP4",
-                "id": "ffffffff-1111-11eb-9dc0-06c6f5278873",
-                "category": [
-                    "host",
-                    "network"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "unknown"
-            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:04:10.083Z",
             "crowdstrike": {
-                "InterfaceIndex": 6,
                 "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InterfaceIndex": 6,
                 "NeighborList": [
                     "40-C7-29-FF-FF-FF",
                     "192.168.2.1",
@@ -4752,409 +4704,406 @@
                     "192.168.2.153",
                     "0"
                 ],
-                "Entitlements": "15",
-                "name": "NeighborListIP4MacV1",
-                "EffectiveTransmissionClass": "3",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NeighborListIP4MacV1"
             },
-            "url": {
-                "scheme": "http"
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NeighborListIP4",
+                "category": [
+                    "host",
+                    "network"
+                ],
+                "created": "2021-07-07T17:04:10.083Z",
+                "id": "ffffffff-1111-11eb-9dc0-06c6f5278873",
+                "ingested": "2022-03-22T18:19:46.426868500Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"NeighborListIP4\",\"ConfigStateHash\":\"1620585913\",\"NeighborList\":\"40-C7-29-FF-FF-FF|192.168.2.1|1|64-9A-BE-FF-FF-FF|192.168.2.10|0|F0-FF-FF-FF-A0-14|192.168.2.43|0|DE-58-FF-FF-5D-3B|192.168.2.113|0|5E-AA-FF-FF-FF-20|192.168.2.128|0|44-FF-FF-FF-03-DD|192.168.2.136|0|EE-74-EE-EE-FF-0D|192.168.2.137|0|3A-FF-FF-FF-03-26|192.168.2.144|0|DE-79-FF-FF-FF-D4|192.168.2.145|0|0E-24-FF-EE-EE-87|192.168.2.152|0|CC-D9-AC-AF-66-F8|192.168.2.153|0|\",\"aip\":\"67.43.156.14\",\"InterfaceIndex\":\"6\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"NeighborListIP4MacV1\",\"id\":\"ffffffff-1111-11eb-9dc0-06c6f5278873\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff8eb649cf8d82be1e65629a0e\",\"timestamp\":\"1625677450083\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff8eb649cf8d82be1e65629a0e",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:04:14.557Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ZipFileWrittenMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ZipFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:04:14.723Z",
+                "id": "ffffffff-1111-11eb-ab6e-0668ec51180b",
+                "ingested": "2022-03-22T18:19:46.426874200Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"ZipFileWritten\",\"ContextTimeStamp\":\"1625677454.557\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365039419134863763\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"07000001000000000000000000000000b1445a0900000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ZipFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-ab6e-0668ec51180b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff2d984e32b702789b54f0f811\",\"timestamp\":\"1625677454723\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user6/Library/Developer/CoreSimulator/Devices/BCE6B46B-E863-4151-AA9D-D71C79438C47/data/Containers/Data/Application/1249A061-F246-4338-AE56-4373E918C9B4/Library/Application Support/com.instacart.instashopper/LogCache/2021-07-06T23:44:46.133Z.zip\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/Users/user6/Library/Developer/CoreSimulator/Devices/BCE6B46B-E863-4151-AA9D-D71C79438C47/data/Containers/Data/Application/1249A061-F246-4338-AE56-4373E918C9B4/Library/Application Support/com.instacart.instashopper/LogCache",
+                "extension": "zip",
+                "inode": "07000001000000000000000000000000b1445a0900000000",
+                "name": "2021-07-06T23:44:46.133Z.zip",
+                "path": "/Users/user6/Library/Developer/CoreSimulator/Devices/BCE6B46B-E863-4151-AA9D-D71C79438C47/data/Containers/Data/Application/1249A061-F246-4338-AE56-4373E918C9B4/Library/Application Support/com.instacart.instashopper/LogCache/2021-07-06T23:44:46.133Z.zip",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff2d984e32b702789b54f0f811",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "365039419134863763",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff2d984e32b702789b54f0f811",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:14.557Z",
-            "file": {
-                "inode": "07000001000000000000000000000000b1445a0900000000",
-                "name": "2021-07-06T23:44:46.133Z.zip",
-                "path": "/Users/user6/Library/Developer/CoreSimulator/Devices/BCE6B46B-E863-4151-AA9D-D71C79438C47/data/Containers/Data/Application/1249A061-F246-4338-AE56-4373E918C9B4/Library/Application Support/com.instacart.instashopper/LogCache/2021-07-06T23:44:46.133Z.zip",
-                "extension": "zip",
-                "type": "file",
-                "directory": "/Users/user6/Library/Developer/CoreSimulator/Devices/BCE6B46B-E863-4151-AA9D-D71C79438C47/data/Containers/Data/Application/1249A061-F246-4338-AE56-4373E918C9B4/Library/Application Support/com.instacart.instashopper/LogCache"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3090255842"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561732568Z",
-                "original": "{\"event_simpleName\":\"ZipFileWritten\",\"ContextTimeStamp\":\"1625677454.557\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365039419134863763\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"07000001000000000000000000000000b1445a0900000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ZipFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-ab6e-0668ec51180b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff2d984e32b702789b54f0f811\",\"timestamp\":\"1625677454723\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user6/Library/Developer/CoreSimulator/Devices/BCE6B46B-E863-4151-AA9D-D71C79438C47/data/Containers/Data/Application/1249A061-F246-4338-AE56-4373E918C9B4/Library/Application Support/com.instacart.instashopper/LogCache/2021-07-06T23:44:46.133Z.zip\"}",
-                "created": "2021-07-07T17:04:14.723Z",
-                "kind": "event",
-                "action": "ZipFileWritten",
-                "id": "ffffffff-1111-11eb-ab6e-0668ec51180b",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "ZipFileWrittenMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            }
-        },
-        {
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffbea440b9aad8b5bf222d303f",
-                "type": "agent",
-                "version": "6.24.13701.0"
-            },
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
             "@timestamp": "2021-07-07T17:04:05.731Z",
-            "file": {
-                "type": "file",
-                "path": "Zero"
+            "crowdstrike": {
+                "AgentLoadFlags": "0",
+                "AgentLocalTime": "2021-07-07T17:04:05.731Z",
+                "BiosManufacturer": "Apple Inc.",
+                "BiosReleaseDate": "01/06/2021",
+                "BiosVersion": "1554.80.3.0.0 (iBridge: 18.16.14347.0.0,0)",
+                "ChasisManufacturer": "Apple Inc.",
+                "ChassisType": "9",
+                "ConfigBuild": "1007.4.0013701.1",
+                "ConfigIDBase": "65994753",
+                "ConfigIDBuild": "13701",
+                "ConfigIDPlatform": "4",
+                "ConfigStateHash": "3967242894",
+                "ConfigurationVersion": "10",
+                "CpuFeaturesMask": "7494065083858915",
+                "CpuSignature": "591594",
+                "CpuVendor": "0",
+                "EffectiveTransmissionClass": "0",
+                "Entitlements": "15",
+                "MicrocodeSignature": "16045690984229358334",
+                "MoboManufacturer": "Apple Inc.",
+                "MoboProductName": "Mac-E1008331FDC96864",
+                "ProvisionState": "1",
+                "SystemManufacturer": "Apple Inc.",
+                "SystemProductName": "MacBookPro16,1",
+                "SystemSerialNumber": "C02F649EMD6R",
+                "SystemSku": " ",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "AgentOnlineMacV13"
             },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14",
-                    "comp2"
-                ],
-                "hash": [
-                    "3967242894"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "host": {
-                "name": "comp2",
-                "hostname": "comp2"
-            },
             "event": {
-                "ingested": "2021-12-30T05:11:46.561733483Z",
-                "original": "{\"AgentVersion\":\"6.24.13701.0\",\"aip\":\"67.43.156.14\",\"ConfigIDBase\":\"65994753\",\"BiosReleaseDate\":\"01/06/2021\",\"CpuFeaturesMask\":\"7494065083858915\",\"ChasisManufacturer\":\"Apple Inc.\",\"SystemSerialNumber\":\"C02F649EMD6R\",\"event_platform\":\"Mac\",\"AgentLoadFlags\":\"0\",\"CpuVendor\":\"0\",\"id\":\"ffffffff-1111-11eb-b3de-06a53f021cc9\",\"BiosVersion\":\"1554.80.3.0.0 (iBridge: 18.16.14347.0.0,0)\",\"CpuSignature\":\"591594\",\"EffectiveTransmissionClass\":\"0\",\"MoboProductName\":\"Mac-E1008331FDC96864\",\"timestamp\":\"1625677460451\",\"MicrocodeSignature\":\"16045690984229358334\",\"event_simpleName\":\"AgentOnline\",\"ContextTimeStamp\":\"1625677445.731\",\"SystemProductName\":\"MacBookPro16,1\",\"MoboManufacturer\":\"Apple Inc.\",\"ConfigStateHash\":\"3967242894\",\"ConfigBuild\":\"1007.4.0013701.1\",\"SystemSku\":\" \",\"SensorGroupingTags\":\"\",\"ConfigurationVersion\":\"10\",\"AgentLocalTime\":\"1625677445.731\",\"BiosManufacturer\":\"Apple Inc.\",\"Entitlements\":\"15\",\"name\":\"AgentOnlineMacV13\",\"ConfigIDPlatform\":\"4\",\"ComputerName\":\"comp2\",\"ChassisType\":\"9\",\"ConfigIDBuild\":\"13701\",\"SystemManufacturer\":\"Apple Inc.\",\"aid\":\"ffffffffbea440b9aad8b5bf222d303f\",\"ProvisionState\":\"1\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"Zero\"}",
-                "created": "2021-07-07T17:04:20.451Z",
-                "kind": "state",
                 "action": "AgentOnline",
-                "id": "ffffffff-1111-11eb-b3de-06a53f021cc9",
                 "category": [
                     "configuration",
                     "package",
                     "host"
                 ],
+                "created": "2021-07-07T17:04:20.451Z",
+                "id": "ffffffff-1111-11eb-b3de-06a53f021cc9",
+                "ingested": "2022-03-22T18:19:46.426878500Z",
+                "kind": "state",
+                "original": "{\"AgentVersion\":\"6.24.13701.0\",\"aip\":\"67.43.156.14\",\"ConfigIDBase\":\"65994753\",\"BiosReleaseDate\":\"01/06/2021\",\"CpuFeaturesMask\":\"7494065083858915\",\"ChasisManufacturer\":\"Apple Inc.\",\"SystemSerialNumber\":\"C02F649EMD6R\",\"event_platform\":\"Mac\",\"AgentLoadFlags\":\"0\",\"CpuVendor\":\"0\",\"id\":\"ffffffff-1111-11eb-b3de-06a53f021cc9\",\"BiosVersion\":\"1554.80.3.0.0 (iBridge: 18.16.14347.0.0,0)\",\"CpuSignature\":\"591594\",\"EffectiveTransmissionClass\":\"0\",\"MoboProductName\":\"Mac-E1008331FDC96864\",\"timestamp\":\"1625677460451\",\"MicrocodeSignature\":\"16045690984229358334\",\"event_simpleName\":\"AgentOnline\",\"ContextTimeStamp\":\"1625677445.731\",\"SystemProductName\":\"MacBookPro16,1\",\"MoboManufacturer\":\"Apple Inc.\",\"ConfigStateHash\":\"3967242894\",\"ConfigBuild\":\"1007.4.0013701.1\",\"SystemSku\":\" \",\"SensorGroupingTags\":\"\",\"ConfigurationVersion\":\"10\",\"AgentLocalTime\":\"1625677445.731\",\"BiosManufacturer\":\"Apple Inc.\",\"Entitlements\":\"15\",\"name\":\"AgentOnlineMacV13\",\"ConfigIDPlatform\":\"4\",\"ComputerName\":\"comp2\",\"ChassisType\":\"9\",\"ConfigIDBuild\":\"13701\",\"SystemManufacturer\":\"Apple Inc.\",\"aid\":\"ffffffffbea440b9aad8b5bf222d303f\",\"ProvisionState\":\"1\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"Zero\"}",
+                "outcome": "success",
                 "type": [
                     "change",
                     "installation",
                     "start"
-                ],
-                "outcome": "success"
+                ]
             },
-            "crowdstrike": {
-                "ConfigIDBase": "65994753",
-                "BiosReleaseDate": "01/06/2021",
-                "CpuFeaturesMask": "7494065083858915",
-                "ChasisManufacturer": "Apple Inc.",
-                "SystemSerialNumber": "C02F649EMD6R",
-                "AgentLoadFlags": "0",
-                "CpuVendor": "0",
-                "BiosVersion": "1554.80.3.0.0 (iBridge: 18.16.14347.0.0,0)",
-                "CpuSignature": "591594",
-                "EffectiveTransmissionClass": "0",
-                "MoboProductName": "Mac-E1008331FDC96864",
-                "MicrocodeSignature": "16045690984229358334",
-                "SystemProductName": "MacBookPro16,1",
-                "MoboManufacturer": "Apple Inc.",
-                "ConfigStateHash": "3967242894",
-                "ConfigBuild": "1007.4.0013701.1",
-                "SystemSku": " ",
-                "ConfigurationVersion": "10",
-                "AgentLocalTime": "2021-07-07T17:04:05.731Z",
-                "BiosManufacturer": "Apple Inc.",
-                "Entitlements": "15",
-                "name": "AgentOnlineMacV13",
-                "ConfigIDPlatform": "4",
-                "ChassisType": "9",
-                "ConfigIDBuild": "13701",
-                "SystemManufacturer": "Apple Inc.",
-                "ProvisionState": "1",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "file": {
+                "path": "Zero",
+                "type": "file"
+            },
+            "host": {
+                "hostname": "comp2",
+                "name": "comp2"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffbea440b9aad8b5bf222d303f",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "6.24.13701.0"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "3967242894"
+                ],
+                "hosts": [
+                    "67.43.156.14",
+                    "comp2"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:03:58.515Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "UnixMode": "384",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "CriticalFileAccessedMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "CriticalFileAccessed",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:03:58.553Z",
+                "id": "ffffffff-1111-11eb-956a-02748d01bd3d",
+                "ingested": "2022-03-22T18:19:46.426884900Z",
+                "kind": "alert",
+                "original": "{\"event_simpleName\":\"CriticalFileAccessed\",\"ContextTimeStamp\":\"1625677438.515\",\"GID\":\"0\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365053399098988534\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"0\",\"event_platform\":\"Mac\",\"UnixMode\":\"384\",\"Entitlements\":\"15\",\"name\":\"CriticalFileAccessedMacV1\",\"id\":\"ffffffff-1111-11eb-956a-02748d01bd3d\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff8eca418b7a861be9c5f7de1d\",\"timestamp\":\"1625677438553\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/db/dslocal/nodes/Default/users/daemon.plist\"}",
+                "outcome": "success",
+                "type": [
+                    "access"
+                ]
+            },
+            "file": {
+                "directory": "/private/var/db/dslocal/nodes/Default/users",
+                "extension": "plist",
+                "name": "daemon.plist",
+                "path": "/private/var/db/dslocal/nodes/Default/users/daemon.plist",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff8eca418b7a861be9c5f7de1d",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "365053399098988534",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff8eca418b7a861be9c5f7de1d",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:03:58.515Z",
-            "file": {
-                "name": "daemon.plist",
-                "path": "/private/var/db/dslocal/nodes/Default/users/daemon.plist",
-                "extension": "plist",
-                "type": "file",
-                "directory": "/private/var/db/dslocal/nodes/Default/users"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561734399Z",
-                "original": "{\"event_simpleName\":\"CriticalFileAccessed\",\"ContextTimeStamp\":\"1625677438.515\",\"GID\":\"0\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365053399098988534\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"0\",\"event_platform\":\"Mac\",\"UnixMode\":\"384\",\"Entitlements\":\"15\",\"name\":\"CriticalFileAccessedMacV1\",\"id\":\"ffffffff-1111-11eb-956a-02748d01bd3d\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff8eca418b7a861be9c5f7de1d\",\"timestamp\":\"1625677438553\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/db/dslocal/nodes/Default/users/daemon.plist\"}",
-                "created": "2021-07-07T17:03:58.553Z",
-                "kind": "alert",
-                "action": "CriticalFileAccessed",
-                "id": "ffffffff-1111-11eb-956a-02748d01bd3d",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "access"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "CriticalFileAccessedMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "UnixMode": "384",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "id": "0",
                 "group": {
                     "id": "0"
-                }
+                },
+                "id": "0"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffbea440b9aad8b5bf222d303f",
-                "type": "agent",
-                "version": "6.24.13701.0"
-            },
             "@timestamp": "2021-07-07T17:04:22.356Z",
+            "crowdstrike": {
+                "ConfigBuild": "1007.4.0013701.1",
+                "ConfigStateHash": "3967242894",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "MajorVersion": "19",
+                "MinorVersion": "6",
+                "OSVersionFileData": "3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d38223f3e0a3c21444f435459504520706c697374205055424c494320222d2f2f4170706c652f2f44544420504c49535420312e302f2f454e222022687474703a2f2f7777772e6170706c652e636f6d2f445444732f50726f70657274794c6973742d312e302e647464223e0a3c706c6973742076657273696f6e3d22312e30223e0a3c646963743e0a093c6b65793e50726f647563744275696c6456657273696f6e3c2f6b65793e0a093c737472696e673e3139483532343c2f737472696e673e0a093c6b65793e50726f64756374436f707972696768743c2f6b65793e0a093c737472696e673e313938332d32303231204170706c6520496e632e3c2f737472696e673e0a093c6b65793e50726f647563744e616d653c2f6b65793e0a093c737472696e673e4d6163204f5320583c2f737472696e673e0a093c6b65793e50726f647563745573657256697369626c6556657273696f6e3c2f6b65793e0a093c737472696e673e31302e31352e373c2f737472696e673e0a093c6b65793e50726f6475637456657273696f6e3c2f6b65793e0a093c737472696e673e31302e31352e373c2f737472696e673e0a093c6b65793e694f53537570706f727456657273696f6e3c2f6b65793e0a093c737472696e673e31332e363c2f737472696e673e0a3c2f646963743e0a3c2f706c6973743e0a",
+                "OSVersionFileName": "/System/Library/CoreServices/SystemVersion.plist",
+                "RFMState": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "OsVersionInfoMacV3"
+            },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
+            "event": {
+                "action": "OsVersionInfo",
+                "category": [
+                    "host"
                 ],
-                "hash": [
-                    "3967242894"
-                ],
-                "ip": [
-                    "67.43.156.14"
+                "created": "2021-07-07T17:04:22.356Z",
+                "id": "ffffffff-1111-11eb-b3de-06a53f021cc9",
+                "ingested": "2022-03-22T18:19:46.426890800Z",
+                "kind": "event",
+                "original": "{\"MajorVersion\":\"19\",\"event_simpleName\":\"OsVersionInfo\",\"OSVersionFileData\":\"3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d38223f3e0a3c21444f435459504520706c697374205055424c494320222d2f2f4170706c652f2f44544420504c49535420312e302f2f454e222022687474703a2f2f7777772e6170706c652e636f6d2f445444732f50726f70657274794c6973742d312e302e647464223e0a3c706c6973742076657273696f6e3d22312e30223e0a3c646963743e0a093c6b65793e50726f647563744275696c6456657273696f6e3c2f6b65793e0a093c737472696e673e3139483532343c2f737472696e673e0a093c6b65793e50726f64756374436f707972696768743c2f6b65793e0a093c737472696e673e313938332d32303231204170706c6520496e632e3c2f737472696e673e0a093c6b65793e50726f647563744e616d653c2f6b65793e0a093c737472696e673e4d6163204f5320583c2f737472696e673e0a093c6b65793e50726f647563745573657256697369626c6556657273696f6e3c2f6b65793e0a093c737472696e673e31302e31352e373c2f737472696e673e0a093c6b65793e50726f6475637456657273696f6e3c2f6b65793e0a093c737472696e673e31302e31352e373c2f737472696e673e0a093c6b65793e694f53537570706f727456657273696f6e3c2f6b65793e0a093c737472696e673e31332e363c2f737472696e673e0a3c2f646963743e0a3c2f706c6973743e0a\",\"ConfigStateHash\":\"3967242894\",\"AgentVersion\":\"6.24.13701.0\",\"aip\":\"67.43.156.14\",\"MinorVersion\":\"6\",\"OSVersionString\":\"Darwin Kernel Version 19.6.0: Tue Jan 12 22:13:05 PST 2021; root:xnu-6153.141.16~1/RELEASE_X86_64\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"OsVersionInfoMacV3\",\"RFMState\":\"0\",\"id\":\"ffffffff-1111-11eb-b3de-06a53f021cc9\",\"OSVersionFileName\":\"/System/Library/CoreServices/SystemVersion.plist\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffbea440b9aad8b5bf222d303f\",\"timestamp\":\"1625677462356\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "info"
                 ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffbea440b9aad8b5bf222d303f",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "6.24.13701.0"
             },
             "os": {
                 "type": "macos",
                 "version": "Darwin Kernel Version 19.6.0: Tue Jan 12 22:13:05 PST 2021; root:xnu-6153.141.16~1/RELEASE_X86_64"
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561735391Z",
-                "original": "{\"MajorVersion\":\"19\",\"event_simpleName\":\"OsVersionInfo\",\"OSVersionFileData\":\"3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d38223f3e0a3c21444f435459504520706c697374205055424c494320222d2f2f4170706c652f2f44544420504c49535420312e302f2f454e222022687474703a2f2f7777772e6170706c652e636f6d2f445444732f50726f70657274794c6973742d312e302e647464223e0a3c706c6973742076657273696f6e3d22312e30223e0a3c646963743e0a093c6b65793e50726f647563744275696c6456657273696f6e3c2f6b65793e0a093c737472696e673e3139483532343c2f737472696e673e0a093c6b65793e50726f64756374436f707972696768743c2f6b65793e0a093c737472696e673e313938332d32303231204170706c6520496e632e3c2f737472696e673e0a093c6b65793e50726f647563744e616d653c2f6b65793e0a093c737472696e673e4d6163204f5320583c2f737472696e673e0a093c6b65793e50726f647563745573657256697369626c6556657273696f6e3c2f6b65793e0a093c737472696e673e31302e31352e373c2f737472696e673e0a093c6b65793e50726f6475637456657273696f6e3c2f6b65793e0a093c737472696e673e31302e31352e373c2f737472696e673e0a093c6b65793e694f53537570706f727456657273696f6e3c2f6b65793e0a093c737472696e673e31332e363c2f737472696e673e0a3c2f646963743e0a3c2f706c6973743e0a\",\"ConfigStateHash\":\"3967242894\",\"AgentVersion\":\"6.24.13701.0\",\"aip\":\"67.43.156.14\",\"MinorVersion\":\"6\",\"OSVersionString\":\"Darwin Kernel Version 19.6.0: Tue Jan 12 22:13:05 PST 2021; root:xnu-6153.141.16~1/RELEASE_X86_64\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"OsVersionInfoMacV3\",\"RFMState\":\"0\",\"id\":\"ffffffff-1111-11eb-b3de-06a53f021cc9\",\"OSVersionFileName\":\"/System/Library/CoreServices/SystemVersion.plist\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffbea440b9aad8b5bf222d303f\",\"timestamp\":\"1625677462356\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:22.356Z",
-                "kind": "event",
-                "action": "OsVersionInfo",
-                "id": "ffffffff-1111-11eb-b3de-06a53f021cc9",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "MajorVersion": "19",
-                "ConfigBuild": "1007.4.0013701.1",
-                "OSVersionFileData": "3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d38223f3e0a3c21444f435459504520706c697374205055424c494320222d2f2f4170706c652f2f44544420504c49535420312e302f2f454e222022687474703a2f2f7777772e6170706c652e636f6d2f445444732f50726f70657274794c6973742d312e302e647464223e0a3c706c6973742076657273696f6e3d22312e30223e0a3c646963743e0a093c6b65793e50726f647563744275696c6456657273696f6e3c2f6b65793e0a093c737472696e673e3139483532343c2f737472696e673e0a093c6b65793e50726f64756374436f707972696768743c2f6b65793e0a093c737472696e673e313938332d32303231204170706c6520496e632e3c2f737472696e673e0a093c6b65793e50726f647563744e616d653c2f6b65793e0a093c737472696e673e4d6163204f5320583c2f737472696e673e0a093c6b65793e50726f647563745573657256697369626c6556657273696f6e3c2f6b65793e0a093c737472696e673e31302e31352e373c2f737472696e673e0a093c6b65793e50726f6475637456657273696f6e3c2f6b65793e0a093c737472696e673e31302e31352e373c2f737472696e673e0a093c6b65793e694f53537570706f727456657273696f6e3c2f6b65793e0a093c737472696e673e31332e363c2f737472696e673e0a3c2f646963743e0a3c2f706c6973743e0a",
-                "ConfigStateHash": "3967242894",
-                "Entitlements": "15",
-                "name": "OsVersionInfoMacV3",
-                "MinorVersion": "6",
-                "RFMState": "0",
-                "OSVersionFileName": "/System/Library/CoreServices/SystemVersion.plist",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff4f4044b689d6420d303e4ecd",
-                "type": "agent",
-                "version": "1007.8.0010912.1"
-            },
-            "@timestamp": "2021-07-07T17:03:56.454Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
+                "hash": [
+                    "3967242894"
+                ],
                 "hosts": [
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "1284133626"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "os": {
-                "type": "linux"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561736356Z",
-                "original": "{\"ConfigBuild\":\"1007.8.0010912.1\",\"event_simpleName\":\"ConfigStateUpdate\",\"event_platform\":\"Lin\",\"ConfigStateHash\":\"1284133626\",\"ConfigStateData\":\"0,0,1007.8.0010912.1|1,c,0|1,10,1|1,11,0|1,12,1|1,13,1|1,14,19|1,15,3|1,1f,4|1,22,3|1,3b,1|1,59,2d|1,d3,263|1,d4,0|1,eb,36|1,201,1|2,0,a8000000032,140000000085,18000000004c,18000000004f,180000000054,18000000022a,180000000248,180000000279,18000000027a,1800000002b4,180400000079,180400000225,180c00000133,180c00000285,181000000128,181000000180,18100000021f,181000000220,181000000280,1c0400000205|\",\"name\":\"ConfigStateUpdateLinV1\",\"aip\":\"67.43.156.14\",\"id\":\"ffffffff-1111-11eb-8e88-068a8894a447\",\"aid\":\"ffffffff4f4044b689d6420d303e4ecd\",\"timestamp\":\"1625677436454\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:03:56.454Z",
-                "kind": "event",
-                "action": "ConfigStateUpdate",
-                "id": "ffffffff-1111-11eb-8e88-068a8894a447",
-                "category": [
-                    "configuration"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:03:56.454Z",
             "crowdstrike": {
-                "name": "ConfigStateUpdateLinV1",
-                "ConfigStateHash": "1284133626",
                 "ConfigStateData": [
                     "0,0,1007.8.0010912.1",
                     "1,c,0",
@@ -5174,435 +5123,516 @@
                     "1,201,1",
                     "2,0,a8000000032,140000000085,18000000004c,18000000004f,180000000054,18000000022a,180000000248,180000000279,18000000027a,1800000002b4,180400000079,180400000225,180c00000133,180c00000285,181000000128,181000000180,18100000021f,181000000220,181000000280,1c0400000205"
                 ],
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "server": {
-                "subdomain": "lfodown01-b",
-                "registered_domain": "cloudsink.net",
-                "address": "lfodown01-b.cloudsink.net",
-                "top_level_domain": "net",
-                "domain": "lfodown01-b.cloudsink.net"
-            },
-            "os": {
-                "type": "linux"
-            },
-            "url": {
-                "path": "/osfm/linux/bde98295e6e5fa4c6ba2acfebc2e9943c836bf2223aebb8b29e03c44df43cb53",
-                "registered_domain": "cloudsink.net",
-                "original": "https://lfodown01-b.cloudsink.net/osfm/linux/bde98295e6e5fa4c6ba2acfebc2e9943c836bf2223aebb8b29e03c44df43cb53",
-                "scheme": "https",
-                "top_level_domain": "net",
-                "domain": "lfodown01-b.cloudsink.net",
-                "subdomain": "lfodown01-b"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff88b948c6abeeee910f6d8c33",
-                "type": "agent",
-                "version": "1007.8.0011611.1"
-            },
-            "@timestamp": "2021-07-07T17:02:45.906Z",
-            "file": {
-                "type": "file",
-                "path": "KernelModuleArchiveExt11611"
+                "ConfigStateHash": "1284133626",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ConfigStateUpdateLinV1"
             },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "ConfigStateUpdate",
+                "category": [
+                    "configuration"
+                ],
+                "created": "2021-07-07T17:03:56.454Z",
+                "id": "ffffffff-1111-11eb-8e88-068a8894a447",
+                "ingested": "2022-03-22T18:19:46.426895200Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.8.0010912.1\",\"event_simpleName\":\"ConfigStateUpdate\",\"event_platform\":\"Lin\",\"ConfigStateHash\":\"1284133626\",\"ConfigStateData\":\"0,0,1007.8.0010912.1|1,c,0|1,10,1|1,11,0|1,12,1|1,13,1|1,14,19|1,15,3|1,1f,4|1,22,3|1,3b,1|1,59,2d|1,d3,263|1,d4,0|1,eb,36|1,201,1|2,0,a8000000032,140000000085,18000000004c,18000000004f,180000000054,18000000022a,180000000248,180000000279,18000000027a,1800000002b4,180400000079,180400000225,180c00000133,180c00000285,181000000128,181000000180,18100000021f,181000000220,181000000280,1c0400000205|\",\"name\":\"ConfigStateUpdateLinV1\",\"aip\":\"67.43.156.14\",\"id\":\"ffffffff-1111-11eb-8e88-068a8894a447\",\"aid\":\"ffffffff4f4044b689d6420d303e4ecd\",\"timestamp\":\"1625677436454\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff4f4044b689d6420d303e4ecd",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0010912.1"
+            },
+            "os": {
+                "type": "linux"
+            },
             "related": {
+                "hash": [
+                    "1284133626"
+                ],
                 "hosts": [
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "1333055909"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561737278Z",
-                "original": "{\"event_simpleName\":\"LFODownloadConfirmation\",\"ConfigStateHash\":\"1333055909\",\"aip\":\"67.43.156.14\",\"DownloadServer\":\"lfodown01-b.cloudsink.net\",\"DownloadPath\":\"/osfm/linux/bde98295e6e5fa4c6ba2acfebc2e9943c836bf2223aebb8b29e03c44df43cb53\",\"DownloadPort\":\"443\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"name\":\"LFODownloadConfirmationLinV1\",\"CompletionEventId\":\"Event_KmaExtDownloadCompleteLinV1\",\"id\":\"ffffffff-1111-11eb-8dee-0201f64cca29\",\"aid\":\"ffffffff88b948c6abeeee910f6d8c33\",\"timestamp\":\"1625677365906\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"KernelModuleArchiveExt11611\"}",
-                "created": "2021-07-07T17:02:45.906Z",
-                "kind": "event",
-                "action": "LFODownloadConfirmation",
-                "id": "ffffffff-1111-11eb-8dee-0201f64cca29",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "LFODownloadConfirmationLinV1",
-                "CompletionEventId": "Event_KmaExtDownloadCompleteLinV1",
-                "ConfigStateHash": "1333055909",
-                "DownloadPort": 443,
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:02:45.906Z",
+            "crowdstrike": {
+                "CompletionEventId": "Event_KmaExtDownloadCompleteLinV1",
+                "ConfigStateHash": "1333055909",
+                "DownloadPort": 443,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LFODownloadConfirmationLinV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "LFODownloadConfirmation",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:02:45.906Z",
+                "id": "ffffffff-1111-11eb-8dee-0201f64cca29",
+                "ingested": "2022-03-22T18:19:46.426900700Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"LFODownloadConfirmation\",\"ConfigStateHash\":\"1333055909\",\"aip\":\"67.43.156.14\",\"DownloadServer\":\"lfodown01-b.cloudsink.net\",\"DownloadPath\":\"/osfm/linux/bde98295e6e5fa4c6ba2acfebc2e9943c836bf2223aebb8b29e03c44df43cb53\",\"DownloadPort\":\"443\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"name\":\"LFODownloadConfirmationLinV1\",\"CompletionEventId\":\"Event_KmaExtDownloadCompleteLinV1\",\"id\":\"ffffffff-1111-11eb-8dee-0201f64cca29\",\"aid\":\"ffffffff88b948c6abeeee910f6d8c33\",\"timestamp\":\"1625677365906\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"KernelModuleArchiveExt11611\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "path": "KernelModuleArchiveExt11611",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff88b948c6abeeee910f6d8c33",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011611.1"
+            },
+            "os": {
+                "type": "linux"
+            },
+            "related": {
+                "hash": [
+                    "1333055909"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "server": {
+                "address": "lfodown01-b.cloudsink.net",
+                "domain": "lfodown01-b.cloudsink.net",
+                "registered_domain": "cloudsink.net",
+                "subdomain": "lfodown01-b",
+                "top_level_domain": "net"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "lfodown01-b.cloudsink.net",
+                "original": "https://lfodown01-b.cloudsink.net/osfm/linux/bde98295e6e5fa4c6ba2acfebc2e9943c836bf2223aebb8b29e03c44df43cb53",
+                "path": "/osfm/linux/bde98295e6e5fa4c6ba2acfebc2e9943c836bf2223aebb8b29e03c44df43cb53",
+                "registered_domain": "cloudsink.net",
+                "scheme": "https",
+                "subdomain": "lfodown01-b",
+                "top_level_domain": "net"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:02:33.633Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "TarFileWrittenMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "TarFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:02:33.895Z",
+                "id": "ffffffff-1111-11eb-9497-028a0bfcf603",
+                "ingested": "2022-03-22T18:19:46.426904900Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"TarFileWritten\",\"ContextTimeStamp\":\"1625677353.633\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365049009681176519\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"050000010000000000000000000000005749420100000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"TarFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-9497-028a0bfcf603\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffe6244708bd09a6c111f63f4a\",\"timestamp\":\"1625677353895\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user7/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/cache/database_cleaner-1.8.5.gem\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/Users/user7/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/cache",
+                "extension": "gem",
+                "inode": "050000010000000000000000000000005749420100000000",
+                "name": "database_cleaner-1.8.5.gem",
+                "path": "/Users/user7/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/cache/database_cleaner-1.8.5.gem",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffe6244708bd09a6c111f63f4a",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "365049009681176519",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffe6244708bd09a6c111f63f4a",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:02:33.633Z",
-            "file": {
-                "inode": "050000010000000000000000000000005749420100000000",
-                "name": "database_cleaner-1.8.5.gem",
-                "path": "/Users/user7/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/cache/database_cleaner-1.8.5.gem",
-                "extension": "gem",
-                "type": "file",
-                "directory": "/Users/user7/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/cache"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561738191Z",
-                "original": "{\"event_simpleName\":\"TarFileWritten\",\"ContextTimeStamp\":\"1625677353.633\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"365049009681176519\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"FileIdentifier\":\"050000010000000000000000000000005749420100000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"TarFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-9497-028a0bfcf603\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffe6244708bd09a6c111f63f4a\",\"timestamp\":\"1625677353895\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user7/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/cache/database_cleaner-1.8.5.gem\"}",
-                "created": "2021-07-07T17:02:33.895Z",
-                "kind": "event",
-                "action": "TarFileWritten",
-                "id": "ffffffff-1111-11eb-9497-028a0bfcf603",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "TarFileWrittenMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff2977460db2898ece881a9358",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:02:30.466Z",
+            "crowdstrike": {
+                "ConfigIDBase": "65994753",
+                "ConfigIDBuild": "13701",
+                "ConfigIDPlatform": "4",
+                "ConfigStateHash": "3967242894",
+                "ConfigurationVersion": "10",
+                "ConnectTime": "2021-07-07T17:02:30.208Z",
+                "ConnectType": "1",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "FailedConnectCount": 404,
+                "NetworkContainmentState": "0",
+                "PreviousConnectTime": "2021-07-07T16:06:03.331Z",
+                "ProvisionState": "0",
+                "VerifiedCertificate": "7431e5f4c3c1ce4690774f0b61e05440883ba9a01ed00ba6abd7806ed3b118cf",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "AgentConnectMacV5"
+            },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3967242894"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "os": {
-                "type": "macos"
-            },
             "event": {
-                "ingested": "2021-12-30T05:11:46.561739118Z",
-                "original": "{\"event_simpleName\":\"AgentConnect\",\"ConfigStateHash\":\"3967242894\",\"NetworkContainmentState\":\"0\",\"VerifiedCertificate\":\"7431e5f4c3c1ce4690774f0b61e05440883ba9a01ed00ba6abd7806ed3b118cf\",\"aip\":\"67.43.156.14\",\"ConfigIDBase\":\"65994753\",\"FailedConnectCount\":\"404\",\"ConnectType\":\"1\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"ConfigurationVersion\":\"10\",\"Entitlements\":\"15\",\"name\":\"AgentConnectMacV5\",\"ConfigIDPlatform\":\"4\",\"PreviousConnectTime\":\"1625673963.331\",\"id\":\"ffffffff-1111-11eb-ba54-02a3616f6acd\",\"ConfigIDBuild\":\"13701\",\"ConnectTime\":\"1625677350.208\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff2977460db2898ece881a9358\",\"ProvisionState\":\"0\",\"timestamp\":\"1625677350466\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:02:30.466Z",
-                "kind": "event",
                 "action": "AgentConnect",
-                "id": "ffffffff-1111-11eb-ba54-02a3616f6acd",
                 "category": [
                     "network",
                     "session"
                 ],
+                "created": "2021-07-07T17:02:30.466Z",
+                "id": "ffffffff-1111-11eb-ba54-02a3616f6acd",
+                "ingested": "2022-03-22T18:19:46.426911600Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"AgentConnect\",\"ConfigStateHash\":\"3967242894\",\"NetworkContainmentState\":\"0\",\"VerifiedCertificate\":\"7431e5f4c3c1ce4690774f0b61e05440883ba9a01ed00ba6abd7806ed3b118cf\",\"aip\":\"67.43.156.14\",\"ConfigIDBase\":\"65994753\",\"FailedConnectCount\":\"404\",\"ConnectType\":\"1\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"ConfigurationVersion\":\"10\",\"Entitlements\":\"15\",\"name\":\"AgentConnectMacV5\",\"ConfigIDPlatform\":\"4\",\"PreviousConnectTime\":\"1625673963.331\",\"id\":\"ffffffff-1111-11eb-ba54-02a3616f6acd\",\"ConfigIDBuild\":\"13701\",\"ConnectTime\":\"1625677350.208\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff2977460db2898ece881a9358\",\"ProvisionState\":\"0\",\"timestamp\":\"1625677350466\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
                 "type": [
                     "connection",
                     "info"
-                ],
-                "outcome": "success"
+                ]
             },
-            "crowdstrike": {
-                "ConfigStateHash": "3967242894",
-                "NetworkContainmentState": "0",
-                "VerifiedCertificate": "7431e5f4c3c1ce4690774f0b61e05440883ba9a01ed00ba6abd7806ed3b118cf",
-                "ConfigIDBase": "65994753",
-                "FailedConnectCount": 404,
-                "ConnectType": "1",
-                "ConfigurationVersion": "10",
-                "Entitlements": "15",
-                "name": "AgentConnectMacV5",
-                "ConfigIDPlatform": "4",
-                "PreviousConnectTime": "2021-07-07T16:06:03.331Z",
-                "ConfigIDBuild": "13701",
-                "ConnectTime": "2021-07-07T17:02:30.208Z",
-                "EffectiveTransmissionClass": "2",
-                "ProvisionState": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "server": {
-                "subdomain": "lfodown01-b",
-                "registered_domain": "cloudsink.net",
-                "address": "lfodown01-b.cloudsink.net",
-                "top_level_domain": "net",
-                "domain": "lfodown01-b.cloudsink.net"
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff2977460db2898ece881a9358",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
             },
             "os": {
                 "type": "macos"
             },
-            "url": {
-                "path": "/metahash+/cfs/channelfiles/0000000503/66d5e9ea15754bcfb5f9152ec7ac90ac/C-00000503-00000000-00000001.sys",
-                "extension": "sys",
-                "registered_domain": "cloudsink.net",
-                "original": "https://lfodown01-b.cloudsink.net/metahash+/cfs/channelfiles/0000000503/66d5e9ea15754bcfb5f9152ec7ac90ac/C-00000503-00000000-00000001.sys",
-                "scheme": "https",
-                "top_level_domain": "net",
-                "domain": "lfodown01-b.cloudsink.net",
-                "subdomain": "lfodown01-b"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff5e8b4724aa10088c4f71cd9a",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:25.235Z",
-            "file": {
-                "type": "file",
-                "path": "C-00000503-00000000-00000001.sys"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
+                "hash": [
+                    "3967242894"
+                ],
                 "hosts": [
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561740114Z",
-                "original": "{\"event_simpleName\":\"LFODownloadConfirmation\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"DownloadServer\":\"lfodown01-b.cloudsink.net\",\"DownloadPath\":\"metahash+/cfs/channelfiles/0000000503/66d5e9ea15754bcfb5f9152ec7ac90ac/C-00000503-00000000-00000001.sys\",\"DownloadPort\":\"443\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"LFODownloadConfirmationMacV1\",\"CompletionEventId\":\"Event_ChannelDataDownloadCompleteMacV1\",\"id\":\"ffffffff-1111-11eb-8b09-069ee8920171\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff5e8b4724aa10088c4f71cd9a\",\"timestamp\":\"1625677525235\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"C-00000503-00000000-00000001.sys\"}",
-                "created": "2021-07-07T17:05:25.235Z",
-                "kind": "event",
-                "action": "LFODownloadConfirmation",
-                "id": "ffffffff-1111-11eb-8b09-069ee8920171",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3090255842",
-                "Entitlements": "15",
-                "name": "LFODownloadConfirmationMacV1",
-                "CompletionEventId": "Event_ChannelDataDownloadCompleteMacV1",
-                "EffectiveTransmissionClass": "0",
-                "DownloadPort": 443,
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:25.235Z",
+            "crowdstrike": {
+                "CompletionEventId": "Event_ChannelDataDownloadCompleteMacV1",
+                "ConfigStateHash": "3090255842",
+                "DownloadPort": 443,
+                "EffectiveTransmissionClass": "0",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LFODownloadConfirmationMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "LFODownloadConfirmation",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:05:25.235Z",
+                "id": "ffffffff-1111-11eb-8b09-069ee8920171",
+                "ingested": "2022-03-22T18:19:46.426919200Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"LFODownloadConfirmation\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"DownloadServer\":\"lfodown01-b.cloudsink.net\",\"DownloadPath\":\"metahash+/cfs/channelfiles/0000000503/66d5e9ea15754bcfb5f9152ec7ac90ac/C-00000503-00000000-00000001.sys\",\"DownloadPort\":\"443\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"LFODownloadConfirmationMacV1\",\"CompletionEventId\":\"Event_ChannelDataDownloadCompleteMacV1\",\"id\":\"ffffffff-1111-11eb-8b09-069ee8920171\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff5e8b4724aa10088c4f71cd9a\",\"timestamp\":\"1625677525235\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"C-00000503-00000000-00000001.sys\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "path": "C-00000503-00000000-00000001.sys",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff5e8b4724aa10088c4f71cd9a",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "server": {
+                "address": "lfodown01-b.cloudsink.net",
+                "domain": "lfodown01-b.cloudsink.net",
+                "registered_domain": "cloudsink.net",
+                "subdomain": "lfodown01-b",
+                "top_level_domain": "net"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "lfodown01-b.cloudsink.net",
+                "extension": "sys",
+                "original": "https://lfodown01-b.cloudsink.net/metahash+/cfs/channelfiles/0000000503/66d5e9ea15754bcfb5f9152ec7ac90ac/C-00000503-00000000-00000001.sys",
+                "path": "/metahash+/cfs/channelfiles/0000000503/66d5e9ea15754bcfb5f9152ec7ac90ac/C-00000503-00000000-00000001.sys",
+                "registered_domain": "cloudsink.net",
+                "scheme": "https",
+                "subdomain": "lfodown01-b",
+                "top_level_domain": "net"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:04:42.148Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "VnodeModificationType": "6",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "AsepFileChangeMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "AsepFileChange",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:04:42.403Z",
+                "id": "ffffffff-1111-11eb-9e50-064be6e56df7",
+                "ingested": "2022-03-22T18:19:46.426926400Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"AsepFileChange\",\"ContextTimeStamp\":\"1625677482.148\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"364936256754041721\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"AsepFileChangeMacV1\",\"id\":\"ffffffff-1111-11eb-9e50-064be6e56df7\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"fffffffff1a64286a233d09974b1b377\",\"timestamp\":\"1625677482403\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/5968e4faeba359dd5270ac282340cc4bd94d348c.asset/AssetData/payloadv2/ecc_data/System/Library/Spotlight/SystemPrefs.mdimporter/Contents/MacOS/SystemPrefs\",\"VnodeModificationType\":\"6\"}",
+                "outcome": "success",
+                "type": [
+                    "creation",
+                    "change"
+                ]
+            },
+            "file": {
+                "directory": "/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/5968e4faeba359dd5270ac282340cc4bd94d348c.asset/AssetData/payloadv2/ecc_data/System/Library/Spotlight/SystemPrefs.mdimporter/Contents/MacOS",
+                "name": "SystemPrefs",
+                "path": "/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/5968e4faeba359dd5270ac282340cc4bd94d348c.asset/AssetData/payloadv2/ecc_data/System/Library/Spotlight/SystemPrefs.mdimporter/Contents/MacOS/SystemPrefs",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "fffffffff1a64286a233d09974b1b377",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "364936256754041721",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "fffffffff1a64286a233d09974b1b377",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:04:42.148Z",
-            "file": {
-                "name": "SystemPrefs",
-                "path": "/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/5968e4faeba359dd5270ac282340cc4bd94d348c.asset/AssetData/payloadv2/ecc_data/System/Library/Spotlight/SystemPrefs.mdimporter/Contents/MacOS/SystemPrefs",
-                "type": "file",
-                "directory": "/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/5968e4faeba359dd5270ac282340cc4bd94d348c.asset/AssetData/payloadv2/ecc_data/System/Library/Spotlight/SystemPrefs.mdimporter/Contents/MacOS"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561741041Z",
-                "original": "{\"event_simpleName\":\"AsepFileChange\",\"ContextTimeStamp\":\"1625677482.148\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"364936256754041721\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"AsepFileChangeMacV1\",\"id\":\"ffffffff-1111-11eb-9e50-064be6e56df7\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"fffffffff1a64286a233d09974b1b377\",\"timestamp\":\"1625677482403\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/5968e4faeba359dd5270ac282340cc4bd94d348c.asset/AssetData/payloadv2/ecc_data/System/Library/Spotlight/SystemPrefs.mdimporter/Contents/MacOS/SystemPrefs\",\"VnodeModificationType\":\"6\"}",
-                "created": "2021-07-07T17:04:42.403Z",
-                "kind": "event",
-                "action": "AsepFileChange",
-                "id": "ffffffff-1111-11eb-9e50-064be6e56df7",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation",
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "AsepFileChangeMacV1",
-                "ConfigStateHash": "1620585913",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
-                "VnodeModificationType": "6"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:10.959Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1284133626",
+                "ContextProcessId": "130732827553316",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "TerminateProcessLinV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "TerminateProcess",
+                "category": [
+                    "process"
+                ],
+                "created": "2021-07-07T17:05:11.067Z",
+                "id": "ffffffff-1111-11eb-97d0-02b2813216eb",
+                "ingested": "2022-03-22T18:19:46.426930900Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"TerminateProcess\",\"RawProcessId\":\"76482\",\"ContextTimeStamp\":\"1625677510.959\",\"ConfigStateHash\":\"1284133626\",\"ContextProcessId\":\"130732827553316\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0010912.1\",\"event_platform\":\"Lin\",\"TargetProcessId\":\"130732827553316\",\"Entitlements\":\"15\",\"name\":\"TerminateProcessLinV2\",\"id\":\"ffffffff-1111-11eb-97d0-02b2813216eb\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffdd094539a02b394c69a70aaf\",\"timestamp\":\"1625677511067\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
                 "serial_number": "ffffffffdd094539a02b394c69a70aaf",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.8.0010912.1"
+            },
+            "os": {
+                "type": "linux"
             },
             "process": {
                 "entity_id": "130732827553316",
@@ -5611,409 +5641,326 @@
                     "id": 0
                 }
             },
-            "@timestamp": "2021-07-07T17:05:10.959Z",
-            "os": {
-                "type": "linux"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "1284133626"
                 ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561741996Z",
-                "original": "{\"event_simpleName\":\"TerminateProcess\",\"RawProcessId\":\"76482\",\"ContextTimeStamp\":\"1625677510.959\",\"ConfigStateHash\":\"1284133626\",\"ContextProcessId\":\"130732827553316\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0010912.1\",\"event_platform\":\"Lin\",\"TargetProcessId\":\"130732827553316\",\"Entitlements\":\"15\",\"name\":\"TerminateProcessLinV2\",\"id\":\"ffffffff-1111-11eb-97d0-02b2813216eb\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffdd094539a02b394c69a70aaf\",\"timestamp\":\"1625677511067\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:11.067Z",
-                "kind": "event",
-                "action": "TerminateProcess",
-                "id": "ffffffff-1111-11eb-97d0-02b2813216eb",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "TerminateProcessLinV2",
-                "ConfigStateHash": "1284133626",
-                "EffectiveTransmissionClass": "2",
-                "ContextProcessId": "130732827553316",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff70cf4070af024397f25007c7",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:02:52.544Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
                 "hosts": [
                     "67.43.156.14"
                 ],
-                "hash": [
-                    "3090255842"
-                ],
                 "ip": [
                     "67.43.156.14"
                 ]
-            },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561742908Z",
-                "original": "{\"ConfigBuild\":\"1007.4.0013701.1\",\"event_simpleName\":\"FirewallEnabled\",\"event_platform\":\"Mac\",\"ConfigStateHash\":\"3090255842\",\"Entitlements\":\"15\",\"name\":\"FirewallEnabledMacV1\",\"aip\":\"67.43.156.14\",\"id\":\"ffffffff-1111-11eb-a9e6-067d21325a03\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff70cf4070af024397f25007c7\",\"timestamp\":\"1625677372544\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:02:52.544Z",
-                "kind": "event",
-                "action": "FirewallEnabled",
-                "id": "ffffffff-1111-11eb-a9e6-067d21325a03",
-                "category": [
-                    "configuration",
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "FirewallEnabledMacV1",
-                "ConfigStateHash": "3090255842",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffed984e248973f3ada1eb543d",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:02:12.283Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561743822Z",
-                "original": "{\"event_simpleName\":\"FsVolumeUnmounted\",\"VolumeName\":\"Install Google Drive\",\"ContextTimeStamp\":\"1625677332.283\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"VolumeMediaBSDName\":\"disk2s2\",\"VolumeMountPoint\":\"/private/tmp/KSInstallAction.dn6J5Xa1M4/m\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"FsVolumeUnmountedMacV1\",\"id\":\"ffffffff-1111-11eb-8fd9-06866dcbd3d5\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffed984e248973f3ada1eb543d\",\"timestamp\":\"1625677334451\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"VolumeIsNetwork\":\"0\"}",
-                "created": "2021-07-07T17:02:14.451Z",
-                "kind": "event",
-                "action": "FsVolumeUnmounted",
-                "id": "ffffffff-1111-11eb-8fd9-06866dcbd3d5",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "VolumeName": "Install Google Drive",
-                "ConfigStateHash": "3090255842",
-                "Entitlements": "15",
-                "name": "FsVolumeUnmountedMacV1",
-                "VolumeMediaBSDName": "disk2s2",
-                "EffectiveTransmissionClass": "2",
-                "VolumeMountPoint": "/private/tmp/KSInstallAction.dn6J5Xa1M4/m",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
-                "VolumeIsNetwork": "0"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "process": {
-                "entity_id": "328911864662804336"
-            },
-            "os": {
-                "type": "linux"
-            },
-            "destination": {
-                "port": 0,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "source": {
-                "port": 23165,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "unknown"
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:02:52.544Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "FirewallEnabledMacV1"
             },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff2a0d484da8f7a9cf8bde7164",
-                "type": "agent",
-                "version": "1007.8.0011308.1"
-            },
-            "@timestamp": "2021-07-07T17:04:34.525Z",
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "FirewallEnabled",
+                "category": [
+                    "configuration",
+                    "host"
+                ],
+                "created": "2021-07-07T17:02:52.544Z",
+                "id": "ffffffff-1111-11eb-a9e6-067d21325a03",
+                "ingested": "2022-03-22T18:19:46.426936500Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.4.0013701.1\",\"event_simpleName\":\"FirewallEnabled\",\"event_platform\":\"Mac\",\"ConfigStateHash\":\"3090255842\",\"Entitlements\":\"15\",\"name\":\"FirewallEnabledMacV1\",\"aip\":\"67.43.156.14\",\"id\":\"ffffffff-1111-11eb-a9e6-067d21325a03\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff70cf4070af024397f25007c7\",\"timestamp\":\"1625677372544\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff70cf4070af024397f25007c7",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:02:12.283Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "VolumeIsNetwork": "0",
+                "VolumeMediaBSDName": "disk2s2",
+                "VolumeMountPoint": "/private/tmp/KSInstallAction.dn6J5Xa1M4/m",
+                "VolumeName": "Install Google Drive",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "FsVolumeUnmountedMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "FsVolumeUnmounted",
+                "category": [
+                    "host"
+                ],
+                "created": "2021-07-07T17:02:14.451Z",
+                "id": "ffffffff-1111-11eb-8fd9-06866dcbd3d5",
+                "ingested": "2022-03-22T18:19:46.426940600Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"FsVolumeUnmounted\",\"VolumeName\":\"Install Google Drive\",\"ContextTimeStamp\":\"1625677332.283\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"VolumeMediaBSDName\":\"disk2s2\",\"VolumeMountPoint\":\"/private/tmp/KSInstallAction.dn6J5Xa1M4/m\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"FsVolumeUnmountedMacV1\",\"id\":\"ffffffff-1111-11eb-8fd9-06866dcbd3d5\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffed984e248973f3ada1eb543d\",\"timestamp\":\"1625677334451\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"VolumeIsNetwork\":\"0\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffed984e248973f3ada1eb543d",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:04:34.525Z",
+            "crowdstrike": {
+                "ConfigStateHash": "2300098580",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NetworkListenIP4LinV5"
+            },
+            "destination": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkListenIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2021-07-07T17:04:34.879Z",
+                "id": "ffffffff-1111-11eb-88fd-06a17d0fdc05",
+                "ingested": "2022-03-22T18:19:46.426946800Z",
+                "kind": "event",
+                "original": "{\"LocalAddressIP4\":\"0.0.0.0\",\"event_simpleName\":\"NetworkListenIP4\",\"ContextTimeStamp\":\"1625677474.525\",\"ConfigStateHash\":\"2300098580\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"328911864662804336\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"23165\",\"Entitlements\":\"15\",\"name\":\"NetworkListenIP4LinV5\",\"id\":\"ffffffff-1111-11eb-88fd-06a17d0fdc05\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff2a0d484da8f7a9cf8bde7164\",\"RemoteAddressIP4\":\"0.0.0.0\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677474879\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "network": {
+                "direction": "unknown",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff2a0d484da8f7a9cf8bde7164",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0011308.1"
+            },
+            "os": {
+                "type": "linux"
+            },
+            "process": {
+                "entity_id": "328911864662804336"
+            },
+            "related": {
+                "hash": [
+                    "2300098580"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "0.0.0.0"
-                ],
-                "hash": [
-                    "2300098580"
                 ],
                 "ip": [
                     "67.43.156.14",
                     "0.0.0.0"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561744824Z",
-                "original": "{\"LocalAddressIP4\":\"0.0.0.0\",\"event_simpleName\":\"NetworkListenIP4\",\"ContextTimeStamp\":\"1625677474.525\",\"ConfigStateHash\":\"2300098580\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"328911864662804336\",\"RemotePort\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.8.0011308.1\",\"event_platform\":\"Lin\",\"LocalPort\":\"23165\",\"Entitlements\":\"15\",\"name\":\"NetworkListenIP4LinV5\",\"id\":\"ffffffff-1111-11eb-88fd-06a17d0fdc05\",\"Protocol\":\"6\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff2a0d484da8f7a9cf8bde7164\",\"RemoteAddressIP4\":\"0.0.0.0\",\"ConnectionDirection\":\"2\",\"InContext\":\"0\",\"timestamp\":\"1625677474879\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:34.879Z",
-                "kind": "event",
-                "action": "NetworkListenIP4",
-                "id": "ffffffff-1111-11eb-88fd-06a17d0fdc05",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
+            "source": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 23165
             },
-            "crowdstrike": {
-                "ConfigStateHash": "2300098580",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkListenIP4LinV5",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2021-07-07T17:05:26.828Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1620585913",
+                "ELFSubType": "4",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "ELFFileWrittenMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ELFFileWritten",
+                "created": "2021-07-07T17:05:27.114Z",
+                "id": "ffffffff-1111-11eb-985c-02152dd35bc1",
+                "ingested": "2022-03-22T18:19:46.426951800Z",
+                "original": "{\"event_simpleName\":\"ELFFileWritten\",\"ContextTimeStamp\":\"1625677526.828\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"363122200934575406\",\"Size\":\"38798952\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"35e590a61d32b72651b0cd23594d04f4671d79a843106136cf6abc324cc19027\",\"FileIdentifier\":\"040000010000000000000000000000006793f80200000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ELFFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-985c-02152dd35bc1\",\"ELFSubType\":\"4\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff28414c2293e35c360213e723\",\"timestamp\":\"1625677527114\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.M2zGjQ/_platform_specific/x86-64/zoom_x86_64.nexe\"}"
+            },
+            "file": {
+                "directory": "/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.M2zGjQ/_platform_specific/x86-64",
+                "extension": "nexe",
+                "hash": {
+                    "sha256": "35e590a61d32b72651b0cd23594d04f4671d79a843106136cf6abc324cc19027"
+                },
+                "inode": "040000010000000000000000000000006793f80200000000",
+                "name": "zoom_x86_64.nexe",
+                "path": "/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.M2zGjQ/_platform_specific/x86-64/zoom_x86_64.nexe",
+                "size": 38798952,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff28414c2293e35c360213e723",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "363122200934575406",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff28414c2293e35c360213e723",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:05:26.828Z",
-            "file": {
-                "inode": "040000010000000000000000000000006793f80200000000",
-                "path": "/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.M2zGjQ/_platform_specific/x86-64/zoom_x86_64.nexe",
-                "extension": "nexe",
-                "size": 38798952,
-                "name": "zoom_x86_64.nexe",
-                "type": "file",
-                "directory": "/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.M2zGjQ/_platform_specific/x86-64",
-                "hash": {
-                    "sha256": "35e590a61d32b72651b0cd23594d04f4671d79a843106136cf6abc324cc19027"
-                }
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "35e590a61d32b72651b0cd23594d04f4671d79a843106136cf6abc324cc19027",
                     "1620585913"
                 ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "action": "ELFFileWritten",
-                "ingested": "2021-12-30T05:11:46.561745760Z",
-                "original": "{\"event_simpleName\":\"ELFFileWritten\",\"ContextTimeStamp\":\"1625677526.828\",\"ConfigStateHash\":\"1620585913\",\"ContextProcessId\":\"363122200934575406\",\"Size\":\"38798952\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"35e590a61d32b72651b0cd23594d04f4671d79a843106136cf6abc324cc19027\",\"FileIdentifier\":\"040000010000000000000000000000006793f80200000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ELFFileWrittenMacV1\",\"id\":\"ffffffff-1111-11eb-985c-02152dd35bc1\",\"ELFSubType\":\"4\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff28414c2293e35c360213e723\",\"timestamp\":\"1625677527114\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/folders/3c/z7j1h7dx3nz3xkl10c1vyxgh0000gp/T/.com.google.Chrome.M2zGjQ/_platform_specific/x86-64/zoom_x86_64.nexe\"}",
-                "id": "ffffffff-1111-11eb-985c-02152dd35bc1",
-                "created": "2021-07-07T17:05:27.114Z"
-            },
-            "crowdstrike": {
-                "name": "ELFFileWrittenMacV1",
-                "ConfigStateHash": "1620585913",
-                "ELFSubType": "4",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            }
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff2d1245c0a32d5efcf9351272",
-                "type": "agent",
-                "version": "6.19.11611.0"
-            },
-            "@timestamp": "2021-07-07T17:03:03.466Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
                 "hosts": [
                     "67.43.156.14"
                 ],
-                "hash": [
-                    "3712162471"
-                ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "os": {
-                "type": "linux",
-                "version": "Linux localhost 4.14.232-176.381.amzn2.x86_64 #1 SMP Wed May 19 00:31:54 UTC 2021 x86_64"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561746686Z",
-                "original": "{\"MajorVersion\":\"4\",\"event_simpleName\":\"OsVersionInfo\",\"OSVersionFileData\":\"4e414d453d22416d617a6f6e204c696e7578220a56455253494f4e3d2232220a49443d22616d7a6e220a49445f4c494b453d2263656e746f73207268656c206665646f7261220a56455253494f4e5f49443d2232220a5052455454595f4e414d453d22416d617a6f6e204c696e75782032220a414e53495f434f4c4f523d22303b3333220a4350455f4e414d453d226370653a322e333a6f3a616d617a6f6e3a616d617a6f6e5f6c696e75783a32220a484f4d455f55524c3d2268747470733a2f2f616d617a6f6e6c696e75782e636f6d2f220a\",\"BootArgs\":\"BOOT_IMAGE\\u003d/boot/vmlinuz-4.14.232-176.381.amzn2.x86_64 root\\u003dUUID\\u003d9f548782-8f9f-4dd9-873a-436ea8f3e8a6 ro console\\u003dtty0 console\\u003dttyS0,115200n8 net.ifnames\\u003d0 biosdevname\\u003d0 nvme_core.io_timeout\\u003d4294967295 rd.emergency\\u003dpoweroff rd.shell\\u003d0\",\"ConfigStateHash\":\"3712162471\",\"AgentVersion\":\"6.19.11611.0\",\"aip\":\"67.43.156.14\",\"MinorVersion\":\"14\",\"OSVersionString\":\"Linux localhost 4.14.232-176.381.amzn2.x86_64 #1 SMP Wed May 19 00:31:54 UTC 2021 x86_64\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"name\":\"OsVersionInfoLinV4\",\"RFMState\":\"1\",\"id\":\"ffffffff-1111-11eb-93d4-0624c36f3a79\",\"OSVersionFileName\":\"/etc/os-release\",\"aid\":\"ffffffff2d1245c0a32d5efcf9351272\",\"timestamp\":\"1625677383466\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:03:03.466Z",
-                "kind": "event",
-                "action": "OsVersionInfo",
-                "id": "ffffffff-1111-11eb-93d4-0624c36f3a79",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "success"
-            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:03:03.466Z",
             "crowdstrike": {
-                "MajorVersion": "4",
-                "ConfigBuild": "1007.8.0011611.1",
-                "OSVersionFileData": "4e414d453d22416d617a6f6e204c696e7578220a56455253494f4e3d2232220a49443d22616d7a6e220a49445f4c494b453d2263656e746f73207268656c206665646f7261220a56455253494f4e5f49443d2232220a5052455454595f4e414d453d22416d617a6f6e204c696e75782032220a414e53495f434f4c4f523d22303b3333220a4350455f4e414d453d226370653a322e333a6f3a616d617a6f6e3a616d617a6f6e5f6c696e75783a32220a484f4d455f55524c3d2268747470733a2f2f616d617a6f6e6c696e75782e636f6d2f220a",
                 "BootArgs": [
                     "BOOT_IMAGE=/boot/vmlinuz-4.14.232-176.381.amzn2.x86_64",
                     "root=UUID=9f548782-8f9f-4dd9-873a-436ea8f3e8a6",
@@ -6026,443 +5973,534 @@
                     "rd.emergency=poweroff",
                     "rd.shell=0"
                 ],
+                "ConfigBuild": "1007.8.0011611.1",
                 "ConfigStateHash": "3712162471",
-                "name": "OsVersionInfoLinV4",
+                "MajorVersion": "4",
                 "MinorVersion": "14",
-                "RFMState": "1",
+                "OSVersionFileData": "4e414d453d22416d617a6f6e204c696e7578220a56455253494f4e3d2232220a49443d22616d7a6e220a49445f4c494b453d2263656e746f73207268656c206665646f7261220a56455253494f4e5f49443d2232220a5052455454595f4e414d453d22416d617a6f6e204c696e75782032220a414e53495f434f4c4f523d22303b3333220a4350455f4e414d453d226370653a322e333a6f3a616d617a6f6e3a616d617a6f6e5f6c696e75783a32220a484f4d455f55524c3d2268747470733a2f2f616d617a6f6e6c696e75782e636f6d2f220a",
                 "OSVersionFileName": "/etc/os-release",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "RFMState": "1",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "OsVersionInfoLinV4"
             },
-            "url": {
-                "scheme": "http"
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "OsVersionInfo",
+                "category": [
+                    "host"
+                ],
+                "created": "2021-07-07T17:03:03.466Z",
+                "id": "ffffffff-1111-11eb-93d4-0624c36f3a79",
+                "ingested": "2022-03-22T18:19:46.426957300Z",
+                "kind": "event",
+                "original": "{\"MajorVersion\":\"4\",\"event_simpleName\":\"OsVersionInfo\",\"OSVersionFileData\":\"4e414d453d22416d617a6f6e204c696e7578220a56455253494f4e3d2232220a49443d22616d7a6e220a49445f4c494b453d2263656e746f73207268656c206665646f7261220a56455253494f4e5f49443d2232220a5052455454595f4e414d453d22416d617a6f6e204c696e75782032220a414e53495f434f4c4f523d22303b3333220a4350455f4e414d453d226370653a322e333a6f3a616d617a6f6e3a616d617a6f6e5f6c696e75783a32220a484f4d455f55524c3d2268747470733a2f2f616d617a6f6e6c696e75782e636f6d2f220a\",\"BootArgs\":\"BOOT_IMAGE\\u003d/boot/vmlinuz-4.14.232-176.381.amzn2.x86_64 root\\u003dUUID\\u003d9f548782-8f9f-4dd9-873a-436ea8f3e8a6 ro console\\u003dtty0 console\\u003dttyS0,115200n8 net.ifnames\\u003d0 biosdevname\\u003d0 nvme_core.io_timeout\\u003d4294967295 rd.emergency\\u003dpoweroff rd.shell\\u003d0\",\"ConfigStateHash\":\"3712162471\",\"AgentVersion\":\"6.19.11611.0\",\"aip\":\"67.43.156.14\",\"MinorVersion\":\"14\",\"OSVersionString\":\"Linux localhost 4.14.232-176.381.amzn2.x86_64 #1 SMP Wed May 19 00:31:54 UTC 2021 x86_64\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"name\":\"OsVersionInfoLinV4\",\"RFMState\":\"1\",\"id\":\"ffffffff-1111-11eb-93d4-0624c36f3a79\",\"OSVersionFileName\":\"/etc/os-release\",\"aid\":\"ffffffff2d1245c0a32d5efcf9351272\",\"timestamp\":\"1625677383466\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff2d1245c0a32d5efcf9351272",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "6.19.11611.0"
+            },
+            "os": {
+                "type": "linux",
+                "version": "Linux localhost 4.14.232-176.381.amzn2.x86_64 #1 SMP Wed May 19 00:31:54 UTC 2021 x86_64"
+            },
+            "related": {
+                "hash": [
+                    "3712162471"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:03:59.099Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "USN": "89566685",
+                "UnixMode": "384",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "CriticalFileModifiedMacV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "CriticalFileModified",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:03:59.398Z",
+                "id": "ffffffff-1111-11eb-9262-0268ab613b49",
+                "ingested": "2022-03-22T18:19:46.426965200Z",
+                "kind": "alert",
+                "original": "{\"event_simpleName\":\"CriticalFileModified\",\"ContextTimeStamp\":\"1625677439.099\",\"GID\":\"0\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364849347227309005\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.13\",\"FileIdentifier\":\"04000001000000000000000000000000cdf3100100000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"0\",\"USN\":\"89566685\",\"event_platform\":\"Mac\",\"UnixMode\":\"384\",\"Entitlements\":\"15\",\"name\":\"CriticalFileModifiedMacV2\",\"id\":\"ffffffff-1111-11eb-9262-0268ab613b49\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff761b4a7d9962dd9e7e776044\",\"timestamp\":\"1625677439398\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/db/dslocal/nodes/Default/users/user9.plist/\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "file": {
+                "directory": "/private/var/db/dslocal/nodes/Default/users",
+                "inode": "04000001000000000000000000000000cdf3100100000000",
+                "name": "user9.plist",
+                "path": "/private/var/db/dslocal/nodes/Default/users/user9.plist/",
+                "type": "dir"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff761b4a7d9962dd9e7e776044",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "364849347227309005",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
+                "ip": [
+                    "67.43.156.13"
+                ]
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff761b4a7d9962dd9e7e776044",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:03:59.099Z",
-            "file": {
-                "inode": "04000001000000000000000000000000cdf3100100000000",
-                "name": "user9.plist",
-                "path": "/private/var/db/dslocal/nodes/Default/users/user9.plist/",
-                "type": "dir",
-                "directory": "/private/var/db/dslocal/nodes/Default/users"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.13"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561747605Z",
-                "original": "{\"event_simpleName\":\"CriticalFileModified\",\"ContextTimeStamp\":\"1625677439.099\",\"GID\":\"0\",\"ConfigStateHash\":\"3090255842\",\"ContextProcessId\":\"364849347227309005\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.13\",\"FileIdentifier\":\"04000001000000000000000000000000cdf3100100000000\",\"ConfigBuild\":\"1007.4.0013701.1\",\"UID\":\"0\",\"USN\":\"89566685\",\"event_platform\":\"Mac\",\"UnixMode\":\"384\",\"Entitlements\":\"15\",\"name\":\"CriticalFileModifiedMacV2\",\"id\":\"ffffffff-1111-11eb-9262-0268ab613b49\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff761b4a7d9962dd9e7e776044\",\"timestamp\":\"1625677439398\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/private/var/db/dslocal/nodes/Default/users/user9.plist/\"}",
-                "created": "2021-07-07T17:03:59.398Z",
-                "kind": "alert",
-                "action": "CriticalFileModified",
-                "id": "ffffffff-1111-11eb-9262-0268ab613b49",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "USN": "89566685",
-                "ConfigStateHash": "3090255842",
-                "UnixMode": "384",
-                "Entitlements": "15",
-                "name": "CriticalFileModifiedMacV2",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "id": "0",
                 "group": {
                     "id": "0"
-                }
+                },
+                "id": "0"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff01c7450180352a7c58a28fb4",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:04:49.786Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561748550Z",
-                "original": "{\"event_simpleName\":\"NeighborListIP6\",\"ConfigStateHash\":\"3090255842\",\"NeighborList\":\"1C-AB-C0-9B-10-A2|2607:fea8:720:1bc8:1eab:c0ff:fe9b:10a2|0|\",\"aip\":\"67.43.156.14\",\"InterfaceIndex\":\"6\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"NeighborListIP6MacV1\",\"id\":\"ffffffff-1111-11eb-ac8a-06b5e1186139\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff01c7450180352a7c58a28fb4\",\"timestamp\":\"1625677489786\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:04:49.786Z",
-                "kind": "state",
-                "action": "NeighborListIP6",
-                "id": "ffffffff-1111-11eb-ac8a-06b5e1186139",
-                "category": [
-                    "host",
-                    "network"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "unknown"
-            },
             "crowdstrike": {
-                "InterfaceIndex": 6,
                 "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InterfaceIndex": 6,
                 "NeighborList": [
                     "1C-AB-C0-9B-10-A2",
                     "2607:fea8:720:1bc8:1eab:c0ff:fe9b:10a2",
                     "0"
                 ],
-                "Entitlements": "15",
-                "name": "NeighborListIP6MacV1",
-                "EffectiveTransmissionClass": "3",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NeighborListIP6MacV1"
             },
-            "url": {
-                "scheme": "http"
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NeighborListIP6",
+                "category": [
+                    "host",
+                    "network"
+                ],
+                "created": "2021-07-07T17:04:49.786Z",
+                "id": "ffffffff-1111-11eb-ac8a-06b5e1186139",
+                "ingested": "2022-03-22T18:19:46.426972900Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"NeighborListIP6\",\"ConfigStateHash\":\"3090255842\",\"NeighborList\":\"1C-AB-C0-9B-10-A2|2607:fea8:720:1bc8:1eab:c0ff:fe9b:10a2|0|\",\"aip\":\"67.43.156.14\",\"InterfaceIndex\":\"6\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"NeighborListIP6MacV1\",\"id\":\"ffffffff-1111-11eb-ac8a-06b5e1186139\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"ffffffff01c7450180352a7c58a28fb4\",\"timestamp\":\"1625677489786\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "unknown",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff01c7450180352a7c58a28fb4",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2021-07-07T17:03:02.785Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1325353086",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "IsOnRemovableDisk": "0",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "NewScriptWrittenMacV3"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NewScriptWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2021-07-07T17:03:03.057Z",
+                "id": "ffffffff-1111-11eb-9dc1-029257dbe83b",
+                "ingested": "2022-03-22T18:19:46.426980600Z",
+                "kind": "event",
+                "original": "{\"event_simpleName\":\"NewScriptWritten\",\"ContextTimeStamp\":\"1625677382.785\",\"UserName\":\"user3\",\"ConfigStateHash\":\"1325353086\",\"ContextProcessId\":\"364952259879648742\",\"Size\":\"8052\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"359fd6e9a46f605d491225325125502ca6ba99a73ac3141f59af96627f128fc6\",\"FileIdentifier\":\"04000001000000000000000000000000ef07570000000000\",\"ConfigBuild\":\"1007.4.0013806.1\",\"event_platform\":\"Mac\",\"IsOnRemovableDisk\":\"0\",\"Entitlements\":\"15\",\"name\":\"NewScriptWrittenMacV3\",\"id\":\"ffffffff-1111-11eb-9dc1-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffcebd42c0890d59b54279d3d3\",\"timestamp\":\"1625677383057\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user3/git/it_eng_scripts/depnotify_starter/dep_notify_starter.sh\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "/Users/user3/git/it_eng_scripts/depnotify_starter",
+                "extension": "sh",
+                "inode": "04000001000000000000000000000000ef07570000000000",
+                "name": "dep_notify_starter.sh",
+                "path": "/Users/user3/git/it_eng_scripts/depnotify_starter/dep_notify_starter.sh",
+                "size": 8052,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffcebd42c0890d59b54279d3d3",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013806.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "364952259879648742",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffcebd42c0890d59b54279d3d3",
-                "type": "agent",
-                "version": "1007.4.0013806.1"
-            },
-            "@timestamp": "2021-07-07T17:03:02.785Z",
-            "file": {
-                "inode": "04000001000000000000000000000000ef07570000000000",
-                "path": "/Users/user3/git/it_eng_scripts/depnotify_starter/dep_notify_starter.sh",
-                "extension": "sh",
-                "size": 8052,
-                "name": "dep_notify_starter.sh",
-                "type": "file",
-                "directory": "/Users/user3/git/it_eng_scripts/depnotify_starter"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "user": [
-                    "user3"
-                ],
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "359fd6e9a46f605d491225325125502ca6ba99a73ac3141f59af96627f128fc6",
                     "1325353086"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
+                ],
+                "user": [
+                    "user3"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561749545Z",
-                "original": "{\"event_simpleName\":\"NewScriptWritten\",\"ContextTimeStamp\":\"1625677382.785\",\"UserName\":\"user3\",\"ConfigStateHash\":\"1325353086\",\"ContextProcessId\":\"364952259879648742\",\"Size\":\"8052\",\"ContextThreadId\":\"0\",\"aip\":\"67.43.156.14\",\"SHA256HashData\":\"359fd6e9a46f605d491225325125502ca6ba99a73ac3141f59af96627f128fc6\",\"FileIdentifier\":\"04000001000000000000000000000000ef07570000000000\",\"ConfigBuild\":\"1007.4.0013806.1\",\"event_platform\":\"Mac\",\"IsOnRemovableDisk\":\"0\",\"Entitlements\":\"15\",\"name\":\"NewScriptWrittenMacV3\",\"id\":\"ffffffff-1111-11eb-9dc1-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffffcebd42c0890d59b54279d3d3\",\"timestamp\":\"1625677383057\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"TargetFileName\":\"/Users/user3/git/it_eng_scripts/depnotify_starter/dep_notify_starter.sh\"}",
-                "created": "2021-07-07T17:03:03.057Z",
-                "kind": "event",
-                "action": "NewScriptWritten",
-                "id": "ffffffff-1111-11eb-9dc1-029257dbe83b",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "NewScriptWrittenMacV3",
-                "ConfigStateHash": "1325353086",
-                "EffectiveTransmissionClass": "2",
-                "IsOnRemovableDisk": "0",
-                "Entitlements": "15",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "name": "user3"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "fffffffff2c7432859ff6bbe1a0bd6af",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:03:07.216Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
-                "hash": [
-                    "1620585913"
-                ],
-                "ip": [
-                    "67.43.156.13"
-                ]
-            },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561750478Z",
-                "original": "{\"event_simpleName\":\"SystemCapacity\",\"ConfigStateHash\":\"1620585913\",\"aip\":\"67.43.156.13\",\"CpuClockSpeed\":\"2400000000\",\"PhysicalCoreCount\":\"8\",\"CpuFeaturesMask\":\"7494065083908067\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LogicalCoreCount\":\"16\",\"Entitlements\":\"15\",\"name\":\"SystemCapacityMacV1\",\"CpuVendor\":\"0\",\"CpuProcessorName\":\"Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz\",\"id\":\"ffffffff-1111-11eb-b714-066001392751\",\"CpuSignature\":\"591597\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"fffffffff2c7432859ff6bbe1a0bd6af\",\"ProcessorPackageCount\":\"1\",\"MemoryTotal\":\"17179869184\",\"timestamp\":\"1625677387216\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:03:07.216Z",
-                "kind": "state",
-                "action": "SystemCapacity",
-                "id": "ffffffff-1111-11eb-b714-066001392751",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "success"
-            },
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
                 "CpuClockSpeed": "2400000000",
-                "PhysicalCoreCount": 8,
                 "CpuFeaturesMask": "7494065083908067",
-                "LogicalCoreCount": 16,
-                "Entitlements": "15",
-                "name": "SystemCapacityMacV1",
-                "CpuVendor": "0",
                 "CpuProcessorName": "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz",
                 "CpuSignature": "591597",
+                "CpuVendor": "0",
                 "EffectiveTransmissionClass": "3",
-                "ProcessorPackageCount": 1,
+                "Entitlements": "15",
+                "LogicalCoreCount": 16,
                 "MemoryTotal": "17179869184",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
+                "PhysicalCoreCount": 8,
+                "ProcessorPackageCount": 1,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "SystemCapacityMacV1"
             },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff0d7b4d839912e55b4755e85b",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
-            "@timestamp": "2021-07-07T17:02:48.429Z",
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
+            "event": {
+                "action": "SystemCapacity",
+                "category": [
+                    "host"
                 ],
+                "created": "2021-07-07T17:03:07.216Z",
+                "id": "ffffffff-1111-11eb-b714-066001392751",
+                "ingested": "2022-03-22T18:19:46.426988500Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"SystemCapacity\",\"ConfigStateHash\":\"1620585913\",\"aip\":\"67.43.156.13\",\"CpuClockSpeed\":\"2400000000\",\"PhysicalCoreCount\":\"8\",\"CpuFeaturesMask\":\"7494065083908067\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"LogicalCoreCount\":\"16\",\"Entitlements\":\"15\",\"name\":\"SystemCapacityMacV1\",\"CpuVendor\":\"0\",\"CpuProcessorName\":\"Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz\",\"id\":\"ffffffff-1111-11eb-b714-066001392751\",\"CpuSignature\":\"591597\",\"EffectiveTransmissionClass\":\"3\",\"aid\":\"fffffffff2c7432859ff6bbe1a0bd6af\",\"ProcessorPackageCount\":\"1\",\"MemoryTotal\":\"17179869184\",\"timestamp\":\"1625677387216\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "fffffffff2c7432859ff6bbe1a0bd6af",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
+                "hash": [
+                    "1620585913"
+                ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
+                "ip": [
+                    "67.43.156.13"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2021-07-07T17:02:48.429Z",
+            "crowdstrike": {
+                "BootTimeFunctionalityLevel": "255",
+                "ConfigStateHash": "3090255842",
+                "CurrentFunctionalityLevel": "2",
+                "EffectiveTransmissionClass": "0",
+                "Entitlements": "15",
+                "FirmwareAnalysisEclConsumerInterfaceVersion": "0",
+                "FirmwareAnalysisEclControlInterfaceVersion": "0",
+                "PciAttachmentState": "65535",
+                "ReasonOfFunctionalityLevel": "3",
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "FirmwareAnalysisStatusMacV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "FirmwareAnalysisStatus",
+                "category": [
+                    "host"
+                ],
+                "created": "2021-07-07T17:02:48.429Z",
+                "id": "ffffffff-1111-11eb-ba57-0214a0d89bf7",
+                "ingested": "2022-03-22T18:19:46.426996500Z",
+                "kind": "state",
+                "original": "{\"event_simpleName\":\"FirmwareAnalysisStatus\",\"ConfigStateHash\":\"3090255842\",\"FirmwareAnalysisEclControlInterfaceVersion\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"FirmwareAnalysisEclConsumerInterfaceVersion\":\"0\",\"BootTimeFunctionalityLevel\":\"255\",\"ReasonOfFunctionalityLevel\":\"3\",\"CurrentFunctionalityLevel\":\"2\",\"Entitlements\":\"15\",\"name\":\"FirmwareAnalysisStatusMacV2\",\"id\":\"ffffffff-1111-11eb-ba57-0214a0d89bf7\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff0d7b4d839912e55b4755e85b\",\"timestamp\":\"1625677368429\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"PciAttachmentState\":\"65535\"}",
+                "outcome": "success",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff0d7b4d839912e55b4755e85b",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "related": {
                 "hash": [
                     "3090255842"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "os": {
-                "type": "macos"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561751505Z",
-                "original": "{\"event_simpleName\":\"FirmwareAnalysisStatus\",\"ConfigStateHash\":\"3090255842\",\"FirmwareAnalysisEclControlInterfaceVersion\":\"0\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"FirmwareAnalysisEclConsumerInterfaceVersion\":\"0\",\"BootTimeFunctionalityLevel\":\"255\",\"ReasonOfFunctionalityLevel\":\"3\",\"CurrentFunctionalityLevel\":\"2\",\"Entitlements\":\"15\",\"name\":\"FirmwareAnalysisStatusMacV2\",\"id\":\"ffffffff-1111-11eb-ba57-0214a0d89bf7\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff0d7b4d839912e55b4755e85b\",\"timestamp\":\"1625677368429\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\",\"PciAttachmentState\":\"65535\"}",
-                "created": "2021-07-07T17:02:48.429Z",
-                "kind": "state",
-                "action": "FirmwareAnalysisStatus",
-                "id": "ffffffff-1111-11eb-ba57-0214a0d89bf7",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "FirmwareAnalysisEclConsumerInterfaceVersion": "0",
-                "ConfigStateHash": "3090255842",
-                "FirmwareAnalysisEclControlInterfaceVersion": "0",
-                "BootTimeFunctionalityLevel": "255",
-                "ReasonOfFunctionalityLevel": "3",
-                "CurrentFunctionalityLevel": "2",
-                "Entitlements": "15",
-                "name": "FirmwareAnalysisStatusMacV2",
-                "EffectiveTransmissionClass": "0",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
-                "PciAttachmentState": "65535"
-            },
-            "url": {
-                "scheme": "http"
-            },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff557f4b99a0afdea9ce8cd6fa",
-                "type": "agent",
-                "version": "1007.4.0013701.1"
-            },
             "@timestamp": "2021-07-07T17:05:04.544Z",
-            "os": {
-                "type": "macos"
+            "crowdstrike": {
+                "ConfigStateHash": "3090255842",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "InDiscards": "0",
+                "InErrors": "0",
+                "InMulticastPkts": "0",
+                "InOctets": "0",
+                "InUcastPkts": "0",
+                "InUnknownProtos": "0",
+                "InterfaceAlias": "utun2",
+                "InterfaceIndex": 17,
+                "InterfaceType": "1",
+                "NetLuidIndex": 2,
+                "OutErrors": "0",
+                "OutMulticastPkts": "0",
+                "OutOctets": "0",
+                "OutUcastPkts": "0",
+                "PhysicalAddressLength": 0,
+                "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
+                "name": "LocalIpAddressIP4MacV1"
             },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "LocalIpAddressIP4",
+                "category": [
+                    "configuration",
+                    "host"
+                ],
+                "created": "2021-07-07T17:05:04.544Z",
+                "id": "ffffffff-1111-11eb-a272-0294ad12fbe7",
+                "ingested": "2022-03-22T18:19:46.427004400Z",
+                "kind": "state",
+                "original": "{\"OutOctets\":\"0\",\"CreationTimeStamp\":\"\",\"aip\":\"67.43.156.13\",\"OutMulticastPkts\":\"0\",\"InErrors\":\"0\",\"InterfaceAlias\":\"utun2\",\"InDiscards\":\"0\",\"InterfaceIndex\":\"17\",\"event_platform\":\"Mac\",\"InterfaceType\":\"1\",\"id\":\"ffffffff-1111-11eb-a272-0294ad12fbe7\",\"PhysicalAddressLength\":\"0\",\"InUcastPkts\":\"0\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677504544\",\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"LocalIpAddressIP4\",\"ConfigStateHash\":\"3090255842\",\"PhysicalAddress\":\"\",\"OutErrors\":\"0\",\"InUnknownProtos\":\"0\",\"OutUcastPkts\":\"0\",\"InMulticastPkts\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"InOctets\":\"0\",\"NetLuidIndex\":\"2\",\"Entitlements\":\"15\",\"name\":\"LocalIpAddressIP4MacV1\",\"aid\":\"ffffffff557f4b99a0afdea9ce8cd6fa\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff557f4b99a0afdea9ce8cd6fa",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0013701.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "related": {
+                "hash": [
+                    "3090255842"
+                ],
                 "hosts": [
                     "67.43.156.13",
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "3090255842"
                 ],
                 "ip": [
                     "67.43.156.13",
@@ -6470,604 +6508,568 @@
                 ]
             },
             "source": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
+                "address": "67.43.156.14",
                 "as": {
                     "number": 35908
                 },
-                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
                 "ip": "67.43.156.14"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561752430Z",
-                "original": "{\"OutOctets\":\"0\",\"CreationTimeStamp\":\"\",\"aip\":\"67.43.156.13\",\"OutMulticastPkts\":\"0\",\"InErrors\":\"0\",\"InterfaceAlias\":\"utun2\",\"InDiscards\":\"0\",\"InterfaceIndex\":\"17\",\"event_platform\":\"Mac\",\"InterfaceType\":\"1\",\"id\":\"ffffffff-1111-11eb-a272-0294ad12fbe7\",\"PhysicalAddressLength\":\"0\",\"InUcastPkts\":\"0\",\"EffectiveTransmissionClass\":\"2\",\"timestamp\":\"1625677504544\",\"LocalAddressIP4\":\"67.43.156.14\",\"event_simpleName\":\"LocalIpAddressIP4\",\"ConfigStateHash\":\"3090255842\",\"PhysicalAddress\":\"\",\"OutErrors\":\"0\",\"InUnknownProtos\":\"0\",\"OutUcastPkts\":\"0\",\"InMulticastPkts\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"InOctets\":\"0\",\"NetLuidIndex\":\"2\",\"Entitlements\":\"15\",\"name\":\"LocalIpAddressIP4MacV1\",\"aid\":\"ffffffff557f4b99a0afdea9ce8cd6fa\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}",
-                "created": "2021-07-07T17:05:04.544Z",
-                "kind": "state",
-                "action": "LocalIpAddressIP4",
-                "id": "ffffffff-1111-11eb-a272-0294ad12fbe7",
-                "category": [
-                    "configuration",
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "OutOctets": "0",
-                "ConfigStateHash": "3090255842",
-                "OutMulticastPkts": "0",
-                "InErrors": "0",
-                "OutErrors": "0",
-                "InUnknownProtos": "0",
-                "OutUcastPkts": "0",
-                "InterfaceAlias": "utun2",
-                "InDiscards": "0",
-                "InMulticastPkts": "0",
-                "InterfaceIndex": 17,
-                "InterfaceType": "1",
-                "InOctets": "0",
-                "NetLuidIndex": 2,
-                "Entitlements": "15",
-                "name": "LocalIpAddressIP4MacV1",
-                "PhysicalAddressLength": 0,
-                "InUcastPkts": "0",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff15754bcfb5f9152ec7ac90ac"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2020-11-08T17:04:59.681Z",
+            "crowdstrike": {
+                "ConfigStateHash": "4288861242",
+                "Entitlements": "15",
+                "NDRoot": "321385814512398584",
+                "RGID": "0",
+                "RUID": "0",
+                "SVGID": "0",
+                "SVUID": "0",
+                "SessionProcessId": "314116638974342642",
+                "SourceProcessId": "321385814512398584",
+                "SourceThreadId": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "ProcessRollup2LinV5"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2",
+                "category": [
+                    "process"
+                ],
+                "created": "2020-11-08T17:04:59.681Z",
+                "id": "ffffffff-1111-11eb-ac87-06decddc17a1",
+                "ingested": "2022-03-22T18:19:46.427012100Z",
+                "kind": "event",
+                "original": "{\"CommandLine\":\"uname -a\",\"ConfigBuild\":\"1007.8.0009806.1\",\"ConfigStateHash\":\"4288861242\",\"Entitlements\":\"15\",\"GID\":\"0\",\"ImageFileName\":\"/bin/uname\",\"MD5HashData\":\"894356eb59e279696c304f07091b7fde\",\"NDRoot\":\"321385814512398584\",\"ParentProcessId\":\"321385814512398584\",\"ProcessEndTime\":\"1604855099.126\",\"ProcessGroupId\":\"0\",\"ProcessStartTime\":\"1604855099.126\",\"RGID\":\"0\",\"RUID\":\"0\",\"RawProcessId\":\"51342\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"de80fe0bd06a96543aaec5c634b08cbfc58dba88ea3a66871434a0dd3a9e9dfa\",\"SVGID\":\"0\",\"SVUID\":\"0\",\"SessionProcessId\":\"314116638974342642\",\"SourceProcessId\":\"321385814512398584\",\"SourceThreadId\":\"0\",\"TargetProcessId\":\"321385814512398605\",\"UID\":\"0\",\"aid\":\"ffffffff70d140ca9ba97f0dddd14137\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Lin\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-ac87-06decddc17a1\",\"name\":\"ProcessRollup2LinV5\",\"timestamp\":\"1604855099681\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff70d140ca9ba97f0dddd14137",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0009806.1"
+            },
+            "os": {
+                "type": "linux"
+            },
             "process": {
                 "args": [
                     "uname",
                     "-a"
                 ],
+                "args_count": 2,
+                "command_line": "uname -a",
+                "end": "2020-11-08T17:04:59.126Z",
+                "entity_id": "321385814512398605",
+                "executable": "/bin/uname",
+                "hash": {
+                    "md5": "894356eb59e279696c304f07091b7fde",
+                    "sha256": "de80fe0bd06a96543aaec5c634b08cbfc58dba88ea3a66871434a0dd3a9e9dfa"
+                },
                 "parent": {
                     "entity_id": "321385814512398584"
                 },
                 "pgid": 0,
-                "start": "2020-11-08T17:04:59.126Z",
-                "end": "2020-11-08T17:04:59.126Z",
                 "pid": 51342,
-                "args_count": 2,
-                "entity_id": "321385814512398605",
-                "command_line": "uname -a",
-                "executable": "/bin/uname",
-                "hash": {
-                    "sha256": "de80fe0bd06a96543aaec5c634b08cbfc58dba88ea3a66871434a0dd3a9e9dfa",
-                    "md5": "894356eb59e279696c304f07091b7fde"
-                },
+                "start": "2020-11-08T17:04:59.126Z",
                 "uptime": 0
             },
-            "os": {
-                "type": "linux"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff70d140ca9ba97f0dddd14137",
-                "type": "agent",
-                "version": "1007.8.0009806.1"
-            },
-            "@timestamp": "2020-11-08T17:04:59.681Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "894356eb59e279696c304f07091b7fde",
                     "de80fe0bd06a96543aaec5c634b08cbfc58dba88ea3a66871434a0dd3a9e9dfa",
                     "4288861242"
                 ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561753440Z",
-                "original": "{\"CommandLine\":\"uname -a\",\"ConfigBuild\":\"1007.8.0009806.1\",\"ConfigStateHash\":\"4288861242\",\"Entitlements\":\"15\",\"GID\":\"0\",\"ImageFileName\":\"/bin/uname\",\"MD5HashData\":\"894356eb59e279696c304f07091b7fde\",\"NDRoot\":\"321385814512398584\",\"ParentProcessId\":\"321385814512398584\",\"ProcessEndTime\":\"1604855099.126\",\"ProcessGroupId\":\"0\",\"ProcessStartTime\":\"1604855099.126\",\"RGID\":\"0\",\"RUID\":\"0\",\"RawProcessId\":\"51342\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"de80fe0bd06a96543aaec5c634b08cbfc58dba88ea3a66871434a0dd3a9e9dfa\",\"SVGID\":\"0\",\"SVUID\":\"0\",\"SessionProcessId\":\"314116638974342642\",\"SourceProcessId\":\"321385814512398584\",\"SourceThreadId\":\"0\",\"TargetProcessId\":\"321385814512398605\",\"UID\":\"0\",\"aid\":\"ffffffff70d140ca9ba97f0dddd14137\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Lin\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-ac87-06decddc17a1\",\"name\":\"ProcessRollup2LinV5\",\"timestamp\":\"1604855099681\"}",
-                "created": "2020-11-08T17:04:59.681Z",
-                "kind": "event",
-                "action": "ProcessRollup2",
-                "id": "ffffffff-1111-11eb-ac87-06decddc17a1",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "4288861242",
-                "SVUID": "0",
-                "SVGID": "0",
-                "RGID": "0",
-                "NDRoot": "321385814512398584",
-                "Entitlements": "15",
-                "SourceThreadId": "0",
-                "SourceProcessId": "321385814512398584",
-                "RUID": "0",
-                "name": "ProcessRollup2LinV5",
-                "SessionProcessId": "314116638974342642",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "id": "0",
                 "group": {
                     "id": "0"
-                }
+                },
+                "id": "0"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff75fc48f15cfe5f095e605c4c",
-                "type": "agent",
-                "version": "1007.4.0011104.1"
-            },
-            "process": {
-                "pid": 28987,
-                "thread": {
-                    "id": 0
-                },
-                "entity_id": "317713210176499254",
-                "hash": {
-                    "sha256": "6de76ab470a16b2a825d223b996d994623473c694c60fccbb71af8691e61c5e0"
-                }
-            },
             "@timestamp": "2020-11-08T17:04:56.730Z",
-            "os": {
-                "type": "macos"
+            "crowdstrike": {
+                "AsepWrittenCount": 0,
+                "ConfigStateHash": "1789338890",
+                "ContextProcessId": "317713210176499254",
+                "DirectoryCreatedCount": 0,
+                "DnsRequestCount": 0,
+                "Entitlements": "15",
+                "ExecutableDeletedCount": 0,
+                "FileDeletedCount": 0,
+                "NetworkBindCount": 0,
+                "NetworkCapableAsepWriteCount": 0,
+                "NetworkCloseCount": 0,
+                "NetworkConnectCount": 0,
+                "NetworkListenCount": 0,
+                "NetworkRecvAcceptCount": 0,
+                "NewExecutableWrittenCount": 0,
+                "SuspectStackCount": 0,
+                "SuspiciousDnsRequestCount": 0,
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "EndOfProcessMacV14"
             },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
+            "event": {
+                "action": "EndOfProcess",
+                "category": [
+                    "process"
                 ],
+                "created": "2020-11-08T17:04:59.646Z",
+                "id": "ffffffff-1111-11eb-809e-02fff4e55a49",
+                "ingested": "2022-03-22T18:19:46.427019900Z",
+                "kind": "event",
+                "original": "{\"AsepWrittenCount\":\"0\",\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1789338890\",\"ContextProcessId\":\"317713210176499254\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604855096.730\",\"DirectoryCreatedCount\":\"0\",\"DnsRequestCount\":\"0\",\"Entitlements\":\"15\",\"ExecutableDeletedCount\":\"0\",\"FileDeletedCount\":\"0\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"RawProcessId\":\"28987\",\"SHA256HashData\":\"6de76ab470a16b2a825d223b996d994623473c694c60fccbb71af8691e61c5e0\",\"SuspectStackCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"TargetProcessId\":\"317713210176499254\",\"aid\":\"ffffffff75fc48f15cfe5f095e605c4c\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-809e-02fff4e55a49\",\"name\":\"EndOfProcessMacV14\",\"timestamp\":\"1604855099646\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff75fc48f15cfe5f095e605c4c",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0011104.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "process": {
+                "entity_id": "317713210176499254",
+                "hash": {
+                    "sha256": "6de76ab470a16b2a825d223b996d994623473c694c60fccbb71af8691e61c5e0"
+                },
+                "pid": 28987,
+                "thread": {
+                    "id": 0
+                }
+            },
+            "related": {
                 "hash": [
                     "6de76ab470a16b2a825d223b996d994623473c694c60fccbb71af8691e61c5e0",
                     "1789338890"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561754459Z",
-                "original": "{\"AsepWrittenCount\":\"0\",\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1789338890\",\"ContextProcessId\":\"317713210176499254\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604855096.730\",\"DirectoryCreatedCount\":\"0\",\"DnsRequestCount\":\"0\",\"Entitlements\":\"15\",\"ExecutableDeletedCount\":\"0\",\"FileDeletedCount\":\"0\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"RawProcessId\":\"28987\",\"SHA256HashData\":\"6de76ab470a16b2a825d223b996d994623473c694c60fccbb71af8691e61c5e0\",\"SuspectStackCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"TargetProcessId\":\"317713210176499254\",\"aid\":\"ffffffff75fc48f15cfe5f095e605c4c\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-809e-02fff4e55a49\",\"name\":\"EndOfProcessMacV14\",\"timestamp\":\"1604855099646\"}",
-                "created": "2020-11-08T17:04:59.646Z",
-                "kind": "event",
-                "action": "EndOfProcess",
-                "id": "ffffffff-1111-11eb-809e-02fff4e55a49",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "FileDeletedCount": 0,
-                "ConfigStateHash": "1789338890",
-                "ContextProcessId": "317713210176499254",
-                "DirectoryCreatedCount": 0,
-                "AsepWrittenCount": 0,
-                "SuspiciousDnsRequestCount": 0,
-                "NetworkConnectCount": 0,
-                "NetworkListenCount": 0,
-                "NetworkCapableAsepWriteCount": 0,
-                "ExecutableDeletedCount": 0,
-                "NetworkBindCount": 0,
-                "DnsRequestCount": 0,
-                "Entitlements": "15",
-                "name": "EndOfProcessMacV14",
-                "NetworkRecvAcceptCount": 0,
-                "NewExecutableWrittenCount": 0,
-                "NetworkCloseCount": 0,
-                "SuspectStackCount": 0,
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "process": {
-                "parent": {
-                    "entity_id": "3099350649383"
-                },
-                "exit_code": 0,
-                "start": "2020-11-08T17:04:56.463Z",
-                "pid": 33016,
-                "thread": {
-                    "id": 93436292950223
-                },
-                "entity_id": "3100508103359",
-                "hash": {
-                    "sha256": "faceb6f5d1cdc5ad50a4a1b92c4cd3fcdabcf7e8d418014a1b1221c1defa3d8f"
-                }
-            },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffb5db4b2e7ec89aba537adcc2",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
             "@timestamp": "2020-11-08T17:04:57.926Z",
+            "crowdstrike": {
+                "AllocateVirtualMemoryCount": 0,
+                "ArchiveFileWrittenCount": 0,
+                "AsepWrittenCount": 0,
+                "BinaryExecutableWrittenCount": 0,
+                "CLICreationCount": 0,
+                "ConHostId": "38188",
+                "ConHostProcessId": "3099352216141",
+                "ConfigStateHash": "3343111420",
+                "ContextProcessId": "3100508103359",
+                "CreateProcessCount": 0,
+                "CycleTime": 2937514388,
+                "DirectoryCreatedCount": 0,
+                "DirectoryEnumeratedCount": 1,
+                "DnsRequestCount": 0,
+                "DocumentFileWrittenCount": 0,
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "ExeAndServiceCount": 0,
+                "ExecutableDeletedCount": 0,
+                "FileDeletedCount": 2,
+                "GenericFileWrittenCount": 0,
+                "ImageSubsystem": "3",
+                "InjectedDllCount": 0,
+                "InjectedThreadCount": 0,
+                "KernelTime": 7500000,
+                "MaxThreadCount": 4,
+                "ModuleLoadCount": 38,
+                "NetworkBindCount": 0,
+                "NetworkCapableAsepWriteCount": 0,
+                "NetworkCloseCount": 0,
+                "NetworkConnectCount": 0,
+                "NetworkConnectCountUdp": 0,
+                "NetworkListenCount": 0,
+                "NetworkModuleLoadCount": 0,
+                "NetworkRecvAcceptCount": 0,
+                "NewExecutableWrittenCount": 0,
+                "PrivilegedProcessHandleCount": 0,
+                "ProtectVirtualMemoryCount": 0,
+                "QueueApcCount": 0,
+                "RegKeySecurityDecreasedCount": 0,
+                "RemovableDiskFileWrittenCount": 0,
+                "RunDllInvocationCount": 0,
+                "ScreenshotsTakenCount": 0,
+                "ScriptEngineInvocationCount": 0,
+                "ServiceEventCount": 0,
+                "SetThreadContextCount": 0,
+                "SnapshotFileOpenCount": 0,
+                "SuspectStackCount": 0,
+                "SuspiciousCredentialModuleLoadCount": 0,
+                "SuspiciousDnsRequestCount": 0,
+                "SuspiciousFontLoadCount": 0,
+                "SuspiciousRawDiskReadCount": 0,
+                "UnsignedModuleLoadCount": 0,
+                "UserMemoryAllocateExecutableCount": 0,
+                "UserMemoryAllocateExecutableRemoteCount": 0,
+                "UserMemoryProtectExecutableCount": 0,
+                "UserMemoryProtectExecutableRemoteCount": 0,
+                "UserTime": 6406250,
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "EndOfProcessV15"
+            },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
+            "event": {
+                "action": "EndOfProcess",
+                "category": [
+                    "process"
                 ],
+                "created": "2020-11-08T17:04:59.935Z",
+                "id": "ffffffff-1111-11eb-8726-063418e4a9e7",
+                "ingested": "2022-03-22T18:19:46.427027700Z",
+                "kind": "event",
+                "original": "{\"AllocateVirtualMemoryCount\":\"0\",\"ArchiveFileWrittenCount\":\"0\",\"AsepWrittenCount\":\"0\",\"BinaryExecutableWrittenCount\":\"0\",\"CLICreationCount\":\"0\",\"ConHostId\":\"38188\",\"ConHostProcessId\":\"3099352216141\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3343111420\",\"ContextData\":\"\",\"ContextProcessId\":\"3100508103359\",\"ContextThreadId\":\"93436292950223\",\"ContextTimeStamp\":\"1604855097.926\",\"CreateProcessCount\":\"0\",\"CycleTime\":\"2937514388\",\"DirectoryCreatedCount\":\"0\",\"DirectoryEnumeratedCount\":\"1\",\"DnsRequestCount\":\"0\",\"DocumentFileWrittenCount\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ExeAndServiceCount\":\"0\",\"ExecutableDeletedCount\":\"0\",\"ExitCode\":\"0\",\"FileDeletedCount\":\"2\",\"GenericFileWrittenCount\":\"0\",\"ImageSubsystem\":\"3\",\"InjectedDllCount\":\"0\",\"InjectedThreadCount\":\"0\",\"KernelTime\":\"7500000\",\"MaxThreadCount\":\"4\",\"ModuleLoadCount\":\"38\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkConnectCountUdp\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkModuleLoadCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"ParentProcessId\":\"3099350649383\",\"PrivilegedProcessHandleCount\":\"0\",\"ProcessStartTime\":\"1604855096.463\",\"ProtectVirtualMemoryCount\":\"0\",\"QueueApcCount\":\"0\",\"RawProcessId\":\"33016\",\"RegKeySecurityDecreasedCount\":\"0\",\"RemovableDiskFileWrittenCount\":\"0\",\"RunDllInvocationCount\":\"0\",\"SHA256HashData\":\"faceb6f5d1cdc5ad50a4a1b92c4cd3fcdabcf7e8d418014a1b1221c1defa3d8f\",\"ScreenshotsTakenCount\":\"0\",\"ScriptEngineInvocationCount\":\"0\",\"ServiceEventCount\":\"0\",\"SetThreadContextCount\":\"0\",\"SnapshotFileOpenCount\":\"0\",\"SuspectStackCount\":\"0\",\"SuspiciousCredentialModuleLoadCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"SuspiciousFontLoadCount\":\"0\",\"SuspiciousRawDiskReadCount\":\"0\",\"TargetProcessId\":\"3100508103359\",\"UnsignedModuleLoadCount\":\"0\",\"UserMemoryAllocateExecutableCount\":\"0\",\"UserMemoryAllocateExecutableRemoteCount\":\"0\",\"UserMemoryProtectExecutableCount\":\"0\",\"UserMemoryProtectExecutableRemoteCount\":\"0\",\"UserSid\":\"S-1-5-18\",\"UserTime\":\"6406250\",\"aid\":\"ffffffffb5db4b2e7ec89aba537adcc2\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-8726-063418e4a9e7\",\"name\":\"EndOfProcessV15\",\"timestamp\":\"1604855099935\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffb5db4b2e7ec89aba537adcc2",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
+            "process": {
+                "entity_id": "3100508103359",
+                "exit_code": 0,
+                "hash": {
+                    "sha256": "faceb6f5d1cdc5ad50a4a1b92c4cd3fcdabcf7e8d418014a1b1221c1defa3d8f"
+                },
+                "parent": {
+                    "entity_id": "3099350649383"
+                },
+                "pid": 33016,
+                "start": "2020-11-08T17:04:56.463Z",
+                "thread": {
+                    "id": 93436292950223
+                }
+            },
+            "related": {
                 "hash": [
                     "faceb6f5d1cdc5ad50a4a1b92c4cd3fcdabcf7e8d418014a1b1221c1defa3d8f",
                     "3343111420"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561755375Z",
-                "original": "{\"AllocateVirtualMemoryCount\":\"0\",\"ArchiveFileWrittenCount\":\"0\",\"AsepWrittenCount\":\"0\",\"BinaryExecutableWrittenCount\":\"0\",\"CLICreationCount\":\"0\",\"ConHostId\":\"38188\",\"ConHostProcessId\":\"3099352216141\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3343111420\",\"ContextData\":\"\",\"ContextProcessId\":\"3100508103359\",\"ContextThreadId\":\"93436292950223\",\"ContextTimeStamp\":\"1604855097.926\",\"CreateProcessCount\":\"0\",\"CycleTime\":\"2937514388\",\"DirectoryCreatedCount\":\"0\",\"DirectoryEnumeratedCount\":\"1\",\"DnsRequestCount\":\"0\",\"DocumentFileWrittenCount\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ExeAndServiceCount\":\"0\",\"ExecutableDeletedCount\":\"0\",\"ExitCode\":\"0\",\"FileDeletedCount\":\"2\",\"GenericFileWrittenCount\":\"0\",\"ImageSubsystem\":\"3\",\"InjectedDllCount\":\"0\",\"InjectedThreadCount\":\"0\",\"KernelTime\":\"7500000\",\"MaxThreadCount\":\"4\",\"ModuleLoadCount\":\"38\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkConnectCountUdp\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkModuleLoadCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"ParentProcessId\":\"3099350649383\",\"PrivilegedProcessHandleCount\":\"0\",\"ProcessStartTime\":\"1604855096.463\",\"ProtectVirtualMemoryCount\":\"0\",\"QueueApcCount\":\"0\",\"RawProcessId\":\"33016\",\"RegKeySecurityDecreasedCount\":\"0\",\"RemovableDiskFileWrittenCount\":\"0\",\"RunDllInvocationCount\":\"0\",\"SHA256HashData\":\"faceb6f5d1cdc5ad50a4a1b92c4cd3fcdabcf7e8d418014a1b1221c1defa3d8f\",\"ScreenshotsTakenCount\":\"0\",\"ScriptEngineInvocationCount\":\"0\",\"ServiceEventCount\":\"0\",\"SetThreadContextCount\":\"0\",\"SnapshotFileOpenCount\":\"0\",\"SuspectStackCount\":\"0\",\"SuspiciousCredentialModuleLoadCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"SuspiciousFontLoadCount\":\"0\",\"SuspiciousRawDiskReadCount\":\"0\",\"TargetProcessId\":\"3100508103359\",\"UnsignedModuleLoadCount\":\"0\",\"UserMemoryAllocateExecutableCount\":\"0\",\"UserMemoryAllocateExecutableRemoteCount\":\"0\",\"UserMemoryProtectExecutableCount\":\"0\",\"UserMemoryProtectExecutableRemoteCount\":\"0\",\"UserSid\":\"S-1-5-18\",\"UserTime\":\"6406250\",\"aid\":\"ffffffffb5db4b2e7ec89aba537adcc2\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-8726-063418e4a9e7\",\"name\":\"EndOfProcessV15\",\"timestamp\":\"1604855099935\"}",
-                "created": "2020-11-08T17:04:59.935Z",
-                "kind": "event",
-                "action": "EndOfProcess",
-                "id": "ffffffff-1111-11eb-8726-063418e4a9e7",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ScreenshotsTakenCount": 0,
-                "NetworkListenCount": 0,
-                "SuspiciousRawDiskReadCount": 0,
-                "NetworkBindCount": 0,
-                "NetworkRecvAcceptCount": 0,
-                "ExeAndServiceCount": 0,
-                "NewExecutableWrittenCount": 0,
-                "NetworkCloseCount": 0,
-                "SuspectStackCount": 0,
-                "CLICreationCount": 0,
-                "UnsignedModuleLoadCount": 0,
-                "UserTime": 6406250,
-                "AllocateVirtualMemoryCount": 0,
-                "ContextProcessId": "3100508103359",
-                "ServiceEventCount": 0,
-                "RemovableDiskFileWrittenCount": 0,
-                "SnapshotFileOpenCount": 0,
-                "InjectedDllCount": 0,
-                "ModuleLoadCount": 38,
-                "UserMemoryProtectExecutableCount": 0,
-                "NetworkCapableAsepWriteCount": 0,
-                "DnsRequestCount": 0,
-                "ArchiveFileWrittenCount": 0,
-                "Entitlements": "15",
-                "name": "EndOfProcessV15",
-                "SetThreadContextCount": 0,
-                "SuspiciousCredentialModuleLoadCount": 0,
-                "cid": "ffffffff30a3407dae27d0503611022d",
-                "FileDeletedCount": 2,
-                "UserMemoryAllocateExecutableCount": 0,
-                "DirectoryCreatedCount": 0,
-                "NetworkConnectCountUdp": 0,
-                "QueueApcCount": 0,
-                "SuspiciousFontLoadCount": 0,
-                "ConHostId": "38188",
-                "NetworkConnectCount": 0,
-                "BinaryExecutableWrittenCount": 0,
-                "CycleTime": 2937514388,
-                "ConHostProcessId": "3099352216141",
-                "PrivilegedProcessHandleCount": 0,
-                "MaxThreadCount": 4,
-                "ImageSubsystem": "3",
-                "GenericFileWrittenCount": 0,
-                "EffectiveTransmissionClass": "3",
-                "ScriptEngineInvocationCount": 0,
-                "RunDllInvocationCount": 0,
-                "CreateProcessCount": 0,
-                "KernelTime": 7500000,
-                "DirectoryEnumeratedCount": 1,
-                "ConfigStateHash": "3343111420",
-                "AsepWrittenCount": 0,
-                "DocumentFileWrittenCount": 0,
-                "SuspiciousDnsRequestCount": 0,
-                "ProtectVirtualMemoryCount": 0,
-                "UserMemoryProtectExecutableRemoteCount": 0,
-                "UserMemoryAllocateExecutableRemoteCount": 0,
-                "ExecutableDeletedCount": 0,
-                "RegKeySecurityDecreasedCount": 0,
-                "InjectedThreadCount": 0,
-                "NetworkModuleLoadCount": 0
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "id": "S-1-5-18"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff1aa0482a5ea94f64e08e7b15",
-                "type": "agent",
-                "version": "1007.4.0009304.1"
-            },
-            "process": {
-                "pid": 10507,
-                "thread": {
-                    "id": 0
-                },
-                "entity_id": "311775981885093125",
-                "hash": {
-                    "sha256": "3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3"
-                }
-            },
             "@timestamp": "2020-11-08T17:05:01.341Z",
-            "os": {
-                "type": "macos"
+            "crowdstrike": {
+                "AsepWrittenCount": 0,
+                "ConfigStateHash": "3344040805",
+                "ContextProcessId": "311775981885093125",
+                "DirectoryCreatedCount": 0,
+                "DnsRequestCount": 0,
+                "Entitlements": "15",
+                "ExecutableDeletedCount": 0,
+                "FileDeletedCount": 0,
+                "NetworkBindCount": 0,
+                "NetworkCapableAsepWriteCount": 0,
+                "NetworkCloseCount": 0,
+                "NetworkConnectCount": 0,
+                "NetworkListenCount": 0,
+                "NetworkRecvAcceptCount": 0,
+                "NewExecutableWrittenCount": 0,
+                "SuspectStackCount": 0,
+                "SuspiciousDnsRequestCount": 0,
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "EndOfProcessMacV12"
             },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
+            "event": {
+                "action": "EndOfProcess",
+                "category": [
+                    "process"
                 ],
+                "created": "2020-11-08T17:05:00.139Z",
+                "id": "ffffffff-1111-11eb-bc03-065126dd0691",
+                "ingested": "2022-03-22T18:19:46.427035600Z",
+                "kind": "event",
+                "original": "{\"AsepWrittenCount\":\"0\",\"ConfigBuild\":\"1007.4.0009304.1\",\"ConfigStateHash\":\"3344040805\",\"ContextProcessId\":\"311775981885093125\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604855101.341\",\"DirectoryCreatedCount\":\"0\",\"DnsRequestCount\":\"0\",\"Entitlements\":\"15\",\"ExecutableDeletedCount\":\"0\",\"FileDeletedCount\":\"0\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"RawProcessId\":\"10507\",\"SHA256HashData\":\"3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3\",\"SuspectStackCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"TargetProcessId\":\"311775981885093125\",\"aid\":\"ffffffff1aa0482a5ea94f64e08e7b15\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-bc03-065126dd0691\",\"name\":\"EndOfProcessMacV12\",\"timestamp\":\"1604855100139\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff1aa0482a5ea94f64e08e7b15",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0009304.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "process": {
+                "entity_id": "311775981885093125",
+                "hash": {
+                    "sha256": "3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3"
+                },
+                "pid": 10507,
+                "thread": {
+                    "id": 0
+                }
+            },
+            "related": {
                 "hash": [
                     "3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3",
                     "3344040805"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561756311Z",
-                "original": "{\"AsepWrittenCount\":\"0\",\"ConfigBuild\":\"1007.4.0009304.1\",\"ConfigStateHash\":\"3344040805\",\"ContextProcessId\":\"311775981885093125\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604855101.341\",\"DirectoryCreatedCount\":\"0\",\"DnsRequestCount\":\"0\",\"Entitlements\":\"15\",\"ExecutableDeletedCount\":\"0\",\"FileDeletedCount\":\"0\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"RawProcessId\":\"10507\",\"SHA256HashData\":\"3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3\",\"SuspectStackCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"TargetProcessId\":\"311775981885093125\",\"aid\":\"ffffffff1aa0482a5ea94f64e08e7b15\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-bc03-065126dd0691\",\"name\":\"EndOfProcessMacV12\",\"timestamp\":\"1604855100139\"}",
-                "created": "2020-11-08T17:05:00.139Z",
-                "kind": "event",
-                "action": "EndOfProcess",
-                "id": "ffffffff-1111-11eb-bc03-065126dd0691",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "FileDeletedCount": 0,
-                "ConfigStateHash": "3344040805",
-                "ContextProcessId": "311775981885093125",
-                "DirectoryCreatedCount": 0,
-                "AsepWrittenCount": 0,
-                "SuspiciousDnsRequestCount": 0,
-                "NetworkConnectCount": 0,
-                "NetworkListenCount": 0,
-                "NetworkCapableAsepWriteCount": 0,
-                "ExecutableDeletedCount": 0,
-                "NetworkBindCount": 0,
-                "DnsRequestCount": 0,
-                "Entitlements": "15",
-                "name": "EndOfProcessMacV12",
-                "NetworkRecvAcceptCount": 0,
-                "NewExecutableWrittenCount": 0,
-                "NetworkCloseCount": 0,
-                "SuspectStackCount": 0,
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "process": {
-                "args": [
-                    "D:\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe",
-                    "--ps2"
-                ],
-                "parent": {
-                    "name": "splunkd.exe",
-                    "entity_id": "17346335177"
-                },
-                "start": "2020-11-08T17:04:59.406Z",
-                "pid": 6116,
-                "args_count": 2,
-                "entity_id": "583707537390",
-                "command_line": "D:\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe --ps2",
-                "executable": "\\Device\\HarddiskVolume2\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe",
-                "hash": {
-                    "sha256": "7f326aad0ee45bfef93daede5597d70422d472084ae3295762654fb5021a8720",
-                    "md5": "571391f723a439e985a2064337e2802a"
-                }
-            },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff3a5a424fa02450da53619745",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
             "@timestamp": "2020-11-08T17:05:00.030Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
-                "hash": [
-                    "571391f723a439e985a2064337e2802a",
-                    "7f326aad0ee45bfef93daede5597d70422d472084ae3295762654fb5021a8720",
-                    "3765958535"
-                ],
-                "ip": [
-                    "67.43.156.13"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561757242Z",
-                "original": "{\"AuthenticationId\":\"999\",\"CommandLine\":\"D:\\\\projects\\\\splunk-forwarder\\\\bin\\\\splunk-powershell.exe --ps2\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3765958535\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume2\\\\projects\\\\splunk-forwarder\\\\bin\\\\splunk-powershell.exe\",\"ImageSubsystem\":\"3\",\"IntegrityLevel\":\"16384\",\"MD5HashData\":\"571391f723a439e985a2064337e2802a\",\"ParentAuthenticationId\":\"999\",\"ParentBaseFileName\":\"splunkd.exe\",\"ParentProcessId\":\"17346335177\",\"ProcessCreateFlags\":\"67634688\",\"ProcessEndTime\":\"\",\"ProcessParameterFlags\":\"24577\",\"ProcessStartTime\":\"1604855099.406\",\"ProcessSxsFlags\":\"64\",\"RawProcessId\":\"6116\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"7f326aad0ee45bfef93daede5597d70422d472084ae3295762654fb5021a8720\",\"SessionId\":\"0\",\"SourceProcessId\":\"17346335177\",\"SourceThreadId\":\"107650023406\",\"Tags\":\"27, 151, 12094627905582, 12094627906234\",\"TargetProcessId\":\"583707537390\",\"TokenType\":\"1\",\"UserSid\":\"S-1-5-18\",\"WindowFlags\":\"384\",\"aid\":\"ffffffff3a5a424fa02450da53619745\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-a09e-06f79d630255\",\"name\":\"ProcessRollup2V17\",\"timestamp\":\"1604855100030\"}",
-                "created": "2020-11-08T17:05:00.030Z",
-                "kind": "event",
-                "action": "ProcessRollup2",
-                "id": "ffffffff-1111-11eb-a09e-06f79d630255",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
             "crowdstrike": {
-                "ConfigStateHash": "3765958535",
-                "ProcessCreateFlags": "67634688",
-                "IntegrityLevel": "16384",
-                "SourceProcessId": "17346335177",
-                "ProcessSxsFlags": "64",
                 "AuthenticationId": "999",
-                "WindowFlags": "384",
-                "TokenType": "1",
-                "ParentAuthenticationId": "999",
-                "Entitlements": "15",
-                "SourceThreadId": "107650023406",
-                "name": "ProcessRollup2V17",
-                "ProcessParameterFlags": "24577",
-                "ImageSubsystem": "3",
+                "ConfigStateHash": "3765958535",
                 "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "ImageSubsystem": "3",
+                "IntegrityLevel": "16384",
+                "ParentAuthenticationId": "999",
+                "ProcessCreateFlags": "67634688",
+                "ProcessParameterFlags": "24577",
+                "ProcessSxsFlags": "64",
                 "SessionId": "0",
+                "SourceProcessId": "17346335177",
+                "SourceThreadId": "107650023406",
                 "Tags": [
                     "27",
                     "151",
                     "12094627905582",
                     "12094627906234"
                 ],
-                "cid": "ffffffff30a3407dae27d0503611022d"
+                "TokenType": "1",
+                "WindowFlags": "384",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "ProcessRollup2V17"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2",
+                "category": [
+                    "process"
+                ],
+                "created": "2020-11-08T17:05:00.030Z",
+                "id": "ffffffff-1111-11eb-a09e-06f79d630255",
+                "ingested": "2022-03-22T18:19:46.427043300Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"999\",\"CommandLine\":\"D:\\\\projects\\\\splunk-forwarder\\\\bin\\\\splunk-powershell.exe --ps2\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3765958535\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume2\\\\projects\\\\splunk-forwarder\\\\bin\\\\splunk-powershell.exe\",\"ImageSubsystem\":\"3\",\"IntegrityLevel\":\"16384\",\"MD5HashData\":\"571391f723a439e985a2064337e2802a\",\"ParentAuthenticationId\":\"999\",\"ParentBaseFileName\":\"splunkd.exe\",\"ParentProcessId\":\"17346335177\",\"ProcessCreateFlags\":\"67634688\",\"ProcessEndTime\":\"\",\"ProcessParameterFlags\":\"24577\",\"ProcessStartTime\":\"1604855099.406\",\"ProcessSxsFlags\":\"64\",\"RawProcessId\":\"6116\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"7f326aad0ee45bfef93daede5597d70422d472084ae3295762654fb5021a8720\",\"SessionId\":\"0\",\"SourceProcessId\":\"17346335177\",\"SourceThreadId\":\"107650023406\",\"Tags\":\"27, 151, 12094627905582, 12094627906234\",\"TargetProcessId\":\"583707537390\",\"TokenType\":\"1\",\"UserSid\":\"S-1-5-18\",\"WindowFlags\":\"384\",\"aid\":\"ffffffff3a5a424fa02450da53619745\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-a09e-06f79d630255\",\"name\":\"ProcessRollup2V17\",\"timestamp\":\"1604855100030\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff3a5a424fa02450da53619745",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
+            "process": {
+                "args": [
+                    "D:\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe",
+                    "--ps2"
+                ],
+                "args_count": 2,
+                "command_line": "D:\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe --ps2",
+                "entity_id": "583707537390",
+                "executable": "\\Device\\HarddiskVolume2\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe",
+                "hash": {
+                    "md5": "571391f723a439e985a2064337e2802a",
+                    "sha256": "7f326aad0ee45bfef93daede5597d70422d472084ae3295762654fb5021a8720"
+                },
+                "parent": {
+                    "entity_id": "17346335177",
+                    "name": "splunkd.exe"
+                },
+                "pid": 6116,
+                "start": "2020-11-08T17:04:59.406Z"
+            },
+            "related": {
+                "hash": [
+                    "571391f723a439e985a2064337e2802a",
+                    "7f326aad0ee45bfef93daede5597d70422d472084ae3295762654fb5021a8720",
+                    "3765958535"
+                ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
+                "ip": [
+                    "67.43.156.13"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "id": "S-1-5-18"
             }
         },
         {
-            "process": {
-                "entity_id": "259090530891",
-                "thread": {
-                    "id": 16409623709004
-                }
-            },
-            "os": {
-                "type": "windows"
+            "@timestamp": "2020-11-08T17:04:55.961Z",
+            "crowdstrike": {
+                "ConfigStateHash": "2784638081",
+                "DnsRequestCount": 1,
+                "DualRequest": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InterfaceIndex": 0,
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "DnsRequestV3"
             },
             "dns": {
                 "question": {
@@ -7075,154 +7077,209 @@
                 },
                 "type": "query"
             },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff4f1444bab96568879cb43556",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:04:55.961Z",
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
+            "event": {
+                "action": "DnsRequest",
+                "category": [
+                    "network"
                 ],
+                "created": "2020-11-08T17:04:59.913Z",
+                "id": "ffffffff-1111-11eb-8077-0606f7dcf2ed",
+                "ingested": "2022-03-22T18:19:46.427051Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"2784638081\",\"ContextProcessId\":\"259090530891\",\"ContextThreadId\":\"16409623709004\",\"ContextTimeStamp\":\"1604855095.961\",\"DnsRequestCount\":\"1\",\"DomainName\":\"comp1.dom2\",\"DualRequest\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InterfaceIndex\":\"0\",\"RequestType\":\"1\",\"aid\":\"ffffffff4f1444bab96568879cb43556\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"DnsRequest\",\"id\":\"ffffffff-1111-11eb-8077-0606f7dcf2ed\",\"name\":\"DnsRequestV3\",\"timestamp\":\"1604855099913\"}",
+                "outcome": "success",
+                "type": [
+                    "protocol"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff4f1444bab96568879cb43556",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
+            "process": {
+                "entity_id": "259090530891",
+                "thread": {
+                    "id": 16409623709004
+                }
+            },
+            "related": {
                 "hash": [
                     "2784638081"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561758169Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"2784638081\",\"ContextProcessId\":\"259090530891\",\"ContextThreadId\":\"16409623709004\",\"ContextTimeStamp\":\"1604855095.961\",\"DnsRequestCount\":\"1\",\"DomainName\":\"comp1.dom2\",\"DualRequest\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InterfaceIndex\":\"0\",\"RequestType\":\"1\",\"aid\":\"ffffffff4f1444bab96568879cb43556\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"DnsRequest\",\"id\":\"ffffffff-1111-11eb-8077-0606f7dcf2ed\",\"name\":\"DnsRequestV3\",\"timestamp\":\"1604855099913\"}",
-                "created": "2020-11-08T17:04:59.913Z",
-                "kind": "event",
-                "action": "DnsRequest",
-                "id": "ffffffff-1111-11eb-8077-0606f7dcf2ed",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "protocol"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "InterfaceIndex": 0,
-                "ConfigStateHash": "2784638081",
-                "DnsRequestCount": 1,
-                "DualRequest": "0",
-                "Entitlements": "15",
-                "name": "DnsRequestV3",
-                "EffectiveTransmissionClass": "3",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:05:01.645Z",
+            "crowdstrike": {
+                "ConfigStateHash": "4288861242",
+                "Entitlements": "15",
+                "UnixMode": "32768",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "CriticalFileAccessedLinV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "CriticalFileAccessed",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:05:02.247Z",
+                "id": "ffffffff-1111-11eb-b70d-027f9ced2001",
+                "ingested": "2022-03-22T18:19:46.427058700Z",
+                "kind": "alert",
+                "original": "{\"ConfigBuild\":\"1007.8.0009806.1\",\"ConfigStateHash\":\"4288861242\",\"ContextProcessId\":\"321385820045701199\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604855101.645\",\"Entitlements\":\"15\",\"GID\":\"0\",\"TargetFileName\":\"/etc/shadow\",\"UID\":\"0\",\"UnixMode\":\"32768\",\"aid\":\"ffffffff32ba43a483e76c6f0a4aa26f\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Lin\",\"event_simpleName\":\"CriticalFileAccessed\",\"id\":\"ffffffff-1111-11eb-b70d-027f9ced2001\",\"name\":\"CriticalFileAccessedLinV1\",\"timestamp\":\"1604855102247\"}",
+                "outcome": "success",
+                "type": [
+                    "access"
+                ]
+            },
+            "file": {
+                "directory": "/etc",
+                "name": "shadow",
+                "path": "/etc/shadow",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff32ba43a483e76c6f0a4aa26f",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.8.0009806.1"
+            },
+            "os": {
+                "type": "linux"
+            },
             "process": {
                 "entity_id": "321385820045701199",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "linux"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff32ba43a483e76c6f0a4aa26f",
-                "type": "agent",
-                "version": "1007.8.0009806.1"
-            },
-            "@timestamp": "2020-11-08T17:05:01.645Z",
-            "file": {
-                "name": "shadow",
-                "path": "/etc/shadow",
-                "type": "file",
-                "directory": "/etc"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "4288861242"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561759089Z",
-                "original": "{\"ConfigBuild\":\"1007.8.0009806.1\",\"ConfigStateHash\":\"4288861242\",\"ContextProcessId\":\"321385820045701199\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604855101.645\",\"Entitlements\":\"15\",\"GID\":\"0\",\"TargetFileName\":\"/etc/shadow\",\"UID\":\"0\",\"UnixMode\":\"32768\",\"aid\":\"ffffffff32ba43a483e76c6f0a4aa26f\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Lin\",\"event_simpleName\":\"CriticalFileAccessed\",\"id\":\"ffffffff-1111-11eb-b70d-027f9ced2001\",\"name\":\"CriticalFileAccessedLinV1\",\"timestamp\":\"1604855102247\"}",
-                "created": "2020-11-08T17:05:02.247Z",
-                "kind": "alert",
-                "action": "CriticalFileAccessed",
-                "id": "ffffffff-1111-11eb-b70d-027f9ced2001",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "access"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "CriticalFileAccessedLinV1",
-                "ConfigStateHash": "4288861242",
-                "UnixMode": "32768",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "id": "0",
                 "group": {
                     "id": "0"
-                }
+                },
+                "id": "0"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:05:09.180Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3344040805",
+                "Entitlements": "15",
+                "MachOSubType": "1",
+                "RGID": "0",
+                "RUID": "0",
+                "SVGID": "0",
+                "SVUID": "0",
+                "SourceProcessId": "311776004953765502",
+                "SourceThreadId": "0",
+                "Tags": [
+                    "27",
+                    "12094627905582",
+                    "12094627906234"
+                ],
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "ProcessRollup2MacV3"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2",
+                "category": [
+                    "process"
+                ],
+                "created": "2020-11-08T17:05:09.180Z",
+                "id": "ffffffff-1111-11eb-bc03-065126dd0691",
+                "ingested": "2022-03-22T18:19:46.427066600Z",
+                "kind": "event",
+                "original": "{\"CommandLine\":\"/usr/bin/plutil -convert xml1 -o - /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist\",\"ConfigBuild\":\"1007.4.0009304.1\",\"ConfigStateHash\":\"3344040805\",\"Entitlements\":\"15\",\"GID\":\"0\",\"ImageFileName\":\"/usr/bin/plutil\",\"MD5HashData\":\"d51cef1b288e2032aee9805deff04bfd\",\"MachOSubType\":\"1\",\"ParentProcessId\":\"311774817965726568\",\"ProcessEndTime\":\"\",\"ProcessGroupId\":\"311774817965726568\",\"ProcessStartTime\":\"1604855111.240\",\"RGID\":\"0\",\"RUID\":\"0\",\"RawProcessId\":\"10692\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3\",\"SVGID\":\"0\",\"SVUID\":\"0\",\"SourceProcessId\":\"311776004953765502\",\"SourceThreadId\":\"0\",\"Tags\":\"27, 12094627905582, 12094627906234\",\"TargetProcessId\":\"311776004953765502\",\"UID\":\"0\",\"aid\":\"ffffffff1aa0482a5ea94f64e08e7b15\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-bc03-065126dd0691\",\"name\":\"ProcessRollup2MacV3\",\"timestamp\":\"1604855109180\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff1aa0482a5ea94f64e08e7b15",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0009304.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "args": [
                     "/usr/bin/plutil",
@@ -7231,263 +7288,219 @@
                     "-o",
                     "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist"
                 ],
+                "args_count": 6,
+                "command_line": "/usr/bin/plutil -convert xml1 -o - /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist",
+                "entity_id": "311776004953765502",
+                "executable": "/usr/bin/plutil",
+                "hash": {
+                    "md5": "d51cef1b288e2032aee9805deff04bfd",
+                    "sha256": "3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3"
+                },
                 "parent": {
                     "entity_id": "311774817965726568"
                 },
                 "pgid": 311774817965726568,
-                "start": "2020-11-08T17:05:11.240Z",
                 "pid": 10692,
-                "args_count": 6,
-                "entity_id": "311776004953765502",
-                "command_line": "/usr/bin/plutil -convert xml1 -o - /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist",
-                "executable": "/usr/bin/plutil",
-                "hash": {
-                    "sha256": "3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3",
-                    "md5": "d51cef1b288e2032aee9805deff04bfd"
-                }
-            },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff1aa0482a5ea94f64e08e7b15",
-                "type": "agent",
-                "version": "1007.4.0009304.1"
-            },
-            "@timestamp": "2020-11-08T17:05:09.180Z",
-            "ecs": {
-                "version": "8.0.0"
+                "start": "2020-11-08T17:05:11.240Z"
             },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "d51cef1b288e2032aee9805deff04bfd",
                     "3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3",
                     "3344040805"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561760092Z",
-                "original": "{\"CommandLine\":\"/usr/bin/plutil -convert xml1 -o - /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist\",\"ConfigBuild\":\"1007.4.0009304.1\",\"ConfigStateHash\":\"3344040805\",\"Entitlements\":\"15\",\"GID\":\"0\",\"ImageFileName\":\"/usr/bin/plutil\",\"MD5HashData\":\"d51cef1b288e2032aee9805deff04bfd\",\"MachOSubType\":\"1\",\"ParentProcessId\":\"311774817965726568\",\"ProcessEndTime\":\"\",\"ProcessGroupId\":\"311774817965726568\",\"ProcessStartTime\":\"1604855111.240\",\"RGID\":\"0\",\"RUID\":\"0\",\"RawProcessId\":\"10692\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"3b00897e1eb587c5f77e3866ff6bdc80f5e70f839543242e0ee5a1581014adc3\",\"SVGID\":\"0\",\"SVUID\":\"0\",\"SourceProcessId\":\"311776004953765502\",\"SourceThreadId\":\"0\",\"Tags\":\"27, 12094627905582, 12094627906234\",\"TargetProcessId\":\"311776004953765502\",\"UID\":\"0\",\"aid\":\"ffffffff1aa0482a5ea94f64e08e7b15\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-bc03-065126dd0691\",\"name\":\"ProcessRollup2MacV3\",\"timestamp\":\"1604855109180\"}",
-                "created": "2020-11-08T17:05:09.180Z",
-                "kind": "event",
-                "action": "ProcessRollup2",
-                "id": "ffffffff-1111-11eb-bc03-065126dd0691",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3344040805",
-                "MachOSubType": "1",
-                "SVUID": "0",
-                "SVGID": "0",
-                "RGID": "0",
-                "Entitlements": "15",
-                "SourceThreadId": "0",
-                "SourceProcessId": "311776004953765502",
-                "RUID": "0",
-                "name": "ProcessRollup2MacV3",
-                "Tags": [
-                    "27",
-                    "12094627905582",
-                    "12094627906234"
-                ],
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "id": "0",
                 "group": {
                     "id": "0"
-                }
+                },
+                "id": "0"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:05:14.133Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3899738370",
+                "DesiredAccess": "1180054",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileAttributes": "0",
+                "FileObject": "18446655033844205120",
+                "Information": "2",
+                "IrpFlags": "2180",
+                "MajorFunction": "0",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "Options": "88080484",
+                "ShareAccess": "1",
+                "Status": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NewScriptWrittenV7"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NewScriptWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:05:14.427Z",
+                "id": "ffffffff-1111-11eb-80b5-06e11a66e03d",
+                "ingested": "2022-03-22T18:19:46.427074200Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3899738370\",\"ContextProcessId\":\"1546527409909\",\"ContextThreadId\":\"4711690090889\",\"ContextTimeStamp\":\"1604855114.133\",\"DesiredAccess\":\"1180054\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"501ee2c32e53fb43b07f419f3236fb45c29e000000002c00\",\"FileObject\":\"18446655033844205120\",\"Information\":\"2\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"88080484\",\"ShareAccess\":\"1\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume4\\\\Windows\\\\Temp\\\\__PSScriptPolicyTest_dvkjnbka.apn.ps1\",\"aid\":\"ffffffff8f1e4b77b4dae5debaa1c8bc\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NewScriptWritten\",\"id\":\"ffffffff-1111-11eb-80b5-06e11a66e03d\",\"name\":\"NewScriptWrittenV7\",\"timestamp\":\"1604855114427\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "\\Device\\HarddiskVolume4\\Windows\\Temp",
+                "extension": "ps1",
+                "inode": "501ee2c32e53fb43b07f419f3236fb45c29e000000002c00",
+                "name": "__PSScriptPolicyTest_dvkjnbka.apn.ps1",
+                "path": "\\Device\\HarddiskVolume4\\Windows\\Temp\\__PSScriptPolicyTest_dvkjnbka.apn.ps1",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff8f1e4b77b4dae5debaa1c8bc",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "1546527409909",
                 "thread": {
                     "id": 4711690090889
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff8f1e4b77b4dae5debaa1c8bc",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:05:14.133Z",
-            "file": {
-                "inode": "501ee2c32e53fb43b07f419f3236fb45c29e000000002c00",
-                "name": "__PSScriptPolicyTest_dvkjnbka.apn.ps1",
-                "path": "\\Device\\HarddiskVolume4\\Windows\\Temp\\__PSScriptPolicyTest_dvkjnbka.apn.ps1",
-                "extension": "ps1",
-                "type": "file",
-                "directory": "\\Device\\HarddiskVolume4\\Windows\\Temp"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "3899738370"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561761013Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3899738370\",\"ContextProcessId\":\"1546527409909\",\"ContextThreadId\":\"4711690090889\",\"ContextTimeStamp\":\"1604855114.133\",\"DesiredAccess\":\"1180054\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"501ee2c32e53fb43b07f419f3236fb45c29e000000002c00\",\"FileObject\":\"18446655033844205120\",\"Information\":\"2\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"88080484\",\"ShareAccess\":\"1\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume4\\\\Windows\\\\Temp\\\\__PSScriptPolicyTest_dvkjnbka.apn.ps1\",\"aid\":\"ffffffff8f1e4b77b4dae5debaa1c8bc\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NewScriptWritten\",\"id\":\"ffffffff-1111-11eb-80b5-06e11a66e03d\",\"name\":\"NewScriptWrittenV7\",\"timestamp\":\"1604855114427\"}",
-                "created": "2020-11-08T17:05:14.427Z",
-                "kind": "event",
-                "action": "NewScriptWritten",
-                "id": "ffffffff-1111-11eb-80b5-06e11a66e03d",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "Status": "0",
-                "Options": "88080484",
-                "ConfigStateHash": "3899738370",
-                "IrpFlags": "2180",
-                "MinorFunction": "0",
-                "Information": "2",
-                "ShareAccess": "1",
-                "MajorFunction": "0",
-                "DesiredAccess": "1180054",
-                "Entitlements": "15",
-                "name": "NewScriptWrittenV7",
-                "OperationFlags": "0",
-                "FileObject": "18446655033844205120",
-                "EffectiveTransmissionClass": "3",
-                "FileAttributes": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "process": {
-                "entity_id": "321275232072440993"
+            "@timestamp": "2020-11-08T17:05:16.421Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1306766522",
+                "ConnectionFlags": "0",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NetworkConnectIP4MacV5"
+            },
+            "destination": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkConnectIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:05:16.502Z",
+                "id": "ffffffff-1111-11eb-aca9-02683aed2a0d",
+                "ingested": "2022-03-22T18:19:46.427081900Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.4.0012205.1\",\"ConfigStateHash\":\"1306766522\",\"ConnectionDirection\":\"1\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"321275232072440993\",\"ContextTimeStamp\":\"1604855116.421\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP4\":\"0.0.0.0\",\"LocalPort\":\"0\",\"Protocol\":\"6\",\"RemoteAddressIP4\":\"67.43.156.14\",\"RemotePort\":\"443\",\"aid\":\"ffffffffd4094240a6b1d12aaf304f4f\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NetworkConnectIP4\",\"id\":\"ffffffff-1111-11eb-aca9-02683aed2a0d\",\"name\":\"NetworkConnectIP4MacV5\",\"timestamp\":\"1604855116502\"}",
+                "outcome": "unknown",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
+            "network": {
+                "direction": "inbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffffd4094240a6b1d12aaf304f4f",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0012205.1"
             },
             "os": {
                 "type": "macos"
             },
-            "destination": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 443,
-                "ip": "67.43.156.14"
-            },
-            "source": {
-                "port": 0,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "inbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffffd4094240a6b1d12aaf304f4f",
-                "type": "agent",
-                "version": "1007.4.0012205.1"
-            },
-            "@timestamp": "2020-11-08T17:05:16.421Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "321275232072440993"
             },
             "related": {
+                "hash": [
+                    "1306766522"
+                ],
                 "hosts": [
                     "67.43.156.13",
                     "0.0.0.0",
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "1306766522"
                 ],
                 "ip": [
                     "67.43.156.13",
@@ -7495,569 +7508,569 @@
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561761923Z",
-                "original": "{\"ConfigBuild\":\"1007.4.0012205.1\",\"ConfigStateHash\":\"1306766522\",\"ConnectionDirection\":\"1\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"321275232072440993\",\"ContextTimeStamp\":\"1604855116.421\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP4\":\"0.0.0.0\",\"LocalPort\":\"0\",\"Protocol\":\"6\",\"RemoteAddressIP4\":\"67.43.156.14\",\"RemotePort\":\"443\",\"aid\":\"ffffffffd4094240a6b1d12aaf304f4f\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NetworkConnectIP4\",\"id\":\"ffffffff-1111-11eb-aca9-02683aed2a0d\",\"name\":\"NetworkConnectIP4MacV5\",\"timestamp\":\"1604855116502\"}",
-                "created": "2020-11-08T17:05:16.502Z",
-                "kind": "event",
-                "action": "NetworkConnectIP4",
-                "id": "ffffffff-1111-11eb-aca9-02683aed2a0d",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "unknown"
+            "source": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 0
             },
-            "crowdstrike": {
-                "name": "NetworkConnectIP4MacV5",
-                "ConfigStateHash": "1306766522",
-                "ConnectionFlags": "0",
-                "InContext": "0",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "process": {
-                "entity_id": "223442259384"
+            "@timestamp": "2020-11-08T17:05:16.849Z",
+            "crowdstrike": {
+                "ConfigStateHash": "2602391615",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NetworkConnectIP4V5"
+            },
+            "destination": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkConnectIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:05:16.942Z",
+                "id": "ffffffff-1111-11eb-b0eb-06be7616c211",
+                "ingested": "2022-03-22T18:19:46.427089600Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"2602391615\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"223442259384\",\"ContextTimeStamp\":\"1604855116.849\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP4\":\"67.43.156.14\",\"LocalPort\":\"53961\",\"Protocol\":\"6\",\"RemoteAddressIP4\":\"67.43.156.14\",\"RemotePort\":\"443\",\"aid\":\"fffffffff000426eb99afaa2ccdcbc17\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NetworkConnectIP4\",\"id\":\"ffffffff-1111-11eb-b0eb-06be7616c211\",\"name\":\"NetworkConnectIP4V5\",\"timestamp\":\"1604855116942\"}",
+                "outcome": "unknown",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
+            "network": {
+                "community_id": "1:gnQhhn0wJhJU+wrHlczmnm7THKs=",
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "fffffffff000426eb99afaa2ccdcbc17",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
             },
             "os": {
                 "type": "windows"
             },
-            "destination": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 443,
-                "ip": "67.43.156.14"
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "port": 53961,
-                "ip": "67.43.156.14"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "community_id": "1:gnQhhn0wJhJU+wrHlczmnm7THKs=",
-                "transport": "tcp",
-                "iana_number": "6",
-                "direction": "outbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "fffffffff000426eb99afaa2ccdcbc17",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:05:16.849Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "223442259384"
             },
             "related": {
+                "hash": [
+                    "2602391615"
+                ],
                 "hosts": [
                     "67.43.156.13",
                     "67.43.156.14"
-                ],
-                "hash": [
-                    "2602391615"
                 ],
                 "ip": [
                     "67.43.156.13",
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561762961Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"2602391615\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"223442259384\",\"ContextTimeStamp\":\"1604855116.849\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP4\":\"67.43.156.14\",\"LocalPort\":\"53961\",\"Protocol\":\"6\",\"RemoteAddressIP4\":\"67.43.156.14\",\"RemotePort\":\"443\",\"aid\":\"fffffffff000426eb99afaa2ccdcbc17\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NetworkConnectIP4\",\"id\":\"ffffffff-1111-11eb-b0eb-06be7616c211\",\"name\":\"NetworkConnectIP4V5\",\"timestamp\":\"1604855116942\"}",
-                "created": "2020-11-08T17:05:16.942Z",
-                "kind": "event",
-                "action": "NetworkConnectIP4",
-                "id": "ffffffff-1111-11eb-b0eb-06be7616c211",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "unknown"
+            "source": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "port": 53961
             },
-            "crowdstrike": {
-                "ConfigStateHash": "2602391615",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkConnectIP4V5",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:04:51.781Z",
+            "crowdstrike": {
+                "AuthenticationId": "6580764513",
+                "AuthenticationPackage": "Negotiate",
+                "ConfigStateHash": "3011122681",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "LogonDomain": "NT AUTHORITY",
+                "LogonTime": "2020-11-08T17:04:51.781Z",
+                "LogonType": "9",
+                "RemoteAccount": "1",
+                "UserFlags": "0",
+                "UserLogonFlags": "12",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "UserLogonV8"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "UserLogon",
+                "category": [
+                    "authentication"
+                ],
+                "created": "2020-11-08T17:05:21.077Z",
+                "id": "ffffffff-1111-11eb-a8cf-0649c95cfa1d",
+                "ingested": "2022-03-22T18:19:46.427097300Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"6580764513\",\"AuthenticationPackage\":\"Negotiate\",\"ClientComputerName\":\"-\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3011122681\",\"ContextProcessId\":\"816054990879\",\"ContextThreadId\":\"52913017705957\",\"ContextTimeStamp\":\"1604855091.781\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"LogonDomain\":\"NT AUTHORITY\",\"LogonServer\":\"\",\"LogonTime\":\"1604855091.781\",\"LogonType\":\"9\",\"PasswordLastSet\":\"\",\"RemoteAccount\":\"1\",\"UserFlags\":\"0\",\"UserIsAdmin\":\"0\",\"UserLogonFlags\":\"12\",\"UserName\":\"SYSTEM\",\"UserPrincipal\":\"user4@dom2\",\"UserSid\":\"S-1-5-18\",\"aid\":\"ffffffff8d2e4b4f9b21b40633a8d579\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserLogon\",\"id\":\"ffffffff-1111-11eb-a8cf-0649c95cfa1d\",\"name\":\"UserLogonV8\",\"timestamp\":\"1604855121077\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff8d2e4b4f9b21b40633a8d579",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "816054990879",
                 "thread": {
                     "id": 52913017705957
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff8d2e4b4f9b21b40633a8d579",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:04:51.781Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "user": [
-                    "SYSTEM",
-                    "user4"
+                "hash": [
+                    "3011122681"
                 ],
                 "hosts": [
                     "67.43.156.13"
                 ],
-                "hash": [
-                    "3011122681"
-                ],
                 "ip": [
                     "67.43.156.13"
+                ],
+                "user": [
+                    "SYSTEM",
+                    "user4"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561763886Z",
-                "original": "{\"AuthenticationId\":\"6580764513\",\"AuthenticationPackage\":\"Negotiate\",\"ClientComputerName\":\"-\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3011122681\",\"ContextProcessId\":\"816054990879\",\"ContextThreadId\":\"52913017705957\",\"ContextTimeStamp\":\"1604855091.781\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"LogonDomain\":\"NT AUTHORITY\",\"LogonServer\":\"\",\"LogonTime\":\"1604855091.781\",\"LogonType\":\"9\",\"PasswordLastSet\":\"\",\"RemoteAccount\":\"1\",\"UserFlags\":\"0\",\"UserIsAdmin\":\"0\",\"UserLogonFlags\":\"12\",\"UserName\":\"SYSTEM\",\"UserPrincipal\":\"user4@dom2\",\"UserSid\":\"S-1-5-18\",\"aid\":\"ffffffff8d2e4b4f9b21b40633a8d579\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserLogon\",\"id\":\"ffffffff-1111-11eb-a8cf-0649c95cfa1d\",\"name\":\"UserLogonV8\",\"timestamp\":\"1604855121077\"}",
-                "created": "2020-11-08T17:05:21.077Z",
-                "kind": "event",
-                "action": "UserLogon",
-                "id": "ffffffff-1111-11eb-a8cf-0649c95cfa1d",
-                "category": [
-                    "authentication"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3011122681",
-                "LogonTime": "2020-11-08T17:04:51.781Z",
-                "LogonType": "9",
-                "LogonDomain": "NT AUTHORITY",
-                "RemoteAccount": "1",
-                "AuthenticationPackage": "Negotiate",
-                "AuthenticationId": "6580764513",
-                "UserFlags": "0",
-                "Entitlements": "15",
-                "name": "UserLogonV8",
-                "UserLogonFlags": "12",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
-                "name": "SYSTEM",
+                "domain": "dom2",
+                "email": "user4@dom2",
                 "full_name": "user4",
                 "id": "S-1-5-18",
-                "email": "user4@dom2",
-                "domain": "dom2"
+                "name": "SYSTEM"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:05:20.785Z",
+            "crowdstrike": {
+                "AuthenticationId": "2007206396",
+                "ConfigStateHash": "3011122681",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileEcpBitmask": "0",
+                "FileObject": "18446708893089967904",
+                "IrpFlags": "1028",
+                "IsOnNetwork": "0",
+                "IsOnRemovableDisk": "0",
+                "IsTransactedFile": "0",
+                "MajorFunction": "18",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "TokenType": "1",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "PeFileWrittenV14"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "PeFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:05:21.109Z",
+                "id": "ffffffff-1111-11eb-b091-06f6cca0a049",
+                "ingested": "2022-03-22T18:19:46.427105Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"2007206396\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3011122681\",\"ContextProcessId\":\"4415814628770\",\"ContextThreadId\":\"41392001729898\",\"ContextTimeStamp\":\"1604855120.785\",\"DiskParentDeviceInstanceId\":\"PCI\\\\VEN_1000\\u0026DEV_0054\\u0026SUBSYS_197615AD\\u0026REV_01\\\\4\\u00261f16fef7\\u00260\\u002600A8\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileEcpBitmask\":\"0\",\"FileIdentifier\":\"b57cb59769dfe71180b4806e6f6e6963ea8902000000cb2c\",\"FileObject\":\"18446708893089967904\",\"IrpFlags\":\"1028\",\"IsOnNetwork\":\"0\",\"IsOnRemovableDisk\":\"0\",\"IsTransactedFile\":\"0\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"SHA256HashData\":\"d0e1b81f3f3f18256f6447703624019eaee9b1068b3f09323eced4f547cc4182\",\"Size\":\"6144\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume2\\\\Users\\\\user10\\\\AppData\\\\Local\\\\Temp\\\\ec1ijefl.dll\",\"TokenType\":\"1\",\"aid\":\"ffffffff2c47454cba360bc404a607bb\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"PeFileWritten\",\"id\":\"ffffffff-1111-11eb-b091-06f6cca0a049\",\"name\":\"PeFileWrittenV14\",\"timestamp\":\"1604855121109\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "device": "PCI\\VEN_1000\u0026DEV_0054\u0026SUBSYS_197615AD\u0026REV_01\\4\u00261f16fef7\u00260\u002600A8",
+                "directory": "\\Device\\HarddiskVolume2\\Users\\user10\\AppData\\Local\\Temp",
+                "extension": "dll",
+                "hash": {
+                    "sha256": "d0e1b81f3f3f18256f6447703624019eaee9b1068b3f09323eced4f547cc4182"
+                },
+                "inode": "b57cb59769dfe71180b4806e6f6e6963ea8902000000cb2c",
+                "name": "ec1ijefl.dll",
+                "path": "\\Device\\HarddiskVolume2\\Users\\user10\\AppData\\Local\\Temp\\ec1ijefl.dll",
+                "size": 6144,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff2c47454cba360bc404a607bb",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "4415814628770",
                 "thread": {
                     "id": 41392001729898
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff2c47454cba360bc404a607bb",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:05:20.785Z",
-            "file": {
-                "inode": "b57cb59769dfe71180b4806e6f6e6963ea8902000000cb2c",
-                "path": "\\Device\\HarddiskVolume2\\Users\\user10\\AppData\\Local\\Temp\\ec1ijefl.dll",
-                "extension": "dll",
-                "size": 6144,
-                "name": "ec1ijefl.dll",
-                "type": "file",
-                "device": "PCI\\VEN_1000\u0026DEV_0054\u0026SUBSYS_197615AD\u0026REV_01\\4\u00261f16fef7\u00260\u002600A8",
-                "directory": "\\Device\\HarddiskVolume2\\Users\\user10\\AppData\\Local\\Temp",
-                "hash": {
-                    "sha256": "d0e1b81f3f3f18256f6447703624019eaee9b1068b3f09323eced4f547cc4182"
-                }
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "d0e1b81f3f3f18256f6447703624019eaee9b1068b3f09323eced4f547cc4182",
                     "3011122681"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561764825Z",
-                "original": "{\"AuthenticationId\":\"2007206396\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3011122681\",\"ContextProcessId\":\"4415814628770\",\"ContextThreadId\":\"41392001729898\",\"ContextTimeStamp\":\"1604855120.785\",\"DiskParentDeviceInstanceId\":\"PCI\\\\VEN_1000\\u0026DEV_0054\\u0026SUBSYS_197615AD\\u0026REV_01\\\\4\\u00261f16fef7\\u00260\\u002600A8\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileEcpBitmask\":\"0\",\"FileIdentifier\":\"b57cb59769dfe71180b4806e6f6e6963ea8902000000cb2c\",\"FileObject\":\"18446708893089967904\",\"IrpFlags\":\"1028\",\"IsOnNetwork\":\"0\",\"IsOnRemovableDisk\":\"0\",\"IsTransactedFile\":\"0\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"SHA256HashData\":\"d0e1b81f3f3f18256f6447703624019eaee9b1068b3f09323eced4f547cc4182\",\"Size\":\"6144\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume2\\\\Users\\\\user10\\\\AppData\\\\Local\\\\Temp\\\\ec1ijefl.dll\",\"TokenType\":\"1\",\"aid\":\"ffffffff2c47454cba360bc404a607bb\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"PeFileWritten\",\"id\":\"ffffffff-1111-11eb-b091-06f6cca0a049\",\"name\":\"PeFileWrittenV14\",\"timestamp\":\"1604855121109\"}",
-                "created": "2020-11-08T17:05:21.109Z",
-                "kind": "event",
-                "action": "PeFileWritten",
-                "id": "ffffffff-1111-11eb-b091-06f6cca0a049",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3011122681",
-                "IsTransactedFile": "0",
-                "IrpFlags": "1028",
-                "MinorFunction": "0",
-                "IsOnNetwork": "0",
-                "AuthenticationId": "2007206396",
-                "FileEcpBitmask": "0",
-                "TokenType": "1",
-                "MajorFunction": "18",
-                "IsOnRemovableDisk": "0",
-                "Entitlements": "15",
-                "name": "PeFileWrittenV14",
-                "OperationFlags": "0",
-                "FileObject": "18446708893089967904",
-                "EffectiveTransmissionClass": "3",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffffe0104823bd3de859d5bc8bc7",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
             "@timestamp": "2020-11-08T17:05:34.461Z",
-            "os": {
-                "type": "windows"
+            "crowdstrike": {
+                "AuthenticationId": "317005428",
+                "AuthenticationPackage": "Negotiate",
+                "ConfigStateHash": "3950066843",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "LogoffTime": "2020-11-08T17:05:32.756Z",
+                "LogonDomain": "dom1",
+                "LogonServer": "srv2",
+                "LogonTime": "2020-11-08T17:05:31.666Z",
+                "LogonType": "7",
+                "PasswordLastSet": "1598119332.510",
+                "RemoteAccount": "1",
+                "UserFlags": "32",
+                "UserLogoffType": "3",
+                "UserLogonFlags": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "UserLogoffV3"
             },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "UserLogoff",
+                "category": [
+                    "authentication"
+                ],
+                "created": "2020-11-08T17:05:34.461Z",
+                "id": "ffffffff-1111-11eb-8913-0287fd11c79b",
+                "ingested": "2022-03-22T18:19:46.427112700Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"317005428\",\"AuthenticationPackage\":\"Negotiate\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3950066843\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"LogoffTime\":\"1604855132.756\",\"LogonDomain\":\"dom1\",\"LogonServer\":\"srv2\",\"LogonTime\":\"1604855131.666\",\"LogonType\":\"7\",\"PasswordLastSet\":\"1598119332.510\",\"RemoteAccount\":\"1\",\"UserFlags\":\"32\",\"UserIsAdmin\":\"0\",\"UserLogoffType\":\"3\",\"UserLogonFlags\":\"0\",\"UserName\":\"user4\",\"UserPrincipal\":\"user.name@dom2.com\",\"UserSid\":\"S-1-5-21-606747145-1364589140-725345543-28636\",\"aid\":\"ffffffffe0104823bd3de859d5bc8bc7\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserLogoff\",\"id\":\"ffffffff-1111-11eb-8913-0287fd11c79b\",\"name\":\"UserLogoffV3\",\"timestamp\":\"1604855134461\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffffe0104823bd3de859d5bc8bc7",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "related": {
-                "user": [
-                    "user4",
-                    "user.name"
+                "hash": [
+                    "3950066843"
                 ],
                 "hosts": [
                     "67.43.156.13",
                     "srv2"
                 ],
-                "hash": [
-                    "3950066843"
-                ],
                 "ip": [
                     "67.43.156.13"
+                ],
+                "user": [
+                    "user4",
+                    "user.name"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561765747Z",
-                "original": "{\"AuthenticationId\":\"317005428\",\"AuthenticationPackage\":\"Negotiate\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3950066843\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"LogoffTime\":\"1604855132.756\",\"LogonDomain\":\"dom1\",\"LogonServer\":\"srv2\",\"LogonTime\":\"1604855131.666\",\"LogonType\":\"7\",\"PasswordLastSet\":\"1598119332.510\",\"RemoteAccount\":\"1\",\"UserFlags\":\"32\",\"UserIsAdmin\":\"0\",\"UserLogoffType\":\"3\",\"UserLogonFlags\":\"0\",\"UserName\":\"user4\",\"UserPrincipal\":\"user.name@dom2.com\",\"UserSid\":\"S-1-5-21-606747145-1364589140-725345543-28636\",\"aid\":\"ffffffffe0104823bd3de859d5bc8bc7\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserLogoff\",\"id\":\"ffffffff-1111-11eb-8913-0287fd11c79b\",\"name\":\"UserLogoffV3\",\"timestamp\":\"1604855134461\"}",
-                "created": "2020-11-08T17:05:34.461Z",
-                "kind": "event",
-                "action": "UserLogoff",
-                "id": "ffffffff-1111-11eb-8913-0287fd11c79b",
-                "category": [
-                    "authentication"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "LogoffTime": "2020-11-08T17:05:32.756Z",
-                "ConfigStateHash": "3950066843",
-                "LogonTime": "2020-11-08T17:05:31.666Z",
-                "LogonType": "7",
-                "LogonDomain": "dom1",
-                "RemoteAccount": "1",
-                "AuthenticationPackage": "Negotiate",
-                "AuthenticationId": "317005428",
-                "PasswordLastSet": "1598119332.510",
-                "UserFlags": "32",
-                "Entitlements": "15",
-                "UserLogoffType": "3",
-                "name": "UserLogoffV3",
-                "UserLogonFlags": "0",
-                "LogonServer": "srv2",
-                "EffectiveTransmissionClass": "2",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "user": {
-                "name": "user4",
-                "full_name": "user.name",
-                "id": "S-1-5-21-606747145-1364589140-725345543-28636",
-                "email": "user.name@dom2.com",
-                "domain": "dom2.com"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            },
+            "user": {
+                "domain": "dom2.com",
+                "email": "user.name@dom2.com",
+                "full_name": "user.name",
+                "id": "S-1-5-21-606747145-1364589140-725345543-28636",
+                "name": "user4"
+            }
         },
         {
+            "@timestamp": "2020-11-08T17:03:45.966Z",
+            "crowdstrike": {
+                "ConfigStateHash": "537307300",
+                "DesiredAccess": "1180054",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileAttributes": "128",
+                "FileObject": "18446695174291796544",
+                "Information": "2",
+                "IrpFlags": "2180",
+                "MajorFunction": "0",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "Options": "83886176",
+                "ShareAccess": "3",
+                "Status": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NewExecutableWrittenV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NewExecutableWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:05:49.643Z",
+                "id": "ffffffff-1111-11eb-93cb-067deb43537b",
+                "ingested": "2022-03-22T18:19:46.427120400Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"537307300\",\"ContextProcessId\":\"635780922149\",\"ContextThreadId\":\"9479299143023\",\"ContextTimeStamp\":\"1604855025.966\",\"DesiredAccess\":\"1180054\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"128\",\"FileIdentifier\":\"0e02a8c7ed9d244887cef0409af0e6190030000000001100\",\"FileObject\":\"18446695174291796544\",\"Information\":\"2\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"83886176\",\"ShareAccess\":\"3\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume4\\\\Program Files\\\\Snow Software\\\\Inventory\\\\Agent\\\\cloudmeteringhost.exe\",\"aid\":\"ffffffff425942f58382dbb11350eeda\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NewExecutableWritten\",\"id\":\"ffffffff-1111-11eb-93cb-067deb43537b\",\"name\":\"NewExecutableWrittenV1\",\"timestamp\":\"1604855149643\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "\\Device\\HarddiskVolume4\\Program Files\\Snow Software\\Inventory\\Agent",
+                "extension": "exe",
+                "inode": "0e02a8c7ed9d244887cef0409af0e6190030000000001100",
+                "name": "cloudmeteringhost.exe",
+                "path": "\\Device\\HarddiskVolume4\\Program Files\\Snow Software\\Inventory\\Agent\\cloudmeteringhost.exe",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff425942f58382dbb11350eeda",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "635780922149",
                 "thread": {
                     "id": 9479299143023
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff425942f58382dbb11350eeda",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:03:45.966Z",
-            "file": {
-                "inode": "0e02a8c7ed9d244887cef0409af0e6190030000000001100",
-                "name": "cloudmeteringhost.exe",
-                "path": "\\Device\\HarddiskVolume4\\Program Files\\Snow Software\\Inventory\\Agent\\cloudmeteringhost.exe",
-                "extension": "exe",
-                "type": "file",
-                "directory": "\\Device\\HarddiskVolume4\\Program Files\\Snow Software\\Inventory\\Agent"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "537307300"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561766676Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"537307300\",\"ContextProcessId\":\"635780922149\",\"ContextThreadId\":\"9479299143023\",\"ContextTimeStamp\":\"1604855025.966\",\"DesiredAccess\":\"1180054\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"128\",\"FileIdentifier\":\"0e02a8c7ed9d244887cef0409af0e6190030000000001100\",\"FileObject\":\"18446695174291796544\",\"Information\":\"2\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"83886176\",\"ShareAccess\":\"3\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume4\\\\Program Files\\\\Snow Software\\\\Inventory\\\\Agent\\\\cloudmeteringhost.exe\",\"aid\":\"ffffffff425942f58382dbb11350eeda\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NewExecutableWritten\",\"id\":\"ffffffff-1111-11eb-93cb-067deb43537b\",\"name\":\"NewExecutableWrittenV1\",\"timestamp\":\"1604855149643\"}",
-                "created": "2020-11-08T17:05:49.643Z",
-                "kind": "event",
-                "action": "NewExecutableWritten",
-                "id": "ffffffff-1111-11eb-93cb-067deb43537b",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "Status": "0",
-                "Options": "83886176",
-                "ConfigStateHash": "537307300",
-                "IrpFlags": "2180",
-                "MinorFunction": "0",
-                "Information": "2",
-                "ShareAccess": "3",
-                "MajorFunction": "0",
-                "DesiredAccess": "1180054",
-                "Entitlements": "15",
-                "name": "NewExecutableWrittenV1",
-                "OperationFlags": "0",
-                "FileObject": "18446695174291796544",
-                "EffectiveTransmissionClass": "3",
-                "FileAttributes": "128",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:05:50.066Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3765958535",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NetworkListenIP4V5"
+            },
+            "destination": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkListenIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:05:50.545Z",
+                "id": "ffffffff-1111-11eb-8726-063418e4a9e7",
+                "ingested": "2022-03-22T18:19:46.427128100Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3765958535\",\"ConnectionDirection\":\"2\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"50714198593318\",\"ContextThreadId\":\"194302491825207\",\"ContextTimeStamp\":\"1604855150.066\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP4\":\"127.0.0.1\",\"LocalPort\":\"59491\",\"Protocol\":\"6\",\"RemoteAddressIP4\":\"0.0.0.0\",\"RemotePort\":\"0\",\"aid\":\"ffffffffa51b4acf9dbc1fc273e6145c\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NetworkListenIP4\",\"id\":\"ffffffff-1111-11eb-8726-063418e4a9e7\",\"name\":\"NetworkListenIP4V5\",\"timestamp\":\"1604855150545\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "network": {
+                "direction": "unknown",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffa51b4acf9dbc1fc273e6145c",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "50714198593318",
                 "thread": {
                     "id": 194302491825207
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "destination": {
-                "port": 0,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "source": {
-                "port": 59491,
-                "address": "127.0.0.1",
-                "ip": "127.0.0.1"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "unknown"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffa51b4acf9dbc1fc273e6145c",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:05:50.066Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
+                "hash": [
+                    "3765958535"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "127.0.0.1",
                     "0.0.0.0"
-                ],
-                "hash": [
-                    "3765958535"
                 ],
                 "ip": [
                     "67.43.156.14",
@@ -8065,32 +8078,87 @@
                     "0.0.0.0"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561767587Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3765958535\",\"ConnectionDirection\":\"2\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"50714198593318\",\"ContextThreadId\":\"194302491825207\",\"ContextTimeStamp\":\"1604855150.066\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP4\":\"127.0.0.1\",\"LocalPort\":\"59491\",\"Protocol\":\"6\",\"RemoteAddressIP4\":\"0.0.0.0\",\"RemotePort\":\"0\",\"aid\":\"ffffffffa51b4acf9dbc1fc273e6145c\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NetworkListenIP4\",\"id\":\"ffffffff-1111-11eb-8726-063418e4a9e7\",\"name\":\"NetworkListenIP4V5\",\"timestamp\":\"1604855150545\"}",
-                "created": "2020-11-08T17:05:50.545Z",
-                "kind": "event",
-                "action": "NetworkListenIP4",
-                "id": "ffffffff-1111-11eb-8726-063418e4a9e7",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
+            "source": {
+                "address": "127.0.0.1",
+                "ip": "127.0.0.1",
+                "port": 59491
             },
-            "crowdstrike": {
-                "ConfigStateHash": "3765958535",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkListenIP4V5",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:05:52.993Z",
+            "crowdstrike": {
+                "ClientComputerName": "com1",
+                "ConfigStateHash": "3011122681",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "EtwRawThreadId": 5304,
+                "LogonDomain": "BROADCAST",
+                "LogonType": "3",
+                "Status": "3221225581",
+                "SubStatus": "3221225578",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "UserLogonFailed2V2"
+            },
+            "destination": {
+                "address": "67.43.156.14",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "UserLogonFailed2",
+                "category": [
+                    "authentication"
+                ],
+                "created": "2020-11-08T17:05:54.274Z",
+                "id": "ffffffff-1111-11eb-a8aa-067029dffccb",
+                "ingested": "2022-03-22T18:19:46.427135800Z",
+                "kind": "event",
+                "original": "{\"ClientComputerName\":\"com1\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3011122681\",\"ContextProcessId\":\"7073822473144\",\"ContextThreadId\":\"48689911139327\",\"ContextTimeStamp\":\"1604855152.993\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"EtwRawProcessId\":\"744\",\"EtwRawThreadId\":\"5304\",\"LogonDomain\":\"BROADCAST\",\"LogonType\":\"3\",\"RemoteAddressIP4\":\"67.43.156.14\",\"Status\":\"3221225581\",\"SubStatus\":\"3221225578\",\"UserName\":\"user5\",\"aid\":\"ffffffffd8844a59acce5e1f4ad01888\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserLogonFailed2\",\"id\":\"ffffffff-1111-11eb-a8aa-067029dffccb\",\"name\":\"UserLogonFailed2V2\",\"timestamp\":\"1604855154274\"}",
+                "outcome": "failure",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffffd8844a59acce5e1f4ad01888",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "7073822473144",
                 "pid": 744,
@@ -8098,292 +8166,255 @@
                     "id": 48689911139327
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "destination": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "as": {
-                    "number": 35908
-                },
-                "address": "67.43.156.14",
-                "ip": "67.43.156.14"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffffd8844a59acce5e1f4ad01888",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:05:52.993Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "user": [
-                    "user5"
+                "hash": [
+                    "3011122681"
                 ],
                 "hosts": [
                     "67.43.156.13",
                     "67.43.156.14",
                     "com1"
                 ],
-                "hash": [
-                    "3011122681"
-                ],
                 "ip": [
                     "67.43.156.13",
                     "67.43.156.14"
+                ],
+                "user": [
+                    "user5"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561768498Z",
-                "original": "{\"ClientComputerName\":\"com1\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3011122681\",\"ContextProcessId\":\"7073822473144\",\"ContextThreadId\":\"48689911139327\",\"ContextTimeStamp\":\"1604855152.993\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"EtwRawProcessId\":\"744\",\"EtwRawThreadId\":\"5304\",\"LogonDomain\":\"BROADCAST\",\"LogonType\":\"3\",\"RemoteAddressIP4\":\"67.43.156.14\",\"Status\":\"3221225581\",\"SubStatus\":\"3221225578\",\"UserName\":\"user5\",\"aid\":\"ffffffffd8844a59acce5e1f4ad01888\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserLogonFailed2\",\"id\":\"ffffffff-1111-11eb-a8aa-067029dffccb\",\"name\":\"UserLogonFailed2V2\",\"timestamp\":\"1604855154274\"}",
-                "created": "2020-11-08T17:05:54.274Z",
-                "kind": "event",
-                "action": "UserLogonFailed2",
-                "id": "ffffffff-1111-11eb-a8aa-067029dffccb",
-                "category": [
-                    "authentication"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "failure"
-            },
-            "crowdstrike": {
-                "Status": "3221225581",
-                "ConfigStateHash": "3011122681",
-                "ClientComputerName": "com1",
-                "Entitlements": "15",
-                "LogonType": "3",
-                "name": "UserLogonFailed2V2",
-                "LogonDomain": "BROADCAST",
-                "EtwRawThreadId": 5304,
-                "EffectiveTransmissionClass": "2",
-                "SubStatus": "3221225578",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "name": "user5"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:05:51.534Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3343111420",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileObject": "18446636884348143072",
+                "IrpFlags": "1028",
+                "MajorFunction": "18",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "ExecutableDeletedV3"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ExecutableDeleted",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:05:54.670Z",
+                "id": "ffffffff-1111-11eb-b23b-064dea059649",
+                "ingested": "2022-03-22T18:19:46.427143600Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3343111420\",\"ContextProcessId\":\"1838383212125\",\"ContextThreadId\":\"27242382481217\",\"ContextTimeStamp\":\"1604855151.534\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileIdentifier\":\"b0754a8f86feffffb0754a8f86feffff09764a8f86feffff\",\"FileObject\":\"18446636884348143072\",\"IrpFlags\":\"1028\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Program Files\\\\WindowsApps\\\\Deleted\\\\Microsoft.Getstarted_9.10.32461.0_x64__8wekyb3d8bbweacf6b996-01b3-402c-bd01-a67529f94699\\\\clrcompression.dll\",\"aid\":\"ffffffff4a0946365161093453e596d4\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ExecutableDeleted\",\"id\":\"ffffffff-1111-11eb-b23b-064dea059649\",\"name\":\"ExecutableDeletedV3\",\"timestamp\":\"1604855154670\"}",
+                "outcome": "success",
+                "type": [
+                    "deletion"
+                ]
+            },
+            "file": {
+                "directory": "\\Device\\HarddiskVolume3\\Program Files\\WindowsApps\\Deleted\\Microsoft.Getstarted_9.10.32461.0_x64__8wekyb3d8bbweacf6b996-01b3-402c-bd01-a67529f94699",
+                "extension": "dll",
+                "inode": "b0754a8f86feffffb0754a8f86feffff09764a8f86feffff",
+                "name": "clrcompression.dll",
+                "path": "\\Device\\HarddiskVolume3\\Program Files\\WindowsApps\\Deleted\\Microsoft.Getstarted_9.10.32461.0_x64__8wekyb3d8bbweacf6b996-01b3-402c-bd01-a67529f94699\\clrcompression.dll",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff4a0946365161093453e596d4",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "1838383212125",
                 "thread": {
                     "id": 27242382481217
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
+            "related": {
+                "hash": [
+                    "3343111420"
+                ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
+                "ip": [
+                    "67.43.156.13"
+                ]
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff4a0946365161093453e596d4",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:05:51.534Z",
-            "file": {
-                "inode": "b0754a8f86feffffb0754a8f86feffff09764a8f86feffff",
-                "name": "clrcompression.dll",
-                "path": "\\Device\\HarddiskVolume3\\Program Files\\WindowsApps\\Deleted\\Microsoft.Getstarted_9.10.32461.0_x64__8wekyb3d8bbweacf6b996-01b3-402c-bd01-a67529f94699\\clrcompression.dll",
-                "extension": "dll",
-                "type": "file",
-                "directory": "\\Device\\HarddiskVolume3\\Program Files\\WindowsApps\\Deleted\\Microsoft.Getstarted_9.10.32461.0_x64__8wekyb3d8bbweacf6b996-01b3-402c-bd01-a67529f94699"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
-                "hash": [
-                    "3343111420"
-                ],
-                "ip": [
-                    "67.43.156.13"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561769428Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3343111420\",\"ContextProcessId\":\"1838383212125\",\"ContextThreadId\":\"27242382481217\",\"ContextTimeStamp\":\"1604855151.534\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileIdentifier\":\"b0754a8f86feffffb0754a8f86feffff09764a8f86feffff\",\"FileObject\":\"18446636884348143072\",\"IrpFlags\":\"1028\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Program Files\\\\WindowsApps\\\\Deleted\\\\Microsoft.Getstarted_9.10.32461.0_x64__8wekyb3d8bbweacf6b996-01b3-402c-bd01-a67529f94699\\\\clrcompression.dll\",\"aid\":\"ffffffff4a0946365161093453e596d4\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ExecutableDeleted\",\"id\":\"ffffffff-1111-11eb-b23b-064dea059649\",\"name\":\"ExecutableDeletedV3\",\"timestamp\":\"1604855154670\"}",
-                "created": "2020-11-08T17:05:54.670Z",
-                "kind": "event",
-                "action": "ExecutableDeleted",
-                "id": "ffffffff-1111-11eb-b23b-064dea059649",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "deletion"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3343111420",
-                "MajorFunction": "18",
-                "IrpFlags": "1028",
-                "Entitlements": "15",
-                "MinorFunction": "0",
-                "name": "ExecutableDeletedV3",
-                "OperationFlags": "0",
-                "FileObject": "18446636884348143072",
-                "EffectiveTransmissionClass": "3",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffffcfe84e8c6a52c4001bd83761",
-                "type": "agent",
-                "version": "1007.4.0009202.1"
-            },
-            "process": {
-                "pid": 20195,
-                "thread": {
-                    "id": 0
-                },
-                "entity_id": "318137549555284836",
-                "hash": {
-                    "sha256": "295fbc2356e8605e804f95cb6d6f992335e247dbf11767fe8781e2a7f889978a"
-                }
-            },
             "@timestamp": "2020-11-08T17:05:35.209Z",
-            "os": {
-                "type": "macos"
+            "crowdstrike": {
+                "AsepWrittenCount": 0,
+                "ConfigStateHash": "230795414",
+                "ContextProcessId": "318137549555284836",
+                "DirectoryCreatedCount": 0,
+                "DnsRequestCount": 0,
+                "Entitlements": "15",
+                "ExecutableDeletedCount": 0,
+                "FileDeletedCount": 0,
+                "NetworkBindCount": 0,
+                "NetworkCapableAsepWriteCount": 0,
+                "NetworkCloseCount": 0,
+                "NetworkConnectCount": 0,
+                "NetworkListenCount": 0,
+                "NetworkRecvAcceptCount": 0,
+                "NewExecutableWrittenCount": 0,
+                "SuspectStackCount": 0,
+                "SuspiciousDnsRequestCount": 0,
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "EndOfProcessMacV11"
             },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.13"
+            "event": {
+                "action": "EndOfProcess",
+                "category": [
+                    "process"
                 ],
+                "created": "2020-11-08T17:06:00.047Z",
+                "id": "ffffffff-1111-11eb-ae31-065d76bec0c3",
+                "ingested": "2022-03-22T18:19:46.427151300Z",
+                "kind": "event",
+                "original": "{\"AsepWrittenCount\":\"0\",\"ConfigBuild\":\"1007.4.0009202.1\",\"ConfigStateHash\":\"230795414\",\"ContextProcessId\":\"318137549555284836\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604855135.209\",\"DirectoryCreatedCount\":\"0\",\"DnsRequestCount\":\"0\",\"Entitlements\":\"15\",\"ExecutableDeletedCount\":\"0\",\"FileDeletedCount\":\"0\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"RawProcessId\":\"20195\",\"SHA256HashData\":\"295fbc2356e8605e804f95cb6d6f992335e247dbf11767fe8781e2a7f889978a\",\"SuspectStackCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"TargetProcessId\":\"318137549555284836\",\"aid\":\"ffffffffcfe84e8c6a52c4001bd83761\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-ae31-065d76bec0c3\",\"name\":\"EndOfProcessMacV11\",\"timestamp\":\"1604855160047\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffffcfe84e8c6a52c4001bd83761",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0009202.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "process": {
+                "entity_id": "318137549555284836",
+                "hash": {
+                    "sha256": "295fbc2356e8605e804f95cb6d6f992335e247dbf11767fe8781e2a7f889978a"
+                },
+                "pid": 20195,
+                "thread": {
+                    "id": 0
+                }
+            },
+            "related": {
                 "hash": [
                     "295fbc2356e8605e804f95cb6d6f992335e247dbf11767fe8781e2a7f889978a",
                     "230795414"
                 ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561770372Z",
-                "original": "{\"AsepWrittenCount\":\"0\",\"ConfigBuild\":\"1007.4.0009202.1\",\"ConfigStateHash\":\"230795414\",\"ContextProcessId\":\"318137549555284836\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604855135.209\",\"DirectoryCreatedCount\":\"0\",\"DnsRequestCount\":\"0\",\"Entitlements\":\"15\",\"ExecutableDeletedCount\":\"0\",\"FileDeletedCount\":\"0\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"RawProcessId\":\"20195\",\"SHA256HashData\":\"295fbc2356e8605e804f95cb6d6f992335e247dbf11767fe8781e2a7f889978a\",\"SuspectStackCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"TargetProcessId\":\"318137549555284836\",\"aid\":\"ffffffffcfe84e8c6a52c4001bd83761\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-ae31-065d76bec0c3\",\"name\":\"EndOfProcessMacV11\",\"timestamp\":\"1604855160047\"}",
-                "created": "2020-11-08T17:06:00.047Z",
-                "kind": "event",
-                "action": "EndOfProcess",
-                "id": "ffffffff-1111-11eb-ae31-065d76bec0c3",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "FileDeletedCount": 0,
-                "ConfigStateHash": "230795414",
-                "ContextProcessId": "318137549555284836",
-                "DirectoryCreatedCount": 0,
-                "AsepWrittenCount": 0,
-                "SuspiciousDnsRequestCount": 0,
-                "NetworkConnectCount": 0,
-                "NetworkListenCount": 0,
-                "NetworkCapableAsepWriteCount": 0,
-                "ExecutableDeletedCount": 0,
-                "NetworkBindCount": 0,
-                "DnsRequestCount": 0,
-                "Entitlements": "15",
-                "name": "EndOfProcessMacV11",
-                "NetworkRecvAcceptCount": 0,
-                "NewExecutableWrittenCount": 0,
-                "NetworkCloseCount": 0,
-                "SuspectStackCount": 0,
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "url": {
-                "scheme": "http"
-            },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2020-11-08T17:06:11.731Z",
+            "crowdstrike": {
+                "ApiReturnValue": "1",
+                "ConfigStateHash": "3338885535",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "RegisterRawInputDevicesEtwV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "RegisterRawInputDevicesEtw",
+                "category": [
+                    "host",
+                    "configuration"
+                ],
+                "created": "2020-11-08T17:06:13.077Z",
+                "id": "ffffffff-1111-11eb-a570-0685ba2a382f",
+                "ingested": "2022-03-22T18:19:46.427159Z",
+                "kind": "event",
+                "original": "{\"ApiReturnValue\":\"1\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextProcessId\":\"683078218537\",\"ContextTimeStamp\":\"1604855171.731\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"EtwRawProcessId\":\"19400\",\"EtwRawThreadId\":\"9384\",\"aid\":\"ffffffff80984ea8b49d9a53f590c566\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RegisterRawInputDevicesEtw\",\"id\":\"ffffffff-1111-11eb-a570-0685ba2a382f\",\"name\":\"RegisterRawInputDevicesEtwV1\",\"timestamp\":\"1604855173077\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
                 "serial_number": "ffffffff80984ea8b49d9a53f590c566",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
             },
             "process": {
                 "entity_id": "683078218537",
@@ -8392,316 +8423,339 @@
                     "id": 9384
                 }
             },
-            "@timestamp": "2020-11-08T17:06:11.731Z",
-            "os": {
-                "type": "windows"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3338885535"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561771292Z",
-                "original": "{\"ApiReturnValue\":\"1\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextProcessId\":\"683078218537\",\"ContextTimeStamp\":\"1604855171.731\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"EtwRawProcessId\":\"19400\",\"EtwRawThreadId\":\"9384\",\"aid\":\"ffffffff80984ea8b49d9a53f590c566\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RegisterRawInputDevicesEtw\",\"id\":\"ffffffff-1111-11eb-a570-0685ba2a382f\",\"name\":\"RegisterRawInputDevicesEtwV1\",\"timestamp\":\"1604855173077\"}",
-                "created": "2020-11-08T17:06:13.077Z",
-                "kind": "event",
-                "action": "RegisterRawInputDevicesEtw",
-                "id": "ffffffff-1111-11eb-a570-0685ba2a382f",
-                "category": [
-                    "host",
-                    "configuration"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "RegisterRawInputDevicesEtwV1",
-                "ConfigStateHash": "3338885535",
-                "ApiReturnValue": "1",
-                "EffectiveTransmissionClass": "3",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "server": {
-                "subdomain": "lfodown01-b",
-                "registered_domain": "cloudsink.net",
-                "address": "lfodown01-b.cloudsink.net",
-                "top_level_domain": "net",
-                "domain": "lfodown01-b.cloudsink.net"
-            },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "path": "/metahash+/cfs/channelfiles/0000000013/b2acba1a30a3407dae27d0503611022d/C-00000013-00000000-00000408.sys",
-                "extension": "sys",
-                "registered_domain": "cloudsink.net",
-                "original": "https://lfodown01-b.cloudsink.net/metahash+/cfs/channelfiles/0000000013/b2acba1a30a3407dae27d0503611022d/C-00000013-00000000-00000408.sys",
-                "scheme": "https",
-                "top_level_domain": "net",
-                "domain": "lfodown01-b.cloudsink.net",
-                "subdomain": "lfodown01-b"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffffc94c645268f64fc900213f",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
             "@timestamp": "2020-11-08T17:06:14.018Z",
-            "file": {
-                "type": "file",
-                "path": "C-00000013-00000000-00000408.sys"
+            "crowdstrike": {
+                "CompletionEventId": "Event_ChannelDataDownloadCompleteV1",
+                "ConfigStateHash": "3338885535",
+                "DownloadPort": 443,
+                "EffectiveTransmissionClass": "0",
+                "Entitlements": "15",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "LFODownloadConfirmationV1"
             },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
+            "event": {
+                "action": "LFODownloadConfirmation",
+                "category": [
+                    "file"
                 ],
+                "created": "2020-11-08T17:06:14.018Z",
+                "id": "ffffffff-1111-11eb-8ab5-0643392fc75d",
+                "ingested": "2022-03-22T18:19:46.427166600Z",
+                "kind": "event",
+                "original": "{\"CompletionEventId\":\"Event_ChannelDataDownloadCompleteV1\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"DownloadPath\":\"metahash+/cfs/channelfiles/0000000013/b2acba1a30a3407dae27d0503611022d/C-00000013-00000000-00000408.sys\",\"DownloadPort\":\"443\",\"DownloadServer\":\"lfodown01-b.cloudsink.net\",\"EffectiveTransmissionClass\":\"0\",\"Entitlements\":\"15\",\"TargetFileName\":\"C-00000013-00000000-00000408.sys\",\"aid\":\"ffffffffffc94c645268f64fc900213f\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"LFODownloadConfirmation\",\"id\":\"ffffffff-1111-11eb-8ab5-0643392fc75d\",\"name\":\"LFODownloadConfirmationV1\",\"timestamp\":\"1604855174018\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "path": "C-00000013-00000000-00000408.sys",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffffc94c645268f64fc900213f",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
+            "related": {
                 "hash": [
                     "3338885535"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561772233Z",
-                "original": "{\"CompletionEventId\":\"Event_ChannelDataDownloadCompleteV1\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"DownloadPath\":\"metahash+/cfs/channelfiles/0000000013/b2acba1a30a3407dae27d0503611022d/C-00000013-00000000-00000408.sys\",\"DownloadPort\":\"443\",\"DownloadServer\":\"lfodown01-b.cloudsink.net\",\"EffectiveTransmissionClass\":\"0\",\"Entitlements\":\"15\",\"TargetFileName\":\"C-00000013-00000000-00000408.sys\",\"aid\":\"ffffffffffc94c645268f64fc900213f\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"LFODownloadConfirmation\",\"id\":\"ffffffff-1111-11eb-8ab5-0643392fc75d\",\"name\":\"LFODownloadConfirmationV1\",\"timestamp\":\"1604855174018\"}",
-                "created": "2020-11-08T17:06:14.018Z",
-                "kind": "event",
-                "action": "LFODownloadConfirmation",
-                "id": "ffffffff-1111-11eb-8ab5-0643392fc75d",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
+            "server": {
+                "address": "lfodown01-b.cloudsink.net",
+                "domain": "lfodown01-b.cloudsink.net",
+                "registered_domain": "cloudsink.net",
+                "subdomain": "lfodown01-b",
+                "top_level_domain": "net"
             },
-            "crowdstrike": {
-                "ConfigStateHash": "3338885535",
-                "Entitlements": "15",
-                "name": "LFODownloadConfirmationV1",
-                "CompletionEventId": "Event_ChannelDataDownloadCompleteV1",
-                "EffectiveTransmissionClass": "0",
-                "DownloadPort": 443,
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "lfodown01-b.cloudsink.net",
+                "extension": "sys",
+                "original": "https://lfodown01-b.cloudsink.net/metahash+/cfs/channelfiles/0000000013/b2acba1a30a3407dae27d0503611022d/C-00000013-00000000-00000408.sys",
+                "path": "/metahash+/cfs/channelfiles/0000000013/b2acba1a30a3407dae27d0503611022d/C-00000013-00000000-00000408.sys",
+                "registered_domain": "cloudsink.net",
+                "scheme": "https",
+                "subdomain": "lfodown01-b",
+                "top_level_domain": "net"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:05:46.590Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1763245019",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileObject": "18446622606546437424",
+                "IrpFlags": "395312",
+                "MajorFunction": "6",
+                "MinorFunction": "0",
+                "NewFileIdentifier": "4b0121a43dfc1f4ca54eea679ddbcd4eef2103000000ca00",
+                "OperationFlags": "0",
+                "TargetFileName": "\\Device\\HarddiskVolume3\\Windows\\assembly\\NativeImages_v4.0.30319_64\\Microsoft.We0722664#\\c2579d00f9849413b8b7948dd00ac863\\Microsoft.WSMan.Management.ni.dll",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NewExecutableRenamedV6"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NewExecutableRenamed",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:06:17.513Z",
+                "id": "ffffffff-1111-11eb-8162-0663305b686f",
+                "ingested": "2022-03-22T18:19:46.427174300Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"2071361595421\",\"ContextThreadId\":\"41650430047375\",\"ContextTimeStamp\":\"1604855146.590\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileIdentifier\":\"4b0121a43dfc1f4ca54eea679ddbcd4eef2103000000ca00\",\"FileObject\":\"18446622606546437424\",\"IrpFlags\":\"395312\",\"MajorFunction\":\"6\",\"MinorFunction\":\"0\",\"NewFileIdentifier\":\"4b0121a43dfc1f4ca54eea679ddbcd4eef2103000000ca00\",\"OperationFlags\":\"0\",\"SourceFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\assembly\\\\temp\\\\EKA0UARWWK\\\\Microsoft.WSMan.Management.ni.dll\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\assembly\\\\NativeImages_v4.0.30319_64\\\\Microsoft.We0722664#\\\\c2579d00f9849413b8b7948dd00ac863\\\\Microsoft.WSMan.Management.ni.dll\",\"aid\":\"ffffffff280b41b956a91e816bd9b9b0\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NewExecutableRenamed\",\"id\":\"ffffffff-1111-11eb-8162-0663305b686f\",\"name\":\"NewExecutableRenamedV6\",\"timestamp\":\"1604855177513\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "file": {
+                "directory": "\\Device\\HarddiskVolume3\\Windows\\assembly\\temp\\EKA0UARWWK",
+                "extension": "dll",
+                "inode": "4b0121a43dfc1f4ca54eea679ddbcd4eef2103000000ca00",
+                "name": "Microsoft.WSMan.Management.ni.dll",
+                "path": "\\Device\\HarddiskVolume3\\Windows\\assembly\\temp\\EKA0UARWWK\\Microsoft.WSMan.Management.ni.dll",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff280b41b956a91e816bd9b9b0",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "2071361595421",
                 "thread": {
                     "id": 41650430047375
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff280b41b956a91e816bd9b9b0",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:05:46.590Z",
-            "file": {
-                "inode": "4b0121a43dfc1f4ca54eea679ddbcd4eef2103000000ca00",
-                "name": "Microsoft.WSMan.Management.ni.dll",
-                "path": "\\Device\\HarddiskVolume3\\Windows\\assembly\\temp\\EKA0UARWWK\\Microsoft.WSMan.Management.ni.dll",
-                "extension": "dll",
-                "type": "file",
-                "directory": "\\Device\\HarddiskVolume3\\Windows\\assembly\\temp\\EKA0UARWWK"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "1763245019"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561773157Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"2071361595421\",\"ContextThreadId\":\"41650430047375\",\"ContextTimeStamp\":\"1604855146.590\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileIdentifier\":\"4b0121a43dfc1f4ca54eea679ddbcd4eef2103000000ca00\",\"FileObject\":\"18446622606546437424\",\"IrpFlags\":\"395312\",\"MajorFunction\":\"6\",\"MinorFunction\":\"0\",\"NewFileIdentifier\":\"4b0121a43dfc1f4ca54eea679ddbcd4eef2103000000ca00\",\"OperationFlags\":\"0\",\"SourceFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\assembly\\\\temp\\\\EKA0UARWWK\\\\Microsoft.WSMan.Management.ni.dll\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\assembly\\\\NativeImages_v4.0.30319_64\\\\Microsoft.We0722664#\\\\c2579d00f9849413b8b7948dd00ac863\\\\Microsoft.WSMan.Management.ni.dll\",\"aid\":\"ffffffff280b41b956a91e816bd9b9b0\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NewExecutableRenamed\",\"id\":\"ffffffff-1111-11eb-8162-0663305b686f\",\"name\":\"NewExecutableRenamedV6\",\"timestamp\":\"1604855177513\"}",
-                "created": "2020-11-08T17:06:17.513Z",
-                "kind": "event",
-                "action": "NewExecutableRenamed",
-                "id": "ffffffff-1111-11eb-8162-0663305b686f",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "1763245019",
-                "NewFileIdentifier": "4b0121a43dfc1f4ca54eea679ddbcd4eef2103000000ca00",
-                "MajorFunction": "6",
-                "IrpFlags": "395312",
-                "Entitlements": "15",
-                "MinorFunction": "0",
-                "name": "NewExecutableRenamedV6",
-                "OperationFlags": "0",
-                "FileObject": "18446622606546437424",
-                "EffectiveTransmissionClass": "3",
-                "TargetFileName": "\\Device\\HarddiskVolume3\\Windows\\assembly\\NativeImages_v4.0.30319_64\\Microsoft.We0722664#\\c2579d00f9849413b8b7948dd00ac863\\Microsoft.WSMan.Management.ni.dll",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:06:05.213Z",
+            "crowdstrike": {
+                "ConfigStateHash": "402097454",
+                "DesiredAccess": "1048577",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileAttributes": "128",
+                "FileObject": "18446641334185168032",
+                "Information": "2",
+                "IrpFlags": "2180",
+                "MajorFunction": "0",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "Options": "35668001",
+                "ShareAccess": "3",
+                "Status": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "DirectoryCreateV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "DirectoryCreate",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:06:20.332Z",
+                "id": "ffffffff-1111-11eb-9411-06b7c99be087",
+                "ingested": "2022-03-22T18:19:46.427182200Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"402097454\",\"ContextProcessId\":\"66601077523\",\"ContextThreadId\":\"2500785639062\",\"ContextTimeStamp\":\"1604855165.213\",\"DesiredAccess\":\"1048577\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"128\",\"FileIdentifier\":\"d2f4250ff1ba3b4ca66e123c5269884ca6f8020000002700\",\"FileObject\":\"18446641334185168032\",\"Information\":\"2\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"35668001\",\"ShareAccess\":\"3\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\CbsTemp\\\\30848497_1904507751\\\\FodWU\",\"aid\":\"ffffffff2c9f4066b0b5f2f00265503c\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"DirectoryCreate\",\"id\":\"ffffffff-1111-11eb-9411-06b7c99be087\",\"name\":\"DirectoryCreateV1\",\"timestamp\":\"1604855180332\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "\\Device\\HarddiskVolume3\\Windows\\CbsTemp\\30848497_1904507751",
+                "inode": "d2f4250ff1ba3b4ca66e123c5269884ca6f8020000002700",
+                "name": "FodWU",
+                "path": "\\Device\\HarddiskVolume3\\Windows\\CbsTemp\\30848497_1904507751\\FodWU",
+                "type": "dir"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff2c9f4066b0b5f2f00265503c",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "66601077523",
                 "thread": {
                     "id": 2500785639062
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff2c9f4066b0b5f2f00265503c",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:06:05.213Z",
-            "file": {
-                "inode": "d2f4250ff1ba3b4ca66e123c5269884ca6f8020000002700",
-                "name": "FodWU",
-                "path": "\\Device\\HarddiskVolume3\\Windows\\CbsTemp\\30848497_1904507751\\FodWU",
-                "type": "dir",
-                "directory": "\\Device\\HarddiskVolume3\\Windows\\CbsTemp\\30848497_1904507751"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "402097454"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561774077Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"402097454\",\"ContextProcessId\":\"66601077523\",\"ContextThreadId\":\"2500785639062\",\"ContextTimeStamp\":\"1604855165.213\",\"DesiredAccess\":\"1048577\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"128\",\"FileIdentifier\":\"d2f4250ff1ba3b4ca66e123c5269884ca6f8020000002700\",\"FileObject\":\"18446641334185168032\",\"Information\":\"2\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"35668001\",\"ShareAccess\":\"3\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\CbsTemp\\\\30848497_1904507751\\\\FodWU\",\"aid\":\"ffffffff2c9f4066b0b5f2f00265503c\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"DirectoryCreate\",\"id\":\"ffffffff-1111-11eb-9411-06b7c99be087\",\"name\":\"DirectoryCreateV1\",\"timestamp\":\"1604855180332\"}",
-                "created": "2020-11-08T17:06:20.332Z",
-                "kind": "event",
-                "action": "DirectoryCreate",
-                "id": "ffffffff-1111-11eb-9411-06b7c99be087",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "Status": "0",
-                "Options": "35668001",
-                "ConfigStateHash": "402097454",
-                "IrpFlags": "2180",
-                "MinorFunction": "0",
-                "Information": "2",
-                "ShareAccess": "3",
-                "MajorFunction": "0",
-                "DesiredAccess": "1048577",
-                "Entitlements": "15",
-                "name": "DirectoryCreateV1",
-                "OperationFlags": "0",
-                "FileObject": "18446641334185168032",
-                "EffectiveTransmissionClass": "3",
-                "FileAttributes": "128",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:06:36.468Z",
+            "crowdstrike": {
+                "AuthenticationId": "999",
+                "ConfigStateHash": "3343111420",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InterfaceGuid": "367ABB81-9844-35F1-AD32-98F038001003",
+                "InterfaceVersion": "131072",
+                "RpcClientProcessId": "949196415400",
+                "RpcClientThreadId": "44209361549673",
+                "RpcNestingLevel": "0",
+                "RpcOpNum": "19",
+                "TokenType": "1",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "ServiceStartedV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ServiceStarted",
+                "category": [
+                    "process"
+                ],
+                "created": "2020-11-08T17:06:36.635Z",
+                "id": "ffffffff-1111-11eb-9c98-02c501fe7d81",
+                "ingested": "2022-03-22T18:19:46.427189900Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"999\",\"CommandLine\":\"C:\\\\WINDOWS\\\\system32\\\\svchost.exe -k netsvcs -p -s wlidsvc\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3343111420\",\"ContextTimeStamp\":\"1604855196.468\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\System32\\\\svchost.exe\",\"InterfaceGuid\":\"367ABB81-9844-35F1-AD32-98F038001003\",\"InterfaceVersion\":\"131072\",\"RpcClientProcessId\":\"949196415400\",\"RpcClientThreadId\":\"44209361549673\",\"RpcNestingLevel\":\"0\",\"RpcOpNum\":\"19\",\"ServiceDisplayName\":\"wlidsvc\",\"TargetProcessId\":\"955370934902\",\"TokenType\":\"1\",\"UserName\":\"user6\",\"aid\":\"fffffffffcc4413057adc260e99b0774\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ServiceStarted\",\"id\":\"ffffffff-1111-11eb-9c98-02c501fe7d81\",\"name\":\"ServiceStartedV2\",\"timestamp\":\"1604855196635\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "fffffffffcc4413057adc260e99b0774",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "args": [
                     "C:\\WINDOWS\\system32\\svchost.exe",
@@ -8712,146 +8766,105 @@
                     "wlidsvc"
                 ],
                 "args_count": 6,
-                "entity_id": "955370934902",
-                "title": "wlidsvc",
                 "command_line": "C:\\WINDOWS\\system32\\svchost.exe -k netsvcs -p -s wlidsvc",
-                "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\svchost.exe"
-            },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "fffffffffcc4413057adc260e99b0774",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:06:36.468Z",
-            "ecs": {
-                "version": "8.0.0"
+                "entity_id": "955370934902",
+                "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\svchost.exe",
+                "title": "wlidsvc"
             },
             "related": {
-                "user": [
-                    "user6"
+                "hash": [
+                    "3343111420"
                 ],
                 "hosts": [
                     "67.43.156.14"
                 ],
-                "hash": [
-                    "3343111420"
-                ],
                 "ip": [
                     "67.43.156.14"
+                ],
+                "user": [
+                    "user6"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561775094Z",
-                "original": "{\"AuthenticationId\":\"999\",\"CommandLine\":\"C:\\\\WINDOWS\\\\system32\\\\svchost.exe -k netsvcs -p -s wlidsvc\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3343111420\",\"ContextTimeStamp\":\"1604855196.468\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\System32\\\\svchost.exe\",\"InterfaceGuid\":\"367ABB81-9844-35F1-AD32-98F038001003\",\"InterfaceVersion\":\"131072\",\"RpcClientProcessId\":\"949196415400\",\"RpcClientThreadId\":\"44209361549673\",\"RpcNestingLevel\":\"0\",\"RpcOpNum\":\"19\",\"ServiceDisplayName\":\"wlidsvc\",\"TargetProcessId\":\"955370934902\",\"TokenType\":\"1\",\"UserName\":\"user6\",\"aid\":\"fffffffffcc4413057adc260e99b0774\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ServiceStarted\",\"id\":\"ffffffff-1111-11eb-9c98-02c501fe7d81\",\"name\":\"ServiceStartedV2\",\"timestamp\":\"1604855196635\"}",
-                "created": "2020-11-08T17:06:36.635Z",
-                "kind": "event",
-                "action": "ServiceStarted",
-                "id": "ffffffff-1111-11eb-9c98-02c501fe7d81",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3343111420",
-                "InterfaceVersion": "131072",
-                "RpcClientThreadId": "44209361549673",
-                "AuthenticationId": "999",
-                "TokenType": "1",
-                "Entitlements": "15",
-                "RpcOpNum": "19",
-                "name": "ServiceStartedV2",
-                "InterfaceGuid": "367ABB81-9844-35F1-AD32-98F038001003",
-                "RpcClientProcessId": "949196415400",
-                "EffectiveTransmissionClass": "3",
-                "RpcNestingLevel": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "name": "user6"
             }
         },
         {
-            "process": {
-                "entity_id": "319255017313886870"
+            "@timestamp": "2020-11-08T17:06:40.751Z",
+            "crowdstrike": {
+                "ConfigStateHash": "203564169",
+                "ConnectionFlags": "0",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NetworkConnectIP6MacV5"
+            },
+            "destination": {
+                "address": "0:0:0:0:0:0:0:1",
+                "ip": "0:0:0:0:0:0:0:1",
+                "port": 2181
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkConnectIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:06:40.836Z",
+                "id": "ffffffff-1111-11eb-81f1-061cdebbd115",
+                "ingested": "2022-03-22T18:19:46.427197600Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"203564169\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"319255017313886870\",\"ContextTimeStamp\":\"1604855200.751\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:0\",\"LocalPort\":\"0\",\"Protocol\":\"6\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:1\",\"RemotePort\":\"2181\",\"aid\":\"ffffffffed0f41575620ab9fb25ce105\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NetworkConnectIP6\",\"id\":\"ffffffff-1111-11eb-81f1-061cdebbd115\",\"name\":\"NetworkConnectIP6MacV5\",\"timestamp\":\"1604855200836\"}",
+                "outcome": "unknown",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffed0f41575620ab9fb25ce105",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0011104.1"
             },
             "os": {
                 "type": "macos"
             },
-            "destination": {
-                "port": 2181,
-                "address": "0:0:0:0:0:0:0:1",
-                "ip": "0:0:0:0:0:0:0:1"
-            },
-            "source": {
-                "port": 0,
-                "address": "0:0:0:0:0:0:0:0",
-                "ip": "0:0:0:0:0:0:0:0"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "outbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffed0f41575620ab9fb25ce105",
-                "type": "agent",
-                "version": "1007.4.0011104.1"
-            },
-            "@timestamp": "2020-11-08T17:06:40.751Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "319255017313886870"
             },
             "related": {
+                "hash": [
+                    "203564169"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "0:0:0:0:0:0:0:0",
                     "0:0:0:0:0:0:0:1"
-                ],
-                "hash": [
-                    "203564169"
                 ],
                 "ip": [
                     "67.43.156.14",
@@ -8859,226 +8872,130 @@
                     "0:0:0:0:0:0:0:1"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561776030Z",
-                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"203564169\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"319255017313886870\",\"ContextTimeStamp\":\"1604855200.751\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:0\",\"LocalPort\":\"0\",\"Protocol\":\"6\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:1\",\"RemotePort\":\"2181\",\"aid\":\"ffffffffed0f41575620ab9fb25ce105\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NetworkConnectIP6\",\"id\":\"ffffffff-1111-11eb-81f1-061cdebbd115\",\"name\":\"NetworkConnectIP6MacV5\",\"timestamp\":\"1604855200836\"}",
-                "created": "2020-11-08T17:06:40.836Z",
-                "kind": "event",
-                "action": "NetworkConnectIP6",
-                "id": "ffffffff-1111-11eb-81f1-061cdebbd115",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "unknown"
+            "source": {
+                "address": "0:0:0:0:0:0:0:0",
+                "ip": "0:0:0:0:0:0:0:0",
+                "port": 0
             },
-            "crowdstrike": {
-                "name": "NetworkConnectIP6MacV5",
-                "ConfigStateHash": "203564169",
-                "ConnectionFlags": "0",
-                "InContext": "0",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:06:52.031Z",
+            "crowdstrike": {
+                "AuthenticationId": "1656178821",
+                "AuthenticationPackage": "Kerberos",
+                "ConfigStateHash": "3338885535",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "LogonDomain": "dom1",
+                "LogonId": "1656178821",
+                "LogonServer": "srv1",
+                "LogonTime": "2020-11-08T17:06:51.249Z",
+                "LogonType": "5",
+                "PasswordLastSet": "1530626210.104",
+                "RemoteAccount": "1",
+                "SessionId": "0",
+                "UserFlags": "32",
+                "UserLogonFlags": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "UserIdentityV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "UserIdentity",
+                "category": [
+                    "authentication",
+                    "iam"
+                ],
+                "created": "2020-11-08T17:06:52.031Z",
+                "id": "ffffffff-1111-11eb-86e3-02db1faa1327",
+                "ingested": "2022-03-22T18:19:46.427205200Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"1656178821\",\"AuthenticationPackage\":\"Kerberos\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextProcessId\":\"30254389526587\",\"ContextThreadId\":\"275230771323179\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"LogonDomain\":\"dom1\",\"LogonId\":\"1656178821\",\"LogonServer\":\"srv1\",\"LogonTime\":\"1604855211.249\",\"LogonType\":\"5\",\"PasswordLastSet\":\"1530626210.104\",\"RemoteAccount\":\"1\",\"SessionId\":\"0\",\"UserCanonical\":\"\",\"UserFlags\":\"32\",\"UserIsAdmin\":\"0\",\"UserLogonFlags\":\"0\",\"UserName\":\"user7\",\"UserPrincipal\":\"user7@dom4.cm\",\"UserSid\":\"S-1-5-21-606747145-1364589140-725345543-183372\",\"aid\":\"ffffffff73164cfa9656c4caff8a2a38\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserIdentity\",\"id\":\"ffffffff-1111-11eb-86e3-02db1faa1327\",\"name\":\"UserIdentityV2\",\"timestamp\":\"1604855212031\"}",
+                "outcome": "success",
+                "type": [
+                    "info",
+                    "user"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff73164cfa9656c4caff8a2a38",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "30254389526587",
                 "thread": {
                     "id": 275230771323179
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff73164cfa9656c4caff8a2a38",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:06:52.031Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "user": [
-                    "user7"
+                "hash": [
+                    "3338885535"
                 ],
                 "hosts": [
                     "67.43.156.13",
                     "srv1"
                 ],
-                "hash": [
-                    "3338885535"
-                ],
                 "ip": [
                     "67.43.156.13"
+                ],
+                "user": [
+                    "user7"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561777027Z",
-                "original": "{\"AuthenticationId\":\"1656178821\",\"AuthenticationPackage\":\"Kerberos\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextProcessId\":\"30254389526587\",\"ContextThreadId\":\"275230771323179\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"LogonDomain\":\"dom1\",\"LogonId\":\"1656178821\",\"LogonServer\":\"srv1\",\"LogonTime\":\"1604855211.249\",\"LogonType\":\"5\",\"PasswordLastSet\":\"1530626210.104\",\"RemoteAccount\":\"1\",\"SessionId\":\"0\",\"UserCanonical\":\"\",\"UserFlags\":\"32\",\"UserIsAdmin\":\"0\",\"UserLogonFlags\":\"0\",\"UserName\":\"user7\",\"UserPrincipal\":\"user7@dom4.cm\",\"UserSid\":\"S-1-5-21-606747145-1364589140-725345543-183372\",\"aid\":\"ffffffff73164cfa9656c4caff8a2a38\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserIdentity\",\"id\":\"ffffffff-1111-11eb-86e3-02db1faa1327\",\"name\":\"UserIdentityV2\",\"timestamp\":\"1604855212031\"}",
-                "created": "2020-11-08T17:06:52.031Z",
-                "kind": "event",
-                "action": "UserIdentity",
-                "id": "ffffffff-1111-11eb-86e3-02db1faa1327",
-                "category": [
-                    "authentication",
-                    "iam"
-                ],
-                "type": [
-                    "info",
-                    "user"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3338885535",
-                "LogonTime": "2020-11-08T17:06:51.249Z",
-                "LogonType": "5",
-                "LogonDomain": "dom1",
-                "RemoteAccount": "1",
-                "AuthenticationPackage": "Kerberos",
-                "AuthenticationId": "1656178821",
-                "PasswordLastSet": "1530626210.104",
-                "UserFlags": "32",
-                "Entitlements": "15",
-                "name": "UserIdentityV2",
-                "UserLogonFlags": "0",
-                "LogonServer": "srv1",
-                "EffectiveTransmissionClass": "2",
-                "LogonId": "1656178821",
-                "SessionId": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "user": {
-                "name": "user7",
-                "full_name": "user7",
-                "id": "S-1-5-21-606747145-1364589140-725345543-183372",
-                "email": "user7@dom4.cm",
-                "domain": "dom4.cm"
-            }
-        },
-        {
-            "process": {
-                "args": [
-                    "C:\\WINDOWS\\System32\\svchost.exe",
-                    "-k",
-                    "netsvcs",
-                    "-p",
-                    "-s",
-                    "NetSetupSvc"
-                ],
-                "parent": {
-                    "entity_id": "2881931477041"
-                },
-                "start": "2020-11-08T13:38:53.215Z",
-                "pid": 6160,
-                "args_count": 6,
-                "entity_id": "2882232404222",
-                "command_line": "C:\\WINDOWS\\System32\\svchost.exe -k netsvcs -p -s NetSetupSvc",
-                "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\svchost.exe",
-                "hash": {
-                    "sha256": "7fd065bac18c5278777ae44908101cdfed72d26fa741367f0ad4d02020787ab6",
-                    "md5": "8a0a29438052faed8a2532da50455756"
-                }
-            },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffbe8a46386afe80c5ef64d0b5",
-                "type": "agent",
-                "version": "1007.3.0010609.1"
+            "url": {
+                "scheme": "http"
             },
+            "user": {
+                "domain": "dom4.cm",
+                "email": "user7@dom4.cm",
+                "full_name": "user7",
+                "id": "S-1-5-21-606747145-1364589140-725345543-183372",
+                "name": "user7"
+            }
+        },
+        {
             "@timestamp": "2020-11-08T17:07:17.946Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "8a0a29438052faed8a2532da50455756",
-                    "7fd065bac18c5278777ae44908101cdfed72d26fa741367f0ad4d02020787ab6",
-                    "4193986770"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561778051Z",
-                "original": "{\"AuthenticationId\":\"999\",\"CommandLine\":\"C:\\\\WINDOWS\\\\System32\\\\svchost.exe -k netsvcs -p -s NetSetupSvc\",\"ConfigBuild\":\"1007.3.0010609.1\",\"ConfigStateHash\":\"4193986770\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\System32\\\\svchost.exe\",\"ImageSubsystem\":\"2\",\"IntegrityLevel\":\"16384\",\"MD5HashData\":\"8a0a29438052faed8a2532da50455756\",\"ParentAuthenticationId\":\"999\",\"ParentProcessId\":\"2881931477041\",\"ProcessCreateFlags\":\"525324\",\"ProcessEndTime\":\"\",\"ProcessParameterFlags\":\"8193\",\"ProcessStartTime\":\"1604842733.215\",\"ProcessSxsFlags\":\"64\",\"RawProcessId\":\"6160\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"7fd065bac18c5278777ae44908101cdfed72d26fa741367f0ad4d02020787ab6\",\"SessionId\":\"0\",\"SourceProcessId\":\"2881931477041\",\"SourceThreadId\":\"70316664105336\",\"Tags\":\"27, 29, 53, 54, 55, 185, 10445360464024, 10445360464025, 10445360464026, 10445360464258, 10445360464273, 10445360464274, 12094627905582, 12094627906234, 211655988347297\",\"TargetProcessId\":\"2882232404222\",\"TokenType\":\"2\",\"UserSid\":\"S-1-5-18\",\"WindowFlags\":\"128\",\"aid\":\"ffffffffbe8a46386afe80c5ef64d0b5\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-b4f9-06e3a7e5503b\",\"name\":\"ProcessRollup2V16\",\"timestamp\":\"1604855237946\"}",
-                "created": "2020-11-08T17:07:17.946Z",
-                "kind": "event",
-                "action": "ProcessRollup2",
-                "id": "ffffffff-1111-11eb-b4f9-06e3a7e5503b",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
             "crowdstrike": {
-                "ConfigStateHash": "4193986770",
-                "ProcessCreateFlags": "525324",
-                "IntegrityLevel": "16384",
-                "SourceProcessId": "2881931477041",
-                "ProcessSxsFlags": "64",
                 "AuthenticationId": "999",
-                "WindowFlags": "128",
-                "TokenType": "2",
-                "ParentAuthenticationId": "999",
-                "Entitlements": "15",
-                "SourceThreadId": "70316664105336",
-                "name": "ProcessRollup2V16",
-                "ProcessParameterFlags": "8193",
-                "ImageSubsystem": "2",
+                "ConfigStateHash": "4193986770",
                 "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "ImageSubsystem": "2",
+                "IntegrityLevel": "16384",
+                "ParentAuthenticationId": "999",
+                "ProcessCreateFlags": "525324",
+                "ProcessParameterFlags": "8193",
+                "ProcessSxsFlags": "64",
                 "SessionId": "0",
+                "SourceProcessId": "2881931477041",
+                "SourceThreadId": "70316664105336",
                 "Tags": [
                     "27",
                     "29",
@@ -9096,399 +9013,486 @@
                     "12094627906234",
                     "211655988347297"
                 ],
-                "cid": "ffffffff30a3407dae27d0503611022d"
+                "TokenType": "2",
+                "WindowFlags": "128",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "ProcessRollup2V16"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2",
+                "category": [
+                    "process"
+                ],
+                "created": "2020-11-08T17:07:17.946Z",
+                "id": "ffffffff-1111-11eb-b4f9-06e3a7e5503b",
+                "ingested": "2022-03-22T18:19:46.427212800Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"999\",\"CommandLine\":\"C:\\\\WINDOWS\\\\System32\\\\svchost.exe -k netsvcs -p -s NetSetupSvc\",\"ConfigBuild\":\"1007.3.0010609.1\",\"ConfigStateHash\":\"4193986770\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\System32\\\\svchost.exe\",\"ImageSubsystem\":\"2\",\"IntegrityLevel\":\"16384\",\"MD5HashData\":\"8a0a29438052faed8a2532da50455756\",\"ParentAuthenticationId\":\"999\",\"ParentProcessId\":\"2881931477041\",\"ProcessCreateFlags\":\"525324\",\"ProcessEndTime\":\"\",\"ProcessParameterFlags\":\"8193\",\"ProcessStartTime\":\"1604842733.215\",\"ProcessSxsFlags\":\"64\",\"RawProcessId\":\"6160\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"7fd065bac18c5278777ae44908101cdfed72d26fa741367f0ad4d02020787ab6\",\"SessionId\":\"0\",\"SourceProcessId\":\"2881931477041\",\"SourceThreadId\":\"70316664105336\",\"Tags\":\"27, 29, 53, 54, 55, 185, 10445360464024, 10445360464025, 10445360464026, 10445360464258, 10445360464273, 10445360464274, 12094627905582, 12094627906234, 211655988347297\",\"TargetProcessId\":\"2882232404222\",\"TokenType\":\"2\",\"UserSid\":\"S-1-5-18\",\"WindowFlags\":\"128\",\"aid\":\"ffffffffbe8a46386afe80c5ef64d0b5\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-b4f9-06e3a7e5503b\",\"name\":\"ProcessRollup2V16\",\"timestamp\":\"1604855237946\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffbe8a46386afe80c5ef64d0b5",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0010609.1"
+            },
+            "os": {
+                "type": "windows"
+            },
+            "process": {
+                "args": [
+                    "C:\\WINDOWS\\System32\\svchost.exe",
+                    "-k",
+                    "netsvcs",
+                    "-p",
+                    "-s",
+                    "NetSetupSvc"
+                ],
+                "args_count": 6,
+                "command_line": "C:\\WINDOWS\\System32\\svchost.exe -k netsvcs -p -s NetSetupSvc",
+                "entity_id": "2882232404222",
+                "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\svchost.exe",
+                "hash": {
+                    "md5": "8a0a29438052faed8a2532da50455756",
+                    "sha256": "7fd065bac18c5278777ae44908101cdfed72d26fa741367f0ad4d02020787ab6"
+                },
+                "parent": {
+                    "entity_id": "2881931477041"
+                },
+                "pid": 6160,
+                "start": "2020-11-08T13:38:53.215Z"
+            },
+            "related": {
+                "hash": [
+                    "8a0a29438052faed8a2532da50455756",
+                    "7fd065bac18c5278777ae44908101cdfed72d26fa741367f0ad4d02020787ab6",
+                    "4193986770"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "id": "S-1-5-18"
             }
         },
         {
+            "@timestamp": "2020-11-08T09:58:32.519Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1763245019",
+                "DesiredAccess": "1179785",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileAttributes": "0",
+                "FileObject": "18446670458156489088",
+                "Information": "1",
+                "IrpFlags": "2180",
+                "MajorFunction": "0",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "Options": "16777312",
+                "ShareAccess": "5",
+                "Status": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "RansomwareOpenFileV4"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "RansomwareOpenFile",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:07:22.091Z",
+                "id": "ffffffff-1111-11eb-9756-06fe7f8f682f",
+                "ingested": "2022-03-22T18:19:46.427220400Z",
+                "kind": "alert",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"1016182570608\",\"ContextThreadId\":\"37343520154472\",\"ContextTimeStamp\":\"1604829512.519\",\"DesiredAccess\":\"1179785\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00\",\"FileObject\":\"18446670458156489088\",\"Information\":\"1\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"16777312\",\"ShareAccess\":\"5\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user11\\\\Downloads\\\\file.pptx\",\"aid\":\"ffffffffac4148947ed68497e89f3308\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RansomwareOpenFile\",\"id\":\"ffffffff-1111-11eb-9756-06fe7f8f682f\",\"name\":\"RansomwareOpenFileV4\",\"timestamp\":\"1604855242091\"}",
+                "outcome": "success",
+                "type": [
+                    "access"
+                ]
+            },
+            "file": {
+                "directory": "\\Device\\HarddiskVolume3\\Users\\user11\\Downloads",
+                "extension": "pptx",
+                "inode": "7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00",
+                "name": "file.pptx",
+                "path": "\\Device\\HarddiskVolume3\\Users\\user11\\Downloads\\file.pptx",
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffac4148947ed68497e89f3308",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "1016182570608",
                 "thread": {
                     "id": 37343520154472
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffac4148947ed68497e89f3308",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T09:58:32.519Z",
-            "file": {
-                "inode": "7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00",
-                "name": "file.pptx",
-                "path": "\\Device\\HarddiskVolume3\\Users\\user11\\Downloads\\file.pptx",
-                "extension": "pptx",
-                "type": "file",
-                "directory": "\\Device\\HarddiskVolume3\\Users\\user11\\Downloads"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "1763245019"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561779078Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"1016182570608\",\"ContextThreadId\":\"37343520154472\",\"ContextTimeStamp\":\"1604829512.519\",\"DesiredAccess\":\"1179785\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00\",\"FileObject\":\"18446670458156489088\",\"Information\":\"1\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"16777312\",\"ShareAccess\":\"5\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user11\\\\Downloads\\\\file.pptx\",\"aid\":\"ffffffffac4148947ed68497e89f3308\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RansomwareOpenFile\",\"id\":\"ffffffff-1111-11eb-9756-06fe7f8f682f\",\"name\":\"RansomwareOpenFileV4\",\"timestamp\":\"1604855242091\"}",
-                "created": "2020-11-08T17:07:22.091Z",
-                "kind": "alert",
-                "action": "RansomwareOpenFile",
-                "id": "ffffffff-1111-11eb-9756-06fe7f8f682f",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "access"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "Status": "0",
-                "Options": "16777312",
-                "ConfigStateHash": "1763245019",
-                "IrpFlags": "2180",
-                "MinorFunction": "0",
-                "Information": "1",
-                "ShareAccess": "5",
-                "MajorFunction": "0",
-                "DesiredAccess": "1179785",
-                "Entitlements": "15",
-                "name": "RansomwareOpenFileV4",
-                "OperationFlags": "0",
-                "FileObject": "18446670458156489088",
-                "EffectiveTransmissionClass": "3",
-                "FileAttributes": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "process": {
-                "parent": {
-                    "entity_id": "1731198143955"
+            "@timestamp": "2020-11-08T17:07:54.377Z",
+            "crowdstrike": {
+                "AllocateVirtualMemoryCount": 0,
+                "ArchiveFileWrittenCount": 0,
+                "AsepWrittenCount": 0,
+                "BinaryExecutableWrittenCount": 0,
+                "CLICreationCount": 0,
+                "ConHostId": "13532",
+                "ConHostProcessId": "1731198143955",
+                "ConfigStateHash": "2030177841",
+                "ContextProcessId": "1741732942772",
+                "CycleTime": 473618996,
+                "DirectoryCreatedCount": 0,
+                "DirectoryEnumeratedCount": 0,
+                "DnsRequestCount": 0,
+                "DocumentFileWrittenCount": 0,
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "ExeAndServiceCount": 0,
+                "ExecutableDeletedCount": 0,
+                "FileDeletedCount": 0,
+                "GenericFileWrittenCount": 0,
+                "ImageSubsystem": "2",
+                "InjectedDllCount": 0,
+                "InjectedThreadCount": 0,
+                "KernelTime": 1406250,
+                "MaxThreadCount": 16,
+                "ModuleLoadCount": 72,
+                "NetworkBindCount": 0,
+                "NetworkCapableAsepWriteCount": 0,
+                "NetworkCloseCount": 0,
+                "NetworkConnectCount": 0,
+                "NetworkConnectCountUdp": 0,
+                "NetworkListenCount": 0,
+                "NetworkModuleLoadCount": 0,
+                "NetworkRecvAcceptCount": 0,
+                "NewExecutableWrittenCount": 0,
+                "PrivilegedProcessHandleCount": 0,
+                "ProtectVirtualMemoryCount": 0,
+                "QueueApcCount": 0,
+                "RegKeySecurityDecreasedCount": 0,
+                "RemovableDiskFileWrittenCount": 0,
+                "RunDllInvocationCount": 0,
+                "ScreenshotsTakenCount": 0,
+                "ScriptEngineInvocationCount": 0,
+                "ServiceEventCount": 0,
+                "SetThreadContextCount": 0,
+                "SnapshotFileOpenCount": 0,
+                "SuspectStackCount": 0,
+                "SuspiciousCredentialModuleLoadCount": 0,
+                "SuspiciousDnsRequestCount": 0,
+                "SuspiciousFontLoadCount": 0,
+                "SuspiciousRawDiskReadCount": 0,
+                "UnsignedModuleLoadCount": 0,
+                "UserMemoryAllocateExecutableCount": 0,
+                "UserMemoryAllocateExecutableRemoteCount": 0,
+                "UserMemoryProtectExecutableCount": 0,
+                "UserMemoryProtectExecutableRemoteCount": 0,
+                "UserTime": 781250,
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "EndOfProcessV14"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "EndOfProcess",
+                "category": [
+                    "process"
+                ],
+                "created": "2020-11-08T17:07:56.657Z",
+                "id": "ffffffff-1111-11eb-b685-0241eaddc553",
+                "ingested": "2022-03-22T18:19:46.427228Z",
+                "kind": "event",
+                "original": "{\"AllocateVirtualMemoryCount\":\"0\",\"ArchiveFileWrittenCount\":\"0\",\"AsepWrittenCount\":\"0\",\"BinaryExecutableWrittenCount\":\"0\",\"CLICreationCount\":\"0\",\"ConHostId\":\"13532\",\"ConHostProcessId\":\"1731198143955\",\"ConfigBuild\":\"1007.3.0010609.1\",\"ConfigStateHash\":\"2030177841\",\"ContextData\":\"\",\"ContextProcessId\":\"1741732942772\",\"ContextThreadId\":\"28523520529271\",\"ContextTimeStamp\":\"1604855274.377\",\"CycleTime\":\"473618996\",\"DirectoryCreatedCount\":\"0\",\"DirectoryEnumeratedCount\":\"0\",\"DnsRequestCount\":\"0\",\"DocumentFileWrittenCount\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ExeAndServiceCount\":\"0\",\"ExecutableDeletedCount\":\"0\",\"ExitCode\":\"0\",\"FileDeletedCount\":\"0\",\"GenericFileWrittenCount\":\"0\",\"ImageSubsystem\":\"2\",\"InjectedDllCount\":\"0\",\"InjectedThreadCount\":\"0\",\"KernelTime\":\"1406250\",\"MaxThreadCount\":\"16\",\"ModuleLoadCount\":\"72\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkConnectCountUdp\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkModuleLoadCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"ParentProcessId\":\"1731198143955\",\"PrivilegedProcessHandleCount\":\"0\",\"ProcessStartTime\":\"1604855154.465\",\"ProtectVirtualMemoryCount\":\"0\",\"QueueApcCount\":\"0\",\"RawProcessId\":\"18176\",\"RegKeySecurityDecreasedCount\":\"0\",\"RemovableDiskFileWrittenCount\":\"0\",\"RunDllInvocationCount\":\"0\",\"SHA256HashData\":\"87419b84f34cdb13f699c0f0803c957e48c27ad83334fcad7bac9ad89c0a466f\",\"ScreenshotsTakenCount\":\"0\",\"ScriptEngineInvocationCount\":\"0\",\"ServiceEventCount\":\"0\",\"SetThreadContextCount\":\"0\",\"SnapshotFileOpenCount\":\"0\",\"SuspectStackCount\":\"0\",\"SuspiciousCredentialModuleLoadCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"SuspiciousFontLoadCount\":\"0\",\"SuspiciousRawDiskReadCount\":\"0\",\"TargetProcessId\":\"1741732942772\",\"UnsignedModuleLoadCount\":\"0\",\"UserMemoryAllocateExecutableCount\":\"0\",\"UserMemoryAllocateExecutableRemoteCount\":\"0\",\"UserMemoryProtectExecutableCount\":\"0\",\"UserMemoryProtectExecutableRemoteCount\":\"0\",\"UserSid\":\"S-1-12-1-1647509123-1308660782-3901357462-3999411581\",\"UserTime\":\"781250\",\"aid\":\"fffffffffdab492a5a20cd0417395a73\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-b685-0241eaddc553\",\"name\":\"EndOfProcessV14\",\"timestamp\":\"1604855276657\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "exit_code": 0,
-                "start": "2020-11-08T17:05:54.465Z",
-                "pid": 18176,
-                "thread": {
-                    "id": 28523520529271
-                },
-                "entity_id": "1741732942772",
-                "hash": {
-                    "sha256": "87419b84f34cdb13f699c0f0803c957e48c27ad83334fcad7bac9ad89c0a466f"
-                }
+                "ip": "67.43.156.13",
+                "serial_number": "fffffffffdab492a5a20cd0417395a73",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0010609.1"
             },
             "os": {
                 "type": "windows"
             },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+            "process": {
+                "entity_id": "1741732942772",
+                "exit_code": 0,
+                "hash": {
+                    "sha256": "87419b84f34cdb13f699c0f0803c957e48c27ad83334fcad7bac9ad89c0a466f"
                 },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "fffffffffdab492a5a20cd0417395a73",
-                "type": "agent",
-                "version": "1007.3.0010609.1"
-            },
-            "@timestamp": "2020-11-08T17:07:54.377Z",
-            "ecs": {
-                "version": "8.0.0"
+                "parent": {
+                    "entity_id": "1731198143955"
+                },
+                "pid": 18176,
+                "start": "2020-11-08T17:05:54.465Z",
+                "thread": {
+                    "id": 28523520529271
+                }
             },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "87419b84f34cdb13f699c0f0803c957e48c27ad83334fcad7bac9ad89c0a466f",
                     "2030177841"
                 ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561780003Z",
-                "original": "{\"AllocateVirtualMemoryCount\":\"0\",\"ArchiveFileWrittenCount\":\"0\",\"AsepWrittenCount\":\"0\",\"BinaryExecutableWrittenCount\":\"0\",\"CLICreationCount\":\"0\",\"ConHostId\":\"13532\",\"ConHostProcessId\":\"1731198143955\",\"ConfigBuild\":\"1007.3.0010609.1\",\"ConfigStateHash\":\"2030177841\",\"ContextData\":\"\",\"ContextProcessId\":\"1741732942772\",\"ContextThreadId\":\"28523520529271\",\"ContextTimeStamp\":\"1604855274.377\",\"CycleTime\":\"473618996\",\"DirectoryCreatedCount\":\"0\",\"DirectoryEnumeratedCount\":\"0\",\"DnsRequestCount\":\"0\",\"DocumentFileWrittenCount\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ExeAndServiceCount\":\"0\",\"ExecutableDeletedCount\":\"0\",\"ExitCode\":\"0\",\"FileDeletedCount\":\"0\",\"GenericFileWrittenCount\":\"0\",\"ImageSubsystem\":\"2\",\"InjectedDllCount\":\"0\",\"InjectedThreadCount\":\"0\",\"KernelTime\":\"1406250\",\"MaxThreadCount\":\"16\",\"ModuleLoadCount\":\"72\",\"NetworkBindCount\":\"0\",\"NetworkCapableAsepWriteCount\":\"0\",\"NetworkCloseCount\":\"0\",\"NetworkConnectCount\":\"0\",\"NetworkConnectCountUdp\":\"0\",\"NetworkListenCount\":\"0\",\"NetworkModuleLoadCount\":\"0\",\"NetworkRecvAcceptCount\":\"0\",\"NewExecutableWrittenCount\":\"0\",\"ParentProcessId\":\"1731198143955\",\"PrivilegedProcessHandleCount\":\"0\",\"ProcessStartTime\":\"1604855154.465\",\"ProtectVirtualMemoryCount\":\"0\",\"QueueApcCount\":\"0\",\"RawProcessId\":\"18176\",\"RegKeySecurityDecreasedCount\":\"0\",\"RemovableDiskFileWrittenCount\":\"0\",\"RunDllInvocationCount\":\"0\",\"SHA256HashData\":\"87419b84f34cdb13f699c0f0803c957e48c27ad83334fcad7bac9ad89c0a466f\",\"ScreenshotsTakenCount\":\"0\",\"ScriptEngineInvocationCount\":\"0\",\"ServiceEventCount\":\"0\",\"SetThreadContextCount\":\"0\",\"SnapshotFileOpenCount\":\"0\",\"SuspectStackCount\":\"0\",\"SuspiciousCredentialModuleLoadCount\":\"0\",\"SuspiciousDnsRequestCount\":\"0\",\"SuspiciousFontLoadCount\":\"0\",\"SuspiciousRawDiskReadCount\":\"0\",\"TargetProcessId\":\"1741732942772\",\"UnsignedModuleLoadCount\":\"0\",\"UserMemoryAllocateExecutableCount\":\"0\",\"UserMemoryAllocateExecutableRemoteCount\":\"0\",\"UserMemoryProtectExecutableCount\":\"0\",\"UserMemoryProtectExecutableRemoteCount\":\"0\",\"UserSid\":\"S-1-12-1-1647509123-1308660782-3901357462-3999411581\",\"UserTime\":\"781250\",\"aid\":\"fffffffffdab492a5a20cd0417395a73\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"EndOfProcess\",\"id\":\"ffffffff-1111-11eb-b685-0241eaddc553\",\"name\":\"EndOfProcessV14\",\"timestamp\":\"1604855276657\"}",
-                "created": "2020-11-08T17:07:56.657Z",
-                "kind": "event",
-                "action": "EndOfProcess",
-                "id": "ffffffff-1111-11eb-b685-0241eaddc553",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ScreenshotsTakenCount": 0,
-                "NetworkListenCount": 0,
-                "SuspiciousRawDiskReadCount": 0,
-                "NetworkBindCount": 0,
-                "NetworkRecvAcceptCount": 0,
-                "ExeAndServiceCount": 0,
-                "NewExecutableWrittenCount": 0,
-                "NetworkCloseCount": 0,
-                "SuspectStackCount": 0,
-                "CLICreationCount": 0,
-                "UnsignedModuleLoadCount": 0,
-                "UserTime": 781250,
-                "AllocateVirtualMemoryCount": 0,
-                "ContextProcessId": "1741732942772",
-                "ServiceEventCount": 0,
-                "RemovableDiskFileWrittenCount": 0,
-                "SnapshotFileOpenCount": 0,
-                "InjectedDllCount": 0,
-                "ModuleLoadCount": 72,
-                "UserMemoryProtectExecutableCount": 0,
-                "NetworkCapableAsepWriteCount": 0,
-                "DnsRequestCount": 0,
-                "ArchiveFileWrittenCount": 0,
-                "Entitlements": "15",
-                "name": "EndOfProcessV14",
-                "SetThreadContextCount": 0,
-                "SuspiciousCredentialModuleLoadCount": 0,
-                "cid": "ffffffff30a3407dae27d0503611022d",
-                "FileDeletedCount": 0,
-                "UserMemoryAllocateExecutableCount": 0,
-                "DirectoryCreatedCount": 0,
-                "NetworkConnectCountUdp": 0,
-                "QueueApcCount": 0,
-                "SuspiciousFontLoadCount": 0,
-                "ConHostId": "13532",
-                "NetworkConnectCount": 0,
-                "BinaryExecutableWrittenCount": 0,
-                "CycleTime": 473618996,
-                "ConHostProcessId": "1731198143955",
-                "PrivilegedProcessHandleCount": 0,
-                "MaxThreadCount": 16,
-                "ImageSubsystem": "2",
-                "GenericFileWrittenCount": 0,
-                "EffectiveTransmissionClass": "3",
-                "ScriptEngineInvocationCount": 0,
-                "RunDllInvocationCount": 0,
-                "KernelTime": 1406250,
-                "DirectoryEnumeratedCount": 0,
-                "ConfigStateHash": "2030177841",
-                "AsepWrittenCount": 0,
-                "DocumentFileWrittenCount": 0,
-                "SuspiciousDnsRequestCount": 0,
-                "ProtectVirtualMemoryCount": 0,
-                "UserMemoryProtectExecutableRemoteCount": 0,
-                "UserMemoryAllocateExecutableRemoteCount": 0,
-                "ExecutableDeletedCount": 0,
-                "RegKeySecurityDecreasedCount": 0,
-                "InjectedThreadCount": 0,
-                "NetworkModuleLoadCount": 0
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "id": "S-1-12-1-1647509123-1308660782-3901357462-3999411581"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:08:37.892Z",
+            "crowdstrike": {
+                "AuthenticationId": "895027",
+                "ConfigStateHash": "3338885535",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileEcpBitmask": "0",
+                "FileObject": "18446636933702558240",
+                "IrpFlags": "1028",
+                "IsOnNetwork": "1",
+                "IsOnRemovableDisk": "0",
+                "MajorFunction": "18",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "TokenType": "1",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "OoxmlFileWrittenV11"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "OoxmlFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:08:49.571Z",
+                "id": "ffffffff-1111-11eb-9165-067ee18a7975",
+                "ingested": "2022-03-22T18:19:46.427235600Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"895027\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextProcessId\":\"1786917081743\",\"ContextThreadId\":\"31685015444484\",\"ContextTimeStamp\":\"1604855317.892\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileEcpBitmask\":\"0\",\"FileIdentifier\":\"0000000000000000be341bb58bc5f1f2a24339010200510e\",\"FileObject\":\"18446636933702558240\",\"IrpFlags\":\"1028\",\"IsOnNetwork\":\"1\",\"IsOnRemovableDisk\":\"0\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Size\":\"223989\",\"TargetFileName\":\"\\\\Device\\\\Mup\\\\intranet.dev\\\\int\\\\Test.pptx\",\"TokenType\":\"1\",\"aid\":\"fffffffffa474d216472f3edb73c75ed\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"OoxmlFileWritten\",\"id\":\"ffffffff-1111-11eb-9165-067ee18a7975\",\"name\":\"OoxmlFileWrittenV11\",\"timestamp\":\"1604855329571\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "directory": "\\Device\\Mup\\intranet.dev\\int",
+                "extension": "pptx",
+                "inode": "0000000000000000be341bb58bc5f1f2a24339010200510e",
+                "name": "Test.pptx",
+                "path": "\\Device\\Mup\\intranet.dev\\int\\Test.pptx",
+                "size": 223989,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "fffffffffa474d216472f3edb73c75ed",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "1786917081743",
                 "thread": {
                     "id": 31685015444484
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "fffffffffa474d216472f3edb73c75ed",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:08:37.892Z",
-            "file": {
-                "inode": "0000000000000000be341bb58bc5f1f2a24339010200510e",
-                "path": "\\Device\\Mup\\intranet.dev\\int\\Test.pptx",
-                "extension": "pptx",
-                "size": 223989,
-                "name": "Test.pptx",
-                "type": "file",
-                "directory": "\\Device\\Mup\\intranet.dev\\int"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "3338885535"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561780920Z",
-                "original": "{\"AuthenticationId\":\"895027\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextProcessId\":\"1786917081743\",\"ContextThreadId\":\"31685015444484\",\"ContextTimeStamp\":\"1604855317.892\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileEcpBitmask\":\"0\",\"FileIdentifier\":\"0000000000000000be341bb58bc5f1f2a24339010200510e\",\"FileObject\":\"18446636933702558240\",\"IrpFlags\":\"1028\",\"IsOnNetwork\":\"1\",\"IsOnRemovableDisk\":\"0\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Size\":\"223989\",\"TargetFileName\":\"\\\\Device\\\\Mup\\\\intranet.dev\\\\int\\\\Test.pptx\",\"TokenType\":\"1\",\"aid\":\"fffffffffa474d216472f3edb73c75ed\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"OoxmlFileWritten\",\"id\":\"ffffffff-1111-11eb-9165-067ee18a7975\",\"name\":\"OoxmlFileWrittenV11\",\"timestamp\":\"1604855329571\"}",
-                "created": "2020-11-08T17:08:49.571Z",
-                "kind": "event",
-                "action": "OoxmlFileWritten",
-                "id": "ffffffff-1111-11eb-9165-067ee18a7975",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3338885535",
-                "IrpFlags": "1028",
-                "MinorFunction": "0",
-                "IsOnNetwork": "1",
-                "AuthenticationId": "895027",
-                "FileEcpBitmask": "0",
-                "TokenType": "1",
-                "MajorFunction": "18",
-                "IsOnRemovableDisk": "0",
-                "Entitlements": "15",
-                "name": "OoxmlFileWrittenV11",
-                "OperationFlags": "0",
-                "FileObject": "18446636933702558240",
-                "EffectiveTransmissionClass": "3",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:09:11.158Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3765958535",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NetworkListenIP6V5"
+            },
+            "destination": {
+                "address": "0:0:0:0:0:0:0:0",
+                "ip": "0:0:0:0:0:0:0:0",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkListenIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:09:11.798Z",
+                "id": "ffffffff-1111-11eb-85f5-02ab029194b9",
+                "ingested": "2022-03-22T18:19:46.427243200Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3765958535\",\"ConnectionDirection\":\"2\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"439029805661\",\"ContextThreadId\":\"273683743193497\",\"ContextTimeStamp\":\"1604855351.158\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"LocalPort\":\"50373\",\"Protocol\":\"6\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:0\",\"RemotePort\":\"0\",\"aid\":\"ffffffff1f924e228a807ea4c0f21b0b\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NetworkListenIP6\",\"id\":\"ffffffff-1111-11eb-85f5-02ab029194b9\",\"name\":\"NetworkListenIP6V5\",\"timestamp\":\"1604855351798\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "network": {
+                "direction": "unknown",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff1f924e228a807ea4c0f21b0b",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "439029805661",
                 "thread": {
                     "id": 273683743193497
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "destination": {
-                "port": 0,
-                "address": "0:0:0:0:0:0:0:0",
-                "ip": "0:0:0:0:0:0:0:0"
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Europe",
-                    "country_name": "Norway",
-                    "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
-                },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "port": 50373,
-                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "unknown"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff1f924e228a807ea4c0f21b0b",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:09:11.158Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
+                "hash": [
+                    "3765958535"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
                     "0:0:0:0:0:0:0:0"
-                ],
-                "hash": [
-                    "3765958535"
                 ],
                 "ip": [
                     "67.43.156.14",
@@ -9496,486 +9500,515 @@
                     "0:0:0:0:0:0:0:0"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561781926Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3765958535\",\"ConnectionDirection\":\"2\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"439029805661\",\"ContextThreadId\":\"273683743193497\",\"ContextTimeStamp\":\"1604855351.158\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"LocalPort\":\"50373\",\"Protocol\":\"6\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:0\",\"RemotePort\":\"0\",\"aid\":\"ffffffff1f924e228a807ea4c0f21b0b\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NetworkListenIP6\",\"id\":\"ffffffff-1111-11eb-85f5-02ab029194b9\",\"name\":\"NetworkListenIP6V5\",\"timestamp\":\"1604855351798\"}",
-                "created": "2020-11-08T17:09:11.798Z",
-                "kind": "event",
-                "action": "NetworkListenIP6",
-                "id": "ffffffff-1111-11eb-85f5-02ab029194b9",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
+            "source": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "port": 50373
             },
-            "crowdstrike": {
-                "ConfigStateHash": "3765958535",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkListenIP6V5",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T14:34:30.744Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1457965279",
+                "Entitlements": "15",
+                "VnodeModificationType": "10",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "AsepFileChangeMacV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "AsepFileChange",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:09:15.495Z",
+                "id": "ffffffff-1111-11eb-b9b4-063e98f9b19b",
+                "ingested": "2022-03-22T18:19:46.427250900Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1457965279\",\"ContextProcessId\":\"321365562189152025\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604846070.744\",\"Entitlements\":\"15\",\"SHA256HashData\":\"e1bed7598ffdecf63a4d240f8309b528fc45068c6cb8137a5090f3afeb57f29d\",\"Size\":\"29646\",\"TargetFileName\":\"/System/Library/CoreServices/SecurityAgentPlugins/HomeDirMechanism.bundle/Contents/MacOS/HomeDirMechanism/..namedfork/rsrc\",\"VnodeModificationType\":\"10\",\"aid\":\"ffffffff1f32487185fcde66a9dc0528\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"AsepFileChange\",\"id\":\"ffffffff-1111-11eb-b9b4-063e98f9b19b\",\"name\":\"AsepFileChangeMacV2\",\"timestamp\":\"1604855355495\"}",
+                "outcome": "success",
+                "type": [
+                    "creation",
+                    "change"
+                ]
+            },
+            "file": {
+                "directory": "/System/Library/CoreServices/SecurityAgentPlugins/HomeDirMechanism.bundle/Contents/MacOS/HomeDirMechanism/..namedfork",
+                "hash": {
+                    "sha256": "e1bed7598ffdecf63a4d240f8309b528fc45068c6cb8137a5090f3afeb57f29d"
+                },
+                "name": "rsrc",
+                "path": "/System/Library/CoreServices/SecurityAgentPlugins/HomeDirMechanism.bundle/Contents/MacOS/HomeDirMechanism/..namedfork/rsrc",
+                "size": 29646,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff1f32487185fcde66a9dc0528",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0011104.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "321365562189152025",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff1f32487185fcde66a9dc0528",
-                "type": "agent",
-                "version": "1007.4.0011104.1"
-            },
-            "@timestamp": "2020-11-08T14:34:30.744Z",
-            "file": {
-                "name": "rsrc",
-                "path": "/System/Library/CoreServices/SecurityAgentPlugins/HomeDirMechanism.bundle/Contents/MacOS/HomeDirMechanism/..namedfork/rsrc",
-                "size": 29646,
-                "type": "file",
-                "directory": "/System/Library/CoreServices/SecurityAgentPlugins/HomeDirMechanism.bundle/Contents/MacOS/HomeDirMechanism/..namedfork",
-                "hash": {
-                    "sha256": "e1bed7598ffdecf63a4d240f8309b528fc45068c6cb8137a5090f3afeb57f29d"
-                }
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "e1bed7598ffdecf63a4d240f8309b528fc45068c6cb8137a5090f3afeb57f29d",
                     "1457965279"
+                ],
+                "hosts": [
+                    "67.43.156.14"
                 ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561782843Z",
-                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1457965279\",\"ContextProcessId\":\"321365562189152025\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604846070.744\",\"Entitlements\":\"15\",\"SHA256HashData\":\"e1bed7598ffdecf63a4d240f8309b528fc45068c6cb8137a5090f3afeb57f29d\",\"Size\":\"29646\",\"TargetFileName\":\"/System/Library/CoreServices/SecurityAgentPlugins/HomeDirMechanism.bundle/Contents/MacOS/HomeDirMechanism/..namedfork/rsrc\",\"VnodeModificationType\":\"10\",\"aid\":\"ffffffff1f32487185fcde66a9dc0528\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"AsepFileChange\",\"id\":\"ffffffff-1111-11eb-b9b4-063e98f9b19b\",\"name\":\"AsepFileChangeMacV2\",\"timestamp\":\"1604855355495\"}",
-                "created": "2020-11-08T17:09:15.495Z",
-                "kind": "event",
-                "action": "AsepFileChange",
-                "id": "ffffffff-1111-11eb-b9b4-063e98f9b19b",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation",
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "AsepFileChangeMacV2",
-                "ConfigStateHash": "1457965279",
-                "Entitlements": "15",
-                "VnodeModificationType": "10",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:06:31.803Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3011122681",
+                "EffectiveTransmissionClass": "2",
+                "Entitlements": "15",
+                "UserLogonFlags": "1",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "UserLogonFailedV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "UserLogonFailed",
+                "category": [
+                    "authentication"
+                ],
+                "created": "2020-11-08T17:06:33.422Z",
+                "id": "ffffffff-1111-11eb-aa5a-0207e26418af",
+                "ingested": "2022-03-22T18:19:46.427258700Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3011122681\",\"ContextProcessId\":\"2932136\",\"ContextThreadId\":\"36157339485804\",\"ContextTimeStamp\":\"1604855191.803\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"LogonTime\":\"\",\"PasswordLastSet\":\"\",\"UserLogonFlags\":\"1\",\"UserName\":\"user7\",\"UserSid\":\"S-1-5-10\",\"aid\":\"ffffffffa5bd4efaa195a7132c576edc\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserLogonFailed\",\"id\":\"ffffffff-1111-11eb-aa5a-0207e26418af\",\"name\":\"UserLogonFailedV1\",\"timestamp\":\"1604855193422\"}",
+                "outcome": "failure",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffffa5bd4efaa195a7132c576edc",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "2932136",
                 "thread": {
                     "id": 36157339485804
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffffa5bd4efaa195a7132c576edc",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:06:31.803Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "user": [
-                    "user7"
-                ],
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "3011122681"
                 ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
                 "ip": [
                     "67.43.156.13"
+                ],
+                "user": [
+                    "user7"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561783813Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3011122681\",\"ContextProcessId\":\"2932136\",\"ContextThreadId\":\"36157339485804\",\"ContextTimeStamp\":\"1604855191.803\",\"EffectiveTransmissionClass\":\"2\",\"Entitlements\":\"15\",\"LogonTime\":\"\",\"PasswordLastSet\":\"\",\"UserLogonFlags\":\"1\",\"UserName\":\"user7\",\"UserSid\":\"S-1-5-10\",\"aid\":\"ffffffffa5bd4efaa195a7132c576edc\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"UserLogonFailed\",\"id\":\"ffffffff-1111-11eb-aa5a-0207e26418af\",\"name\":\"UserLogonFailedV1\",\"timestamp\":\"1604855193422\"}",
-                "created": "2020-11-08T17:06:33.422Z",
-                "kind": "event",
-                "action": "UserLogonFailed",
-                "id": "ffffffff-1111-11eb-aa5a-0207e26418af",
-                "category": [
-                    "authentication"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "failure"
-            },
-            "crowdstrike": {
-                "name": "UserLogonFailedV1",
-                "UserLogonFlags": "1",
-                "ConfigStateHash": "3011122681",
-                "EffectiveTransmissionClass": "2",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "user": {
-                "name": "user7",
-                "id": "S-1-5-10"
-            }
-        },
-        {
-            "process": {
-                "entity_id": "56042872298"
-            },
-            "os": {
-                "type": "windows"
-            },
-            "destination": {
-                "geo": {
-                    "continent_name": "Europe",
-                    "country_name": "Norway",
-                    "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
-                },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "port": 443,
-                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-            },
-            "source": {
-                "geo": {
-                    "continent_name": "Europe",
-                    "country_name": "Norway",
-                    "location": {
-                        "lon": 10.0,
-                        "lat": 62.0
-                    },
-                    "country_iso_code": "NO"
-                },
-                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "port": 49689,
-                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "network": {
-                "community_id": "1:H+oCOL0YBAZDUBNuLG0b/Xuke3g=",
-                "transport": "tcp",
-                "iana_number": "6",
-                "direction": "outbound"
+            "url": {
+                "scheme": "http"
             },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff6854438eb4181691ec47e43d",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
+            "user": {
+                "id": "S-1-5-10",
+                "name": "user7"
+            }
+        },
+        {
             "@timestamp": "2020-11-08T17:05:36.669Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1858880895",
+                "ConnectionFlags": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NetworkConnectIP6V5"
+            },
+            "destination": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "port": 443
+            },
             "ecs": {
                 "version": "8.0.0"
             },
+            "event": {
+                "action": "NetworkConnectIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:06:39.798Z",
+                "id": "ffffffff-1111-11eb-a889-061944805289",
+                "ingested": "2022-03-22T18:19:46.427266400Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1858880895\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"56042872298\",\"ContextTimeStamp\":\"1604855136.669\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"LocalPort\":\"49689\",\"Protocol\":\"6\",\"RemoteAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"RemotePort\":\"443\",\"aid\":\"ffffffff6854438eb4181691ec47e43d\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NetworkConnectIP6\",\"id\":\"ffffffff-1111-11eb-a889-061944805289\",\"name\":\"NetworkConnectIP6V5\",\"timestamp\":\"1604855199798\"}",
+                "outcome": "unknown",
+                "type": [
+                    "start",
+                    "connection"
+                ]
+            },
+            "network": {
+                "community_id": "1:H+oCOL0YBAZDUBNuLG0b/Xuke3g=",
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff6854438eb4181691ec47e43d",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
+            "process": {
+                "entity_id": "56042872298"
+            },
             "related": {
+                "hash": [
+                    "1858880895"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
-                ],
-                "hash": [
-                    "1858880895"
                 ],
                 "ip": [
                     "67.43.156.14",
                     "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561784749Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1858880895\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"56042872298\",\"ContextTimeStamp\":\"1604855136.669\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"LocalPort\":\"49689\",\"Protocol\":\"6\",\"RemoteAddressIP6\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"RemotePort\":\"443\",\"aid\":\"ffffffff6854438eb4181691ec47e43d\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"NetworkConnectIP6\",\"id\":\"ffffffff-1111-11eb-a889-061944805289\",\"name\":\"NetworkConnectIP6V5\",\"timestamp\":\"1604855199798\"}",
-                "created": "2020-11-08T17:06:39.798Z",
-                "kind": "event",
-                "action": "NetworkConnectIP6",
-                "id": "ffffffff-1111-11eb-a889-061944805289",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "connection"
-                ],
-                "outcome": "unknown"
+            "source": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "port": 49689
             },
-            "crowdstrike": {
-                "ConfigStateHash": "1858880895",
-                "ConnectionFlags": "0",
-                "Entitlements": "15",
-                "name": "NetworkConnectIP6V5",
-                "EffectiveTransmissionClass": "3",
-                "InContext": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T16:42:35.987Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1789338890",
+                "Entitlements": "15",
+                "TargetFileName": "/Library/Application Support/JAMF/tmp/6B24D2B6-BC17-4470-8078-91A787A19478",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NewExecutableRenamedMacV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NewExecutableRenamed",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:06:53.224Z",
+                "id": "ffffffff-1111-11eb-8773-06939a2f0915",
+                "ingested": "2022-03-22T18:19:46.427274300Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1789338890\",\"ContextProcessId\":\"321382909294815631\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604853755.987\",\"Entitlements\":\"15\",\"SHA256HashData\":\"fa07e991e0c3f3661794bba39061433265162b10cd9036751941cc45e6a4b583\",\"Size\":\"165\",\"SourceFileName\":\"/Library/Application Support/JAMF/tmp/.dat.nosync2c98.VBwjsq\",\"TargetFileName\":\"/Library/Application Support/JAMF/tmp/6B24D2B6-BC17-4470-8078-91A787A19478\",\"aid\":\"ffffffffc07b49d6b7426e970523671a\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NewExecutableRenamed\",\"id\":\"ffffffff-1111-11eb-8773-06939a2f0915\",\"name\":\"NewExecutableRenamedMacV1\",\"timestamp\":\"1604855213224\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "file": {
+                "directory": "/Library/Application Support/JAMF/tmp",
+                "extension": "VBwjsq",
+                "hash": {
+                    "sha256": "fa07e991e0c3f3661794bba39061433265162b10cd9036751941cc45e6a4b583"
+                },
+                "name": ".dat.nosync2c98.VBwjsq",
+                "path": "/Library/Application Support/JAMF/tmp/.dat.nosync2c98.VBwjsq",
+                "size": 165,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffc07b49d6b7426e970523671a",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0011104.1"
+            },
+            "os": {
+                "type": "macos"
+            },
             "process": {
                 "entity_id": "321382909294815631",
                 "thread": {
                     "id": 0
                 }
             },
-            "os": {
-                "type": "macos"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffc07b49d6b7426e970523671a",
-                "type": "agent",
-                "version": "1007.4.0011104.1"
-            },
-            "@timestamp": "2020-11-08T16:42:35.987Z",
-            "file": {
-                "path": "/Library/Application Support/JAMF/tmp/.dat.nosync2c98.VBwjsq",
-                "extension": "VBwjsq",
-                "size": 165,
-                "name": ".dat.nosync2c98.VBwjsq",
-                "type": "file",
-                "directory": "/Library/Application Support/JAMF/tmp",
-                "hash": {
-                    "sha256": "fa07e991e0c3f3661794bba39061433265162b10cd9036751941cc45e6a4b583"
-                }
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "fa07e991e0c3f3661794bba39061433265162b10cd9036751941cc45e6a4b583",
                     "1789338890"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561785893Z",
-                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1789338890\",\"ContextProcessId\":\"321382909294815631\",\"ContextThreadId\":\"0\",\"ContextTimeStamp\":\"1604853755.987\",\"Entitlements\":\"15\",\"SHA256HashData\":\"fa07e991e0c3f3661794bba39061433265162b10cd9036751941cc45e6a4b583\",\"Size\":\"165\",\"SourceFileName\":\"/Library/Application Support/JAMF/tmp/.dat.nosync2c98.VBwjsq\",\"TargetFileName\":\"/Library/Application Support/JAMF/tmp/6B24D2B6-BC17-4470-8078-91A787A19478\",\"aid\":\"ffffffffc07b49d6b7426e970523671a\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NewExecutableRenamed\",\"id\":\"ffffffff-1111-11eb-8773-06939a2f0915\",\"name\":\"NewExecutableRenamedMacV1\",\"timestamp\":\"1604855213224\"}",
-                "created": "2020-11-08T17:06:53.224Z",
-                "kind": "event",
-                "action": "NewExecutableRenamed",
-                "id": "ffffffff-1111-11eb-8773-06939a2f0915",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "NewExecutableRenamedMacV1",
-                "ConfigStateHash": "1789338890",
-                "Entitlements": "15",
-                "TargetFileName": "/Library/Application Support/JAMF/tmp/6B24D2B6-BC17-4470-8078-91A787A19478",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "process": {
-                "entity_id": "321367236803434269"
+            "@timestamp": "2020-11-08T17:07:48.323Z",
+            "crowdstrike": {
+                "ConfigStateHash": "203564169",
+                "ConnectionFlags": "0",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NetworkListenIP6MacV5"
+            },
+            "destination": {
+                "address": "0:0:0:0:0:0:0:0",
+                "ip": "0:0:0:0:0:0:0:0",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkListenIP6",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:07:48.755Z",
+                "id": "ffffffff-1111-11eb-9a50-0669ff09604d",
+                "ingested": "2022-03-22T18:19:46.427282200Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"203564169\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"321367236803434269\",\"ContextTimeStamp\":\"1604855268.323\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:0\",\"LocalPort\":\"51076\",\"Protocol\":\"6\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:0\",\"RemotePort\":\"0\",\"aid\":\"ffffffffa60a47af4ebd2a76070f0d4f\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NetworkListenIP6\",\"id\":\"ffffffff-1111-11eb-9a50-0669ff09604d\",\"name\":\"NetworkListenIP6MacV5\",\"timestamp\":\"1604855268755\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffa60a47af4ebd2a76070f0d4f",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0011104.1"
             },
             "os": {
                 "type": "macos"
             },
-            "destination": {
-                "port": 0,
-                "address": "0:0:0:0:0:0:0:0",
-                "ip": "0:0:0:0:0:0:0:0"
-            },
-            "source": {
-                "port": 51076,
-                "address": "0:0:0:0:0:0:0:0",
-                "ip": "0:0:0:0:0:0:0:0"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "outbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffa60a47af4ebd2a76070f0d4f",
-                "type": "agent",
-                "version": "1007.4.0011104.1"
-            },
-            "@timestamp": "2020-11-08T17:07:48.323Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "321367236803434269"
             },
             "related": {
+                "hash": [
+                    "203564169"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "0:0:0:0:0:0:0:0"
-                ],
-                "hash": [
-                    "203564169"
                 ],
                 "ip": [
                     "67.43.156.14",
                     "0:0:0:0:0:0:0:0"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561786820Z",
-                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"203564169\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"321367236803434269\",\"ContextTimeStamp\":\"1604855268.323\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP6\":\"0:0:0:0:0:0:0:0\",\"LocalPort\":\"51076\",\"Protocol\":\"6\",\"RemoteAddressIP6\":\"0:0:0:0:0:0:0:0\",\"RemotePort\":\"0\",\"aid\":\"ffffffffa60a47af4ebd2a76070f0d4f\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NetworkListenIP6\",\"id\":\"ffffffff-1111-11eb-9a50-0669ff09604d\",\"name\":\"NetworkListenIP6MacV5\",\"timestamp\":\"1604855268755\"}",
-                "created": "2020-11-08T17:07:48.755Z",
-                "kind": "event",
-                "action": "NetworkListenIP6",
-                "id": "ffffffff-1111-11eb-9a50-0669ff09604d",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
+            "source": {
+                "address": "0:0:0:0:0:0:0:0",
+                "ip": "0:0:0:0:0:0:0:0",
+                "port": 51076
             },
-            "crowdstrike": {
-                "name": "NetworkListenIP6MacV5",
-                "ConfigStateHash": "203564169",
-                "ConnectionFlags": "0",
-                "InContext": "0",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:08:00.307Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3765958535",
+                "DualRequest": "0",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InterfaceIndex": 0,
+                "RequestType": "1",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "SuspiciousDnsRequestV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "SuspiciousDnsRequest",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:08:43.217Z",
+                "id": "ffffffff-1111-11eb-885e-02ac336efd4b",
+                "ingested": "2022-03-22T18:19:46.427289900Z",
+                "kind": "alert",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3765958535\",\"ContextProcessId\":\"1611521722601\",\"ContextThreadId\":\"53405065993811\",\"ContextTimeStamp\":\"1604855280.307\",\"DomainName\":\"raw.githubusercontent.com\",\"DualRequest\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InterfaceIndex\":\"0\",\"RequestType\":\"1\",\"aid\":\"ffffffff6d724d38af99c628fb904626\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"SuspiciousDnsRequest\",\"id\":\"ffffffff-1111-11eb-885e-02ac336efd4b\",\"name\":\"SuspiciousDnsRequestV2\",\"timestamp\":\"1604855323217\"}",
+                "outcome": "success",
+                "type": [
+                    "start",
+                    "protocol"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.13",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.13",
                 "serial_number": "ffffffff6d724d38af99c628fb904626",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
             },
             "process": {
                 "entity_id": "1611521722601",
@@ -9983,97 +10016,91 @@
                     "id": 53405065993811
                 }
             },
-            "@timestamp": "2020-11-08T17:08:00.307Z",
-            "os": {
-                "type": "windows"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "3765958535"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561787743Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3765958535\",\"ContextProcessId\":\"1611521722601\",\"ContextThreadId\":\"53405065993811\",\"ContextTimeStamp\":\"1604855280.307\",\"DomainName\":\"raw.githubusercontent.com\",\"DualRequest\":\"0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"InterfaceIndex\":\"0\",\"RequestType\":\"1\",\"aid\":\"ffffffff6d724d38af99c628fb904626\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"SuspiciousDnsRequest\",\"id\":\"ffffffff-1111-11eb-885e-02ac336efd4b\",\"name\":\"SuspiciousDnsRequestV2\",\"timestamp\":\"1604855323217\"}",
-                "created": "2020-11-08T17:08:43.217Z",
-                "kind": "alert",
-                "action": "SuspiciousDnsRequest",
-                "id": "ffffffff-1111-11eb-885e-02ac336efd4b",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start",
-                    "protocol"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "InterfaceIndex": 0,
-                "ConfigStateHash": "3765958535",
-                "DualRequest": "0",
-                "Entitlements": "15",
-                "name": "SuspiciousDnsRequestV2",
-                "EffectiveTransmissionClass": "3",
-                "RequestType": "1",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "url": {
-                "scheme": "http"
-            },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2020-11-08T17:08:35.034Z",
+            "crowdstrike": {
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "VolumeDeviceCharacteristics": "131072",
+                "VolumeDeviceObjectFlags": "134479872",
+                "VolumeDeviceType": "8",
+                "VolumeDriveLetter": "C:",
+                "VolumeFileSystemDevice": "\\Ntfs",
+                "VolumeFileSystemDriver": "\\FileSystem\\Ntfs",
+                "VolumeFileSystemType": "2",
+                "VolumeIsEncrypted": "0",
+                "VolumeMountPoint": "\\??\\Volume{9b46da3f-ce44-432f-9230-c9201504bfd7}",
+                "VolumeName": "\\Device\\HarddiskVolume4",
+                "VolumeRealDeviceName": "\\Device\\HarddiskVolume4",
+                "VolumeSectorSize": "512",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "FsVolumeMountedV6"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "FsVolumeMounted",
+                "category": [
+                    "host"
+                ],
+                "created": "2020-11-08T17:08:49.102Z",
+                "id": "ffffffff-1111-11eb-9be9-024459b713c5",
+                "ingested": "2022-03-22T18:19:46.427297500Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"100.3.0011603.1\",\"ContextProcessId\":\"4492535979973\",\"ContextThreadId\":\"14023068415125\",\"ContextTimeStamp\":\"1604855315.034\",\"DiskParentDeviceInstanceId\":\"PCI\\\\VEN_8086\\u0026DEV_31E3\\u0026SUBSYS_080C1028\\u0026REV_03\\\\3\\u002611583659\\u00260\\u002690\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"VolumeDeviceCharacteristics\":\"131072\",\"VolumeDeviceObjectFlags\":\"134479872\",\"VolumeDeviceType\":\"8\",\"VolumeDriveLetter\":\"C:\",\"VolumeFileSystemDevice\":\"\\\\Ntfs\",\"VolumeFileSystemDriver\":\"\\\\FileSystem\\\\Ntfs\",\"VolumeFileSystemType\":\"2\",\"VolumeIsEncrypted\":\"0\",\"VolumeMountPoint\":\"\\\\??\\\\Volume{9b46da3f-ce44-432f-9230-c9201504bfd7}\",\"VolumeName\":\"\\\\Device\\\\HarddiskVolume4\",\"VolumeRealDeviceName\":\"\\\\Device\\\\HarddiskVolume4\",\"VolumeSectorSize\":\"512\",\"aid\":\"ffffffff1990483499a736373600eef7\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"FsVolumeMounted\",\"id\":\"ffffffff-1111-11eb-9be9-024459b713c5\",\"name\":\"FsVolumeMountedV6\",\"timestamp\":\"1604855329102\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "file": {
+                "device": "PCI\\VEN_8086\u0026DEV_31E3\u0026SUBSYS_080C1028\u0026REV_03\\3\u002611583659\u00260\u002690"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff1990483499a736373600eef7",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "100.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "4492535979973",
                 "thread": {
                     "id": 14023068415125
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff1990483499a736373600eef7",
-                "type": "agent",
-                "version": "100.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:08:35.034Z",
-            "file": {
-                "device": "PCI\\VEN_8086\u0026DEV_31E3\u0026SUBSYS_080C1028\u0026REV_03\\3\u002611583659\u00260\u002690"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
                 "hosts": [
                     "67.43.156.13"
@@ -10082,97 +10109,82 @@
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561791966Z",
-                "original": "{\"ConfigBuild\":\"100.3.0011603.1\",\"ContextProcessId\":\"4492535979973\",\"ContextThreadId\":\"14023068415125\",\"ContextTimeStamp\":\"1604855315.034\",\"DiskParentDeviceInstanceId\":\"PCI\\\\VEN_8086\\u0026DEV_31E3\\u0026SUBSYS_080C1028\\u0026REV_03\\\\3\\u002611583659\\u00260\\u002690\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"VolumeDeviceCharacteristics\":\"131072\",\"VolumeDeviceObjectFlags\":\"134479872\",\"VolumeDeviceType\":\"8\",\"VolumeDriveLetter\":\"C:\",\"VolumeFileSystemDevice\":\"\\\\Ntfs\",\"VolumeFileSystemDriver\":\"\\\\FileSystem\\\\Ntfs\",\"VolumeFileSystemType\":\"2\",\"VolumeIsEncrypted\":\"0\",\"VolumeMountPoint\":\"\\\\??\\\\Volume{9b46da3f-ce44-432f-9230-c9201504bfd7}\",\"VolumeName\":\"\\\\Device\\\\HarddiskVolume4\",\"VolumeRealDeviceName\":\"\\\\Device\\\\HarddiskVolume4\",\"VolumeSectorSize\":\"512\",\"aid\":\"ffffffff1990483499a736373600eef7\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"FsVolumeMounted\",\"id\":\"ffffffff-1111-11eb-9be9-024459b713c5\",\"name\":\"FsVolumeMountedV6\",\"timestamp\":\"1604855329102\"}",
-                "created": "2020-11-08T17:08:49.102Z",
-                "kind": "event",
-                "action": "FsVolumeMounted",
-                "id": "ffffffff-1111-11eb-9be9-024459b713c5",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "VolumeName": "\\Device\\HarddiskVolume4",
-                "VolumeSectorSize": "512",
-                "VolumeRealDeviceName": "\\Device\\HarddiskVolume4",
-                "VolumeMountPoint": "\\??\\Volume{9b46da3f-ce44-432f-9230-c9201504bfd7}",
-                "VolumeDriveLetter": "C:",
-                "VolumeDeviceObjectFlags": "134479872",
-                "VolumeFileSystemDevice": "\\Ntfs",
-                "VolumeIsEncrypted": "0",
-                "VolumeFileSystemType": "2",
-                "VolumeFileSystemDriver": "\\FileSystem\\Ntfs",
-                "Entitlements": "15",
-                "name": "FsVolumeMountedV6",
-                "VolumeDeviceCharacteristics": "131072",
-                "EffectiveTransmissionClass": "3",
-                "VolumeDeviceType": "8",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "process": {
-                "entity_id": "321210562584146513"
+            "@timestamp": "2020-11-08T17:05:27.011Z",
+            "crowdstrike": {
+                "ConfigStateHash": "1789338890",
+                "ConnectionFlags": "0",
+                "Entitlements": "15",
+                "InContext": "0",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "NetworkListenIP4MacV5"
+            },
+            "destination": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0",
+                "port": 0
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "NetworkListenIP4",
+                "category": [
+                    "network"
+                ],
+                "created": "2020-11-08T17:05:28.936Z",
+                "id": "ffffffff-1111-11eb-ae74-065212970c5d",
+                "ingested": "2022-03-22T18:19:46.427305300Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1789338890\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"321210562584146513\",\"ContextTimeStamp\":\"1604855127.011\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP4\":\"127.0.0.1\",\"LocalPort\":\"53\",\"Protocol\":\"6\",\"RemoteAddressIP4\":\"0.0.0.0\",\"RemotePort\":\"0\",\"aid\":\"ffffffffe5ff467b4f0c4fd41a4462bb\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NetworkListenIP4\",\"id\":\"ffffffff-1111-11eb-ae74-065212970c5d\",\"name\":\"NetworkListenIP4MacV5\",\"timestamp\":\"1604855128936\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffe5ff467b4f0c4fd41a4462bb",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0011104.1"
             },
             "os": {
                 "type": "macos"
             },
-            "destination": {
-                "port": 0,
-                "address": "0.0.0.0",
-                "ip": "0.0.0.0"
-            },
-            "source": {
-                "port": 53,
-                "address": "127.0.0.1",
-                "ip": "127.0.0.1"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "network": {
-                "iana_number": "6",
-                "transport": "tcp",
-                "direction": "outbound"
-            },
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffffe5ff467b4f0c4fd41a4462bb",
-                "type": "agent",
-                "version": "1007.4.0011104.1"
-            },
-            "@timestamp": "2020-11-08T17:05:27.011Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "321210562584146513"
             },
             "related": {
+                "hash": [
+                    "1789338890"
+                ],
                 "hosts": [
                     "67.43.156.14",
                     "127.0.0.1",
                     "0.0.0.0"
-                ],
-                "hash": [
-                    "1789338890"
                 ],
                 "ip": [
                     "67.43.156.14",
@@ -10180,516 +10192,454 @@
                     "0.0.0.0"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561793240Z",
-                "original": "{\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1789338890\",\"ConnectionDirection\":\"0\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"321210562584146513\",\"ContextTimeStamp\":\"1604855127.011\",\"Entitlements\":\"15\",\"InContext\":\"0\",\"LocalAddressIP4\":\"127.0.0.1\",\"LocalPort\":\"53\",\"Protocol\":\"6\",\"RemoteAddressIP4\":\"0.0.0.0\",\"RemotePort\":\"0\",\"aid\":\"ffffffffe5ff467b4f0c4fd41a4462bb\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"NetworkListenIP4\",\"id\":\"ffffffff-1111-11eb-ae74-065212970c5d\",\"name\":\"NetworkListenIP4MacV5\",\"timestamp\":\"1604855128936\"}",
-                "created": "2020-11-08T17:05:28.936Z",
-                "kind": "event",
-                "action": "NetworkListenIP4",
-                "id": "ffffffff-1111-11eb-ae74-065212970c5d",
-                "category": [
-                    "network"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
+            "source": {
+                "address": "127.0.0.1",
+                "ip": "127.0.0.1",
+                "port": 53
             },
-            "crowdstrike": {
-                "name": "NetworkListenIP4MacV5",
-                "ConfigStateHash": "1789338890",
-                "ConnectionFlags": "0",
-                "InContext": "0",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             }
         },
         {
-            "process": {
-                "entity_id": "224116976578",
-                "title": "gpsvc",
-                "executable": "\\Device\\HarddiskVolume1\\Windows\\System32\\gpsvc.dll"
+            "@timestamp": "2020-11-08T17:06:25.108Z",
+            "crowdstrike": {
+                "AuthenticationId": "999",
+                "ConfigStateHash": "3338885535",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "InterfaceGuid": "367ABB81-9844-35F1-AD32-98F038001003",
+                "InterfaceVersion": "131072",
+                "RpcClientProcessId": "219053851298",
+                "RpcClientThreadId": "22047924482692",
+                "RpcNestingLevel": "0",
+                "RpcOpNum": "19",
+                "TargetThreadId": "22920092479704",
+                "TokenType": "1",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "HostedServiceStartedV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "HostedServiceStarted",
+                "category": [
+                    "package"
+                ],
+                "created": "2020-11-08T17:06:24.068Z",
+                "id": "ffffffff-1111-11eb-860c-0606af112d55",
+                "ingested": "2022-03-22T18:19:46.427313100Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"999\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextTimeStamp\":\"1604855185.108\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume1\\\\Windows\\\\System32\\\\gpsvc.dll\",\"InterfaceGuid\":\"367ABB81-9844-35F1-AD32-98F038001003\",\"InterfaceVersion\":\"131072\",\"RpcClientProcessId\":\"219053851298\",\"RpcClientThreadId\":\"22047924482692\",\"RpcNestingLevel\":\"0\",\"RpcOpNum\":\"19\",\"ServiceDisplayName\":\"gpsvc\",\"TargetProcessId\":\"224116976578\",\"TargetThreadId\":\"22920092479704\",\"TokenType\":\"1\",\"UserName\":\"user7\",\"aid\":\"ffffffff59514ea68b4693ddfb9b6643\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"HostedServiceStarted\",\"id\":\"ffffffff-1111-11eb-860c-0606af112d55\",\"name\":\"HostedServiceStartedV2\",\"timestamp\":\"1604855184068\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff59514ea68b4693ddfb9b6643",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
             },
             "os": {
                 "type": "windows"
             },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff59514ea68b4693ddfb9b6643",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:06:25.108Z",
-            "ecs": {
-                "version": "8.0.0"
+            "process": {
+                "entity_id": "224116976578",
+                "executable": "\\Device\\HarddiskVolume1\\Windows\\System32\\gpsvc.dll",
+                "title": "gpsvc"
             },
             "related": {
-                "user": [
-                    "user7"
+                "hash": [
+                    "3338885535"
                 ],
                 "hosts": [
                     "67.43.156.13"
                 ],
-                "hash": [
-                    "3338885535"
-                ],
                 "ip": [
                     "67.43.156.13"
+                ],
+                "user": [
+                    "user7"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561794169Z",
-                "original": "{\"AuthenticationId\":\"999\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextTimeStamp\":\"1604855185.108\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume1\\\\Windows\\\\System32\\\\gpsvc.dll\",\"InterfaceGuid\":\"367ABB81-9844-35F1-AD32-98F038001003\",\"InterfaceVersion\":\"131072\",\"RpcClientProcessId\":\"219053851298\",\"RpcClientThreadId\":\"22047924482692\",\"RpcNestingLevel\":\"0\",\"RpcOpNum\":\"19\",\"ServiceDisplayName\":\"gpsvc\",\"TargetProcessId\":\"224116976578\",\"TargetThreadId\":\"22920092479704\",\"TokenType\":\"1\",\"UserName\":\"user7\",\"aid\":\"ffffffff59514ea68b4693ddfb9b6643\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"HostedServiceStarted\",\"id\":\"ffffffff-1111-11eb-860c-0606af112d55\",\"name\":\"HostedServiceStartedV2\",\"timestamp\":\"1604855184068\"}",
-                "created": "2020-11-08T17:06:24.068Z",
-                "kind": "event",
-                "action": "HostedServiceStarted",
-                "id": "ffffffff-1111-11eb-860c-0606af112d55",
-                "category": [
-                    "package"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "TargetThreadId": "22920092479704",
-                "ConfigStateHash": "3338885535",
-                "InterfaceVersion": "131072",
-                "RpcClientThreadId": "22047924482692",
-                "AuthenticationId": "999",
-                "TokenType": "1",
-                "Entitlements": "15",
-                "RpcOpNum": "19",
-                "name": "HostedServiceStartedV2",
-                "InterfaceGuid": "367ABB81-9844-35F1-AD32-98F038001003",
-                "RpcClientProcessId": "219053851298",
-                "EffectiveTransmissionClass": "3",
-                "RpcNestingLevel": "0",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "name": "user7"
             }
         },
         {
+            "@timestamp": "2020-11-08T17:08:19.018Z",
+            "crowdstrike": {
+                "ConfigStateHash": "3338885535",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "TargetThreadId": "24238019995551",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "HostedServiceStoppedV1"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "HostedServiceStopped",
+                "category": [
+                    "package"
+                ],
+                "created": "2020-11-08T17:08:22.512Z",
+                "id": "ffffffff-1111-11eb-9b11-0602a5689467",
+                "ingested": "2022-03-22T18:19:46.427320700Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextTimeStamp\":\"1604855299.018\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ServiceDisplayName\":\"wuauserv\",\"TargetProcessId\":\"661455186053\",\"TargetThreadId\":\"24238019995551\",\"aid\":\"ffffffff2b5a4bf5afc6682595faa016\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"HostedServiceStopped\",\"id\":\"ffffffff-1111-11eb-9b11-0602a5689467\",\"name\":\"HostedServiceStoppedV1\",\"timestamp\":\"1604855302512\"}",
+                "outcome": "success",
+                "type": [
+                    "end"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.13",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.13",
                 "serial_number": "ffffffff2b5a4bf5afc6682595faa016",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
             },
             "process": {
                 "entity_id": "661455186053",
                 "title": "wuauserv"
             },
-            "@timestamp": "2020-11-08T17:08:19.018Z",
-            "os": {
-                "type": "windows"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "3338885535"
+                ],
+                "hosts": [
+                    "67.43.156.13"
                 ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561795106Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextTimeStamp\":\"1604855299.018\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ServiceDisplayName\":\"wuauserv\",\"TargetProcessId\":\"661455186053\",\"TargetThreadId\":\"24238019995551\",\"aid\":\"ffffffff2b5a4bf5afc6682595faa016\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"HostedServiceStopped\",\"id\":\"ffffffff-1111-11eb-9b11-0602a5689467\",\"name\":\"HostedServiceStoppedV1\",\"timestamp\":\"1604855302512\"}",
-                "created": "2020-11-08T17:08:22.512Z",
-                "kind": "event",
-                "action": "HostedServiceStopped",
-                "id": "ffffffff-1111-11eb-9b11-0602a5689467",
-                "category": [
-                    "package"
-                ],
-                "type": [
-                    "end"
-                ],
-                "outcome": "success"
-            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
+            "@timestamp": "2020-11-08T17:07:07.625Z",
             "crowdstrike": {
-                "name": "HostedServiceStoppedV1",
-                "TargetThreadId": "24238019995551",
+                "AuthenticationId": "3443175",
                 "ConfigStateHash": "3338885535",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+                "FileEcpBitmask": "0",
+                "FileObject": "18446603341701082336",
+                "IrpFlags": "1028",
+                "IsOnNetwork": "0",
+                "IsOnRemovableDisk": "0",
+                "MajorFunction": "18",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "TokenType": "1",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "PdfFileWrittenV11"
             },
-            "url": {
-                "scheme": "http"
+            "ecs": {
+                "version": "8.0.0"
             },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
+            "event": {
+                "action": "PdfFileWritten",
+                "category": [
+                    "file"
+                ],
+                "created": "2020-11-08T17:07:44.313Z",
+                "id": "ffffffff-1111-11eb-baea-02dccfbb7779",
+                "ingested": "2022-03-22T18:19:46.427328500Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"3443175\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextProcessId\":\"1091372257857\",\"ContextThreadId\":\"36855848099771\",\"ContextTimeStamp\":\"1604855227.625\",\"DiskParentDeviceInstanceId\":\"PCI\\\\VEN_1179\\u0026DEV_0113\\u0026SUBSYS_00011179\\u0026REV_01\\\\4\\u00263ad42678\\u00260\\u002600E0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileEcpBitmask\":\"0\",\"FileIdentifier\":\"f5ce07c6af67ec4ebe0846ff200bfc2f54f7020000002100\",\"FileObject\":\"18446603341701082336\",\"IrpFlags\":\"1028\",\"IsOnNetwork\":\"0\",\"IsOnRemovableDisk\":\"0\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Size\":\"288041\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user12\\\\AppData\\\\Local\\\\Packages\\\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\\\\TempState\\\\Downloads\\\\ex.pdf.8e41hf8.partial\",\"TokenType\":\"1\",\"aid\":\"ffffffff32cb4abc50bc133b31a69946\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"PdfFileWritten\",\"id\":\"ffffffff-1111-11eb-baea-02dccfbb7779\",\"name\":\"PdfFileWrittenV11\",\"timestamp\":\"1604855264313\"}",
+                "outcome": "success",
+                "type": [
+                    "creation"
+                ]
+            },
+            "file": {
+                "device": "PCI\\VEN_1179\u0026DEV_0113\u0026SUBSYS_00011179\u0026REV_01\\4\u00263ad42678\u00260\u002600E0",
+                "directory": "\\Device\\HarddiskVolume3\\Users\\user12\\AppData\\Local\\Packages\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\\TempState\\Downloads",
+                "extension": "partial",
+                "inode": "f5ce07c6af67ec4ebe0846ff200bfc2f54f7020000002100",
+                "name": "ex.pdf.8e41hf8.partial",
+                "path": "\\Device\\HarddiskVolume3\\Users\\user12\\AppData\\Local\\Packages\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\\TempState\\Downloads\\ex.pdf.8e41hf8.partial",
+                "size": 288041,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff32cb4abc50bc133b31a69946",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "1091372257857",
                 "thread": {
                     "id": 36855848099771
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff32cb4abc50bc133b31a69946",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T17:07:07.625Z",
-            "file": {
-                "inode": "f5ce07c6af67ec4ebe0846ff200bfc2f54f7020000002100",
-                "path": "\\Device\\HarddiskVolume3\\Users\\user12\\AppData\\Local\\Packages\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\\TempState\\Downloads\\ex.pdf.8e41hf8.partial",
-                "extension": "partial",
-                "size": 288041,
-                "name": "ex.pdf.8e41hf8.partial",
-                "type": "file",
-                "device": "PCI\\VEN_1179\u0026DEV_0113\u0026SUBSYS_00011179\u0026REV_01\\4\u00263ad42678\u00260\u002600E0",
-                "directory": "\\Device\\HarddiskVolume3\\Users\\user12\\AppData\\Local\\Packages\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\\TempState\\Downloads"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
                 "hash": [
                     "3338885535"
                 ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
                 "ip": [
                     "67.43.156.14"
                 ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561796028Z",
-                "original": "{\"AuthenticationId\":\"3443175\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"3338885535\",\"ContextProcessId\":\"1091372257857\",\"ContextThreadId\":\"36855848099771\",\"ContextTimeStamp\":\"1604855227.625\",\"DiskParentDeviceInstanceId\":\"PCI\\\\VEN_1179\\u0026DEV_0113\\u0026SUBSYS_00011179\\u0026REV_01\\\\4\\u00263ad42678\\u00260\\u002600E0\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileEcpBitmask\":\"0\",\"FileIdentifier\":\"f5ce07c6af67ec4ebe0846ff200bfc2f54f7020000002100\",\"FileObject\":\"18446603341701082336\",\"IrpFlags\":\"1028\",\"IsOnNetwork\":\"0\",\"IsOnRemovableDisk\":\"0\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Size\":\"288041\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user12\\\\AppData\\\\Local\\\\Packages\\\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\\\\TempState\\\\Downloads\\\\ex.pdf.8e41hf8.partial\",\"TokenType\":\"1\",\"aid\":\"ffffffff32cb4abc50bc133b31a69946\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"PdfFileWritten\",\"id\":\"ffffffff-1111-11eb-baea-02dccfbb7779\",\"name\":\"PdfFileWrittenV11\",\"timestamp\":\"1604855264313\"}",
-                "created": "2020-11-08T17:07:44.313Z",
-                "kind": "event",
-                "action": "PdfFileWritten",
-                "id": "ffffffff-1111-11eb-baea-02dccfbb7779",
-                "category": [
-                    "file"
-                ],
-                "type": [
-                    "creation"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "3338885535",
-                "IrpFlags": "1028",
-                "MinorFunction": "0",
-                "IsOnNetwork": "0",
-                "AuthenticationId": "3443175",
-                "FileEcpBitmask": "0",
-                "TokenType": "1",
-                "MajorFunction": "18",
-                "IsOnRemovableDisk": "0",
-                "Entitlements": "15",
-                "name": "PdfFileWrittenV11",
-                "OperationFlags": "0",
-                "FileObject": "18446603341701082336",
-                "EffectiveTransmissionClass": "3",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            }
-        },
-        {
-            "process": {
-                "args": [
-                    "C:\\WINDOWS\\system32\\backgroundTaskHost.exe",
-                    "-ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca"
-                ],
-                "parent": {
-                    "name": "svchost.exe",
-                    "entity_id": "2439558094566"
-                },
-                "start": "2020-11-08T17:06:21.648Z",
-                "pid": 22272,
-                "args_count": 2,
-                "entity_id": "2450046082233",
-                "command_line": "\"C:\\WINDOWS\\system32\\backgroundTaskHost.exe\" -ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca",
-                "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\backgroundTaskHost.exe",
-                "hash": {
-                    "sha256": "b8e176fe76a1454a00c4af0f8bf8870650d9c33d3e333239a59445c5b35c9a37",
-                    "md5": "50d5fd1290d94d46acca0585311e74d5"
-                }
-            },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
             },
             "tags": [
                 "preserve_original_event"
             ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff655344736aca58d17fb570f0",
-                "type": "agent",
-                "version": "1007.3.0012309.1"
-            },
+            "url": {
+                "scheme": "http"
+            }
+        },
+        {
             "@timestamp": "2020-11-08T17:06:22.022Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "50d5fd1290d94d46acca0585311e74d5",
-                    "b8e176fe76a1454a00c4af0f8bf8870650d9c33d3e333239a59445c5b35c9a37",
-                    "3998263252"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561796969Z",
-                "original": "{\"AuthenticationId\":\"3783389\",\"CommandLine\":\"\\\"C:\\\\WINDOWS\\\\system32\\\\backgroundTaskHost.exe\\\" -ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca\",\"ConfigBuild\":\"1007.3.0012309.1\",\"ConfigStateHash\":\"3998263252\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\System32\\\\backgroundTaskHost.exe\",\"ImageSubsystem\":\"2\",\"IntegrityLevel\":\"4096\",\"MD5HashData\":\"50d5fd1290d94d46acca0585311e74d5\",\"ParentAuthenticationId\":\"3783389\",\"ParentBaseFileName\":\"svchost.exe\",\"ParentProcessId\":\"2439558094566\",\"ProcessCreateFlags\":\"525332\",\"ProcessEndTime\":\"\",\"ProcessParameterFlags\":\"16385\",\"ProcessStartTime\":\"1604855181.648\",\"ProcessSxsFlags\":\"1600\",\"RawProcessId\":\"22272\",\"RpcClientProcessId\":\"2439558094566\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"b8e176fe76a1454a00c4af0f8bf8870650d9c33d3e333239a59445c5b35c9a37\",\"SessionId\":\"1\",\"SourceProcessId\":\"2439558094566\",\"SourceThreadId\":\"77538684027214\",\"Tags\":\"41, 12094627905582, 12094627906234\",\"TargetProcessId\":\"2450046082233\",\"TokenType\":\"2\",\"UserSid\":\"S-1-12-1-3697283754-1083485977-2164330645-2516515886\",\"WindowFlags\":\"128\",\"aid\":\"ffffffff655344736aca58d17fb570f0\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-8462-02ade3b2f949\",\"name\":\"ProcessRollup2V18\",\"timestamp\":\"1604855182022\"}",
-                "created": "2020-11-08T17:06:22.022Z",
-                "kind": "event",
-                "action": "ProcessRollup2",
-                "id": "ffffffff-1111-11eb-8462-02ade3b2f949",
-                "category": [
-                    "process"
-                ],
-                "type": [
-                    "start"
-                ],
-                "outcome": "success"
-            },
             "crowdstrike": {
-                "ConfigStateHash": "3998263252",
-                "ProcessCreateFlags": "525332",
-                "IntegrityLevel": "4096",
-                "SourceProcessId": "2439558094566",
-                "ProcessSxsFlags": "1600",
                 "AuthenticationId": "3783389",
-                "WindowFlags": "128",
-                "TokenType": "2",
-                "ParentAuthenticationId": "3783389",
-                "Entitlements": "15",
-                "SourceThreadId": "77538684027214",
-                "name": "ProcessRollup2V18",
-                "RpcClientProcessId": "2439558094566",
-                "ProcessParameterFlags": "16385",
-                "ImageSubsystem": "2",
+                "ConfigStateHash": "3998263252",
                 "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "ImageSubsystem": "2",
+                "IntegrityLevel": "4096",
+                "ParentAuthenticationId": "3783389",
+                "ProcessCreateFlags": "525332",
+                "ProcessParameterFlags": "16385",
+                "ProcessSxsFlags": "1600",
+                "RpcClientProcessId": "2439558094566",
                 "SessionId": "1",
+                "SourceProcessId": "2439558094566",
+                "SourceThreadId": "77538684027214",
                 "Tags": [
                     "41",
                     "12094627905582",
                     "12094627906234"
                 ],
-                "cid": "ffffffff30a3407dae27d0503611022d"
+                "TokenType": "2",
+                "WindowFlags": "128",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "ProcessRollup2V18"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "ProcessRollup2",
+                "category": [
+                    "process"
+                ],
+                "created": "2020-11-08T17:06:22.022Z",
+                "id": "ffffffff-1111-11eb-8462-02ade3b2f949",
+                "ingested": "2022-03-22T18:19:46.427336500Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"3783389\",\"CommandLine\":\"\\\"C:\\\\WINDOWS\\\\system32\\\\backgroundTaskHost.exe\\\" -ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca\",\"ConfigBuild\":\"1007.3.0012309.1\",\"ConfigStateHash\":\"3998263252\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"ImageFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Windows\\\\System32\\\\backgroundTaskHost.exe\",\"ImageSubsystem\":\"2\",\"IntegrityLevel\":\"4096\",\"MD5HashData\":\"50d5fd1290d94d46acca0585311e74d5\",\"ParentAuthenticationId\":\"3783389\",\"ParentBaseFileName\":\"svchost.exe\",\"ParentProcessId\":\"2439558094566\",\"ProcessCreateFlags\":\"525332\",\"ProcessEndTime\":\"\",\"ProcessParameterFlags\":\"16385\",\"ProcessStartTime\":\"1604855181.648\",\"ProcessSxsFlags\":\"1600\",\"RawProcessId\":\"22272\",\"RpcClientProcessId\":\"2439558094566\",\"SHA1HashData\":\"0000000000000000000000000000000000000000\",\"SHA256HashData\":\"b8e176fe76a1454a00c4af0f8bf8870650d9c33d3e333239a59445c5b35c9a37\",\"SessionId\":\"1\",\"SourceProcessId\":\"2439558094566\",\"SourceThreadId\":\"77538684027214\",\"Tags\":\"41, 12094627905582, 12094627906234\",\"TargetProcessId\":\"2450046082233\",\"TokenType\":\"2\",\"UserSid\":\"S-1-12-1-3697283754-1083485977-2164330645-2516515886\",\"WindowFlags\":\"128\",\"aid\":\"ffffffff655344736aca58d17fb570f0\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"ProcessRollup2\",\"id\":\"ffffffff-1111-11eb-8462-02ade3b2f949\",\"name\":\"ProcessRollup2V18\",\"timestamp\":\"1604855182022\"}",
+                "outcome": "success",
+                "type": [
+                    "start"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff655344736aca58d17fb570f0",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0012309.1"
+            },
+            "os": {
+                "type": "windows"
+            },
+            "process": {
+                "args": [
+                    "C:\\WINDOWS\\system32\\backgroundTaskHost.exe",
+                    "-ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca"
+                ],
+                "args_count": 2,
+                "command_line": "\"C:\\WINDOWS\\system32\\backgroundTaskHost.exe\" -ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca",
+                "entity_id": "2450046082233",
+                "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\backgroundTaskHost.exe",
+                "hash": {
+                    "md5": "50d5fd1290d94d46acca0585311e74d5",
+                    "sha256": "b8e176fe76a1454a00c4af0f8bf8870650d9c33d3e333239a59445c5b35c9a37"
+                },
+                "parent": {
+                    "entity_id": "2439558094566",
+                    "name": "svchost.exe"
+                },
+                "pid": 22272,
+                "start": "2020-11-08T17:06:21.648Z"
+            },
+            "related": {
+                "hash": [
+                    "50d5fd1290d94d46acca0585311e74d5",
+                    "b8e176fe76a1454a00c4af0f8bf8870650d9c33d3e333239a59445c5b35c9a37",
+                    "3998263252"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "id": "S-1-12-1-3697283754-1083485977-2164330645-2516515886"
             }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff1f32487185fcde66a9dc0528",
-                "type": "agent",
-                "version": "1007.4.0011104.1"
-            },
             "@timestamp": "2020-11-08T17:09:15.388Z",
-            "os": {
-                "type": "macos"
+            "crowdstrike": {
+                "AuthenticationId": "326190744",
+                "AuthenticationUuid": "98467113-C771-4845-B71B-89B3CE9F93C9",
+                "AuthenticationUuidAsString": "13714698-71C7-4548-B71B-89B3CE9F93C9",
+                "ConfigStateHash": "1457965279",
+                "Entitlements": "15",
+                "UserSid": "S-1-5-21-3629339319-2376021926-2724479216-652382488",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "UserIdentityMacV2"
             },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "user": [
-                    "user8"
-                ],
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "1457965279"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
             "event": {
-                "ingested": "2021-12-30T05:11:46.561797900Z",
-                "original": "{\"AuthenticationId\":\"326190744\",\"AuthenticationUuid\":\"98467113-C771-4845-B71B-89B3CE9F93C9\",\"AuthenticationUuidAsString\":\"13714698-71C7-4548-B71B-89B3CE9F93C9\",\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1457965279\",\"Entitlements\":\"15\",\"UID\":\"326190744\",\"UserPrincipal\":\"user8@dom6\",\"UserSid\":\"S-1-5-21-3629339319-2376021926-2724479216-652382488\",\"aid\":\"ffffffff1f32487185fcde66a9dc0528\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"UserIdentity\",\"id\":\"ffffffff-1111-11eb-b9b4-063e98f9b19b\",\"name\":\"UserIdentityMacV2\",\"timestamp\":\"1604855355388\"}",
-                "created": "2020-11-08T17:09:15.388Z",
-                "kind": "event",
                 "action": "UserIdentity",
-                "id": "ffffffff-1111-11eb-b9b4-063e98f9b19b",
                 "category": [
                     "authentication",
                     "iam"
                 ],
+                "created": "2020-11-08T17:09:15.388Z",
+                "id": "ffffffff-1111-11eb-b9b4-063e98f9b19b",
+                "ingested": "2022-03-22T18:19:46.427344200Z",
+                "kind": "event",
+                "original": "{\"AuthenticationId\":\"326190744\",\"AuthenticationUuid\":\"98467113-C771-4845-B71B-89B3CE9F93C9\",\"AuthenticationUuidAsString\":\"13714698-71C7-4548-B71B-89B3CE9F93C9\",\"ConfigBuild\":\"1007.4.0011104.1\",\"ConfigStateHash\":\"1457965279\",\"Entitlements\":\"15\",\"UID\":\"326190744\",\"UserPrincipal\":\"user8@dom6\",\"UserSid\":\"S-1-5-21-3629339319-2376021926-2724479216-652382488\",\"aid\":\"ffffffff1f32487185fcde66a9dc0528\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"UserIdentity\",\"id\":\"ffffffff-1111-11eb-b9b4-063e98f9b19b\",\"name\":\"UserIdentityMacV2\",\"timestamp\":\"1604855355388\"}",
+                "outcome": "success",
                 "type": [
                     "info",
                     "user"
-                ],
-                "outcome": "success"
+                ]
             },
-            "crowdstrike": {
-                "UserSid": "S-1-5-21-3629339319-2376021926-2724479216-652382488",
-                "AuthenticationUuidAsString": "13714698-71C7-4548-B71B-89B3CE9F93C9",
-                "ConfigStateHash": "1457965279",
-                "Entitlements": "15",
-                "name": "UserIdentityMacV2",
-                "AuthenticationUuid": "98467113-C771-4845-B71B-89B3CE9F93C9",
-                "AuthenticationId": "326190744",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "user": {
-                "full_name": "user8",
-                "id": "326190744",
-                "email": "user8@dom6",
-                "domain": "dom6"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
             "observer": {
+                "address": "67.43.156.14",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.14",
-                "serial_number": "ffffffffcdb543135e7fcdf8e5a8fbdb",
+                "serial_number": "ffffffff1f32487185fcde66a9dc0528",
                 "type": "agent",
-                "version": "1007.3.0011603.1"
+                "vendor": "crowdstrike",
+                "version": "1007.4.0011104.1"
             },
-            "@timestamp": "2020-11-08T17:05:57.555Z",
             "os": {
-                "type": "windows"
-            },
-            "ecs": {
-                "version": "8.0.0"
+                "type": "macos"
             },
             "related": {
+                "hash": [
+                    "1457965279"
+                ],
                 "hosts": [
                     "67.43.156.14"
                 ],
-                "hash": [
-                    "1874387338"
-                ],
                 "ip": [
                     "67.43.156.14"
+                ],
+                "user": [
+                    "user8"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561798844Z",
-                "original": "{\"BootArgs\":\" NOEXECUTE=OPTIN  HYPERVISORLAUNCHTYPE=AUTO  FVEBOOT=2125824  NOVGA\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1874387338\",\"EffectiveTransmissionClass\":\"0\",\"Entitlements\":\"15\",\"MachineDomain\":\"\",\"aid\":\"ffffffffcdb543135e7fcdf8e5a8fbdb\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"HostInfo\",\"id\":\"ffffffff-1111-11eb-9bbd-061290dcd983\",\"name\":\"HostInfoV2\",\"timestamp\":\"1604855157555\"}",
-                "created": "2020-11-08T17:05:57.555Z",
-                "kind": "event",
-                "action": "HostInfo",
-                "id": "ffffffff-1111-11eb-9bbd-061290dcd983",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "info"
-                ],
-                "outcome": "success"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
+            "user": {
+                "domain": "dom6",
+                "email": "user8@dom6",
+                "full_name": "user8",
+                "id": "326190744"
+            }
+        },
+        {
+            "@timestamp": "2020-11-08T17:05:57.555Z",
             "crowdstrike": {
-                "name": "HostInfoV2",
                 "BootArgs": [
                     "NOEXECUTE=OPTIN",
                     "HYPERVISORLAUNCHTYPE=AUTO",
@@ -10699,121 +10649,201 @@
                 "ConfigStateHash": "1874387338",
                 "EffectiveTransmissionClass": "0",
                 "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "HostInfoV2"
             },
-            "url": {
-                "scheme": "http"
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "HostInfo",
+                "category": [
+                    "host"
+                ],
+                "created": "2020-11-08T17:05:57.555Z",
+                "id": "ffffffff-1111-11eb-9bbd-061290dcd983",
+                "ingested": "2022-03-22T18:19:46.427352100Z",
+                "kind": "event",
+                "original": "{\"BootArgs\":\" NOEXECUTE=OPTIN  HYPERVISORLAUNCHTYPE=AUTO  FVEBOOT=2125824  NOVGA\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1874387338\",\"EffectiveTransmissionClass\":\"0\",\"Entitlements\":\"15\",\"MachineDomain\":\"\",\"aid\":\"ffffffffcdb543135e7fcdf8e5a8fbdb\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"HostInfo\",\"id\":\"ffffffff-1111-11eb-9bbd-061290dcd983\",\"name\":\"HostInfoV2\",\"timestamp\":\"1604855157555\"}",
+                "outcome": "success",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffffcdb543135e7fcdf8e5a8fbdb",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
+            "related": {
+                "hash": [
+                    "1874387338"
+                ],
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
+            "@timestamp": "2020-11-08T15:57:10.593Z",
+            "crowdstrike": {
+                "AuthenticationId": "703298",
+                "ConfigStateHash": "2642284486",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "FileEcpBitmask": "0",
+                "FileObject": "18446664963104449168",
+                "IrpFlags": "1028",
+                "IsOnNetwork": "0",
+                "IsOnRemovableDisk": "1",
+                "MajorFunction": "18",
+                "MinorFunction": "0",
+                "OperationFlags": "0",
+                "TokenType": "1",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "GenericFileWrittenV11"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "GenericFileWritten",
+                "created": "2020-11-08T15:57:11.298Z",
+                "id": "ffffffff-1111-11eb-800a-06cecfd73923",
+                "ingested": "2022-03-22T18:19:46.427359700Z",
+                "original": "{\"AuthenticationId\":\"703298\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"2642284486\",\"ContextProcessId\":\"1161025471861\",\"ContextThreadId\":\"34929528116709\",\"ContextTimeStamp\":\"1604851030.593\",\"DiskParentDeviceInstanceId\":\"USB\\\\VID_1058\\u0026PID_2621\\\\57583431453939315A4C5255\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileEcpBitmask\":\"0\",\"FileIdentifier\":\"262fbc677256cf4c8d6c6a227285a072c06830873b000000\",\"FileObject\":\"18446664963104449168\",\"IrpFlags\":\"1028\",\"IsOnNetwork\":\"0\",\"IsOnRemovableDisk\":\"1\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Size\":\"517029\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume5\\\\01.png.tmp$$\",\"TokenType\":\"1\",\"UserName\":\"user9\",\"aid\":\"ffffffff16bf4c7bb5ad755a4722025c\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"GenericFileWritten\",\"id\":\"ffffffff-1111-11eb-800a-06cecfd73923\",\"name\":\"GenericFileWrittenV11\",\"timestamp\":\"1604851031298\"}"
+            },
+            "file": {
+                "device": "USB\\VID_1058\u0026PID_2621\\57583431453939315A4C5255",
+                "directory": "\\Device\\HarddiskVolume5",
+                "extension": "tmp$$",
+                "inode": "262fbc677256cf4c8d6c6a227285a072c06830873b000000",
+                "name": "01.png.tmp$$",
+                "path": "\\Device\\HarddiskVolume5\\01.png.tmp$$",
+                "size": 517029,
+                "type": "file"
+            },
+            "observer": {
+                "address": "67.43.156.13",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "serial_number": "ffffffff16bf4c7bb5ad755a4722025c",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
+            },
             "process": {
                 "entity_id": "1161025471861",
                 "thread": {
                     "id": 34929528116709
                 }
             },
-            "os": {
-                "type": "windows"
-            },
-            "url": {
-                "scheme": "http"
-            },
-            "tags": [
-                "preserve_original_event"
-            ],
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.13",
-                "serial_number": "ffffffff16bf4c7bb5ad755a4722025c",
-                "type": "agent",
-                "version": "1007.3.0011603.1"
-            },
-            "@timestamp": "2020-11-08T15:57:10.593Z",
-            "file": {
-                "inode": "262fbc677256cf4c8d6c6a227285a072c06830873b000000",
-                "path": "\\Device\\HarddiskVolume5\\01.png.tmp$$",
-                "extension": "tmp$$",
-                "size": 517029,
-                "name": "01.png.tmp$$",
-                "type": "file",
-                "device": "USB\\VID_1058\u0026PID_2621\\57583431453939315A4C5255",
-                "directory": "\\Device\\HarddiskVolume5"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "user": [
-                    "user9"
+                "hash": [
+                    "2642284486"
                 ],
                 "hosts": [
                     "67.43.156.13"
                 ],
-                "hash": [
-                    "2642284486"
-                ],
                 "ip": [
                     "67.43.156.13"
+                ],
+                "user": [
+                    "user9"
                 ]
             },
-            "event": {
-                "action": "GenericFileWritten",
-                "ingested": "2021-12-30T05:11:46.561799762Z",
-                "original": "{\"AuthenticationId\":\"703298\",\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"2642284486\",\"ContextProcessId\":\"1161025471861\",\"ContextThreadId\":\"34929528116709\",\"ContextTimeStamp\":\"1604851030.593\",\"DiskParentDeviceInstanceId\":\"USB\\\\VID_1058\\u0026PID_2621\\\\57583431453939315A4C5255\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileEcpBitmask\":\"0\",\"FileIdentifier\":\"262fbc677256cf4c8d6c6a227285a072c06830873b000000\",\"FileObject\":\"18446664963104449168\",\"IrpFlags\":\"1028\",\"IsOnNetwork\":\"0\",\"IsOnRemovableDisk\":\"1\",\"MajorFunction\":\"18\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Size\":\"517029\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume5\\\\01.png.tmp$$\",\"TokenType\":\"1\",\"UserName\":\"user9\",\"aid\":\"ffffffff16bf4c7bb5ad755a4722025c\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"GenericFileWritten\",\"id\":\"ffffffff-1111-11eb-800a-06cecfd73923\",\"name\":\"GenericFileWrittenV11\",\"timestamp\":\"1604851031298\"}",
-                "id": "ffffffff-1111-11eb-800a-06cecfd73923",
-                "created": "2020-11-08T15:57:11.298Z"
-            },
-            "crowdstrike": {
-                "ConfigStateHash": "2642284486",
-                "IrpFlags": "1028",
-                "MinorFunction": "0",
-                "IsOnNetwork": "0",
-                "AuthenticationId": "703298",
-                "FileEcpBitmask": "0",
-                "TokenType": "1",
-                "MajorFunction": "18",
-                "IsOnRemovableDisk": "1",
-                "Entitlements": "15",
-                "name": "GenericFileWrittenV11",
-                "OperationFlags": "0",
-                "FileObject": "18446664963104449168",
-                "EffectiveTransmissionClass": "3",
-                "cid": "ffffffff30a3407dae27d0503611022d"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "scheme": "http"
             },
             "user": {
                 "name": "user9"
             }
         },
         {
+            "@timestamp": "2020-11-08T15:54:59.164Z",
+            "crowdstrike": {
+                "ConfigStateHash": "666346415",
+                "EffectiveTransmissionClass": "3",
+                "Entitlements": "15",
+                "VolumeName": "\\Device\\HarddiskVolume27",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "FsVolumeUnmountedV2"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "FsVolumeUnmounted",
+                "category": [
+                    "host"
+                ],
+                "created": "2020-11-08T15:54:59.812Z",
+                "id": "ffffffff-1111-11eb-9f70-0634389d9ea9",
+                "ingested": "2022-03-22T18:19:46.427367700Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"666346415\",\"ContextProcessId\":\"1717987648455\",\"ContextThreadId\":\"55064470042288\",\"ContextTimeStamp\":\"1604850899.164\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"VolumeName\":\"\\\\Device\\\\HarddiskVolume27\",\"aid\":\"ffffffff896b43725b83c79aa79959da\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"FsVolumeUnmounted\",\"id\":\"ffffffff-1111-11eb-9f70-0634389d9ea9\",\"name\":\"FsVolumeUnmountedV2\",\"timestamp\":\"1604850899812\"}",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
             "observer": {
+                "address": "67.43.156.13",
                 "geo": {
                     "continent_name": "Asia",
+                    "country_iso_code": "BT",
                     "country_name": "Bhutan",
                     "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "address": "67.43.156.13",
-                "vendor": "crowdstrike",
                 "ip": "67.43.156.13",
                 "serial_number": "ffffffff896b43725b83c79aa79959da",
                 "type": "agent",
+                "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
+            },
+            "os": {
+                "type": "windows"
             },
             "process": {
                 "entity_id": "1717987648455",
@@ -10821,142 +10851,147 @@
                     "id": 55064470042288
                 }
             },
-            "@timestamp": "2020-11-08T15:54:59.164Z",
-            "os": {
-                "type": "windows"
-            },
-            "ecs": {
-                "version": "8.0.0"
-            },
             "related": {
-                "hosts": [
-                    "67.43.156.13"
-                ],
                 "hash": [
                     "666346415"
                 ],
+                "hosts": [
+                    "67.43.156.13"
+                ],
                 "ip": [
                     "67.43.156.13"
                 ]
             },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561800681Z",
-                "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"666346415\",\"ContextProcessId\":\"1717987648455\",\"ContextThreadId\":\"55064470042288\",\"ContextTimeStamp\":\"1604850899.164\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"VolumeName\":\"\\\\Device\\\\HarddiskVolume27\",\"aid\":\"ffffffff896b43725b83c79aa79959da\",\"aip\":\"67.43.156.13\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"FsVolumeUnmounted\",\"id\":\"ffffffff-1111-11eb-9f70-0634389d9ea9\",\"name\":\"FsVolumeUnmountedV2\",\"timestamp\":\"1604850899812\"}",
-                "created": "2020-11-08T15:54:59.812Z",
-                "kind": "event",
-                "action": "FsVolumeUnmounted",
-                "id": "ffffffff-1111-11eb-9f70-0634389d9ea9",
-                "category": [
-                    "host"
-                ],
-                "type": [
-                    "change"
-                ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "FsVolumeUnmountedV2",
-                "VolumeName": "\\Device\\HarddiskVolume27",
-                "ConfigStateHash": "666346415",
-                "EffectiveTransmissionClass": "3",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "url": {
-                "scheme": "http"
-            },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "ffffffff899541b94b9adff8922aa70a",
-                "type": "agent",
-                "version": "1007.4.0009906.1"
-            },
-            "process": {
-                "entity_id": "66426035996442255"
-            },
             "@timestamp": "2020-11-08T15:58:18.548Z",
-            "os": {
-                "type": "macos"
+            "crowdstrike": {
+                "ConfigStateHash": "3429017943",
+                "Entitlements": "15",
+                "cid": "ffffffff30a3407dae27d0503611022d",
+                "name": "FirewallDisabledMacV1"
             },
             "ecs": {
                 "version": "8.0.0"
             },
-            "related": {
-                "hosts": [
-                    "67.43.156.14"
-                ],
-                "hash": [
-                    "3429017943"
-                ],
-                "ip": [
-                    "67.43.156.14"
-                ]
-            },
             "event": {
-                "ingested": "2021-12-30T05:11:46.561801595Z",
-                "original": "{\"ConfigBuild\":\"1007.4.0009906.1\",\"ConfigStateHash\":\"3429017943\",\"ContextProcessId\":\"66426035996442255\",\"ContextTimeStamp\":\"1604851098.548\",\"Entitlements\":\"15\",\"aid\":\"ffffffff899541b94b9adff8922aa70a\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"FirewallDisabled\",\"id\":\"ffffffff-1111-11eb-9d4c-02f402df8c1f\",\"name\":\"FirewallDisabledMacV1\",\"timestamp\":\"1604851040625\"}",
-                "created": "2020-11-08T15:57:20.625Z",
-                "kind": "event",
                 "action": "FirewallDisabled",
-                "id": "ffffffff-1111-11eb-9d4c-02f402df8c1f",
                 "category": [
                     "configuration",
                     "host"
                 ],
+                "created": "2020-11-08T15:57:20.625Z",
+                "id": "ffffffff-1111-11eb-9d4c-02f402df8c1f",
+                "ingested": "2022-03-22T18:19:46.427375600Z",
+                "kind": "event",
+                "original": "{\"ConfigBuild\":\"1007.4.0009906.1\",\"ConfigStateHash\":\"3429017943\",\"ContextProcessId\":\"66426035996442255\",\"ContextTimeStamp\":\"1604851098.548\",\"Entitlements\":\"15\",\"aid\":\"ffffffff899541b94b9adff8922aa70a\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Mac\",\"event_simpleName\":\"FirewallDisabled\",\"id\":\"ffffffff-1111-11eb-9d4c-02f402df8c1f\",\"name\":\"FirewallDisabledMacV1\",\"timestamp\":\"1604851040625\"}",
+                "outcome": "success",
                 "type": [
                     "change"
+                ]
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "ffffffff899541b94b9adff8922aa70a",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "1007.4.0009906.1"
+            },
+            "os": {
+                "type": "macos"
+            },
+            "process": {
+                "entity_id": "66426035996442255"
+            },
+            "related": {
+                "hash": [
+                    "3429017943"
                 ],
-                "outcome": "success"
-            },
-            "crowdstrike": {
-                "name": "FirewallDisabledMacV1",
-                "ConfigStateHash": "3429017943",
-                "Entitlements": "15",
-                "cid": "ffffffff30a3407dae27d0503611022d"
-            },
-            "url": {
-                "scheme": "http"
+                "hosts": [
+                    "67.43.156.14"
+                ],
+                "ip": [
+                    "67.43.156.14"
+                ]
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         },
         {
-            "observer": {
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lon": 90.5,
-                        "lat": 27.5
-                    },
-                    "country_iso_code": "BT"
-                },
-                "address": "67.43.156.14",
-                "vendor": "crowdstrike",
-                "ip": "67.43.156.14",
-                "serial_number": "fffffffffffaaaaaaaaabbbbbbbb",
-                "type": "agent",
-                "version": "6.31.14404.0"
+            "crowdstrike": {
+                "AgentLoadFlags": "0",
+                "AgentLocalTime": "2021-11-09T05:47:19.952Z",
+                "AgentTimeOffset": 125.319,
+                "BiosManufacturer": "Apple Inc.",
+                "BiosVersion": "1554.140.20.0.0 (iBridge: 18.16.14759.0.1,0)",
+                "ChassisType": "Laptop",
+                "ConfigBuild": "1007.4.0014404.1",
+                "ConfigIDBuild": "14404",
+                "FirstSeen": "2021-07-07T18:26:31.000Z",
+                "HostHiddenStatus": "Visible",
+                "ProductType": "1",
+                "SystemManufacturer": "Apple Inc.",
+                "SystemProductName": "MacBookPro16,2",
+                "Time": "2021-11-09T09:00:27.353Z",
+                "cid": "ffffffff30a3407dae27d0503611022ff"
             },
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2022-03-22T18:19:46.427383400Z",
+                "original": "{\"AgentLoadFlags\":\"0\",\"AgentLocalTime\":\"1636436839.9529998\",\"AgentTimeOffset\":\"125.319\",\"AgentVersion\":\"6.31.14404.0\",\"BiosManufacturer\":\"Apple Inc.\",\"BiosVersion\":\"1554.140.20.0.0 (iBridge: 18.16.14759.0.1,0)\",\"ChassisType\":\"Laptop\",\"City\":\"San Francisco\",\"ComputerName\":\"mac1\",\"ConfigBuild\":\"1007.4.0014404.1\",\"ConfigIDBuild\":\"14404\",\"Continent\":\"North America\",\"Country\":\"United States\",\"FalconGroupingTags\":\"-\",\"FirstSeen\":\"1625682391.0\",\"HostHiddenStatus\":\"Visible\",\"MachineDomain\":\"none\",\"OU\":\"none\",\"PointerSize\":\"none\",\"ProductType\":\"1\",\"SensorGroupingTags\":\"-\",\"ServicePackMajor\":\"none\",\"SiteName\":\"none\",\"SystemManufacturer\":\"Apple Inc.\",\"SystemProductName\":\"MacBookPro16,2\",\"Time\":\"1636448427.3539999\",\"Timezone\":\"America/Los_Angeles\",\"Version\":\"Big Sur (11.0)\",\"aid\":\"fffffffffffaaaaaaaaabbbbbbbb\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022ff\",\"event_platform\":\"Mac\"}"
+            },
+            "host": {
+                "geo": {
+                    "city_name": "San Francisco",
+                    "continent_name": "North America",
+                    "country_name": "United States",
+                    "timezone": "America/Los_Angeles"
+                },
+                "hostname": "mac1",
+                "name": "mac1"
+            },
+            "observer": {
+                "address": "67.43.156.14",
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.14",
+                "serial_number": "fffffffffffaaaaaaaaabbbbbbbb",
+                "type": "agent",
+                "vendor": "crowdstrike",
+                "version": "6.31.14404.0"
+            },
+            "os": {
+                "type": "macos",
+                "version": "Big Sur (11.0)"
             },
             "related": {
                 "hosts": [
@@ -10967,47 +11002,12 @@
                     "67.43.156.14"
                 ]
             },
-            "os": {
-                "type": "macos",
-                "version": "Big Sur (11.0)"
-            },
-            "host": {
-                "geo": {
-                    "continent_name": "North America",
-                    "country_name": "United States",
-                    "city_name": "San Francisco",
-                    "timezone": "America/Los_Angeles"
-                },
-                "name": "mac1",
-                "hostname": "mac1"
-            },
-            "event": {
-                "ingested": "2021-12-30T05:11:46.561802517Z",
-                "original": "{\"AgentLoadFlags\":\"0\",\"AgentLocalTime\":\"1636436839.9529998\",\"AgentTimeOffset\":\"125.319\",\"AgentVersion\":\"6.31.14404.0\",\"BiosManufacturer\":\"Apple Inc.\",\"BiosVersion\":\"1554.140.20.0.0 (iBridge: 18.16.14759.0.1,0)\",\"ChassisType\":\"Laptop\",\"City\":\"San Francisco\",\"ComputerName\":\"mac1\",\"ConfigBuild\":\"1007.4.0014404.1\",\"ConfigIDBuild\":\"14404\",\"Continent\":\"North America\",\"Country\":\"United States\",\"FalconGroupingTags\":\"-\",\"FirstSeen\":\"1625682391.0\",\"HostHiddenStatus\":\"Visible\",\"MachineDomain\":\"none\",\"OU\":\"none\",\"PointerSize\":\"none\",\"ProductType\":\"1\",\"SensorGroupingTags\":\"-\",\"ServicePackMajor\":\"none\",\"SiteName\":\"none\",\"SystemManufacturer\":\"Apple Inc.\",\"SystemProductName\":\"MacBookPro16,2\",\"Time\":\"1636448427.3539999\",\"Timezone\":\"America/Los_Angeles\",\"Version\":\"Big Sur (11.0)\",\"aid\":\"fffffffffffaaaaaaaaabbbbbbbb\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022ff\",\"event_platform\":\"Mac\"}"
-            },
-            "crowdstrike": {
-                "SystemProductName": "MacBookPro16,2",
-                "ProductType": "1",
-                "Time": "2021-11-09T09:00:27.353Z",
-                "ConfigBuild": "1007.4.0014404.1",
-                "AgentTimeOffset": 125.319,
-                "FirstSeen": "2021-07-07T18:26:31.000Z",
-                "HostHiddenStatus": "Visible",
-                "AgentLocalTime": "2021-11-09T05:47:19.952Z",
-                "BiosManufacturer": "Apple Inc.",
-                "AgentLoadFlags": "0",
-                "BiosVersion": "1554.140.20.0.0 (iBridge: 18.16.14759.0.1,0)",
-                "ChassisType": "Laptop",
-                "ConfigIDBuild": "14404",
-                "SystemManufacturer": "Apple Inc.",
-                "cid": "ffffffff30a3407dae27d0503611022ff"
-            },
-            "url": {
-                "scheme": "http"
-            },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "url": {
+                "scheme": "http"
+            }
         }
     ]
 }

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
@@ -4849,7 +4849,7 @@
                 "AgentLoadFlags": "0",
                 "AgentLocalTime": "2021-07-07T17:04:05.731Z",
                 "BiosManufacturer": "Apple Inc.",
-                "BiosReleaseDate": "01/06/2021",
+                "BiosReleaseDate": "2021-01-06T00:00:00.000Z",
                 "BiosVersion": "1554.80.3.0.0 (iBridge: 18.16.14347.0.0,0)",
                 "ChasisManufacturer": "Apple Inc.",
                 "ChassisType": "9",

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -1191,6 +1191,13 @@ processors:
       formats:
         - UNIX
       if: ctx?.crowdstrike?.Time != null && ctx?.crowdstrike?.Time != ""
+  - date:
+      field: crowdstrike.BiosReleaseDate
+      target_field: crowdstrike.BiosReleaseDate
+      formats:
+        - MM/dd/yyyy
+        - strict_date_optional_time
+      if: ctx?.crowdstrike?.BiosReleaseDate != null && ctx?.crowdstrike?.BiosReleaseDate != ""
   - convert:
       field: crowdstrike.AgentTimeOffset
       target_field: crowdstrike.AgentTimeOffset

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike Logs
-version: 1.2.4
+version: 1.2.5
 description: Collect and parse falcon logs from Crowdstrike products with Elastic Agent.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

- Adds date parsing for the BiosReleaseDate field

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Checked to make sure other date fields were being parsed

## How to test this PR locally

``` sh
elastic-package clean
elastic-package check
elastic-package stack up -d
eval "$(elastic-package stack shellinit)"
elastic-package test
```