### PR TITLE
Exclude ecosystem as owner of subdirectories of packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Everything outside of packages is maintained by the ecosystem team.
 * @elastic/ecosystem
-/packages/*
+/packages/
 
 # CODEOWNERS file is checked by CI.
 /.github/CODEOWNERS

--- a/dev/codeowners/codeowners.go
+++ b/dev/codeowners/codeowners.go
@@ -103,6 +103,13 @@ func (codeowners *githubOwners) checkSingleField(field string) error {
 			if matches || strings.HasPrefix(field, path) {
 				return fmt.Errorf("%q would remove owners for %q", field, path)
 			}
+
+			if strings.HasPrefix(path, field) {
+				_, err := filepath.Rel(field, path)
+				if err == nil {
+					return fmt.Errorf("%q would remove owners for %q", field, path)
+				}
+			}
 		}
 
 		// Excluding other files is fine.

--- a/dev/codeowners/codeowners_test.go
+++ b/dev/codeowners/codeowners_test.go
@@ -99,6 +99,10 @@ func TestReadGithubOwners(t *testing.T) {
 			codeownersPath: "testdata/CODEOWNERS-invalid-override",
 			valid:          false,
 		},
+		{
+			codeownersPath: "testdata/CODEOWNERS-invalid-override-wildcard",
+			valid:          false,
+		},
 	}
 
 	for _, c := range cases {

--- a/dev/codeowners/testdata/CODEOWNERS-invalid-override-wildcard
+++ b/dev/codeowners/testdata/CODEOWNERS-invalid-override-wildcard
@@ -1,5 +1,5 @@
 # This is not valid because there is an override that would remove owners of a directory.
 
 /testdata/devexp @elastic/integrations @elastic/integrations-developer-experience
-/testdata/
+/testdata/*
 

--- a/dev/codeowners/testdata/CODEOWNERS-multiple-owners
+++ b/dev/codeowners/testdata/CODEOWNERS-multiple-owners
@@ -1,4 +1,5 @@
 # This is a valid test file with multiple owners for a path
 
 /testdata/devexp @elastic/integrations @elastic/integrations-developer-experience
+/testdata/devexp/manifest.yml @elastic/integrations
 /testdata/integration @elastic/integrations

--- a/dev/codeowners/testdata/CODEOWNERS-valid
+++ b/dev/codeowners/testdata/CODEOWNERS-valid
@@ -1,7 +1,7 @@
 # This is a valid test file
 * @elastic/ecosystem
 
-/testdata/*
+/testdata/
 
 /testdata/devexp @elastic/integrations-developer-experience
 /testdata/integration @elastic/integrations


### PR DESCRIPTION
/packages/* only include the first level of files under /packages.
Removing the wildcard matches everything under /packages.

Fixes issue reproduced in https://github.com/elastic/integrations/pull/3131.