### PR TITLE
panw: remove invalid field values from pipeline

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.3"
+  changes:
+    - description: Remove invalid field values
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxx
 - version: "1.5.2"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove invalid field values
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/3094
 - version: "1.5.2"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
@@ -952,7 +952,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000+05:45",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
@@ -26,7 +26,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -163,7 +162,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -300,7 +298,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -437,7 +434,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -574,7 +570,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -711,7 +706,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -848,7 +842,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -985,7 +978,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1122,7 +1114,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1259,7 +1250,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1396,7 +1386,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1533,7 +1522,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1670,7 +1658,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1807,7 +1794,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1942,7 +1928,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2079,7 +2064,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2216,7 +2200,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2351,7 +2334,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2488,7 +2470,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2625,7 +2606,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2762,7 +2742,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2899,7 +2878,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3036,7 +3014,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3173,7 +3150,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3310,7 +3286,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3447,7 +3422,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3584,7 +3558,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3721,7 +3694,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3858,7 +3830,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3995,7 +3966,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4132,7 +4102,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4269,7 +4238,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4406,7 +4374,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4543,7 +4510,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4678,7 +4644,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4813,7 +4778,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4948,7 +4912,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5083,7 +5046,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5218,7 +5180,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5353,7 +5314,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5488,7 +5448,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5623,7 +5582,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5758,7 +5716,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5886,7 +5843,6 @@
             "event": {
                 "action": "spyware_detected",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6025,7 +5981,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6160,7 +6115,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6295,7 +6249,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6430,7 +6383,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6565,7 +6517,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6700,7 +6651,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6835,7 +6785,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6970,7 +6919,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7105,7 +7053,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7233,7 +7180,6 @@
             "event": {
                 "action": "file_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7375,7 +7321,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7503,7 +7448,6 @@
             "event": {
                 "action": "file_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7638,7 +7582,6 @@
             "event": {
                 "action": "file_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7780,7 +7723,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7908,7 +7850,6 @@
             "event": {
                 "action": "file_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8043,7 +7984,6 @@
             "event": {
                 "action": "file_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8185,7 +8125,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8320,7 +8259,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8455,7 +8393,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8583,7 +8520,6 @@
             "event": {
                 "action": "file_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8725,7 +8661,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8860,7 +8795,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8988,7 +8922,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9123,7 +9056,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9265,7 +9197,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9393,7 +9324,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9535,7 +9465,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9663,7 +9592,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9798,7 +9726,6 @@
             "event": {
                 "action": "file_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9933,7 +9860,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10068,7 +9994,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10203,7 +10128,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10338,7 +10262,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10480,7 +10403,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10608,7 +10530,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10743,7 +10664,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10878,7 +10798,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11013,7 +10932,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11148,7 +11066,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11283,7 +11200,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11418,7 +11334,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11553,7 +11468,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11688,7 +11602,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11823,7 +11736,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11958,7 +11870,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12093,7 +12004,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12235,7 +12145,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12363,7 +12272,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12498,7 +12406,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12640,7 +12547,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12768,7 +12674,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12903,7 +12808,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -13038,7 +12942,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -13173,7 +13076,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -13308,7 +13210,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -13443,7 +13344,6 @@
             "event": {
                 "action": "data_match",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic-sample.log-expected.json
@@ -28,7 +28,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -161,7 +160,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -294,7 +292,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -427,7 +424,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -560,7 +556,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -693,7 +688,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -826,7 +820,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -959,7 +952,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -1092,7 +1084,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -1225,7 +1216,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -1358,7 +1348,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -1491,7 +1480,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -1624,7 +1612,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -1757,7 +1744,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000Z",
@@ -1890,7 +1876,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -2023,7 +2008,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -2156,7 +2140,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -2289,7 +2272,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -2422,7 +2404,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -2555,7 +2536,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -2688,7 +2668,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -2821,7 +2800,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -2954,7 +2932,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -3087,7 +3064,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -3220,7 +3196,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -3353,7 +3328,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -3486,7 +3460,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -3619,7 +3592,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -3752,7 +3724,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -3885,7 +3856,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:17.000Z",
@@ -4018,7 +3988,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -4151,7 +4120,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -4284,7 +4252,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -4417,7 +4384,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -4550,7 +4516,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -4683,7 +4648,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -4816,7 +4780,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -4949,7 +4912,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -5082,7 +5044,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -5215,7 +5176,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -5339,7 +5299,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -5472,7 +5431,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -5596,7 +5554,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -5729,7 +5686,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -5862,7 +5818,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -5986,7 +5941,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:22.000Z",
@@ -6119,7 +6073,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -6252,7 +6205,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -6385,7 +6337,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -6518,7 +6469,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -6651,7 +6601,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -6784,7 +6733,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -6917,7 +6865,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -7050,7 +6997,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -7183,7 +7129,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -7316,7 +7261,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -7449,7 +7393,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -7582,7 +7525,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -7715,7 +7657,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -7848,7 +7789,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -7981,7 +7921,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -8114,7 +8053,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -8247,7 +8185,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:27.000Z",
@@ -8380,7 +8317,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -8513,7 +8449,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -8646,7 +8581,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -8779,7 +8713,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -8912,7 +8845,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -9045,7 +8977,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -9178,7 +9109,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -9311,7 +9241,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -9444,7 +9373,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -9577,7 +9505,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -9710,7 +9637,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -9843,7 +9769,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -9976,7 +9901,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -10109,7 +10033,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -10232,7 +10155,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:32.000Z",
@@ -10365,7 +10287,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -10498,7 +10419,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -10621,7 +10541,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -10744,7 +10663,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -10877,7 +10795,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -11010,7 +10927,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -11143,7 +11059,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -11276,7 +11191,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -11409,7 +11323,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -11532,7 +11445,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -11665,7 +11577,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -11798,7 +11709,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -11931,7 +11841,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -12064,7 +11973,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -12197,7 +12105,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:37.000Z",
@@ -12330,7 +12237,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:42.000Z",
@@ -12463,7 +12369,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:42.000Z",
@@ -12596,7 +12501,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:42.000Z",
@@ -12719,7 +12623,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:42.000Z",
@@ -12852,7 +12755,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:42.000Z",
@@ -12985,7 +12887,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:42.000Z",
@@ -13118,7 +13019,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:42.000Z",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
@@ -28,7 +28,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2012-10-30T09:46:12.000-05:00",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-threat-sample.log-expected.json
@@ -29,7 +29,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -197,7 +196,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -365,7 +363,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -533,7 +530,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -701,7 +697,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -869,7 +864,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1037,7 +1031,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1205,7 +1198,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1373,7 +1365,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1541,7 +1532,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1709,7 +1699,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -1877,7 +1866,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2045,7 +2033,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2213,7 +2200,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2381,7 +2367,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2549,7 +2534,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2717,7 +2701,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -2885,7 +2868,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3053,7 +3035,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3221,7 +3202,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3389,7 +3369,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3557,7 +3536,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3725,7 +3703,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -3893,7 +3870,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4061,7 +4037,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4229,7 +4204,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4397,7 +4371,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4565,7 +4538,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4733,7 +4705,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -4901,7 +4872,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5069,7 +5039,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5237,7 +5206,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5405,7 +5373,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5573,7 +5540,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5741,7 +5707,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -5909,7 +5874,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6077,7 +6041,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6245,7 +6208,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6413,7 +6375,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6581,7 +6542,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6749,7 +6709,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -6917,7 +6876,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7085,7 +7043,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7253,7 +7210,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7421,7 +7377,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7589,7 +7544,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7757,7 +7711,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -7925,7 +7878,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8093,7 +8045,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8261,7 +8212,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8429,7 +8379,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8597,7 +8546,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8765,7 +8713,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -8933,7 +8880,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9101,7 +9047,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9269,7 +9214,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9437,7 +9381,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9605,7 +9548,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9773,7 +9715,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -9941,7 +9882,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10109,7 +10049,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10277,7 +10216,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10445,7 +10383,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10613,7 +10550,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10781,7 +10717,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -10949,7 +10884,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11117,7 +11051,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11285,7 +11218,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11453,7 +11385,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11621,7 +11552,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11789,7 +11719,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -11957,7 +11886,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12125,7 +12053,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12293,7 +12220,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12461,7 +12387,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],
@@ -12629,7 +12554,6 @@
             "event": {
                 "action": "url_filtering",
                 "category": [
-                    "security_threat",
                     "intrusion_detection",
                     "network"
                 ],

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-traffic-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-traffic-sample.log-expected.json
@@ -31,7 +31,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:07.000Z",
@@ -194,7 +193,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:09.000Z",
@@ -348,7 +346,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:09.000Z",
@@ -511,7 +508,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:15.000Z",
@@ -665,7 +661,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:15.000Z",
@@ -828,7 +823,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:15.000Z",
@@ -991,7 +985,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:21.000Z",
@@ -1145,7 +1138,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:21.000Z",
@@ -1308,7 +1300,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:22.000Z",
@@ -1471,7 +1462,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:23.000Z",
@@ -1634,7 +1624,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:24.000Z",
@@ -1797,7 +1786,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:24.000Z",
@@ -1960,7 +1948,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:24.000Z",
@@ -2123,7 +2110,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:24.000Z",
@@ -2286,7 +2272,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:24.000Z",
@@ -2449,7 +2434,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:27.000Z",
@@ -2603,7 +2587,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:27.000Z",
@@ -2766,7 +2749,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:28.000Z",
@@ -2929,7 +2911,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:28.000Z",
@@ -3092,7 +3073,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:29.000Z",
@@ -3246,7 +3226,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:29.000Z",
@@ -3409,7 +3388,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:29.000Z",
@@ -3572,7 +3550,6 @@
             "event": {
                 "action": "flow_started",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:30.000Z",
@@ -3735,7 +3712,6 @@
             "event": {
                 "action": "flow_dropped",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:32.000Z",
@@ -3898,7 +3874,6 @@
             "event": {
                 "action": "flow_denied",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:33.000Z",
@@ -4051,7 +4026,6 @@
             },
             "event": {
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:34.000Z",
@@ -4211,7 +4185,6 @@
             },
             "event": {
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:37.000Z",
@@ -4372,7 +4345,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:38.000Z",
@@ -4535,7 +4507,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:38.000Z",
@@ -4698,7 +4669,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:39.000Z",
@@ -4852,7 +4822,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:39.000Z",
@@ -5006,7 +4975,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:39.000Z",
@@ -5169,7 +5137,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:40.000Z",
@@ -5332,7 +5299,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:40.000Z",
@@ -5495,7 +5461,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:42.000Z",
@@ -5658,7 +5623,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:42.000Z",
@@ -5821,7 +5785,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -5984,7 +5947,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -6147,7 +6109,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -6310,7 +6271,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -6473,7 +6433,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -6636,7 +6595,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -6799,7 +6757,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -6962,7 +6919,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -7125,7 +7081,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -7288,7 +7243,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -7451,7 +7405,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -7614,7 +7567,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -7777,7 +7729,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:45.000Z",
@@ -7940,7 +7891,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -8092,7 +8042,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -8255,7 +8204,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -8418,7 +8366,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -8581,7 +8528,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -8744,7 +8690,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -8907,7 +8852,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -9070,7 +9014,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -9233,7 +9176,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -9396,7 +9338,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -9559,7 +9500,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -9722,7 +9662,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -9885,7 +9824,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -10048,7 +9986,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:46.000Z",
@@ -10211,7 +10148,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -10374,7 +10310,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -10537,7 +10472,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -10700,7 +10634,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -10863,7 +10796,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -11026,7 +10958,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -11189,7 +11120,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -11352,7 +11282,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -11515,7 +11444,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -11678,7 +11606,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -11841,7 +11768,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:47.000Z",
@@ -12004,7 +11930,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:48.000Z",
@@ -12167,7 +12092,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:48.000Z",
@@ -12330,7 +12254,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:48.000Z",
@@ -12493,7 +12416,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:49.000Z",
@@ -12655,7 +12577,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:49.000Z",
@@ -12817,7 +12738,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:49.000Z",
@@ -12979,7 +12899,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:49.000Z",
@@ -13141,7 +13060,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:49.000Z",
@@ -13304,7 +13222,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:49.000Z",
@@ -13467,7 +13384,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:49.000Z",
@@ -13630,7 +13546,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -13793,7 +13708,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -13956,7 +13870,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -14119,7 +14032,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -14282,7 +14194,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -14445,7 +14356,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -14608,7 +14518,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -14771,7 +14680,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -14934,7 +14842,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:50.000Z",
@@ -15097,7 +15004,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:51.000Z",
@@ -15260,7 +15166,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:52.000Z",
@@ -15414,7 +15319,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:52.000Z",
@@ -15577,7 +15481,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:52.000Z",
@@ -15740,7 +15643,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:52.000Z",
@@ -15903,7 +15805,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:52.000Z",
@@ -16066,7 +15967,6 @@
             "event": {
                 "action": "flow_terminated",
                 "category": [
-                    "network_traffic",
                     "network"
                 ],
                 "created": "2018-11-30T16:09:52.000Z",

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/threat.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/threat.yml
@@ -94,7 +94,6 @@ processors:
   - append:
       field: event.category
       value:
-        - security_threat
         - intrusion_detection
         - network
 

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
@@ -136,7 +136,6 @@ processors:
   - append:
       field: event.category
       value:
-        - network_traffic
         - network
 
 # event.start is the time the session started.

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Networks Logs
-version: 1.5.2
+version: 1.5.3
 release: ga
 description: Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This removes two invalid field values from event.category. The valid values were already set so no replacement is required.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3049

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
