### PR TITLE
[google_workspace} Fix pagination bug that skipped events when more than one page is present

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.4"
+  changes:
+    - description: Fix pagination to prevent skipped events when more than one page is present.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3140
 - version: "1.3.3"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -12,7 +12,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: "[[.cursor.last_execution_datetime]]"
+      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -12,7 +12,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: "[[.cursor.last_execution_datetime]]"
+      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -12,7 +12,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: "[[.cursor.last_execution_datetime]]"
+      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -12,7 +12,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: "[[.cursor.last_execution_datetime]]"
+      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -12,7 +12,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: "[[.cursor.last_execution_datetime]]"
+      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -12,7 +12,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: "[[.cursor.last_execution_datetime]]"
+      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace Audit Reports
-version: 1.3.3
+version: 1.3.4
 release: ga
 description: Collect audit reports from Google Workspaces with Elastic Agent.
 type: integration


### PR DESCRIPTION

<!-- Type f change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Fixes the module config to prevent skipping events by using incorrect startDate values on pagination.



## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
