### PR TITLE
Schedule weekly with v8.3

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -35,11 +35,11 @@ pipeline {
             )
           }
         }
-        stage('with stack v8.2') {
+        stage('with stack v8.3') {
           steps {
             build(
               job: env.INTEGRATION_JOB,
-              parameters: [stringParam(name: 'stackVersion', value: '8.2.0-SNAPSHOT')],
+              parameters: [stringParam(name: 'stackVersion', value: '8.3.0-SNAPSHOT')],
               quietPeriod: 0,
               wait: true,
               propagate: true,


### PR DESCRIPTION
This PR adjusts our daily schedule to use v8.3 stack for testing. We have packages that require it: fim, cloud_security_posture.

Spotted [here](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/535/)