### PR TITLE
Add new ecs fields to containerd integration

### DIFF
--- a/packages/containerd/changelog.yml
+++ b/packages/containerd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add new ECS fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/3057
+      link: https://github.com/elastic/integrations/pull/3059
 - version: "0.1.0"
   changes:
     - description: Create containerd package

--- a/packages/containerd/changelog.yml
+++ b/packages/containerd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Add new ECS fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3057
 - version: "0.1.0"
   changes:
     - description: Create containerd package

--- a/packages/containerd/data_stream/blkio/fields/ecs.yml
+++ b/packages/containerd/data_stream/blkio/fields/ecs.yml
@@ -7,3 +7,16 @@
 - external: ecs
   name: container.id
   dimension: true
+- name: container.disk.read.bytes
+  type: long
+  format: bytes
+  metric_type: counter
+  description: |
+    Bytes read during the life of the container
+- name: container.disk.write.bytes
+  type: long
+  format: bytes
+  unit: byte
+  metric_type: counter
+  description: |
+    Bytes written during the life of the container

--- a/packages/containerd/data_stream/cpu/fields/ecs.yml
+++ b/packages/containerd/data_stream/cpu/fields/ecs.yml
@@ -7,3 +7,10 @@
 - external: ecs
   name: container.id
   dimension: true
+- name: container.cpu.usage
+  type: scaled_float
+  format: percent
+  unit: percent
+  metric_type: gauge
+  description: |
+    Total CPU usage normalized by the number of CPU cores.

--- a/packages/containerd/data_stream/memory/fields/ecs.yml
+++ b/packages/containerd/data_stream/memory/fields/ecs.yml
@@ -7,3 +7,10 @@
 - external: ecs
   name: container.id
   dimension: true
+- name: container.memory.usage
+  type: scaled_float
+  format: percent
+  unit: percent
+  metric_type: gauge
+  description: |
+    Memory usage percentage.

--- a/packages/containerd/docs/README.md
+++ b/packages/containerd/docs/README.md
@@ -44,6 +44,7 @@ from containerd's metrics APIs.
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| container.cpu.usage | Total CPU usage normalized by the number of CPU cores. | scaled_float | percent | gauge |
 | container.id | Unique container id. | keyword |  |  |
 | containerd.cpu.system.total | Total user and system CPU time spent in seconds. | double | s | gauge |
 | containerd.cpu.usage.cpu.\*.ns | CPU usage nanoseconds in this cpu. | object |  |  |
@@ -171,6 +172,7 @@ from containerd's metrics APIs.
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
 | container.id | Unique container id. | keyword |  |  |
+| container.memory.usage | Memory usage percentage. | scaled_float | percent | gauge |
 | containerd.memory.activeFiles | Total active file bytes. | long | byte | gauge |
 | containerd.memory.cache | Total cache bytes. | long | byte | gauge |
 | containerd.memory.inactiveFiles | Total inactive file bytes. | long | byte | gauge |
@@ -323,6 +325,8 @@ from containerd's metrics APIs.
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| container.disk.read.bytes | Bytes read during the life of the container | long |  | counter |
+| container.disk.write.bytes | Bytes written during the life of the container | long | byte | counter |
 | container.id | Unique container id. | keyword |  |  |
 | containerd.blkio.device | Name of block device | keyword |  |  |
 | containerd.blkio.read.bytes | Bytes read during the life of the container | long | byte | gauge |

--- a/packages/containerd/manifest.yml
+++ b/packages/containerd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: containerd
 title: "Containerd"
-version: 0.1.0
+version: 0.2.0
 license: basic
 description: "Collect metrics from containerd containers."
 type: integration


### PR DESCRIPTION
Add new ECS container fields. 
Fields are:

1. container.cpu.usage
2. container.memory.usage
3. container.disk.read.bytes
4. container.disk.write.bytes