### PR TITLE
[auditd]: set event.outcome value as per ECS specification

### DIFF
--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.2"
+  changes:
+    - description: Set event.outcome value according ECS specification
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "2.1.1"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set event.outcome value according ECS specification
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/3079
 - version: "2.1.1"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
@@ -21,7 +21,7 @@
                 "action": "mac_ipsec_event",
                 "kind": "event",
                 "original": "type=MAC_IPSEC_EVENT msg=audit(1485893834.891:18877201): op=SPD-delete auid=4294967295 ses=4294967295 res=1 src=192.168.2.0 src_prefixlen=24 dst=192.168.0.0 dst_prefixlen=16",
-                "outcome": "1"
+                "outcome": "success"
             },
             "source": {
                 "address": "192.168.2.0",
@@ -642,7 +642,7 @@
                 ],
                 "kind": "event",
                 "original": "node=localhost.localdomain type=CONFIG_CHANGE msg=audit(1594053514.707:5): audit_failure=1 old=1 auid=4294967295 ses=4294967295 subj=system_u:system_r:unconfined_service_t:s0 res=1",
-                "outcome": "1",
+                "outcome": "success",
                 "type": [
                     "change"
                 ]
@@ -1764,7 +1764,7 @@
                 ],
                 "kind": "event",
                 "original": "type=CONFIG_CHANGE msg=audit(1481077231.371:478): auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 op=\"add_rule\" key=(null) list=4 res=1",
-                "outcome": "1",
+                "outcome": "success",
                 "type": [
                     "change"
                 ]

--- a/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2114,10 +2114,21 @@ processors:
       ignore_failure: true
       field: auditd.log.msg
       target_field: message
-  - rename:
+  - set:
+      if: (ctx?.auditd?.log?.res != null && ["1", "success"].contains(ctx.auditd.log.res))
+      field: event.outcome
+      value: "success"
       ignore_failure: true
-      field: auditd.log.res
-      target_field: event.outcome
+  - set:
+      if: (ctx?.auditd?.log?.res != null && ["0", "failed"].contains(ctx.auditd.log.res))
+      field: event.outcome
+      value: "failure"
+      ignore_failure: true
+  - set:
+      if: (ctx?.auditd?.log?.res != null && !["0", "1", "success", "failed"].contains(ctx.auditd.log.res))
+      field: event.outcome
+      value: "unknown"
+      ignore_failure: true
    # The processor below populates process.args list from argN fields.
    #
    # It handles the common case of a complete record: Contains argc=N and a0 to aN-1,
@@ -2218,6 +2229,7 @@ processors:
         - auditd.log.epoch
         - auditd.log.copy
         - auditd.log.arch
+        - auditd.log.res
       ignore_failure: true
       ignore_missing: true
   - remove:

--- a/packages/auditd/data_stream/log/sample_event.json
+++ b/packages/auditd/data_stream/log/sample_event.json
@@ -1,11 +1,12 @@
 {
     "@timestamp": "2016-01-03T00:37:51.394Z",
     "agent": {
-        "ephemeral_id": "26e35ddc-258e-426f-87cf-40517f808d30",
-        "id": "82d0dfd8-3946-4ac0-a092-a9146a71e3f7",
+        "ephemeral_id": "ef6d17d9-f955-48be-a4c5-6b4ea1fe9772",
+        "hostname": "docker-fleet-agent",
+        "id": "f386c08a-1dcf-444a-a259-9c33fa001606",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "7.17.0"
     },
     "auditd": {
         "log": {
@@ -22,37 +23,36 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "82d0dfd8-3946-4ac0-a092-a9146a71e3f7",
+        "id": "f386c08a-1dcf-444a-a259-9c33fa001606",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "7.17.0"
     },
     "event": {
         "action": "proctitle",
         "agent_id_status": "verified",
         "dataset": "auditd.log",
-        "ingested": "2021-12-24T01:30:55Z",
+        "ingested": "2022-04-13T05:23:36Z",
         "kind": "event"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "4ccba669f0df47fa3f57a9e4169ae7f1",
         "ip": [
-            "192.168.224.7"
+            "172.19.0.7"
         ],
         "mac": [
-            "02:42:c0:a8:e0:07"
+            "02:42:ac:13:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.11.0-41-generic",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.104-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (Core)"
+            "version": "20.04.3 LTS (Focal Fossa)"
         }
     },
     "input": {

--- a/packages/auditd/docs/README.md
+++ b/packages/auditd/docs/README.md
@@ -214,6 +214,7 @@ An example event for `log` looks as following:
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
 | host.os.name | Operating system name, without the version. | keyword |
+| host.os.name.text | Multi-field of `host.os.name`. | text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -225,14 +226,18 @@ An example event for `log` looks as following:
 | process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.executable | Absolute path to the process executable. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
 | process.exit_code | The exit code of the process, if this is a termination event. The field should be absent if there is no exit code for the event (e.g. process start). | long |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.parent.pid | Process id. | long |
 | process.pid | Process id. | long |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
+| source.as.organization.name.text | Multi-field of `source.as.organization.name`. | match_only_text |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
@@ -250,6 +255,7 @@ An example event for `log` looks as following:
 | user.effective.group.name | Name of the group. | keyword |
 | user.effective.id | Unique identifier of the user. | keyword |
 | user.effective.name | Short name or login of the user. | keyword |
+| user.effective.name.text | Multi-field of `user.effective.name`. | match_only_text |
 | user.filesystem.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.filesystem.group.name | Name of the group. | keyword |
 | user.filesystem.id | One or multiple unique identifiers of the user. | keyword |
@@ -257,6 +263,7 @@ An example event for `log` looks as following:
 | user.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
+| user.name.text | Multi-field of `user.name`. | match_only_text |
 | user.owner.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.owner.group.name | Name of the group. | keyword |
 | user.owner.id | One or multiple unique identifiers of the user. | keyword |
@@ -269,5 +276,6 @@ An example event for `log` looks as following:
 | user.target.group.name | Name of the group. | keyword |
 | user.target.id | Unique identifier of the user. | keyword |
 | user.target.name | Short name or login of the user. | keyword |
+| user.target.name.text | Multi-field of `user.target.name`. | match_only_text |
 | user.terminal | Terminal or tty device on which the user is performing the observed activity. | keyword |
 

--- a/packages/auditd/docs/README.md
+++ b/packages/auditd/docs/README.md
@@ -20,11 +20,12 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2016-01-03T00:37:51.394Z",
     "agent": {
-        "ephemeral_id": "26e35ddc-258e-426f-87cf-40517f808d30",
-        "id": "82d0dfd8-3946-4ac0-a092-a9146a71e3f7",
+        "ephemeral_id": "ef6d17d9-f955-48be-a4c5-6b4ea1fe9772",
+        "hostname": "docker-fleet-agent",
+        "id": "f386c08a-1dcf-444a-a259-9c33fa001606",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "7.17.0"
     },
     "auditd": {
         "log": {
@@ -41,37 +42,36 @@ An example event for `log` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "82d0dfd8-3946-4ac0-a092-a9146a71e3f7",
+        "id": "f386c08a-1dcf-444a-a259-9c33fa001606",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "7.17.0"
     },
     "event": {
         "action": "proctitle",
         "agent_id_status": "verified",
         "dataset": "auditd.log",
-        "ingested": "2021-12-24T01:30:55Z",
+        "ingested": "2022-04-13T05:23:36Z",
         "kind": "event"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "4ccba669f0df47fa3f57a9e4169ae7f1",
         "ip": [
-            "192.168.224.7"
+            "172.19.0.7"
         ],
         "mac": [
-            "02:42:c0:a8:e0:07"
+            "02:42:ac:13:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.11.0-41-generic",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.104-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (Core)"
+            "version": "20.04.3 LTS (Focal Fossa)"
         }
     },
     "input": {
@@ -214,7 +214,6 @@ An example event for `log` looks as following:
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
 | host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -226,18 +225,14 @@ An example event for `log` looks as following:
 | process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.executable.text | Multi-field of `process.executable`. | match_only_text |
 | process.exit_code | The exit code of the process, if this is a termination event. The field should be absent if there is no exit code for the event (e.g. process start). | long |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
-| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.parent.pid | Process id. | long |
 | process.pid | Process id. | long |
 | process.working_directory | The working directory of the process. | keyword |
-| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
-| source.as.organization.name.text | Multi-field of `source.as.organization.name`. | match_only_text |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
@@ -255,7 +250,6 @@ An example event for `log` looks as following:
 | user.effective.group.name | Name of the group. | keyword |
 | user.effective.id | Unique identifier of the user. | keyword |
 | user.effective.name | Short name or login of the user. | keyword |
-| user.effective.name.text | Multi-field of `user.effective.name`. | match_only_text |
 | user.filesystem.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.filesystem.group.name | Name of the group. | keyword |
 | user.filesystem.id | One or multiple unique identifiers of the user. | keyword |
@@ -263,7 +257,6 @@ An example event for `log` looks as following:
 | user.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
-| user.name.text | Multi-field of `user.name`. | match_only_text |
 | user.owner.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.owner.group.name | Name of the group. | keyword |
 | user.owner.id | One or multiple unique identifiers of the user. | keyword |
@@ -276,6 +269,5 @@ An example event for `log` looks as following:
 | user.target.group.name | Name of the group. | keyword |
 | user.target.id | Unique identifier of the user. | keyword |
 | user.target.name | Short name or login of the user. | keyword |
-| user.target.name.text | Multi-field of `user.target.name`. | match_only_text |
 | user.terminal | Terminal or tty device on which the user is performing the observed activity. | keyword |
 

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd
-version: 2.1.1
+version: 2.1.2
 release: ga
 description: Collect logs from Linux audit daemon with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

The PR sets/fixes `event.outcome` value as per ECS specification.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

`elastic-package test pipeline -v -g`

## Related issues

- Closes #3043 