### PR TITLE
[cisco_umbrella] Fix dns logs populating destination.ip instead of source.nat.ip

### DIFF
--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Fix use of destination.ip instead of source.nat.ip in DNS logs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3218
 - version: "0.6.0"
   changes:
     - description: Update to ECS 8.2

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
@@ -17,22 +17,6 @@
                     "policy_identity_type": "Test Policy Name"
                 }
             },
-            "destination": {
-                "address": "81.2.69.144",
-                "geo": {
-                    "city_name": "London",
-                    "continent_name": "Europe",
-                    "country_iso_code": "GB",
-                    "country_name": "United Kingdom",
-                    "location": {
-                        "lat": 51.5142,
-                        "lon": -0.0931
-                    },
-                    "region_iso_code": "GB-ENG",
-                    "region_name": "England"
-                },
-                "ip": "81.2.69.144"
-            },
             "dns": {
                 "question": {
                     "name": "elastic.co.",
@@ -74,7 +58,10 @@
             },
             "source": {
                 "address": "192.168.1.1",
-                "ip": "192.168.1.1"
+                "ip": "192.168.1.1",
+                "nat": {
+                    "ip": "81.2.69.144"
+                }
             },
             "tags": [
                 "preserve_original_event"
@@ -103,22 +90,6 @@
                     "identity_types": "SomeIdentityType",
                     "policy_identity_type": "Test Policy Name"
                 }
-            },
-            "destination": {
-                "address": "67.43.156.12",
-                "as": {
-                    "number": 35908
-                },
-                "geo": {
-                    "continent_name": "Asia",
-                    "country_iso_code": "BT",
-                    "country_name": "Bhutan",
-                    "location": {
-                        "lat": 27.5,
-                        "lon": 90.5
-                    }
-                },
-                "ip": "67.43.156.12"
             },
             "dns": {
                 "question": {
@@ -161,7 +132,10 @@
             },
             "source": {
                 "address": "192.168.1.1",
-                "ip": "192.168.1.1"
+                "ip": "192.168.1.1",
+                "nat": {
+                    "ip": "67.43.156.12"
+                }
             },
             "tags": [
                 "preserve_original_event"
@@ -184,22 +158,6 @@
                     "identity_types": "Roaming Computers,AD Users",
                     "policy_identity_type": "Roaming Computers"
                 }
-            },
-            "destination": {
-                "address": "81.2.69.144",
-                "geo": {
-                    "city_name": "London",
-                    "continent_name": "Europe",
-                    "country_iso_code": "GB",
-                    "country_name": "United Kingdom",
-                    "location": {
-                        "lat": 51.5142,
-                        "lon": -0.0931
-                    },
-                    "region_iso_code": "GB-ENG",
-                    "region_name": "England"
-                },
-                "ip": "81.2.69.144"
             },
             "dns": {
                 "question": {
@@ -257,7 +215,10 @@
                         "lon": 90.5
                     }
                 },
-                "ip": "67.43.156.12"
+                "ip": "67.43.156.12",
+                "nat": {
+                    "ip": "81.2.69.144"
+                }
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/cisco_umbrella/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_umbrella/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -24,7 +24,7 @@ processors:
         - user.name
         - cisco.umbrella.identities
         - source.address
-        - destination.address
+        - source.nat.ip
         - cisco.umbrella.action
         - dns.question.type
         - dns.response_code
@@ -236,16 +236,39 @@ processors:
       value: connection
       if: ctx?.cisco?.umbrella?.action != null
   # Converting address fields to either ip or domain
-  - grok:
+  - convert:
       field: source.address
-      patterns:
-        - "(?:%{IP:source.ip}|%{GREEDYDATA:source.domain})"
-      ignore_failure: true
-  - grok:
+      target_field: source.ip
+      type: ip
+      ignore_missing: true
+      on_failure:
+        - set:
+            copy_from: source.address
+            field: source.domain
+            override: true
+
+  - convert:
       field: destination.address
-      patterns:
-        - "(?:%{IP:destination.ip}|%{GREEDYDATA:destination.domain})"
-      ignore_failure: true
+      target_field: destination.ip
+      type: ip
+      ignore_missing: true
+      on_failure:
+        - set:
+            field: destination.domain
+            copy_from: destination.address
+            override: true
+
+  # For nat, there's no address or domain subfield.
+  # If the value is not a valid IP, it must be removed
+  # or ingestion will fail. Probably just an empty value.
+  - convert:
+      field: source.nat.ip
+      type: ip
+      ignore_missing: true
+      on_failure:
+        - remove:
+            field: source.nat.ip
+
   - community_id:
       ignore_missing: true
   - geoip:

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_umbrella
 title: Cisco Umbrella
-version: 0.6.0
+version: 0.6.1
 license: basic
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Changes the Cisco Umbrella ingest pipeline to populate the `source.nat.ip` field instead of `destination.ip`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/beats/pull/31454