### PR TITLE
[Microsoft SQL Server] Fix field conflict

### DIFF
--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.3"
+  changes:
+    - description: Fix mapper_parsing_exception when parsing sqlserver.audit.event_time.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.4.2"
   changes:
     - description: Fix mapper_parsing_exception when parsing sqlserver.audit.event_time.

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "0.4.3"
   changes:
-    - description: Fix mapper_parsing_exception when parsing sqlserver.audit.event_time.
+    - description: Fix field conflict for `winlog.record_id`
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2894
 - version: "0.4.2"
   changes:
     - description: Fix mapper_parsing_exception when parsing sqlserver.audit.event_time.

--- a/packages/microsoft_sqlserver/data_stream/audit/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/microsoft_sqlserver/data_stream/audit/_dev/test/pipeline/test-events.json-expected.json
@@ -124,7 +124,7 @@
                     "Classic"
                 ],
                 "provider_name": "MSSQLSERVER$AUDIT",
-                "record_id": 17607,
+                "record_id": "17607",
                 "user": {
                     "domain": "NT SERVICE",
                     "identifier": "S-1-5-80-3880718306-3832830129-1677859214-2598158968-1052248003",
@@ -258,7 +258,7 @@
                     "Classic"
                 ],
                 "provider_name": "MSSQLSERVER$AUDIT",
-                "record_id": 26134,
+                "record_id": "26134",
                 "user": {
                     "domain": "NT SERVICE",
                     "identifier": "S-1-5-80-3880718306-3832830129-1677859214-2598158968-1052248003",
@@ -389,7 +389,7 @@
                     "Classic"
                 ],
                 "provider_name": "MSSQLSERVER$AUDIT",
-                "record_id": 27810,
+                "record_id": "27810",
                 "user": {
                     "domain": "NT SERVICE",
                     "identifier": "S-1-5-80-3880718306-3832830129-1677859214-2598158968-1052248003",
@@ -516,7 +516,7 @@
                     "Classic"
                 ],
                 "provider_name": "MSSQLSERVER$AUDIT",
-                "record_id": 28002,
+                "record_id": "28002",
                 "user": {
                     "domain": "NT SERVICE",
                     "identifier": "S-1-5-80-3880718306-3832830129-1677859214-2598158968-1052248003",

--- a/packages/microsoft_sqlserver/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_sqlserver/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -1229,6 +1229,11 @@ processors:
 - set:
     field: user.target.id
     copy_from: sqlserver.audit.target_server_principal_sid
+    
+- convert:
+    field: winlog.record_id
+    type: string
+    ignore_missing: true
 ##
 # Clean up
 ##

--- a/packages/microsoft_sqlserver/data_stream/audit/fields/winlog.yml
+++ b/packages/microsoft_sqlserver/data_stream/audit/fields/winlog.yml
@@ -72,7 +72,7 @@
         The name of the channel from which this record was read. This value is one of the names from the `event_logs` collection in the configuration.
 
     - name: record_id
-      type: long
+      type: keyword
       required: true
       description: >
         The record ID of the event log record. The first record written to an event log is record number 1, and other records are numbered sequentially. If the record number reaches the maximum value (2^32^ for the Event Logging API and 2^64^ for the Windows Event Log API), the next record number will be 0.

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -133,7 +133,7 @@ The SQL Server audit dataset provides events from the configured Windows event l
 | winlog.process.thread.id |  | long |
 | winlog.provider_guid | A globally unique identifier that identifies the provider that logged the event. | keyword |
 | winlog.provider_name | The source of the event log record (the application or service that logged the record). | keyword |
-| winlog.record_id | The record ID of the event log record. The first record written to an event log is record number 1, and other records are numbered sequentially. If the record number reaches the maximum value (2^32^ for the Event Logging API and 2^64^ for the Windows Event Log API), the next record number will be 0. | long |
+| winlog.record_id | The record ID of the event log record. The first record written to an event log is record number 1, and other records are numbered sequentially. If the record number reaches the maximum value (2^32^ for the Event Logging API and 2^64^ for the Windows Event Log API), the next record number will be 0. | keyword |
 | winlog.related_activity_id | A globally unique identifier that identifies the activity to which control was transferred to. The related events would then have this identifier as their `activity_id` identifier. | keyword |
 | winlog.task | The task defined in the event. Task and opcode are typically used to identify the location in the application from where the event was logged. The category used by the Event Logging API (on pre Windows Vista operating systems) is written to this field. | keyword |
 | winlog.user.domain | The domain that the account associated with this event is a member of. | keyword |

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: 0.4.2
+version: 0.4.3
 license: basic
 description: Collect audit events from Microsoft SQL Server with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fix field conflict for `winlog.record_id`

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2870 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
