### PR TITLE
network_traffic: change release stability to beta

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Change release stability to beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2793
 - version: "0.7.1"
   changes:
     - description: Fix mapping for tls.detailed.client_certificate_chain.

--- a/packages/network_traffic/data_stream/amqp/manifest.yml
+++ b/packages/network_traffic/data_stream/amqp/manifest.yml
@@ -1,5 +1,5 @@
 title: AMQP
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/cassandra/manifest.yml
+++ b/packages/network_traffic/data_stream/cassandra/manifest.yml
@@ -1,5 +1,5 @@
 title: Cassandra
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/dhcpv4/manifest.yml
+++ b/packages/network_traffic/data_stream/dhcpv4/manifest.yml
@@ -1,5 +1,5 @@
 title: DHCP
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/dns/manifest.yml
+++ b/packages/network_traffic/data_stream/dns/manifest.yml
@@ -1,5 +1,5 @@
 title: DNS
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/flow/manifest.yml
+++ b/packages/network_traffic/data_stream/flow/manifest.yml
@@ -1,5 +1,5 @@
 title: Flows
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/http/manifest.yml
+++ b/packages/network_traffic/data_stream/http/manifest.yml
@@ -1,5 +1,5 @@
 title: HTTP
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/icmp/manifest.yml
+++ b/packages/network_traffic/data_stream/icmp/manifest.yml
@@ -1,5 +1,5 @@
 title: ICMP
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/memcached/manifest.yml
+++ b/packages/network_traffic/data_stream/memcached/manifest.yml
@@ -1,5 +1,5 @@
 title: Memcached
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/mongodb/manifest.yml
+++ b/packages/network_traffic/data_stream/mongodb/manifest.yml
@@ -1,5 +1,5 @@
 title: MongoDB
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/mysql/manifest.yml
+++ b/packages/network_traffic/data_stream/mysql/manifest.yml
@@ -1,5 +1,5 @@
 title: MySQL
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/nfs/manifest.yml
+++ b/packages/network_traffic/data_stream/nfs/manifest.yml
@@ -1,5 +1,5 @@
 title: NFS
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/pgsql/manifest.yml
+++ b/packages/network_traffic/data_stream/pgsql/manifest.yml
@@ -1,5 +1,5 @@
 title: PostgreSQL
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/redis/manifest.yml
+++ b/packages/network_traffic/data_stream/redis/manifest.yml
@@ -1,5 +1,5 @@
 title: Redis
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/sip/manifest.yml
+++ b/packages/network_traffic/data_stream/sip/manifest.yml
@@ -1,5 +1,5 @@
 title: SIP
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/thrift/manifest.yml
+++ b/packages/network_traffic/data_stream/thrift/manifest.yml
@@ -1,5 +1,5 @@
 title: Thrift
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/data_stream/tls/manifest.yml
+++ b/packages/network_traffic/data_stream/tls/manifest.yml
@@ -1,5 +1,5 @@
 title: TLS
-release: experimental
+release: beta
 type: logs
 streams:
   - input: packet

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,13 +1,13 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: 0.7.1
+version: 0.8.0
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
 categories:
   - web
-release: experimental
+release: beta
 conditions:
   kibana.version: ^7.17.0 || ^8.0.0
 policy_templates:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Changes the release status to beta.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
