### PR TITLE
ci: smart stages for PRs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("${obltGitHubComments()}")
+    issueCommentTrigger("(${obltGitHubComments()}|^/test all)")
   }
   parameters {
     string(name: 'stackVersion', defaultValue: '', description: 'Version of the stack to use for testing.')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -146,7 +146,29 @@ def checkGitDiff() {
   }
 }
 
-def isPrAffected(integrationName) {
+/**
+* Helper function to validate if the given integration is enabled
+* If it's a branch, a daily build, a GitHub comment or the changeset
+* contains the integration then it will be true, otherwise false.
+*/
+def isPackageEnabled(integrationName) {
+  if (isBranch()) {
+    log(level: 'INFO', text: "[${integrationName}] is affected: running on ${BRANCH_NAME} branch.")
+    return true
+  }
+  if (isDailyEnabled(integrationName)) {
+    return true
+  }
+  if (isPrAffected(integrationName)) {
+    return true
+  }
+  return env.GITHUB_COMMENT?.contains('all')}
+}
+
+def isDailyEnabled(integrationName) {
+  if (isPR()) {
+    return false
+  }
   def manifest = readYaml(file: "${integrationName}/manifest.yml")
 
   // Packages supported in Kibana >= 8.0.0, shouldn't be included in daily tests of the stack 7.x
@@ -163,10 +185,11 @@ def isPrAffected(integrationName) {
       }
     }
   }
+}
 
-  if (env.BRANCH_NAME == "main") {
-    echo "[${integrationName}] PR is affected: running on main branch"
-    return true
+def isPrAffected(integrationName) {
+  if (!isPR()) {
+    return false
   }
 
   // Source: https://github.com/elastic/apm-pipeline-library/blob/721115cf0fdb2b5a4e1cb6a576bfbb7035d14485/vars/getGitMatchingGroup.groovy#L40-L41

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,6 +41,10 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+        dir("${BASE_DIR}"){
+          // TODO: '^.ci/Jenkinsfile' too
+          setEnvVar('COMMON_CHANGES', isGitRegionMatch(patterns: [ '(^go.*|.go-version)' ], shouldMatchAll: false).toString())
+        }
       }
     }
     stage('Check Go sources') {
@@ -149,7 +153,8 @@ def checkGitDiff() {
 /**
 * Helper function to validate if the given integration is enabled
 * If it's a branch, a daily build, a GitHub comment or the changeset
-* contains the integration then it will be true, otherwise false.
+* contains the integration or some common changes then it will be true,
+* otherwise false.
 */
 def isPackageEnabled(integrationName) {
   if (isBranch()) {
@@ -162,7 +167,7 @@ def isPackageEnabled(integrationName) {
   if (isPrAffected(integrationName)) {
     return true
   }
-  return env.GITHUB_COMMENT?.contains('all')}
+  return env.GITHUB_COMMENT?.contains('all') || env.COMMON_CHANGES == 'true'
 }
 
 def isDailyEnabled(integrationName) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
             // Include hack to skip temporary files with "@tmp" suffix.
             // For reference: https://issues.jenkins.io/browse/JENKINS-52750
             findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
-              if (isPrAffected(it)) {
+              if (isPackageEnabled(it)) {
                 integrations[it] = {
                   withNode(labels: 'ubuntu-20 && immutable', sleepMin: 10, sleepMax: 100) {
                     stage("${it}: check") {


### PR DESCRIPTION
## What does this PR do?

Run "check" and "test":
1) only for affected packages in PRs.
2) for all the packages if a github command `/test all`
3) for all the packages if a daily or a branch build
4) for all the packages if changes in go.mod/sum and Jenkinsfile

## Why

Re-enable https://github.com/elastic/integrations/pull/474 since https://github.com/elastic/integrations/pull/2334 added a 
regression and therefore all the integrations are always triggered.

