### PR TITLE
[M365 Defender] Update m365 config to exit gracefully when split errors

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.3"
+  changes:
+    - description: Add fail_on_template_error to split operation in httpjson
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3181
 - version: "1.0.2"
   changes:
     - description: Fix mapping for comments field and add missing fields

--- a/packages/m365_defender/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/m365_defender/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -23,9 +23,11 @@ response.split:
   split:
     target: body.alerts
     keep_parent: true
+    fail_on_template_error: true
     split:
       target: body.alerts.entities
       keep_parent: true
+      fail_on_template_error: true
 cursor:
   lastUpdateTime:
     value: "[[.last_response.body.lastUpdateTime]]"

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: m365_defender
 title: M365 Defender Logs
-version: 1.0.2
+version: 1.0.3
 description: Collect logs from M365 Defender API with Elastic Agent.
 categories:
   - "network"


### PR DESCRIPTION
## What does this PR do?

Adds some options to the split transform for httpjson to fix possible duplicates.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


