### PR TITLE
ci: disable stages if only docs changes or .github

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,9 +41,10 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-        setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true).toString())
-        // Skip all the stages except check Go sources for changeset's with asciidoc, md or .github changes only
-        setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '(.*\\.(asciidoc|md)|^\\.github/.*)' ], shouldMatchAll: true).toString())
+        dir("${BASE_DIR}"){
+          // Skip all the stages except check Go sources for changeset's with asciidoc, md or .github changes only
+          setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '(.*\\.(asciidoc|md)|^\\.github/.*)' ], shouldMatchAll: true).toString())
+        }
       }
     }
     stage('Check Go sources') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,9 +41,15 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+        setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true).toString())
+        // Skip all the stages except check Go sources for changeset's with asciidoc, md or .github changes only
+        setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '(.*\\.(asciidoc|md)|^\\.github/.*)' ], shouldMatchAll: true).toString())
       }
     }
     stage('Check Go sources') {
+      when {
+        expression { return env.ONLY_DOCS == "false" }
+      }
       steps {
         dir("${BASE_DIR}"){
           withMageEnv(){
@@ -54,6 +60,9 @@ pipeline {
       }
     }
     stage('Check integrations') {
+      when {
+        expression { return env.ONLY_DOCS == "false" }
+      }
       steps {
         script {
           dir("${BASE_DIR}/packages") {
@@ -115,7 +124,9 @@ pipeline {
   }
   post {
     always {
-      publishCoverageReports()
+      whenTrue(env.ONLY_DOCS == "false") {
+        publishCoverageReports()
+      }
     }
     cleanup {
       notifyBuildResult(prComment: true)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -42,15 +42,12 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}")
         stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
         dir("${BASE_DIR}"){
-          // Skip all the stages except check Go sources for changeset's with asciidoc, md or .github changes only
-          setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '(.*\\.(asciidoc|md)|^\\.github/.*)' ], shouldMatchAll: true).toString())
+          // Skip all the stages except check Go sources for changeset's with ^docs/*.md or ^.github only
+          setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '(^docs/.*\\.md|^\\.github/.*)' ], shouldMatchAll: true).toString())
         }
       }
     }
     stage('Check Go sources') {
-      when {
-        expression { return env.ONLY_DOCS == "false" }
-      }
       steps {
         dir("${BASE_DIR}"){
           withMageEnv(){


### PR DESCRIPTION
## What does this PR do?

Faster builds for changes which are not verified/validated by the build system

## Why

Smart builds reduce the cost (money and time) for commits which don't need to be validated


Therefore, https://github.com/elastic/integrations/pull/2874 could be a good candidate to be done in a few minutes rather than dozens of minutes.