### PR TITLE
Update cloud security posture README

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
-- version: "0.0.1"
+- version: "0.0.2"
   changes:
+    - description: Change README
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3190
     - description: Initial draft of the package
       type: enhancement
       link: https://github.com/elastic/integrations/pull/3113

--- a/packages/cloud_security_posture/docs/README.md
+++ b/packages/cloud_security_posture/docs/README.md
@@ -2,15 +2,6 @@
 
 This integration compares [Kubernetes](https://kubernetes.io/) configuration against CIS benchmark checks. It computes a score that ranges between 0 - 100. This integration requires access to node files, node processes, and the Kuberenetes api-server therefore it assumes the agent will be installed as a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) with the proper [Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) and [RoleBindings](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) attached.
 
-See agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/running-on-kubernetes-managed-by-fleet.html).
-
-Additionally, In order for the integration to be installed, The Cloud Security Posture Kibana plugin must be enabled.
-
-This could be done by adding the following configuration line to `kibana.yml`:
-```
-xpack.cloudSecurityPosture.enabled: true
-```
-
 ## Leader election
 
 To collect cluster level data (compared to node level information) the integration makes use of the [leader election](https://www.elastic.co/guide/en/fleet/master/kubernetes_leaderelection-provider.html) mechanism.
@@ -26,3 +17,87 @@ The Kubernetes package is tested with Kubernetes 1.21.x
 ## Dashboard
 
 CIS Kubernetes Benchmark integration is shipped including default dashboards and screens to manage the benchmark rules and inspect the compliance score and findings.
+
+## Deployment
+
+#### Configure Kibana
+
+In order for the integration to be installed, The Cloud Security Posture Kibana plugin must be enabled.
+
+This could be done by adding the following configuration line to `kibana.yml`:
+```
+xpack.cloudSecurityPosture.enabled: true
+```
+For Cloud users, see [Edit Kibana user settings](https://www.elastic.co/guide/en/cloud/current/ec-manage-kibana-settings.html).
+
+
+#### Deploy the Elastic agent
+
+Just like every other integration, the KSPM integration requires an Elastic agent to be deployed.
+
+See agent [installation instructions](https://www.elastic.co/guide/en/fleet/current/running-on-kubernetes-managed-by-fleet.html).
+
+Note, if you want to add this integration to existing Elastic agents (deployed prior to 8.3 release), you'll have to update your Deamonset to include the additional required volumes and volume mounts.
+This can be done in a few steps:
+
+1. Create a patch file including all the necessary volumes and volume mounts:
+```bash
+cat << EOF > volumes-patch.yml
+spec:
+  template:
+    spec:
+      containers:
+      - name: elastic-agent
+        volumeMounts:
+        - mountPath: /hostfs/proc
+          name: proc
+          readOnly: true
+        - mountPath: /hostfs/sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /var/log
+          name: varlog
+          readOnly: true
+        - mountPath: /hostfs/etc/kubernetes
+          name: etc-kubernetes
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /proc
+          type: ""
+        name: proc
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: ""
+        name: cgroup
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/log
+          type: ""
+        name: varlog
+      - hostPath:
+          path: /etc/kubernetes
+          type: ""
+        name: etc-kubernetes
+EOF
+```
+
+2. Apply the patch file to your Kubernetes cluster
+```bash
+kubectl patch ds elastic-agent -n kube-system --patch-file volumes-patch.yml
+# Expected result:
+# daemonset.apps/elastic-agent patched
+```
+
+3. Check if the update was successful
+```bash
+kubectl rollout status ds/elastic-agent -n kube-system
+# Expected result:
+# daemon set "elastic-agent" successfully rolled out
+```

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "CIS Kubernetes Benchmark"
-version: 0.0.1
+version: 0.0.2
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
 type: integration


### PR DESCRIPTION
## What does this PR do?

Update the integration readme to include deployment instructions for users who already have elastic-agent DaemonSet deployed and need to update it's volumes and mounts.

## Screenshots
![localhost_5601_app_integrations_detail_cloud_security_posture-0 0 2_overview](https://user-images.githubusercontent.com/63912106/165134133-1d5c115c-8bb5-48d7-a3f3-660a5706a57e.png)

