### PR TITLE
elasticsearch/index_recovery: fix version field mapping

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,10 +1,15 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Fix version mapping in the index_recovery data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2896
 - version: "0.2.0"
   changes:
     - description: Update to ECS 1.12.0
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1692
-- version: 0.1.0
+- version: "0.1.0"
   changes:
     - description: initial release
       type: enhancement

--- a/packages/elasticsearch/data_stream/index_recovery/fields/package-fields.yml
+++ b/packages/elasticsearch/data_stream/index_recovery/fields/package-fields.yml
@@ -14,7 +14,7 @@
       type: alias
       path: elasticsearch.node.name
 - name: version
-  type: long
+  type: keyword
 - name: index_recovery
   type: group
   fields:

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 0.2.0
+version: 0.2.1
 release: experimental
 description: Elasticsearch Integration
 type: integration


### PR DESCRIPTION

## What does this PR do?

elasticsearch index_recovery data stream has version mapped as long in package-fields.yml and system auth data_stream has version mapped as keyword in fields.yml. This changes elasticsearch to use `keyword`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2885
