### PR TITLE
[Microsoft Defender Endpoint] Add support for custom azure resource

### DIFF
--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.0"
+  changes:
+    - description: Add possibility to choose azure resource
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2916
 - version: "2.0.1"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -4,7 +4,7 @@ auth.oauth2.client.id: {{client_id}}
 auth.oauth2.client.secret: {{client_secret}}
 auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/oauth2/token
 auth.oauth2.provider: azure
-auth.oauth2.azure.resource: https://api.securitycenter.windows.com/
+auth.oauth2.azure.resource: {{azure_resource}}
 request.url: {{request_url}}
 request.method: GET
 {{#if proxy_url }}

--- a/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
@@ -35,6 +35,14 @@ streams:
         show_user: true
         default: 5m
         description: The interval between requests to the HTTP API.
+      - name: azure_resource
+        type: text
+        title: Azure Resource
+        multi: false
+        required: true
+        default: https://api.securitycenter.windows.com/
+        show_user: false
+        description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: 2.0.1
+version: 2.1.0
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "network"


### PR DESCRIPTION
## What does this PR do?

Certain Azure tenants requires a custom resource, like for example FED or government tenants, this PR adds support for overwriting the resource.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


