### PR TITLE
Remove default codeowners for new packages and code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,11 @@
-# Default owners
+# Everything outside of packages is maintained by the ecosystem team.
 * @elastic/ecosystem
+/packages/*
 
+# CODEOWNERS file is checked by CI.
+/.github/CODEOWNERS
+
+# Package owners below.
 /packages/1password @elastic/security-external-integrations
 /packages/activemq @elastic/integrations
 /packages/akamai @elastic/security-external-integrations

--- a/dev/codeowners/codeowners_test.go
+++ b/dev/codeowners/codeowners_test.go
@@ -33,6 +33,11 @@ func TestCheckManifest(t *testing.T) {
 			valid:          true,
 		},
 		{
+			codeownersPath: "testdata/CODEOWNERS-no-owner",
+			manifestPath:   "testdata/devexp/manifest.yml",
+			valid:          false,
+		},
+		{
 			codeownersPath: "testdata/CODEOWNERS-empty",
 			manifestPath:   "testdata/devexp/manifest.yml",
 			valid:          false,
@@ -84,11 +89,15 @@ func TestReadGithubOwners(t *testing.T) {
 		},
 		{
 			codeownersPath: "testdata/CODEOWNERS-no-owner",
-			valid:          false,
+			valid:          true,
 		},
 		{
 			codeownersPath: "testdata/CODEOWNERS-multiple-owners",
 			valid:          true,
+		},
+		{
+			codeownersPath: "testdata/CODEOWNERS-invalid-override",
+			valid:          false,
 		},
 	}
 

--- a/dev/codeowners/testdata/CODEOWNERS-invalid-override
+++ b/dev/codeowners/testdata/CODEOWNERS-invalid-override
@@ -1,0 +1,5 @@
+# This is not valid because there is an override that would remove owners of a directory.
+
+/testdata/devexp @elastic/integrations @elastic/integrations-developer-experience
+/testdata/*
+

--- a/dev/codeowners/testdata/CODEOWNERS-no-owner
+++ b/dev/codeowners/testdata/CODEOWNERS-no-owner
@@ -1,4 +1,4 @@
-# This is invalid, a path has no owner.
+# This syntax is valid, but a path has no owner.
 
-/testdata/devexp @elastic/integrations-developer-experience
-/testdata/integration 
+/testdata/integration @elastic/integrations-developer-experience
+/testdata/devexp

--- a/dev/codeowners/testdata/CODEOWNERS-valid
+++ b/dev/codeowners/testdata/CODEOWNERS-valid
@@ -1,4 +1,7 @@
 # This is a valid test file
+* @elastic/ecosystem
+
+/testdata/*
 
 /testdata/devexp @elastic/integrations-developer-experience
 /testdata/integration @elastic/integrations


### PR DESCRIPTION
This is creating noise in pull requests for new integrations.

CI check can be enough to ensure that each package has an entry in the
CODEOWNERS file.