### PR TITLE
Improve s3 integration tile information

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.6"
+  changes:
+    - description: Improve s3 integration tile title and description
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3240
 - version: "1.14.5"
   changes:
     - description: Fix duplicate titles for integrations

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -96,24 +96,24 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: cloudtrail
-    title: AWS Cloudtrail
-    description: Collect AWS Cloudtrail logs with Elastic Agent
+    title: AWS CloudTrail
+    description: Collect AWS CloudTrail logs with Elastic Agent
     data_streams:
       - cloudtrail
     categories:
       - security
     inputs:
       - type: aws-s3
-        title: Collect Cloudtrail logs from S3
-        description: Collecting logs from Cloudtrail using aws-s3 input
+        title: Collect CloudTrail logs from S3
+        description: Collecting logs from CloudTrail using aws-s3 input
         input_group: logs
       - type: aws-cloudwatch
-        title: Collect Cloudtrail logs from CloudWatch
-        description: Collecting logs from Cloudtrail using aws-cloudwatch input
+        title: Collect CloudTrail logs from CloudWatch
+        description: Collecting logs from CloudTrail using aws-cloudwatch input
         input_group: logs
       - type: httpjson
-        title: Collect Cloudtrail logs from third-party REST API (experimental)
-        description: Collect Cloudtrail logs using third-party REST API (experimental)
+        title: Collect CloudTrail logs from third-party REST API (experimental)
+        description: Collect CloudTrail logs using third-party REST API (experimental)
         input_group: logs
     icons:
       - src: /img/logo_cloudtrail.svg

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.14.5
+version: 1.14.6
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration
@@ -150,7 +150,7 @@ policy_templates:
         size: 32x32
         type: image/svg+xml
   - name: dynamodb
-    title: AWS DynamoDB Metrics
+    title: Amazon DynamoDB Metrics
     description: Collect Amazon DynamoDB metrics with Elastic Agent
     data_streams:
       - dynamodb
@@ -172,7 +172,7 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: ebs
-    title: AWS EBS Metrics
+    title: Amazon EBS Metrics
     description: Collect Amazon Elastic Block Storage metrics with Elastic Agent
     data_streams:
       - ebs
@@ -194,8 +194,8 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: ec2
-    title: AWS EC2
-    description: Collect logs and metrics from Amazon Elastic Compute Cloud service with Elastic Agent
+    title: Amazon EC2
+    description: Collect logs and metrics for Amazon Elastic Compute Cloud service with Elastic Agent
     data_streams:
       - ec2_logs
       - ec2_metrics
@@ -224,7 +224,7 @@ policy_templates:
         type: image/png
   - name: elb
     title: AWS ELB
-    description: Collect logs and metrics from Amazon Elastic Load Balancing service with Elastic Agent
+    description: Collect logs and metrics for Amazon Elastic Load Balancing service with Elastic Agent
     data_streams:
       - elb_logs
       - elb_metrics
@@ -259,7 +259,7 @@ policy_templates:
         type: image/png
   - name: lambda
     title: AWS Lambda Metrics
-    description: Collect Lambda metrics from CloudWatch with Elastic Agent
+    description: Collect Lambda metrics with Elastic Agent
     data_streams:
       - lambda
     inputs:
@@ -278,8 +278,8 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: natgateway
-    title: AWS NAT Gateway Metrics
-    description: Collect Amazon NAT Gateways metrics from CloudWatch with Elastic Agent
+    title: Amazon NAT Gateway Metrics
+    description: Collect Amazon NAT Gateways metrics with Elastic Agent
     data_streams:
       - natgateway
     categories:
@@ -338,8 +338,8 @@ policy_templates:
         size: 1366x1274
         type: image/png
   - name: rds
-    title: AWS RDS Metrics
-    description: Collect RDS metrics from Amazon Relational Database Service with Elastic Agent
+    title: Amazon RDS Metrics
+    description: Collect Amazon Relational Database Service metrics with Elastic Agent
     data_streams:
       - rds
     categories:
@@ -360,8 +360,8 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: s3
-    title: AWS S3
-    description: Collect logs and metrics from Amazon Simple Storage Service with Elastic Agent
+    title: Amazon S3 monitoring
+    description: Collect server access logs, storage & request metrics for Amazon S3 with Elastic Agent
     data_streams:
       - s3_daily_storage
       - s3_request
@@ -393,8 +393,8 @@ policy_templates:
         size: 1684x897
         type: image/png
   - name: s3_storage_lens
-    title: AWS S3 Storage Lens
-    description: Collect S3 Storage Lens metrics with Elastic Agent
+    title: Amazon S3 Storage Lens
+    description: Collect Amazon S3 Storage Lens metrics with Elastic Agent
     data_streams:
       - s3_storage_lens
     categories:
@@ -415,8 +415,8 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: sns
-    title: AWS SNS Metrics
-    description: Collect SNS metrics with Elastic Agent
+    title: Amazon SNS Metrics
+    description: Collect Amazon SNS metrics with Elastic Agent
     data_streams:
       - sns
     inputs:
@@ -435,8 +435,8 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: sqs
-    title: AWS SQS Metrics
-    description: Collect SQS metrics with Elastic Agent
+    title: Amazon SQS Metrics
+    description: Collect Amazon SQS metrics with Elastic Agent
     data_streams:
       - sqs
     inputs:
@@ -487,8 +487,8 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: vpcflow
-    title: AWS VPC Flow Logs
-    description: Collect VPC flow logs from Amazon Web Services with Elastic Agent
+    title: Amazon VPC Flow Logs
+    description: Collect Amazon VPC flow logs with Elastic Agent
     data_streams:
       - vpcflow
     categories:
@@ -509,7 +509,7 @@ policy_templates:
         size: 32x32
         type: image/svg+xml
   - name: vpn
-    title: AWS VPN Metrics
+    title: Amazon VPN Metrics
     description: Collect VPN metrics with Elastic Agent
     data_streams:
       - vpn
@@ -564,8 +564,8 @@ policy_templates:
         size: 32x40
         type: image/svg+xml
   - name: cloudfront
-    title: AWS CloudFront
-    description: Collect AWS CloudFront logs with Elastic Agent
+    title: Amazon CloudFront
+    description: Collect Amazon CloudFront logs with Elastic Agent
     data_streams:
       - cloudfront_logs
     inputs:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -76,7 +76,7 @@ vars:
     description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
 policy_templates:
   - name: billing
-    title: AWS Billing Metrics
+    title: AWS Billing
     description: Collect billing metrics with Elastic Agent
     data_streams:
       - billing
@@ -96,7 +96,7 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: cloudtrail
-    title: AWS Cloudtrail Logs
+    title: AWS Cloudtrail
     description: Collect AWS Cloudtrail logs with Elastic Agent
     data_streams:
       - cloudtrail
@@ -150,7 +150,7 @@ policy_templates:
         size: 32x32
         type: image/svg+xml
   - name: dynamodb
-    title: Amazon DynamoDB Metrics
+    title: Amazon DynamoDB
     description: Collect Amazon DynamoDB metrics with Elastic Agent
     data_streams:
       - dynamodb
@@ -172,7 +172,7 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: ebs
-    title: Amazon EBS Metrics
+    title: Amazon EBS
     description: Collect Amazon Elastic Block Storage metrics with Elastic Agent
     data_streams:
       - ebs
@@ -258,7 +258,7 @@ policy_templates:
         size: 1684x897
         type: image/png
   - name: lambda
-    title: AWS Lambda Metrics
+    title: AWS Lambda
     description: Collect Lambda metrics with Elastic Agent
     data_streams:
       - lambda
@@ -278,7 +278,7 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: natgateway
-    title: Amazon NAT Gateway Metrics
+    title: Amazon NAT Gateway
     description: Collect Amazon NAT Gateways metrics with Elastic Agent
     data_streams:
       - natgateway
@@ -338,7 +338,7 @@ policy_templates:
         size: 1366x1274
         type: image/png
   - name: rds
-    title: Amazon RDS Metrics
+    title: Amazon RDS
     description: Collect Amazon Relational Database Service metrics with Elastic Agent
     data_streams:
       - rds
@@ -360,8 +360,8 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: s3
-    title: Amazon S3 monitoring
-    description: Collect server access logs, storage & request metrics for Amazon S3 with Elastic Agent
+    title: Amazon S3
+    description: Monitor Amazon S3 buckets by collecting access logs, storage & request metrics with Elastic Agent
     data_streams:
       - s3_daily_storage
       - s3_request
@@ -415,7 +415,7 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: sns
-    title: Amazon SNS Metrics
+    title: Amazon SNS
     description: Collect Amazon SNS metrics with Elastic Agent
     data_streams:
       - sns
@@ -435,7 +435,7 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: sqs
-    title: Amazon SQS Metrics
+    title: Amazon SQS
     description: Collect Amazon SQS metrics with Elastic Agent
     data_streams:
       - sqs
@@ -455,7 +455,7 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: transitgateway
-    title: AWS Transit Gateway Metrics
+    title: AWS Transit Gateway
     description: Collect AWS Transit Gateways metrics with Elastic Agent
     data_streams:
       - transitgateway
@@ -472,7 +472,7 @@ policy_templates:
         size: 32x32
         type: image/svg+xml
   - name: usage
-    title: AWS Usage Metrics
+    title: AWS Usage
     description: Collect AWS usage metrics with Elastic Agent
     data_streams:
       - usage
@@ -487,7 +487,7 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: vpcflow
-    title: Amazon VPC Flow Logs
+    title: Amazon VPC
     description: Collect Amazon VPC flow logs with Elastic Agent
     data_streams:
       - vpcflow
@@ -509,7 +509,7 @@ policy_templates:
         size: 32x32
         type: image/svg+xml
   - name: vpn
-    title: Amazon VPN Metrics
+    title: Amazon VPN
     description: Collect VPN metrics with Elastic Agent
     data_streams:
       - vpn
@@ -526,7 +526,7 @@ policy_templates:
         size: 32x32
         type: image/svg+xml
   - name: waf
-    title: AWS WAF Logs
+    title: AWS WAF
     description: Collect AWS WAF logs with Elastic Agent
     data_streams:
       - waf


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR changes `s3` integration tile's title and description to better explain what this integration does.
Also several services in AWS should be called Amazon XXX instead of AWS XXX. For example, S3, RDS, EC2 and etc.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/3237

## Screenshots
<img width="1235" alt="Screen Shot 2022-04-29 at 2 46 41 PM" src="https://user-images.githubusercontent.com/14081635/166067058-03e76320-61db-4ce7-9e15-07c4391f54eb.png">



