### PR TITLE
[awsfargate] bump package version

### DIFF
--- a/packages/awsfargate/changelog.yml
+++ b/packages/awsfargate/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Improve description and screenshots
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/3130
+      link: https://github.com/elastic/integrations/pull/3109
 - version: 0.1.0
   changes:
     - description: initial release

--- a/packages/awsfargate/changelog.yml
+++ b/packages/awsfargate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.1.1
+  changes:
+    - description: Improve description and screenshots
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3130
 - version: 0.1.0
   changes:
     - description: initial release

--- a/packages/awsfargate/manifest.yml
+++ b/packages/awsfargate/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: awsfargate
 title: AWS Fargate
-version: 0.1.0
+version: 0.1.1
 license: basic
 description: Collects metrics from containers and tasks running on Amazon ECS clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

TL;DR  — I forgot to bump the package version in the last PR and this one fixes it.

Bump package version to 0.1.1 to release the last minor changes merged without a proper versioning.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #3109 
