### PR TITLE
Send dataYaml (Rules Activation YAML) to Agent

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.8"
+  changes:
+    - description: Send dataYaml (Rules Activation YAML) to cloudbeat
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3241
 - version: "0.0.7"
   changes:
     - description: Add rule template assets

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/stream.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/stream.yml.hbs
@@ -1,2 +1,4 @@
+name: Findings
+data_yaml: {{dataYaml}}
 processors:
   - add_cluster_id: ~

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "CIS Kubernetes Benchmark"
-version: 0.0.7
+version: 0.0.8
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

The information in `dataYaml` var (which is functionally the Rules Activation YAML) is sent to cloudbeat via the Agent policy, where it can be consumed for cloudbeat to know which rules to run.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Within the package directory,
```
elastic-package build
elastic-package up
```

Create an Agent policy and view its full contents. Changes made to the `dataYaml` var will be reflected as data stream input in the Agent policy.