### PR TITLE
Update owner of Logstash

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,7 @@
 /packages/kubernetes @elastic/obs-cloudnative-monitoring
 /packages/linux @elastic/integrations
 /packages/log @elastic/integrations
-/packages/logstash @elastic/integrations
+/packages/logstash @elastic/infra-monitoring-ui
 /packages/m365_defender @elastic/security-external-integrations
 /packages/mattermost @elastic/security-external-integrations
 /packages/microsoft_defender_endpoint @elastic/security-external-integrations

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -65,4 +65,4 @@ policy_templates:
         title: Collect Logstash node metrics and stats
         description: Collecting node metrics and stats from Logstash instances
 owner:
-  github: elastic/integrations
+  github: elastic/infra-monitoring-ui


### PR DESCRIPTION
We should also be the owner of the Logstash integration until ownership is moved to the Logstash teams.