### PR TITLE
Fix duplicate titles in AWS integration

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.5"
+  changes:
+    - description: Fix duplicate titles for integrations
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3226
 - version: "1.14.4"
   changes:
     - description: Fix cloudfront integration grok pattern

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -132,6 +132,10 @@ policy_templates:
       - cloudwatch_logs
       - cloudwatch_metrics
     inputs:
+      - type: aws-s3
+        title: Collect logs from S3
+        description: Collecting logs using aws-s3 input
+        input_group: logs
       - type: aws-cloudwatch
         title: Collect logs from CloudWatch
         description: Collecting logs using aws-cloudwatch input
@@ -397,7 +401,7 @@ policy_templates:
       - datastore
     inputs:
       - type: aws/metrics
-        title: Collect AWS S3 Storage Lens metrics
+        title: Collect S3 Storage Lens metrics
         description: Collect S3 Storage Lens metrics using AWS CloudWatch
         input_group: metrics
     icons:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.14.4
+version: 1.14.5
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration
@@ -77,13 +77,13 @@ vars:
 policy_templates:
   - name: billing
     title: AWS Billing Metrics
-    description: Collect billing metrics from Amazon Web Services with Elastic Agent
+    description: Collect billing metrics with Elastic Agent
     data_streams:
       - billing
     inputs:
       - type: aws/metrics
         title: Collect billing metrics
-        description: Collect billing metrics
+        description: Collect billing metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_billing.svg
@@ -97,23 +97,23 @@ policy_templates:
         type: image/png
   - name: cloudtrail
     title: AWS Cloudtrail Logs
-    description: Collect and parse logs from AWS Cloudtrail with Elastic Agent
+    description: Collect AWS Cloudtrail logs with Elastic Agent
     data_streams:
       - cloudtrail
     categories:
       - security
     inputs:
       - type: aws-s3
-        title: Collect logs from S3
-        description: Collecting logs using aws-s3 input
+        title: Collect Cloudtrail logs from S3
+        description: Collecting logs from Cloudtrail using aws-s3 input
         input_group: logs
       - type: aws-cloudwatch
-        title: Collect logs from CloudWatch
-        description: Collecting logs using aws-cloudwatch input
+        title: Collect Cloudtrail logs from CloudWatch
+        description: Collecting logs from Cloudtrail using aws-cloudwatch input
         input_group: logs
       - type: httpjson
-        title: Collect logs from third-party REST API (experimental)
-        description: Collect logs from third-party REST API (experimental)
+        title: Collect Cloudtrail logs from third-party REST API (experimental)
+        description: Collect Cloudtrail logs using third-party REST API (experimental)
         input_group: logs
     icons:
       - src: /img/logo_cloudtrail.svg
@@ -132,17 +132,13 @@ policy_templates:
       - cloudwatch_logs
       - cloudwatch_metrics
     inputs:
-      - type: aws-s3
-        title: Collect logs from S3
-        description: Collecting logs using aws-s3 input
-        input_group: logs
       - type: aws-cloudwatch
         title: Collect logs from CloudWatch
         description: Collecting logs using aws-cloudwatch input
         input_group: logs
       - type: aws/metrics
         title: Collect metrics from CloudWatch
-        description: Collecting metrics from AWS CloudWatch
+        description: Collecting metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_cloudwatch.svg
@@ -151,7 +147,7 @@ policy_templates:
         type: image/svg+xml
   - name: dynamodb
     title: AWS DynamoDB Metrics
-    description: Collect metrics from Amazon DynamoDB service with Elastic Agent
+    description: Collect Amazon DynamoDB metrics with Elastic Agent
     data_streams:
       - dynamodb
     categories:
@@ -173,7 +169,7 @@ policy_templates:
         type: image/png
   - name: ebs
     title: AWS EBS Metrics
-    description: Collect metrics from Amazon Elastic Block Storage service with Elastic Agent
+    description: Collect Amazon Elastic Block Storage metrics with Elastic Agent
     data_streams:
       - ebs
     categories:
@@ -181,7 +177,7 @@ policy_templates:
     inputs:
       - type: aws/metrics
         title: Collect EBS metrics
-        description: Collect EBS metrics
+        description: Collect EBS metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_ebs.svg
@@ -201,15 +197,15 @@ policy_templates:
       - ec2_metrics
     inputs:
       - type: aws-s3
-        title: Collect logs from S3
-        description: Collecting logs using aws-s3 input
+        title: Collect EC2 logs from S3
+        description: Collecting logs from EC2 using aws-s3 input
         input_group: logs
       - type: aws-cloudwatch
-        title: Collect logs from CloudWatch
-        description: Collecting logs using aws-cloudwatch input
+        title: Collect EC2 logs from CloudWatch
+        description: Collecting logs from EC2 using aws-cloudwatch input
         input_group: logs
       - type: aws/metrics
-        title: Collect metrics from EC2 service
+        title: Collect EC2 metrics
         description: Collecting EC2 metrics using AWS CloudWatch
         input_group: metrics
     icons:
@@ -232,15 +228,15 @@ policy_templates:
       - network
     inputs:
       - type: aws-s3
-        title: Collect logs from S3
+        title: Collect ELB logs from S3
         description: Collecting logs from ELB using aws-s3 input
         input_group: logs
       - type: aws-cloudwatch
-        title: Collect logs from CloudWatch
+        title: Collect ELB logs from CloudWatch
         description: Collecting logs from ELB using aws-cloudwatch input
         input_group: logs
       - type: aws/metrics
-        title: Collect metrics from ELB service
+        title: Collect ELB metrics
         description: Collecting ELB metrics using AWS CloudWatch
         input_group: metrics
     icons:
@@ -259,13 +255,13 @@ policy_templates:
         type: image/png
   - name: lambda
     title: AWS Lambda Metrics
-    description: Collect metrics from AWS Lambda service with Elastic Agent
+    description: Collect Lambda metrics from CloudWatch with Elastic Agent
     data_streams:
       - lambda
     inputs:
       - type: aws/metrics
         title: Collect Lambda metrics
-        description: Collect Lambda metrics
+        description: Collect Lambda metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_lambda.svg
@@ -279,7 +275,7 @@ policy_templates:
         type: image/png
   - name: natgateway
     title: AWS NAT Gateway Metrics
-    description: Collect metrics from Amazon NAT Gateways with Elastic Agent
+    description: Collect Amazon NAT Gateways metrics from CloudWatch with Elastic Agent
     data_streams:
       - natgateway
     categories:
@@ -287,7 +283,7 @@ policy_templates:
     inputs:
       - type: aws/metrics
         title: Collect NATGateway metrics
-        description: Collect NATGateway metrics
+        description: Collect NATGateway metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_natgateway.svg
@@ -296,7 +292,7 @@ policy_templates:
         type: image/svg+xml
   - name: firewall
     title: AWS Network Firewall
-    description: Collect logs and metrics from AWS Network Firewall with Elastic Agent
+    description: Collect AWS Network Firewall logs and metrics with Elastic Agent
     categories:
       - security
     data_streams:
@@ -304,16 +300,16 @@ policy_templates:
       - firewall_metrics
     inputs:
       - type: aws-s3
-        title: Collect logs from S3
+        title: Collect Network Firewall logs from S3
         description: Collecting logs from Network Firewall using aws-s3 input
         input_group: logs
       - type: aws-cloudwatch
-        title: Collect logs from CloudWatch
+        title: Collect Network Firewall logs from CloudWatch
         description: Collecting logs from Network Firewall using aws-cloudwatch input
         input_group: logs
       - type: aws/metrics
-        title: Collect metrics from Network Firewall
-        description: Collecting metrics from AWS Network Firewall
+        title: Collect Network Firewall metrics
+        description: Collecting AWS Network Firewall metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_firewall.svg
@@ -339,7 +335,7 @@ policy_templates:
         type: image/png
   - name: rds
     title: AWS RDS Metrics
-    description: Collect metrics from Amazon Relational Database Service with Elastic Agent
+    description: Collect RDS metrics from Amazon Relational Database Service with Elastic Agent
     data_streams:
       - rds
     categories:
@@ -347,7 +343,7 @@ policy_templates:
     inputs:
       - type: aws/metrics
         title: Collect RDS metrics
-        description: Collect RDS metrics
+        description: Collect RDS metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_rds.svg
@@ -371,11 +367,11 @@ policy_templates:
       - security
     inputs:
       - type: aws-s3
-        title: Collect logs from S3
+        title: Collect S3 access logs from S3
         description: Collecting S3 access logs using aws-s3 input
         input_group: logs
       - type: aws/metrics
-        title: Collect metrics from S3
+        title: Collect S3 metrics
         description: Collecting S3 metrics using AWS CloudWatch
         input_group: metrics
     icons:
@@ -394,15 +390,15 @@ policy_templates:
         type: image/png
   - name: s3_storage_lens
     title: AWS S3 Storage Lens
-    description: Collect metrics from AWS S3 Storage Lens with Elastic Agent
+    description: Collect S3 Storage Lens metrics with Elastic Agent
     data_streams:
       - s3_storage_lens
     categories:
       - datastore
     inputs:
       - type: aws/metrics
-        title: Collect metrics from AWS S3 Storage Lens
-        description: Collecting AWS S3 Storage Lens metrics using AWS CloudWatch
+        title: Collect AWS S3 Storage Lens metrics
+        description: Collect S3 Storage Lens metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_s3_storage_lens.svg
@@ -416,13 +412,13 @@ policy_templates:
         type: image/png
   - name: sns
     title: AWS SNS Metrics
-    description: Collect metrics from Amazon Simple Notification Service with Elastic Agent
+    description: Collect SNS metrics with Elastic Agent
     data_streams:
       - sns
     inputs:
       - type: aws/metrics
         title: Collect SNS metrics
-        description: Collect SNS metrics
+        description: Collect SNS metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_sns.svg
@@ -436,13 +432,13 @@ policy_templates:
         type: image/png
   - name: sqs
     title: AWS SQS Metrics
-    description: Collect metrics from Amazon Simple Queue Service with Elastic Agent
+    description: Collect SQS metrics with Elastic Agent
     data_streams:
       - sqs
     inputs:
       - type: aws/metrics
         title: Collect SQS metrics
-        description: Collect SQS metrics
+        description: Collect SQS metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_sqs.svg
@@ -456,7 +452,7 @@ policy_templates:
         type: image/png
   - name: transitgateway
     title: AWS Transit Gateway Metrics
-    description: Collect metrics from AWS Transit Gateways with Elastic Agent
+    description: Collect AWS Transit Gateways metrics with Elastic Agent
     data_streams:
       - transitgateway
     categories:
@@ -464,7 +460,7 @@ policy_templates:
     inputs:
       - type: aws/metrics
         title: Collect Transit Gateway metrics
-        description: Collect Transit Gateway metrics
+        description: Collect Transit Gateway metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_transitgateway.svg
@@ -473,13 +469,13 @@ policy_templates:
         type: image/svg+xml
   - name: usage
     title: AWS Usage Metrics
-    description: Collect usage metrics from Amazon Web Services with Elastic Agent
+    description: Collect AWS usage metrics with Elastic Agent
     data_streams:
       - usage
     inputs:
       - type: aws/metrics
         title: Collect Usage metrics
-        description: Collect Usage metrics
+        description: Collect Usage metrics using AWS CloudWatch
         input_group: metrics
     screenshots:
       - src: /img/metricbeat-aws-usage-overview.png
@@ -496,11 +492,11 @@ policy_templates:
       - security
     inputs:
       - type: aws-s3
-        title: Collect logs from S3
+        title: Collect VPC flow logs from S3
         description: Collecting VPC Flow logs using aws-s3 input
         input_group: logs
       - type: aws-cloudwatch
-        title: Collect logs from CloudWatch
+        title: Collect VPC flow logs from CloudWatch
         description: Collecting VPC Flow logs using aws-cloudwatch input
         input_group: logs
     icons:
@@ -510,7 +506,7 @@ policy_templates:
         type: image/svg+xml
   - name: vpn
     title: AWS VPN Metrics
-    description: Collect VPN metrics from Amazon Web Services with Elastic Agent
+    description: Collect VPN metrics with Elastic Agent
     data_streams:
       - vpn
     categories:
@@ -518,7 +514,7 @@ policy_templates:
     inputs:
       - type: aws/metrics
         title: Collect VPN metrics
-        description: Collect VPN metrics
+        description: Collect VPN metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_vpn.svg
@@ -527,7 +523,7 @@ policy_templates:
         type: image/svg+xml
   - name: waf
     title: AWS WAF Logs
-    description: Collect AWS WAF logs
+    description: Collect AWS WAF logs with Elastic Agent
     data_streams:
       - waf
     categories:
@@ -535,11 +531,11 @@ policy_templates:
       - security
     inputs:
       - type: aws-s3
-        title: Collect logs from S3
+        title: Collect WAF logs from S3
         description: Collecting WAF logs using aws-s3 input
         input_group: logs
       - type: aws-cloudwatch
-        title: Collect logs from CloudWatch
+        title: Collect WAF logs from CloudWatch
         description: Collecting WAF logs using aws-cloudwatch input
         input_group: logs
     icons:
@@ -549,14 +545,14 @@ policy_templates:
         type: image/svg+xml
   - name: route53
     title: AWS Route 53
-    description: Collect logs from AWS Route53 with Elastic Agent
+    description: Collect AWS Route53 logs with Elastic Agent
     data_streams:
       - route53_public_logs
       - route53_resolver_logs
     inputs:
       - type: aws-cloudwatch
-        title: Collect logs from Route53
-        description: Collecting logs from Route53 using aws-cloudwatch input
+        title: Collect Route53 logs
+        description: Collecting Route53 logs using aws-cloudwatch input
         input_group: logs
     icons:
       - src: /img/logo_route53.svg
@@ -565,13 +561,13 @@ policy_templates:
         type: image/svg+xml
   - name: cloudfront
     title: AWS CloudFront
-    description: Collect logs from AWS CloudFront with Elastic Agent
+    description: Collect AWS CloudFront logs with Elastic Agent
     data_streams:
       - cloudfront_logs
     inputs:
       - type: aws-s3
-        title: Collect logs from CloudFront
-        description: Collecting logs from CloudFront using aws-s3 input
+        title: Collect CloudFront logs
+        description: Collecting CloudFront logs using aws-s3 input
         input_group: logs
     icons:
       - src: /img/logo_cloudfront.svg


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix duplicate titles in AWS integration. When adding AWS integration, in the configure integration page, without this PR you will see multiple `Collect logs from S3` titles and multiple `Collect logs from CloudWatch` titles. They are meant for adding different integrations but accidentally were named to be all the same.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Screenshots

Before:
<img width="685" alt="Screen Shot 2022-04-28 at 8 23 36 PM" src="https://user-images.githubusercontent.com/14081635/165876366-c4174143-9bf6-4a6c-a3c4-85ff89eb06ce.png">

After:
<img width="703" alt="Screen Shot 2022-04-28 at 8 21 37 PM" src="https://user-images.githubusercontent.com/14081635/165876230-bd44c073-f751-4990-9001-769cd4ce3102.png">


