### PR TITLE
Use stack v8.2 for daily testing

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -35,11 +35,11 @@ pipeline {
             )
           }
         }
-        stage('with stack v8.1') {
+        stage('with stack v8.2') {
           steps {
             build(
               job: env.INTEGRATION_JOB,
-              parameters: [stringParam(name: 'stackVersion', value: '8.1.0-SNAPSHOT')],
+              parameters: [stringParam(name: 'stackVersion', value: '8.2.0-SNAPSHOT')],
               quietPeriod: 0,
               wait: true,
               propagate: true,


### PR DESCRIPTION
This PR modifies the daily schedule to test using 8.2.0-SNAPSHOT.

This [Jenkins pipeline](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/325/pipeline) discovered the inconsistency between the stack version used for testing and the requirement defined in the package.