### PR TITLE
[httpjson] Fixing typo in httpjson.yml.hbs

### DIFF
--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.1.1"
+  changes:
+    - description: Fixes typo in config template
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2815
 - version: "1.1.0"
   changes:
     - description: Fixes issues with certain configuration fields not working

--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fixes typo in config template
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/2815
+      link: https://github.com/elastic/integrations/pull/2883
 - version: "1.1.0"
   changes:
     - description: Fixes issues with certain configuration fields not working

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -48,7 +48,7 @@ auth.oauth2.azure.tenant_id: {{oauth_azure_tenant_id}}
 auth.oauth2.azure.resource: {{oauth_azure_resource}}
 {{/if}}
 {{#if oauth_endpoint_params}}
-auth.oauth2.azure.resource: 
+auth.oauth2.endpoint_params: 
   {{oauth_endpoint_params}}
 {{/if}}
 {{/if}}

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -3,7 +3,7 @@ name: httpjson
 title: Custom HTTPJSON Input
 description: Collect custom data from REST API's with Elastic Agent.
 type: integration
-version: 1.1.0
+version: 1.1.1
 release: ga
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the httpjson.yml.hbs template file

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
