### PR TITLE
[cisco_asa] fix visualizations

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.2"
+  changes:
+    - description: Change visualizations to use event.code instead of cisco.asa.message_id.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3146
 - version: "2.2.1"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/cisco_asa/kibana/search/cisco_asa-14fce5e0-498f-11e9-b8ce-ed898b5ef295.json
+++ b/packages/cisco_asa/kibana/search/cisco_asa-14fce5e0-498f-11e9-b8ce-ed898b5ef295.json
@@ -12,7 +12,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "cisco.asa.message_id :*"
+                    "query": "data_stream.dataset:cisco_asa.log"
                 },
                 "version": true
             }

--- a/packages/cisco_asa/kibana/search/cisco_asa-753406e0-4986-11e9-b8ce-ed898b5ef295.json
+++ b/packages/cisco_asa/kibana/search/cisco_asa-753406e0-4986-11e9-b8ce-ed898b5ef295.json
@@ -12,7 +12,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "cisco.asa.message_id:* and event.action:\"flow-expiration\""
+                    "query": "data_stream.dataset:cisco_asa.log and event.action:\"flow-expiration\""
                 },
                 "version": true
             }

--- a/packages/cisco_asa/kibana/search/cisco_asa-96c6ff60-4986-11e9-b8ce-ed898b5ef295.json
+++ b/packages/cisco_asa/kibana/search/cisco_asa-96c6ff60-4986-11e9-b8ce-ed898b5ef295.json
@@ -12,7 +12,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "cisco.asa.message_id:* and event.action:\"firewall-rule\""
+                    "query": "data_stream.dataset:cisco_asa.log and event.action:\"firewall-rule\""
                 },
                 "version": true
             }

--- a/packages/cisco_asa/kibana/visualization/cisco_asa-fd89b1e0-49a2-11e9-b8ce-ed898b5ef295.json
+++ b/packages/cisco_asa/kibana/visualization/cisco_asa-fd89b1e0-49a2-11e9-b8ce-ed898b5ef295.json
@@ -30,7 +30,7 @@
                     "id": "2",
                     "params": {
                         "customLabel": "ID",
-                        "field": "cisco.asa.message_id",
+                        "field": "event.code",
                         "missingBucket": false,
                         "missingBucketLabel": "Missing",
                         "order": "desc",

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: 2.2.1
+version: 2.2.2
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

- stop using `cisco.asa.message_id` in visualization, field no longer populated.
- use data_stream to limit to cisco asa events.
- use event.code instead which has same info as `cisco.asa.message_id` did

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes #3142

## Screenshots

### Before
<img width="1819" alt="Screen Shot 2022-04-20 at 12 49 09" src="https://user-images.githubusercontent.com/57081003/164292968-bfe120c3-4ed2-471e-a793-e36aeafd8872.png">


### After
<img width="1819" alt="Screen Shot 2022-04-20 at 12 30 28" src="https://user-images.githubusercontent.com/57081003/164292985-e2edd65d-04e1-4485-9465-d35b5edf0071.png">

