### PR TITLE
[cisco_duo] Fix dashboards for 8.x

### DIFF
--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.4"
+  changes:
+    - description: Fix dashboard issues.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3030
 - version: "1.1.3"
   changes:
     - description: Add mapping for event.created.

--- a/packages/cisco_duo/kibana/dashboard/cisco_duo-6b585210-0faa-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/dashboard/cisco_duo-6b585210-0faa-11ec-8b4b-67126a72b1d4.json
@@ -4,11 +4,33 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "cisco_duo.summary"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "cisco_duo.summary"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.summary\""
-                },
-                "filter": []
+                    "query": ""
+                }
             }
         },
         "optionsJSON": {
@@ -29,9 +51,9 @@
                     "y": 0
                 },
                 "panelIndex": "3b33c381-80ab-4111-ab09-fcc73e3f9a0b",
-                "panelRefName": "panel_0",
+                "panelRefName": "panel_3b33c381-80ab-4111-ab09-fcc73e3f9a0b",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -45,9 +67,9 @@
                     "y": 13
                 },
                 "panelIndex": "e6ac6ace-57bd-4d11-b92b-a051cece0d4c",
-                "panelRefName": "panel_1",
+                "panelRefName": "panel_e6ac6ace-57bd-4d11-b92b-a051cece0d4c",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -62,10 +84,10 @@
                     "y": 13
                 },
                 "panelIndex": "b31e0b4a-7166-421d-bb0a-e02cc3def401",
-                "panelRefName": "panel_2",
+                "panelRefName": "panel_b31e0b4a-7166-421d-bb0a-e02cc3def401",
                 "title": "[Cisco Duo] Integrations Count",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -79,9 +101,9 @@
                     "y": 13
                 },
                 "panelIndex": "85c0ed49-374f-448d-a9b4-88f4600d6ad8",
-                "panelRefName": "panel_3",
+                "panelRefName": "panel_85c0ed49-374f-448d-a9b4-88f4600d6ad8",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -95,48 +117,51 @@
                     "y": 13
                 },
                 "panelIndex": "80fb20e4-3445-450f-8b05-bcf29c015d7a",
-                "panelRefName": "panel_4",
+                "panelRefName": "panel_80fb20e4-3445-450f-8b05-bcf29c015d7a",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             }
         ],
         "timeRestore": false,
         "title": "[Cisco Duo] Summary Logs",
         "version": 1
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-6b585210-0faa-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "dashboard": "7.15.0"
+        "dashboard": "7.17.0"
     },
     "references": [
         {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
             "id": "cisco_duo-9818eda0-1063-11ec-8b4b-67126a72b1d4",
-            "name": "panel_0",
+            "name": "3b33c381-80ab-4111-ab09-fcc73e3f9a0b:panel_3b33c381-80ab-4111-ab09-fcc73e3f9a0b",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-32c97410-0fa0-11ec-8b4b-67126a72b1d4",
-            "name": "panel_1",
+            "name": "e6ac6ace-57bd-4d11-b92b-a051cece0d4c:panel_e6ac6ace-57bd-4d11-b92b-a051cece0d4c",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-1b1c61d0-0fa8-11ec-8b4b-67126a72b1d4",
-            "name": "panel_2",
+            "name": "b31e0b4a-7166-421d-bb0a-e02cc3def401:panel_b31e0b4a-7166-421d-bb0a-e02cc3def401",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-8342fad0-0fa8-11ec-8b4b-67126a72b1d4",
-            "name": "panel_3",
+            "name": "85c0ed49-374f-448d-a9b4-88f4600d6ad8:panel_85c0ed49-374f-448d-a9b4-88f4600d6ad8",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-1e9e23a0-0faa-11ec-8b4b-67126a72b1d4",
-            "name": "panel_4",
+            "name": "80fb20e4-3445-450f-8b05-bcf29c015d7a:panel_80fb20e4-3445-450f-8b05-bcf29c015d7a",
             "type": "visualization"
         }
     ],
-    "type": "dashboard",
-    "updated_at": "2021-09-08T05:14:17.009Z",
-    "version": "WzU5ODksMV0="
+    "type": "dashboard"
 }

--- a/packages/cisco_duo/kibana/dashboard/cisco_duo-a48b1130-0fb4-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/dashboard/cisco_duo-a48b1130-0fb4-11ec-8b4b-67126a72b1d4.json
@@ -4,11 +4,11 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
+                "filter": [],
                 "query": {
                     "language": "kuery",
                     "query": "data_stream.dataset : \"cisco_duo.telephony\""
-                },
-                "filter": []
+                }
             }
         },
         "optionsJSON": {
@@ -70,10 +70,10 @@
         "title": "[Cisco Duo] Telephony Logs",
         "version": 1
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-a48b1130-0fb4-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "dashboard": "7.15.0"
+        "dashboard": "7.17.0"
     },
     "references": [
         {
@@ -92,7 +92,5 @@
             "type": "visualization"
         }
     ],
-    "type": "dashboard",
-    "updated_at": "2021-09-07T09:09:11.381Z",
-    "version": "WzM1OTQsMV0="
+    "type": "dashboard"
 }

--- a/packages/cisco_duo/kibana/dashboard/cisco_duo-bd7d4870-0fbe-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/dashboard/cisco_duo-bd7d4870-0fbe-11ec-8b4b-67126a72b1d4.json
@@ -4,11 +4,33 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "cisco_duo.auth"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "cisco_duo.auth"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.auth\""
-                },
-                "filter": []
+                    "query": ""
+                }
             }
         },
         "optionsJSON": {
@@ -18,46 +40,36 @@
         },
         "panelsJSON": [
             {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "map",
-                "gridData": {
-                    "x": 0,
-                    "y": 0,
-                    "w": 48,
-                    "h": 20,
-                    "i": "25031c05-54c2-4d92-a275-1fa3a2bdf399"
-                },
-                "panelIndex": "25031c05-54c2-4d92-a275-1fa3a2bdf399",
                 "embeddableConfig": {
+                    "enhancements": {},
+                    "hiddenLayers": [],
+                    "isLayerTOCOpen": true,
+                    "mapBuffer": {
+                        "maxLat": 85.05113,
+                        "maxLon": 180,
+                        "minLat": -85.05113,
+                        "minLon": -180
+                    },
                     "mapCenter": {
                         "lat": 19.94277,
                         "lon": 0,
                         "zoom": 0.99
                     },
-                    "mapBuffer": {
-                        "minLon": -180,
-                        "minLat": -85.05113,
-                        "maxLon": 180,
-                        "maxLat": 85.05113
-                    },
-                    "isLayerTOCOpen": true,
-                    "openTOCDetails": [],
-                    "hiddenLayers": [],
-                    "enhancements": {}
+                    "openTOCDetails": []
                 },
-                "panelRefName": "panel_0"
+                "gridData": {
+                    "h": 20,
+                    "i": "25031c05-54c2-4d92-a275-1fa3a2bdf399",
+                    "w": 48,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "25031c05-54c2-4d92-a275-1fa3a2bdf399",
+                "panelRefName": "panel_25031c05-54c2-4d92-a275-1fa3a2bdf399",
+                "type": "map",
+                "version": "7.17.2"
             },
             {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
-                "gridData": {
-                    "x": 0,
-                    "y": 20,
-                    "w": 24,
-                    "h": 17,
-                    "i": "14cc4daa-2411-4927-be9d-20fc287bd46f"
-                },
-                "panelIndex": "14cc4daa-2411-4927-be9d-20fc287bd46f",
                 "embeddableConfig": {
                     "enhancements": {},
                     "savedVis": {
@@ -235,115 +247,115 @@
                         "uiState": {}
                     }
                 },
-                "panelRefName": "panel_1"
+                "gridData": {
+                    "h": 17,
+                    "i": "14cc4daa-2411-4927-be9d-20fc287bd46f",
+                    "w": 24,
+                    "x": 0,
+                    "y": 20
+                },
+                "panelIndex": "14cc4daa-2411-4927-be9d-20fc287bd46f",
+                "panelRefName": "panel_14cc4daa-2411-4927-be9d-20fc287bd46f",
+                "type": "visualization",
+                "version": "7.17.2"
             },
             {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
-                    "x": 24,
-                    "y": 20,
-                    "w": 24,
                     "h": 17,
-                    "i": "988a5cf4-cba9-4437-9323-fe7f37e2beba"
+                    "i": "988a5cf4-cba9-4437-9323-fe7f37e2beba",
+                    "w": 24,
+                    "x": 24,
+                    "y": 20
                 },
                 "panelIndex": "988a5cf4-cba9-4437-9323-fe7f37e2beba",
+                "panelRefName": "panel_988a5cf4-cba9-4437-9323-fe7f37e2beba",
+                "type": "visualization",
+                "version": "7.17.2"
+            },
+            {
                 "embeddableConfig": {
                     "enhancements": {}
                 },
-                "panelRefName": "panel_2"
-            },
-            {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
                 "gridData": {
-                    "x": 0,
-                    "y": 37,
-                    "w": 24,
                     "h": 17,
-                    "i": "410d1a65-1a7a-4680-95a9-1ecac80433b2"
+                    "i": "410d1a65-1a7a-4680-95a9-1ecac80433b2",
+                    "w": 24,
+                    "x": 0,
+                    "y": 37
                 },
                 "panelIndex": "410d1a65-1a7a-4680-95a9-1ecac80433b2",
+                "panelRefName": "panel_410d1a65-1a7a-4680-95a9-1ecac80433b2",
+                "type": "visualization",
+                "version": "7.17.2"
+            },
+            {
                 "embeddableConfig": {
                     "enhancements": {}
                 },
-                "panelRefName": "panel_3"
-            },
-            {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
                 "gridData": {
-                    "x": 24,
-                    "y": 37,
-                    "w": 24,
                     "h": 17,
-                    "i": "f56f5a11-3d30-4a6a-bdf1-0b32c7e26547"
+                    "i": "f56f5a11-3d30-4a6a-bdf1-0b32c7e26547",
+                    "w": 24,
+                    "x": 24,
+                    "y": 37
                 },
                 "panelIndex": "f56f5a11-3d30-4a6a-bdf1-0b32c7e26547",
+                "panelRefName": "panel_f56f5a11-3d30-4a6a-bdf1-0b32c7e26547",
+                "type": "visualization",
+                "version": "7.17.2"
+            },
+            {
                 "embeddableConfig": {
                     "enhancements": {}
                 },
-                "panelRefName": "panel_4"
-            },
-            {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
                 "gridData": {
-                    "x": 0,
-                    "y": 54,
-                    "w": 24,
                     "h": 17,
-                    "i": "90ee91c4-ebe8-4a2e-898b-e3492f302162"
+                    "i": "90ee91c4-ebe8-4a2e-898b-e3492f302162",
+                    "w": 24,
+                    "x": 0,
+                    "y": 54
                 },
                 "panelIndex": "90ee91c4-ebe8-4a2e-898b-e3492f302162",
+                "panelRefName": "panel_90ee91c4-ebe8-4a2e-898b-e3492f302162",
+                "type": "visualization",
+                "version": "7.17.2"
+            },
+            {
                 "embeddableConfig": {
                     "enhancements": {}
                 },
-                "panelRefName": "panel_5"
-            },
-            {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
                 "gridData": {
-                    "x": 24,
-                    "y": 54,
-                    "w": 24,
                     "h": 17,
-                    "i": "d676d2bc-e5cc-41c5-ab3d-d380e7cf24ae"
+                    "i": "d676d2bc-e5cc-41c5-ab3d-d380e7cf24ae",
+                    "w": 24,
+                    "x": 24,
+                    "y": 54
                 },
                 "panelIndex": "d676d2bc-e5cc-41c5-ab3d-d380e7cf24ae",
+                "panelRefName": "panel_d676d2bc-e5cc-41c5-ab3d-d380e7cf24ae",
+                "type": "visualization",
+                "version": "7.17.2"
+            },
+            {
                 "embeddableConfig": {
                     "enhancements": {}
                 },
-                "panelRefName": "panel_6"
-            },
-            {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
                 "gridData": {
-                    "x": 0,
-                    "y": 71,
-                    "w": 24,
                     "h": 17,
-                    "i": "2c3d7bcf-27ad-4fa0-9db2-a19282133333"
+                    "i": "2c3d7bcf-27ad-4fa0-9db2-a19282133333",
+                    "w": 24,
+                    "x": 0,
+                    "y": 71
                 },
                 "panelIndex": "2c3d7bcf-27ad-4fa0-9db2-a19282133333",
-                "embeddableConfig": {
-                    "enhancements": {}
-                },
-                "panelRefName": "panel_7"
+                "panelRefName": "panel_2c3d7bcf-27ad-4fa0-9db2-a19282133333",
+                "type": "visualization",
+                "version": "7.17.2"
             },
             {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
-                "gridData": {
-                    "x": 24,
-                    "y": 71,
-                    "w": 24,
-                    "h": 17,
-                    "i": "42f72b64-1bbf-49bd-909a-af8fcbc4c4e9"
-                },
-                "panelIndex": "42f72b64-1bbf-49bd-909a-af8fcbc4c4e9",
                 "embeddableConfig": {
                     "enhancements": {},
                     "savedVis": {
@@ -420,19 +432,19 @@
                         }
                     }
                 },
-                "panelRefName": "panel_8"
+                "gridData": {
+                    "h": 17,
+                    "i": "42f72b64-1bbf-49bd-909a-af8fcbc4c4e9",
+                    "w": 24,
+                    "x": 24,
+                    "y": 71
+                },
+                "panelIndex": "42f72b64-1bbf-49bd-909a-af8fcbc4c4e9",
+                "panelRefName": "panel_42f72b64-1bbf-49bd-909a-af8fcbc4c4e9",
+                "type": "visualization",
+                "version": "7.17.2"
             },
             {
-                "version": "7.15.0-SNAPSHOT",
-                "type": "visualization",
-                "gridData": {
-                    "x": 0,
-                    "y": 88,
-                    "w": 24,
-                    "h": 15,
-                    "i": "bbabe39a-d588-40c3-81d5-fcfe6448b0ff"
-                },
-                "panelIndex": "bbabe39a-d588-40c3-81d5-fcfe6448b0ff",
                 "embeddableConfig": {
                     "enhancements": {},
                     "savedVis": {
@@ -508,71 +520,104 @@
                         }
                     }
                 },
-                "panelRefName": "panel_9"
+                "gridData": {
+                    "h": 15,
+                    "i": "bbabe39a-d588-40c3-81d5-fcfe6448b0ff",
+                    "w": 24,
+                    "x": 0,
+                    "y": 88
+                },
+                "panelIndex": "bbabe39a-d588-40c3-81d5-fcfe6448b0ff",
+                "panelRefName": "panel_bbabe39a-d588-40c3-81d5-fcfe6448b0ff",
+                "type": "visualization",
+                "version": "7.17.2"
             }
         ],
         "timeRestore": false,
         "title": "[Cisco Duo] Authentication Logs",
         "version": 1
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-bd7d4870-0fbe-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "dashboard": "7.15.0"
+        "dashboard": "7.17.0"
     },
     "references": [
         {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
             "id": "cisco_duo-158c0e80-148c-11ec-9386-31989719f9db",
-            "name": "panel_0",
+            "name": "25031c05-54c2-4d92-a275-1fa3a2bdf399:panel_25031c05-54c2-4d92-a275-1fa3a2bdf399",
             "type": "map"
         },
         {
             "id": "cisco_duo-66ca2220-0fd0-11ec-8b4b-67126a72b1d4",
-            "name": "panel_1",
+            "name": "14cc4daa-2411-4927-be9d-20fc287bd46f:panel_14cc4daa-2411-4927-be9d-20fc287bd46f",
             "type": "visualization"
         },
         {
+            "id": "logs-*",
+            "name": "14cc4daa-2411-4927-be9d-20fc287bd46f:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "14cc4daa-2411-4927-be9d-20fc287bd46f:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
             "id": "cisco_duo-7633dff0-0fd3-11ec-8b4b-67126a72b1d4",
-            "name": "panel_2",
+            "name": "988a5cf4-cba9-4437-9323-fe7f37e2beba:panel_988a5cf4-cba9-4437-9323-fe7f37e2beba",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-f14ab7b0-0fd1-11ec-8b4b-67126a72b1d4",
-            "name": "panel_3",
+            "name": "410d1a65-1a7a-4680-95a9-1ecac80433b2:panel_410d1a65-1a7a-4680-95a9-1ecac80433b2",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-7a1ff1c0-0fd4-11ec-8b4b-67126a72b1d4",
-            "name": "panel_4",
+            "name": "f56f5a11-3d30-4a6a-bdf1-0b32c7e26547:panel_f56f5a11-3d30-4a6a-bdf1-0b32c7e26547",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-e2482680-0fd6-11ec-8b4b-67126a72b1d4",
-            "name": "panel_5",
+            "name": "90ee91c4-ebe8-4a2e-898b-e3492f302162:panel_90ee91c4-ebe8-4a2e-898b-e3492f302162",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-8e8d9a00-0fd8-11ec-8b4b-67126a72b1d4",
-            "name": "panel_6",
+            "name": "d676d2bc-e5cc-41c5-ab3d-d380e7cf24ae:panel_d676d2bc-e5cc-41c5-ab3d-d380e7cf24ae",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-692d5e20-0fde-11ec-8b4b-67126a72b1d4",
-            "name": "panel_7",
+            "name": "2c3d7bcf-27ad-4fa0-9db2-a19282133333:panel_2c3d7bcf-27ad-4fa0-9db2-a19282133333",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-dfdd2050-0fde-11ec-8b4b-67126a72b1d4",
-            "name": "panel_8",
+            "name": "42f72b64-1bbf-49bd-909a-af8fcbc4c4e9:panel_42f72b64-1bbf-49bd-909a-af8fcbc4c4e9",
             "type": "visualization"
         },
         {
+            "id": "logs-*",
+            "name": "42f72b64-1bbf-49bd-909a-af8fcbc4c4e9:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "type": "index-pattern"
+        },
+        {
             "id": "cisco_duo-315d3b40-0fdf-11ec-8b4b-67126a72b1d4",
-            "name": "panel_9",
+            "name": "bbabe39a-d588-40c3-81d5-fcfe6448b0ff:panel_bbabe39a-d588-40c3-81d5-fcfe6448b0ff",
             "type": "visualization"
+        },
+        {
+            "id": "logs-*",
+            "name": "bbabe39a-d588-40c3-81d5-fcfe6448b0ff:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "type": "index-pattern"
         }
     ],
-    "type": "dashboard",
-    "updated_at": "2021-09-13T12:15:16.772Z",
-    "version": "WzE5NTMsMV0="
+    "type": "dashboard"
 }

--- a/packages/cisco_duo/kibana/dashboard/cisco_duo-f2277ef0-0fd8-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/dashboard/cisco_duo-f2277ef0-0fd8-11ec-8b4b-67126a72b1d4.json
@@ -4,11 +4,33 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "cisco_duo.offline_enrollment"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "cisco_duo.offline_enrollment"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.offline_enrollment\""
-                },
-                "filter": []
+                    "query": ""
+                }
             }
         },
         "optionsJSON": {
@@ -29,9 +51,9 @@
                     "y": 0
                 },
                 "panelIndex": "9e1a3121-6df9-41a0-b167-3f837016650a",
-                "panelRefName": "panel_0",
+                "panelRefName": "panel_9e1a3121-6df9-41a0-b167-3f837016650a",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -45,13 +67,16 @@
                     "y": 0
                 },
                 "panelIndex": "fd1a3e7c-5e1b-4fa1-8796-45abfa64e536",
-                "panelRefName": "panel_1",
+                "panelRefName": "panel_fd1a3e7c-5e1b-4fa1-8796-45abfa64e536",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {}
+                    "enhancements": {},
+                    "vis": {
+                        "legendOpen": false
+                    }
                 },
                 "gridData": {
                     "h": 15,
@@ -61,9 +86,9 @@
                     "y": 0
                 },
                 "panelIndex": "73433d45-2afb-45aa-b823-e048841115c2",
-                "panelRefName": "panel_2",
+                "panelRefName": "panel_73433d45-2afb-45aa-b823-e048841115c2",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -77,9 +102,9 @@
                     "y": 0
                 },
                 "panelIndex": "a0546004-8d4b-444d-af9d-23a249df93e3",
-                "panelRefName": "panel_3",
+                "panelRefName": "panel_a0546004-8d4b-444d-af9d-23a249df93e3",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -93,9 +118,9 @@
                     "y": 15
                 },
                 "panelIndex": "68f7d41f-43dd-49d6-88ac-afa36a19ebeb",
-                "panelRefName": "panel_4",
+                "panelRefName": "panel_68f7d41f-43dd-49d6-88ac-afa36a19ebeb",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -109,9 +134,9 @@
                     "y": 0
                 },
                 "panelIndex": "cc8c06d5-4825-4b25-9d69-e6fec23d07b3",
-                "panelRefName": "panel_5",
+                "panelRefName": "panel_cc8c06d5-4825-4b25-9d69-e6fec23d07b3",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             },
             {
                 "embeddableConfig": {
@@ -125,58 +150,61 @@
                     "y": 15
                 },
                 "panelIndex": "91d1ac3b-5cec-4e60-9179-18aaf7ce6198",
-                "panelRefName": "panel_6",
+                "panelRefName": "panel_91d1ac3b-5cec-4e60-9179-18aaf7ce6198",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.17.2"
             }
         ],
         "timeRestore": false,
         "title": "[Cisco Duo] Offline Enrollment Logs",
         "version": 1
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-f2277ef0-0fd8-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "dashboard": "7.15.0"
+        "dashboard": "7.17.0"
     },
     "references": [
         {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
             "id": "cisco_duo-10edf670-1088-11ec-8b4b-67126a72b1d4",
-            "name": "panel_0",
+            "name": "9e1a3121-6df9-41a0-b167-3f837016650a:panel_9e1a3121-6df9-41a0-b167-3f837016650a",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-d1ba6030-1085-11ec-8b4b-67126a72b1d4",
-            "name": "panel_1",
+            "name": "fd1a3e7c-5e1b-4fa1-8796-45abfa64e536:panel_fd1a3e7c-5e1b-4fa1-8796-45abfa64e536",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-2e81b860-1089-11ec-8b4b-67126a72b1d4",
-            "name": "panel_2",
+            "name": "73433d45-2afb-45aa-b823-e048841115c2:panel_73433d45-2afb-45aa-b823-e048841115c2",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-6872e680-1088-11ec-8b4b-67126a72b1d4",
-            "name": "panel_3",
+            "name": "a0546004-8d4b-444d-af9d-23a249df93e3:panel_a0546004-8d4b-444d-af9d-23a249df93e3",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-f7bdbe50-0fd9-11ec-8b4b-67126a72b1d4",
-            "name": "panel_4",
+            "name": "68f7d41f-43dd-49d6-88ac-afa36a19ebeb:panel_68f7d41f-43dd-49d6-88ac-afa36a19ebeb",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-c228b5c0-1087-11ec-8b4b-67126a72b1d4",
-            "name": "panel_5",
+            "name": "cc8c06d5-4825-4b25-9d69-e6fec23d07b3:panel_cc8c06d5-4825-4b25-9d69-e6fec23d07b3",
             "type": "visualization"
         },
         {
             "id": "cisco_duo-1952e300-1085-11ec-8b4b-67126a72b1d4",
-            "name": "panel_6",
+            "name": "91d1ac3b-5cec-4e60-9179-18aaf7ce6198:panel_91d1ac3b-5cec-4e60-9179-18aaf7ce6198",
             "type": "visualization"
         }
     ],
-    "type": "dashboard",
-    "updated_at": "2021-09-08T09: 46: 25.547Z",
-    "version": "WzcwNjIsMV0="
+    "type": "dashboard"
 }

--- a/packages/cisco_duo/kibana/map/cisco_duo-158c0e80-148c-11ec-9386-31989719f9db.json
+++ b/packages/cisco_duo/kibana/map/cisco_duo-158c0e80-148c-11ec-9386-31989719f9db.json
@@ -3,88 +3,83 @@
         "description": "",
         "layerListJSON": [
             {
-                "sourceDescriptor": {
-                    "type": "EMS_TMS",
-                    "isAutoSelect": true
-                },
-                "id": "ce0cde1e-240f-4a56-bc83-60374450e029",
-                "label": null,
-                "minZoom": 0,
-                "maxZoom": 24,
                 "alpha": 1,
-                "visible": true,
+                "id": "ce0cde1e-240f-4a56-bc83-60374450e029",
+                "includeInFitToBounds": true,
+                "label": null,
+                "maxZoom": 24,
+                "minZoom": 0,
+                "sourceDescriptor": {
+                    "isAutoSelect": true,
+                    "type": "EMS_TMS"
+                },
                 "style": {
                     "type": "TILE"
                 },
-                "includeInFitToBounds": true,
-                "type": "VECTOR_TILE"
+                "type": "VECTOR_TILE",
+                "visible": true
             },
             {
+                "alpha": 0.75,
+                "id": "4e14ab8b-6ac0-4c0d-92e4-56b7074b28f6",
+                "includeInFitToBounds": true,
+                "label": "Failed login attempts",
+                "maxZoom": 24,
+                "minZoom": 0,
                 "sourceDescriptor": {
-                    "geoField": "source.geo.location",
-                    "requestType": "heatmap",
-                    "id": "768d716e-4cb1-435c-b301-f26d08954838",
-                    "type": "ES_GEO_GRID",
                     "applyGlobalQuery": true,
                     "applyGlobalTime": true,
+                    "geoField": "source.geo.location",
+                    "id": "768d716e-4cb1-435c-b301-f26d08954838",
+                    "indexPatternRefName": "layer_1_source_index_pattern",
                     "metrics": [
                         {
                             "type": "count"
                         }
                     ],
+                    "requestType": "heatmap",
                     "resolution": "COARSE",
-                    "indexPatternRefName": "layer_1_source_index_pattern"
+                    "type": "ES_GEO_GRID"
                 },
-                "id": "4e14ab8b-6ac0-4c0d-92e4-56b7074b28f6",
-                "label": "Failed login attempts",
-                "minZoom": 0,
-                "maxZoom": 24,
-                "alpha": 0.75,
-                "visible": true,
                 "style": {
-                    "type": "HEATMAP",
-                    "colorRampName": "theclassic"
+                    "colorRampName": "theclassic",
+                    "type": "HEATMAP"
                 },
-                "includeInFitToBounds": true,
-                "type": "HEATMAP"
+                "type": "HEATMAP",
+                "visible": true
             }
         ],
         "mapStateJSON": {
-            "zoom": 0.99,
             "center": {
-                "lon": 0,
-                "lat": 19.94277
-            },
-            "timeFilters": {
-                "from": "now-15m",
-                "to": "now"
-            },
-            "refreshConfig": {
-                "isPaused": true,
-                "interval": 0
-            },
-            "query": {
-                "query": "event.dataset : \"cisco_duo.auth\"",
-                "language": "kuery"
+                "lat": 19.94277,
+                "lon": 0
             },
             "filters": [],
+            "query": {
+                "language": "kuery",
+                "query": "event.dataset : \"cisco_duo.auth\""
+            },
+            "refreshConfig": {
+                "interval": 0,
+                "isPaused": true
+            },
             "settings": {
                 "autoFitToDataBounds": false,
                 "backgroundColor": "#ffffff",
+                "browserLocation": {
+                    "zoom": 2
+                },
                 "disableInteractive": false,
                 "disableTooltipControl": false,
-                "hideToolbarOverlay": false,
-                "hideLayerControl": false,
-                "hideViewControl": false,
-                "initialLocation": "LAST_SAVED_LOCATION",
                 "fixedLocation": {
                     "lat": 0,
                     "lon": 0,
                     "zoom": 2
                 },
-                "browserLocation": {
-                    "zoom": 2
-                },
+                "hideLayerControl": false,
+                "hideToolbarOverlay": false,
+                "hideViewControl": false,
+                "initialLocation": "LAST_SAVED_LOCATION",
                 "maxZoom": 24,
                 "minZoom": 0,
                 "showScaleControl": false,
@@ -93,7 +88,12 @@
                 "spatialFiltersAlpa": 0.3,
                 "spatialFiltersFillColor": "#DA8B45",
                 "spatialFiltersLineColor": "#DA8B45"
-            }
+            },
+            "timeFilters": {
+                "from": "now-15m",
+                "to": "now"
+            },
+            "zoom": 0.99
         },
         "title": "[Cisco Duo] Failed Login attempts",
         "uiStateJSON": {
@@ -101,7 +101,7 @@
             "openTOCDetails": []
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-158c0e80-148c-11ec-9386-31989719f9db",
     "migrationVersion": {
         "map": "7.14.0"
@@ -113,7 +113,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "map",
-    "updated_at": "2021-09-13T12:14:03.121Z",
-    "version": "WzE5NDQsMV0="
+    "type": "map"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-10edf670-1088-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-10edf670-1088-11ec-8b4b-67126a72b1d4.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.offline_enrollment\""
+                    "query": ""
                 }
             }
         },
@@ -59,10 +59,10 @@
             "type": "metric"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-10edf670-1088-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -71,7 +71,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-08T09: 35: 12.733Z",
-    "version": "WzY5NDgsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-1952e300-1085-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-1952e300-1085-11ec-8b4b-67126a72b1d4.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.offline_enrollment\""
+                    "query": ""
                 }
             }
         },
@@ -45,6 +45,7 @@
                 }
             ],
             "params": {
+                "autoFitRowToContent": false,
                 "perPage": 10,
                 "percentageCol": "",
                 "showMetricsAtAllLevels": false,
@@ -57,10 +58,10 @@
             "type": "table"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-1952e300-1085-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -69,7 +70,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-08T09: 46: 15.805Z",
-    "version": "WzcwNTcsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-1b1c61d0-0fa8-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-1b1c61d0-0fa8-11ec-8b4b-67126a72b1d4.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.summary\""
+                    "query": ""
                 }
             }
         },
@@ -63,10 +63,10 @@
             "type": "metric"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-1b1c61d0-0fa8-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -75,7 +75,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T06:52:02.546Z",
-    "version": "WzI4NjEsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-1e9e23a0-0faa-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-1e9e23a0-0faa-11ec-8b4b-67126a72b1d4.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.summary\""
+                    "query": ""
                 }
             }
         },
@@ -63,10 +63,10 @@
             "type": "metric"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-1e9e23a0-0faa-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -75,7 +75,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T07:06:27.423Z",
-    "version": "WzMwOTQsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-2c710c70-0fbb-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-2c710c70-0fbb-11ec-8b4b-67126a72b1d4.json
@@ -74,10 +74,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-2c710c70-0fbb-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -86,7 +86,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T09:08:32.065Z",
-    "version": "WzM1NzQsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-2e81b860-1089-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-2e81b860-1089-11ec-8b4b-67126a72b1d4.json
@@ -7,16 +7,12 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.offline_enrollment\""
+                    "query": ""
                 }
             }
         },
         "title": "[Cisco Duo] Factor used for offline enrollment",
-        "uiStateJSON": {
-            "vis": {
-                "legendOpen": false
-            }
-        },
+        "uiStateJSON": {},
         "version": 1,
         "visState": {
             "aggs": [
@@ -73,10 +69,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-2e81b860-1089-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -85,7 +81,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-08T09: 43: 11.852Z",
-    "version": "WzcwMjQsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-315d3b40-0fdf-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-315d3b40-0fdf-11ec-8b4b-67126a72b1d4.json
@@ -7,16 +7,12 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.auth\""
+                    "query": ""
                 }
             }
         },
         "title": "[Cisco Duo] Password set in user devices",
-        "uiStateJSON": {
-            "vis": {
-                "legendOpen": true
-            }
-        },
+        "uiStateJSON": {},
         "version": 1,
         "visState": {
             "aggs": [
@@ -75,10 +71,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-315d3b40-0fdf-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -87,7 +83,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T13:26:22.200Z",
-    "version": "WzU1MDUsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-32c97410-0fa0-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-32c97410-0fa0-11ec-8b4b-67126a72b1d4.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.summary\""
+                    "query": ""
                 }
             }
         },
@@ -63,10 +63,10 @@
             "type": "metric"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-32c97410-0fa0-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -75,7 +75,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T05:56:16.274Z",
-    "version": "WzI2OTcsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-3c0a89a0-0fba-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-3c0a89a0-0fba-11ec-8b4b-67126a72b1d4.json
@@ -74,10 +74,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-3c0a89a0-0fba-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -86,7 +86,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T09:12:25.046Z",
-    "version": "WzM2NjAsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-43e47440-0fb7-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-43e47440-0fb7-11ec-8b4b-67126a72b1d4.json
@@ -76,10 +76,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-43e47440-0fb7-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -88,7 +88,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T08:40:33.418Z",
-    "version": "WzMzNzgsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-66ca2220-0fd0-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-66ca2220-0fd0-11ec-8b4b-67126a72b1d4.json
@@ -29,12 +29,12 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset :\"cisco_duo.auth\""
+                    "query": ""
                 }
             }
         },
         "title": "[Cisco Duo] Authentication Failed login attempts by Source IP",
-        "uiStateJSON": "{}",
+        "uiStateJSON": {},
         "version": 1,
         "visState": {
             "aggs": [
@@ -177,10 +177,10 @@
             "type": "histogram"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-66ca2220-0fd0-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -194,7 +194,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T11:40:29.384Z",
-    "version": "WzQ1MjEsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-6872e680-1088-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-6872e680-1088-11ec-8b4b-67126a72b1d4.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.offline_enrollment\""
+                    "query": ""
                 }
             }
         },
@@ -59,10 +59,10 @@
             "type": "metric"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-6872e680-1088-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -71,7 +71,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-08T09: 37: 39.565Z",
-    "version": "WzY5ODEsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-692d5e20-0fde-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-692d5e20-0fde-11ec-8b4b-67126a72b1d4.json
@@ -7,16 +7,12 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.auth\""
+                    "query": ""
                 }
             }
         },
         "title": "[Cisco Duo] Encryption enabled in user devices",
-        "uiStateJSON": {
-            "vis": {
-                "legendOpen": true
-            }
-        },
+        "uiStateJSON": {},
         "version": 1,
         "visState": {
             "aggs": [
@@ -75,10 +71,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-692d5e20-0fde-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -87,7 +83,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T13:20:46.344Z",
-    "version": "WzUzOTIsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-7633dff0-0fd3-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-7633dff0-0fd3-11ec-8b4b-67126a72b1d4.json
@@ -89,10 +89,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-7633dff0-0fd3-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -101,7 +101,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T12:02:23.737Z",
-    "version": "WzQ2NzIsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-7a1ff1c0-0fd4-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-7a1ff1c0-0fd4-11ec-8b4b-67126a72b1d4.json
@@ -29,7 +29,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.auth\""
+                    "query": ""
                 }
             }
         },
@@ -66,6 +66,7 @@
                 }
             ],
             "params": {
+                "autoFitRowToContent": false,
                 "perPage": 10,
                 "percentageCol": "",
                 "showMetricsAtAllLevels": false,
@@ -78,10 +79,10 @@
             "type": "table"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-7a1ff1c0-0fd4-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -95,7 +96,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T12:09:39.813Z",
-    "version": "WzQ4MjMsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-8342fad0-0fa8-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-8342fad0-0fa8-11ec-8b4b-67126a72b1d4.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.summary\""
+                    "query": ""
                 }
             }
         },
@@ -63,10 +63,10 @@
             "type": "metric"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-8342fad0-0fa8-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -75,7 +75,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T06:54:57.281Z",
-    "version": "WzI5MzEsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-8e8d9a00-0fd8-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-8e8d9a00-0fd8-11ec-8b4b-67126a72b1d4.json
@@ -90,10 +90,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-8e8d9a00-0fd8-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -102,7 +102,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T12:38:52.070Z",
-    "version": "WzUwNjQsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-9818eda0-1063-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-9818eda0-1063-11ec-8b4b-67126a72b1d4.json
@@ -63,12 +63,13 @@
                         "separate_axis": 0,
                         "split_mode": "everything",
                         "stacked": "none",
+                        "time_range_mode": "entire_time_range",
                         "type": "timeseries"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
-                "time_field": "",
+                "time_field": "@timestamp",
                 "time_range_mode": "entire_time_range",
                 "tooltip_mode": "show_all",
                 "truncate_legend": 1,
@@ -79,19 +80,11 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-9818eda0-1063-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
-    "references": [
-        {
-            "id": "logs-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "type": "index-pattern"
-        }
-    ],
-    "type": "visualization",
-    "updated_at": "2021-09-08T05:14:08.126Z",
-    "version": "WzU5ODEsMV0="
+    "references": [],
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-c228b5c0-1087-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-c228b5c0-1087-11ec-8b4b-67126a72b1d4.json
@@ -59,10 +59,10 @@
             "type": "metric"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-c228b5c0-1087-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -71,7 +71,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-08T09: 33: 00.577Z",
-    "version": "WzY5MTEsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-d1ba6030-1085-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-d1ba6030-1085-11ec-8b4b-67126a72b1d4.json
@@ -59,10 +59,10 @@
             "type": "metric"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-d1ba6030-1085-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -71,7 +71,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-08T09: 19: 07.706Z",
-    "version": "WzY4NjEsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-dfdd2050-0fde-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-dfdd2050-0fde-11ec-8b4b-67126a72b1d4.json
@@ -76,10 +76,10 @@
             "type": "pie"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-dfdd2050-0fde-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -88,7 +88,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T13:24:05.466Z",
-    "version": "WzU0NTIsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-e2482680-0fd6-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-e2482680-0fd6-11ec-8b4b-67126a72b1d4.json
@@ -33,7 +33,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"cisco_duo.auth\" and event.outcome : \"failed\""
+                            "query": "data_stream.dataset : \"cisco_duo.auth\" and event.outcome : \"failure\""
                         },
                         "formatter": "number",
                         "id": "28cb790c-2e1a-4805-84aa-1ed88babbed1",
@@ -66,6 +66,7 @@
                         "stacked": "none",
                         "terms_field": "event.reason",
                         "terms_size": "100",
+                        "time_range_mode": "entire_time_range",
                         "type": "timeseries"
                     }
                 ],
@@ -82,19 +83,11 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-e2482680-0fd6-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
-    "references": [
-        {
-            "id": "logs-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-            "type": "index-pattern"
-        }
-    ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T12:26:53.549Z",
-    "version": "WzQ5NDYsMV0="
+    "references": [],
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-f14ab7b0-0fd1-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-f14ab7b0-0fd1-11ec-8b4b-67126a72b1d4.json
@@ -66,6 +66,7 @@
                 }
             ],
             "params": {
+                "autoFitRowToContent": false,
                 "perPage": 10,
                 "percentageCol": "",
                 "showMetricsAtAllLevels": false,
@@ -78,10 +79,10 @@
             "type": "table"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-f14ab7b0-0fd1-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -95,7 +96,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-07T12:29:14.016Z",
-    "version": "WzQ5OTAsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/kibana/visualization/cisco_duo-f7bdbe50-0fd9-11ec-8b4b-67126a72b1d4.json
+++ b/packages/cisco_duo/kibana/visualization/cisco_duo-f7bdbe50-0fd9-11ec-8b4b-67126a72b1d4.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset : \"cisco_duo.offline_enrollment\""
+                    "query": ""
                 }
             }
         },
@@ -64,6 +64,7 @@
                 }
             ],
             "params": {
+                "autoFitRowToContent": false,
                 "perPage": 10,
                 "percentageCol": "",
                 "showMetricsAtAllLevels": false,
@@ -76,10 +77,10 @@
             "type": "table"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.17.2",
     "id": "cisco_duo-f7bdbe50-0fd9-11ec-8b4b-67126a72b1d4",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "7.17.0"
     },
     "references": [
         {
@@ -88,7 +89,5 @@
             "type": "index-pattern"
         }
     ],
-    "type": "visualization",
-    "updated_at": "2021-09-08T09: 45: 37.189Z",
-    "version": "WzcwNDQsMV0="
+    "type": "visualization"
 }

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_duo
 title: Cisco Duo
-version: 1.1.3
+version: 1.1.4
 license: basic
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
@@ -9,7 +9,7 @@ categories:
   - security
 release: ga
 conditions:
-  kibana.version: ^7.16.0 || ^8.0.0
+  kibana.version: ^7.17.2 || ^8.0.0
 screenshots:
   - src: /img/cisco_duo-screenshot.png
     title: Cisco Duo authentication log dashboard


### PR DESCRIPTION
## What does this PR do?

I imported the dashboards into 7.17.2, replaced some of the data_stream.dataset kuery values
with filters, then exported the dashboard back out.

I had to make one modification to add the `time_field: @timestamp` to the TSVB visualization
in the summary dashboard.

Because the dashboards were exported from 7.17.2 I changed the minimum Kibana version requirement.

Fixes #3023

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Test on 7.17.2
- [x] Test on 8.1.2

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #3023

## Screenshots

<img width="1688" alt="Screen Shot 2022-04-07 at 11 47 00" src="https://user-images.githubusercontent.com/4565752/162242401-3e9359b0-0d15-44c6-bd06-e2f15f0ecb56.png">
<img width="1690" alt="Screen Shot 2022-04-07 at 11 47 31" src="https://user-images.githubusercontent.com/4565752/162242406-5339ea24-d2af-488e-b1e9-0ca92c5f8213.png">
<img width="1690" alt="Screen Shot 2022-04-07 at 11 47 19" src="https://user-images.githubusercontent.com/4565752/162242410-0bc393fa-cc6d-4c28-8c33-0bd6f362dad4.png">
<img width="1689" alt="Screen Shot 2022-04-07 at 11 47 10" src="https://user-images.githubusercontent.com/4565752/162242413-273e4226-2262-4539-b6d0-198db4bc77d2.png">
