### PR TITLE
ci: use the Jenkins Code Coverage Plug-in with source support

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -278,6 +278,8 @@ def publishCoverageReports() {
       def bucketUri = getCoverageBucketURI() + "*.xml"
       googleStorageDownload(bucketUri: bucketUri, credentialsId: "${JOB_GCS_CREDENTIALS}", localDirectory: 'build/test-coverage', pathPrefix: getCoveragePathPrefix())
       coverageReport('build/test-coverage')
+      publishCoverage(adapters: [coberturaAdapter("build/test-coverage/*.xml")],
+                      sourceFileResolver: sourceFiles('STORE_ALL_BUILD'))
     }
   }
 }


### PR DESCRIPTION
### What

Enrich the CI with the source integration as stated in https://github.com/elastic/elastic-package/pull/585#issuecomment-970071779

### Test

If you go to [here](https://beats-ci.elastic.co/job/Ingest-manager/job/integrations/job/PR-2986/1/coverage/)

Then you will see the code coverage.

<img width="1764" alt="image" src="https://user-images.githubusercontent.com/2871786/161514028-8ce1500a-61f0-49b3-90ae-715e117732ae.png">

And you can also navigate to the specific file, like if. you click `1password/data_stream/item_usages/elasticsearch/ingest_pipeline/default.yml` 

<img width="1449" alt="image" src="https://user-images.githubusercontent.com/2871786/161514295-05e2ce5b-315e-445c-aaef-f2e700c4ba54.png">


There are some source files that are not shown in the report as reported also in the console output when using this new step:

```
[2022-04-04T08:32:50.495Z] Unable to find source file rabbitmq/exchange in workspace /var/lib/jenkins/workspace/est-manager_integrations_PR-2986/src/github.com/elastic/integrations
[2022-04-04T08:32:50.495Z] Starting copy source file activemq/log. 
[2022-04-04T08:32:50.546Z] Unable to find source file activemq/log in workspace /var/lib/jenkins/workspace/est-manager_integrations_PR-2986/src/github.com/elastic/integrations
[2022-04-04T08:32:50.546Z] Starting copy source file containerd/blkio.
``` 

See the entire log -> [here](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/PR-2986/1/pipeline/23369/#step-23375-log-1222)