### PR TITLE
Fix aws.dimensions.* for rds data stream

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.7"
+  changes:
+    - description: Fix aws.dimensions.* for rds data stream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3253
 - version: "1.14.6"
   changes:
     - description: Improve s3 integration tile title and description

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -4,6 +4,12 @@
     - description: Fix aws.dimensions.* for rds data stream
       type: bugfix
       link: https://github.com/elastic/integrations/pull/3253
+    - description: Fix aws.dimensions.* for sns data stream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3253
+    - description: Add aws.dimensions.* for dynamodb data stream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3253
 - version: "1.14.6"
   changes:
     - description: Improve s3 integration tile title and description

--- a/packages/aws/data_stream/dynamodb/fields/fields.yml
+++ b/packages/aws/data_stream/dynamodb/fields/fields.yml
@@ -1,115 +1,145 @@
-- name: aws.dynamodb
+- name: aws
   type: group
   fields:
-    - name: metrics
+    - name: dimensions
       type: group
       fields:
-        - name: SuccessfulRequestLatency
+        - name: DelegatedOperation
+          type: keyword
+          description: This dimension limits the data to operations DynamoDB performs on your behalf.
+        - name: GlobalSecondaryIndexName
+          type: keyword
+          description: This dimension limits the data to a global secondary index on a table.
+        - name: Operation
+          type: keyword
+          description: This dimension limits the data to one of the DynamoDB operations, such as PutItem, DeleteItem, UpdateItem, etc.
+        - name: OperationType
+          type: keyword
+          description: This dimension limits the data to operation type Read and Write.
+        - name: Verb
+          type: keyword
+          description: This dimension limits the data to one of the DynamoDB PartiQL verbs.
+        - name: ReceivingRegion
+          type: keyword
+          description: This dimension limits the data to a particular AWS region.
+        - name: StreamLabel
+          type: keyword
+          description: This dimension limits the data to a specific stream label.
+        - name: TableName
+          type: keyword
+          description: This dimension limits the data to a specific table.
+    - name: dynamodb
+      type: group
+      fields:
+        - name: metrics
           type: group
           fields:
-            - name: avg
+            - name: SuccessfulRequestLatency
+              type: group
+              fields:
+                - name: avg
+                  type: double
+                - name: max
+                  type: double
+            - name: OnlineIndexPercentageProgress.avg
               type: double
-            - name: max
+              description: |
+                The percentage of completion when a new global secondary index is being added to a table.
+            - name: ProvisionedWriteCapacityUnits.avg
               type: double
-        - name: OnlineIndexPercentageProgress.avg
-          type: double
-          description: |
-            The percentage of completion when a new global secondary index is being added to a table.
-        - name: ProvisionedWriteCapacityUnits.avg
-          type: double
-          description: |
-            The number of provisioned write capacity units for a table or a global secondary index.
-        - name: ProvisionedReadCapacityUnits.avg
-          type: double
-          description: |
-            The number of provisioned read capacity units for a table or a global secondary index.
-        - name: ConsumedReadCapacityUnits
-          type: group
-          fields:
-            - name: avg
+              description: |
+                The number of provisioned write capacity units for a table or a global secondary index.
+            - name: ProvisionedReadCapacityUnits.avg
               type: double
-            - name: sum
+              description: |
+                The number of provisioned read capacity units for a table or a global secondary index.
+            - name: ConsumedReadCapacityUnits
+              type: group
+              fields:
+                - name: avg
+                  type: double
+                - name: sum
+                  type: long
+            - name: ConsumedWriteCapacityUnits
+              type: group
+              fields:
+                - name: avg
+                  type: double
+                - name: sum
+                  type: long
+            - name: ReplicationLatency
+              type: group
+              fields:
+                - name: avg
+                  type: double
+                - name: max
+                  type: double
+            - name: TransactionConflict
+              type: group
+              fields:
+                - name: avg
+                  type: double
+                - name: sum
+                  type: long
+            - name: AccountProvisionedReadCapacityUtilization.avg
+              type: double
+              description: |
+                The average percentage of provisioned read capacity units utilized by the account.
+            - name: AccountProvisionedWriteCapacityUtilization.avg
+              type: double
+              description: |
+                The average percentage of provisioned write capacity units utilized by the account.
+            - name: SystemErrors.sum
               type: long
-        - name: ConsumedWriteCapacityUnits
-          type: group
-          fields:
-            - name: avg
-              type: double
-            - name: sum
+              description: |
+                The requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 500 status code during the specified time period.
+            - name: ConditionalCheckFailedRequests.sum
               type: long
-        - name: ReplicationLatency
-          type: group
-          fields:
-            - name: avg
-              type: double
-            - name: max
-              type: double
-        - name: TransactionConflict
-          type: group
-          fields:
-            - name: avg
-              type: double
-            - name: sum
+              description: |
+                The number of failed attempts to perform conditional writes.
+            - name: PendingReplicationCount.sum
               type: long
-        - name: AccountProvisionedReadCapacityUtilization.avg
-          type: double
-          description: |
-            The average percentage of provisioned read capacity units utilized by the account.
-        - name: AccountProvisionedWriteCapacityUtilization.avg
-          type: double
-          description: |
-            The average percentage of provisioned write capacity units utilized by the account.
-        - name: SystemErrors.sum
-          type: long
-          description: |
-            The requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 500 status code during the specified time period.
-        - name: ConditionalCheckFailedRequests.sum
-          type: long
-          description: |
-            The number of failed attempts to perform conditional writes.
-        - name: PendingReplicationCount.sum
-          type: long
-          description: |
-            The number of item updates that are written to one replica table, but that have not yet been written to another replica in the global table.
-        - name: ReadThrottleEvents.sum
-          type: long
-          description: |
-            Requests to DynamoDB that exceed the provisioned read capacity units for a table or a global secondary index.
-        - name: ThrottledRequests.sum
-          type: long
-          description: |
-            Requests to DynamoDB that exceed the provisioned throughput limits on a resource (such as a table or an index).
-        - name: WriteThrottleEvents.sum
-          type: long
-          description: |
-            Requests to DynamoDB that exceed the provisioned write capacity units for a table or a global secondary index.
-        - name: AccountMaxReads.max
-          type: long
-          description: |
-            The maximum number of read capacity units that can be used by an account. This limit does not apply to on-demand tables or global secondary indexes.
-        - name: AccountMaxTableLevelReads.max
-          type: long
-          description: |
-            The maximum number of read capacity units that can be used by a table or global secondary index of an account. For on-demand tables this limit caps the maximum read request units a table or a global secondary index can use.
-        - name: AccountMaxTableLevelWrites.max
-          type: long
-          description: |
-            The maximum number of write capacity units that can be used by a table or global secondary index of an account. For on-demand tables this limit caps the maximum write request units a table or a global secondary index can use.
-        - name: AccountMaxWrites.max
-          type: long
-          description: |
-            The maximum number of write capacity units that can be used by an account. This limit does not apply to on-demand tables or global secondary indexes.
-        - name: MaxProvisionedTableReadCapacityUtilization.max
-          type: double
-          description: |
-            The percentage of provisioned read capacity units utilized by the highest provisioned read table or global secondary index of an account.
-        - name: MaxProvisionedTableWriteCapacityUtilization.max
-          type: double
-          description: |
-            The percentage of provisioned write capacity utilized by the highest provisioned write table or global secondary index of an account.
-- name: aws.cloudwatch
-  type: group
-  fields:
-    - name: namespace
-      type: keyword
-      description: The namespace specified when query cloudwatch api.
+              description: |
+                The number of item updates that are written to one replica table, but that have not yet been written to another replica in the global table.
+            - name: ReadThrottleEvents.sum
+              type: long
+              description: |
+                Requests to DynamoDB that exceed the provisioned read capacity units for a table or a global secondary index.
+            - name: ThrottledRequests.sum
+              type: long
+              description: |
+                Requests to DynamoDB that exceed the provisioned throughput limits on a resource (such as a table or an index).
+            - name: WriteThrottleEvents.sum
+              type: long
+              description: |
+                Requests to DynamoDB that exceed the provisioned write capacity units for a table or a global secondary index.
+            - name: AccountMaxReads.max
+              type: long
+              description: |
+                The maximum number of read capacity units that can be used by an account. This limit does not apply to on-demand tables or global secondary indexes.
+            - name: AccountMaxTableLevelReads.max
+              type: long
+              description: |
+                The maximum number of read capacity units that can be used by a table or global secondary index of an account. For on-demand tables this limit caps the maximum read request units a table or a global secondary index can use.
+            - name: AccountMaxTableLevelWrites.max
+              type: long
+              description: |
+                The maximum number of write capacity units that can be used by a table or global secondary index of an account. For on-demand tables this limit caps the maximum write request units a table or a global secondary index can use.
+            - name: AccountMaxWrites.max
+              type: long
+              description: |
+                The maximum number of write capacity units that can be used by an account. This limit does not apply to on-demand tables or global secondary indexes.
+            - name: MaxProvisionedTableReadCapacityUtilization.max
+              type: double
+              description: |
+                The percentage of provisioned read capacity units utilized by the highest provisioned read table or global secondary index of an account.
+            - name: MaxProvisionedTableWriteCapacityUtilization.max
+              type: double
+              description: |
+                The percentage of provisioned write capacity utilized by the highest provisioned write table or global secondary index of an account.
+    - name: cloudwatch
+      type: group
+      fields:
+        - name: namespace
+          type: keyword
+          description: The namespace specified when query cloudwatch api.

--- a/packages/aws/data_stream/rds/fields/fields.yml
+++ b/packages/aws/data_stream/rds/fields/fields.yml
@@ -10,12 +10,9 @@
         - name: DBClusterIdentifier
           type: keyword
           description: This dimension filters the data that you request for a specific Amazon Aurora DB cluster.
-        - name: DBClusterIdentifier,Role
+        - name: Role
           type: keyword
-          description: This dimension filters the data that you request for a specific Aurora DB cluster, aggregating the metric by instance role (WRITER/READER).
-        - name: DbClusterIdentifier, EngineName
-          type: keyword
-          description: This dimension filters the data that you request for a specific Aurora DB cluster, aggregating the metric by engine name.
+          description: This dimension filters the data that you request by instance role (WRITER/READER).
         - name: DatabaseClass
           type: keyword
           description: This dimension filters the data that you request for all instances in a database class.

--- a/packages/aws/data_stream/rds/sample_event.json
+++ b/packages/aws/data_stream/rds/sample_event.json
@@ -1,89 +1,101 @@
 {
-    "@timestamp": "2020-05-28T17:58:34.537Z",
+    "@timestamp": "2022-04-29T22:06:00.000Z",
     "ecs": {
-        "version": "1.5.0"
-    },
-    "service": {
-        "type": "aws"
-    },
-    "aws": {
-        "rds": {
-            "latency": {
-                "dml": 0,
-                "insert": 0,
-                "update": 0,
-                "commit": 0,
-                "ddl": 0,
-                "delete": 0,
-                "select": 0.21927814569536422
-            },
-            "queries": 6.197934021992669,
-            "aurora_bin_log_replica_lag": 0,
-            "transactions": {
-                "blocked": 0,
-                "active": 0
-            },
-            "deadlocks": 0,
-            "login_failures": 0,
-            "throughput": {
-                "network": 1.399813358218904,
-                "insert": 0,
-                "ddl": 0,
-                "select": 2.5165408396246853,
-                "delete": 0,
-                "commit": 0,
-                "network_transmit": 0.699906679109452,
-                "update": 0,
-                "dml": 0,
-                "network_receive": 0.699906679109452
-            },
-            "cpu": {
-                "total": {
-                    "pct": 0.03
-                }
-            },
-            "db_instance": {
-                "arn": "arn:aws:rds:eu-west-1:428152502467:db:database-1-instance-1-eu-west-1a",
-                "class": "db.r5.large",
-                "identifier": "database-1-instance-1-eu-west-1a",
-                "status": "available"
-            },
-            "cache_hit_ratio.result_set": 0,
-            "aurora_replica.lag.ms": 19.576,
-            "free_local_storage.bytes": 32431271936,
-            "cache_hit_ratio.buffer": 100,
-            "disk_usage": {
-                "bin_log.bytes": 0
-            },
-            "db_instance.identifier": "database-1-instance-1-eu-west-1a",
-            "freeable_memory.bytes": 4436537344,
-            "engine_uptime.sec": 10463030,
-            "database_connections": 0
-        }
-    },
-    "cloud": {
-        "provider": "aws",
-        "region": "eu-west-1",
-        "account": {
-            "id": "428152502467",
-            "name": "elastic-beats"
-        },
-        "availability_zone": "eu-west-1a"
-    },
-    "event": {
-        "dataset": "aws.rds",
-        "module": "aws",
-        "duration": 10777919184
+        "version": "8.0.0"
     },
     "metricset": {
         "name": "rds",
         "period": 60000
     },
-    "agent": {
-        "name": "MacBook-Elastic.local",
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b",
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30"
+    "service": {
+        "type": "aws"
+    },
+    "cloud": {
+        "provider": "aws",
+        "region": "us-east-1",
+        "account": {
+            "name": "test",
+            "id": "123456789"
+        }
+    },
+    "aws": {
+        "rds": {
+            "free_local_storage": {
+                "bytes": 26268446720
+            },
+            "aurora_replica": {
+                "lag_max": {
+                    "ms": 20.304000854492188
+                },
+                "lag_min": {
+                    "ms": 20.304000854492188
+                }
+            },
+            "engine_uptime": {
+                "sec": 49034043.5
+            },
+            "throughput": {
+                "dml": 0.49996361679093426,
+                "network": 1.4025011270098342,
+                "network_transmit": 0.7012505635049171,
+                "update": 0,
+                "ddl": 0,
+                "delete": 0,
+                "insert": 0.49996361679093426,
+                "network_receive": 0.7012505635049171,
+                "select": 3.191082392137672,
+                "commit": 0.49996361679093426
+            },
+            "deadlocks": 0,
+            "aurora_volume_left_total": {
+                "bytes": 70007366615040
+            },
+            "database_connections": 0,
+            "freeable_memory": {
+                "bytes": 4668841984
+            },
+            "swap_usage": {
+                "bytes": 0
+            },
+            "queries": 9.079938078523146,
+            "latency": {
+                "write": 0.0011471449704016914,
+                "delete": 0,
+                "commit": 7.523700000000001,
+                "ddl": 0,
+                "dml": 0.19436666666666666,
+                "select": 0.23795217035217037,
+                "insert": 0.19436666666666666,
+                "read": 0,
+                "update": 0
+            },
+            "transactions": {
+                "active": 0,
+                "blocked": 0
+            },
+            "login_failures": 0,
+            "aurora_bin_log_replica_lag": 0,
+            "cache_hit_ratio": {
+                "result_set": 0,
+                "buffer": 100
+            }
+        },
+        "cloudwatch": {
+            "namespace": "AWS/RDS"
+        },
+        "dimensions": {
+            "Role": "WRITER",
+            "DBClusterIdentifier": "database-1"
+        },
+        "tags": {
+            "cluster": "database-1",
+            "dept": "eng",
+            "created-by": "ks"
+        }
+    },
+    "event": {
+        "duration": 23004180977,
+        "dataset": "aws.rds",
+        "module": "aws"
     }
 }

--- a/packages/aws/data_stream/sns/fields/fields.yml
+++ b/packages/aws/data_stream/sns/fields/fields.yml
@@ -7,9 +7,6 @@
         - name: Application
           type: keyword
           description: Filters on application objects, which represent an app and device registered with one of the supported push notification services, such as APNs and FCM.
-        - name: Application,Platform
-          type: keyword
-          description: Filters on application and platform objects, where the platform objects are for the supported push notification services, such as APNs and FCM.
         - name: Country
           type: keyword
           description: Filters on the destination country or region of an SMS message.

--- a/packages/aws/docs/dynamodb.md
+++ b/packages/aws/docs/dynamodb.md
@@ -74,6 +74,14 @@ An example event for `dynamodb` looks as following:
 | aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.\* | Metric dimensions. | object |
+| aws.dimensions.DelegatedOperation | This dimension limits the data to operations DynamoDB performs on your behalf. | keyword |
+| aws.dimensions.GlobalSecondaryIndexName | This dimension limits the data to a global secondary index on a table. | keyword |
+| aws.dimensions.Operation | This dimension limits the data to one of the DynamoDB operations, such as PutItem, DeleteItem, UpdateItem, etc. | keyword |
+| aws.dimensions.OperationType | This dimension limits the data to operation type Read and Write. | keyword |
+| aws.dimensions.ReceivingRegion | This dimension limits the data to a particular AWS region. | keyword |
+| aws.dimensions.StreamLabel | This dimension limits the data to a specific stream label. | keyword |
+| aws.dimensions.TableName | This dimension limits the data to a specific table. | keyword |
+| aws.dimensions.Verb | This dimension limits the data to one of the DynamoDB PartiQL verbs. | keyword |
 | aws.dynamodb.metrics.AccountMaxReads.max | The maximum number of read capacity units that can be used by an account. This limit does not apply to on-demand tables or global secondary indexes. | long |
 | aws.dynamodb.metrics.AccountMaxTableLevelReads.max | The maximum number of read capacity units that can be used by a table or global secondary index of an account. For on-demand tables this limit caps the maximum read request units a table or a global secondary index can use. | long |
 | aws.dynamodb.metrics.AccountMaxTableLevelWrites.max | The maximum number of write capacity units that can be used by a table or global secondary index of an account. For on-demand tables this limit caps the maximum write request units a table or a global secondary index can use. | long |
@@ -106,7 +114,7 @@ An example event for `dynamodb` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |

--- a/packages/aws/docs/rds.md
+++ b/packages/aws/docs/rds.md
@@ -6,92 +6,104 @@ An example event for `rds` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-05-28T17:58:34.537Z",
+    "@timestamp": "2022-04-29T22:06:00.000Z",
     "ecs": {
-        "version": "1.5.0"
-    },
-    "service": {
-        "type": "aws"
-    },
-    "aws": {
-        "rds": {
-            "latency": {
-                "dml": 0,
-                "insert": 0,
-                "update": 0,
-                "commit": 0,
-                "ddl": 0,
-                "delete": 0,
-                "select": 0.21927814569536422
-            },
-            "queries": 6.197934021992669,
-            "aurora_bin_log_replica_lag": 0,
-            "transactions": {
-                "blocked": 0,
-                "active": 0
-            },
-            "deadlocks": 0,
-            "login_failures": 0,
-            "throughput": {
-                "network": 1.399813358218904,
-                "insert": 0,
-                "ddl": 0,
-                "select": 2.5165408396246853,
-                "delete": 0,
-                "commit": 0,
-                "network_transmit": 0.699906679109452,
-                "update": 0,
-                "dml": 0,
-                "network_receive": 0.699906679109452
-            },
-            "cpu": {
-                "total": {
-                    "pct": 0.03
-                }
-            },
-            "db_instance": {
-                "arn": "arn:aws:rds:eu-west-1:428152502467:db:database-1-instance-1-eu-west-1a",
-                "class": "db.r5.large",
-                "identifier": "database-1-instance-1-eu-west-1a",
-                "status": "available"
-            },
-            "cache_hit_ratio.result_set": 0,
-            "aurora_replica.lag.ms": 19.576,
-            "free_local_storage.bytes": 32431271936,
-            "cache_hit_ratio.buffer": 100,
-            "disk_usage": {
-                "bin_log.bytes": 0
-            },
-            "db_instance.identifier": "database-1-instance-1-eu-west-1a",
-            "freeable_memory.bytes": 4436537344,
-            "engine_uptime.sec": 10463030,
-            "database_connections": 0
-        }
-    },
-    "cloud": {
-        "provider": "aws",
-        "region": "eu-west-1",
-        "account": {
-            "id": "428152502467",
-            "name": "elastic-beats"
-        },
-        "availability_zone": "eu-west-1a"
-    },
-    "event": {
-        "dataset": "aws.rds",
-        "module": "aws",
-        "duration": 10777919184
+        "version": "8.0.0"
     },
     "metricset": {
         "name": "rds",
         "period": 60000
     },
-    "agent": {
-        "name": "MacBook-Elastic.local",
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b",
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30"
+    "service": {
+        "type": "aws"
+    },
+    "cloud": {
+        "provider": "aws",
+        "region": "us-east-1",
+        "account": {
+            "name": "test",
+            "id": "123456789"
+        }
+    },
+    "aws": {
+        "rds": {
+            "free_local_storage": {
+                "bytes": 26268446720
+            },
+            "aurora_replica": {
+                "lag_max": {
+                    "ms": 20.304000854492188
+                },
+                "lag_min": {
+                    "ms": 20.304000854492188
+                }
+            },
+            "engine_uptime": {
+                "sec": 49034043.5
+            },
+            "throughput": {
+                "dml": 0.49996361679093426,
+                "network": 1.4025011270098342,
+                "network_transmit": 0.7012505635049171,
+                "update": 0,
+                "ddl": 0,
+                "delete": 0,
+                "insert": 0.49996361679093426,
+                "network_receive": 0.7012505635049171,
+                "select": 3.191082392137672,
+                "commit": 0.49996361679093426
+            },
+            "deadlocks": 0,
+            "aurora_volume_left_total": {
+                "bytes": 70007366615040
+            },
+            "database_connections": 0,
+            "freeable_memory": {
+                "bytes": 4668841984
+            },
+            "swap_usage": {
+                "bytes": 0
+            },
+            "queries": 9.079938078523146,
+            "latency": {
+                "write": 0.0011471449704016914,
+                "delete": 0,
+                "commit": 7.523700000000001,
+                "ddl": 0,
+                "dml": 0.19436666666666666,
+                "select": 0.23795217035217037,
+                "insert": 0.19436666666666666,
+                "read": 0,
+                "update": 0
+            },
+            "transactions": {
+                "active": 0,
+                "blocked": 0
+            },
+            "login_failures": 0,
+            "aurora_bin_log_replica_lag": 0,
+            "cache_hit_ratio": {
+                "result_set": 0,
+                "buffer": 100
+            }
+        },
+        "cloudwatch": {
+            "namespace": "AWS/RDS"
+        },
+        "dimensions": {
+            "Role": "WRITER",
+            "DBClusterIdentifier": "database-1"
+        },
+        "tags": {
+            "cluster": "database-1",
+            "dept": "eng",
+            "created-by": "ks"
+        }
+    },
+    "event": {
+        "duration": 23004180977,
+        "dataset": "aws.rds",
+        "module": "aws"
     }
 }
 ```
@@ -105,11 +117,10 @@ An example event for `rds` looks as following:
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.\* | Metric dimensions. | object |
 | aws.dimensions.DBClusterIdentifier | This dimension filters the data that you request for a specific Amazon Aurora DB cluster. | keyword |
-| aws.dimensions.DBClusterIdentifier,Role | This dimension filters the data that you request for a specific Aurora DB cluster, aggregating the metric by instance role (WRITER/READER). | keyword |
 | aws.dimensions.DBInstanceIdentifier | This dimension filters the data that you request for a specific DB instance. | keyword |
 | aws.dimensions.DatabaseClass | This dimension filters the data that you request for all instances in a database class. | keyword |
-| aws.dimensions.DbClusterIdentifier, EngineName | This dimension filters the data that you request for a specific Aurora DB cluster, aggregating the metric by engine name. | keyword |
 | aws.dimensions.EngineName | This dimension filters the data that you request for the identified engine name only. | keyword |
+| aws.dimensions.Role | This dimension filters the data that you request by instance role (WRITER/READER). | keyword |
 | aws.dimensions.SourceRegion | This dimension filters the data that you request for the specified region only. | keyword |
 | aws.rds.aurora_bin_log_replica_lag | The amount of time a replica DB cluster running on Aurora with MySQL compatibility lags behind the source DB cluster. | long |
 | aws.rds.aurora_global_db.data_transfer.bytes | In an Aurora Global Database, the amount of redo log data transferred from the master AWS Region to a secondary AWS Region. | long |

--- a/packages/aws/docs/sns.md
+++ b/packages/aws/docs/sns.md
@@ -73,7 +73,6 @@ An example event for `sns` looks as following:
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.\* | Metric dimensions. | object |
 | aws.dimensions.Application | Filters on application objects, which represent an app and device registered with one of the supported push notification services, such as APNs and FCM. | keyword |
-| aws.dimensions.Application,Platform | Filters on application and platform objects, where the platform objects are for the supported push notification services, such as APNs and FCM. | keyword |
 | aws.dimensions.Country | Filters on the destination country or region of an SMS message. | keyword |
 | aws.dimensions.Platform | Filters on platform objects for the push notification services, such as APNs and FCM. | keyword |
 | aws.dimensions.SMSType | Filters on the message type of SMS message. | keyword |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.14.6
+version: 1.14.7
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix the RDS dimension fields in fields.yml file. When collecting dimension information from CloudWatch, if there are more than one dimension key, these keys are separated into different dimensions with their own entries. For example: dimension `DBClusterIdentifier, Role` will separate into `aws.dimesnions.DBClusterIdentifier` and `aws.dimensions.Role`. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
