### PR TITLE
Add skip_major option to docker/diskio

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,5 +1,9 @@
 # newer versions go on top
-
+- version: "2.2.0"
+  changes:
+    - description: Add skip_major flag
+      type: bugfix
+      link: http://github.com/elastic/integrations/pull/3254
 - version: "2.1.1"
   changes:
     - description: Fix missing dedot options

--- a/packages/docker/data_stream/diskio/agent/stream/stream.yml.hbs
+++ b/packages/docker/data_stream/diskio/agent/stream/stream.yml.hbs
@@ -6,6 +6,7 @@ hosts:
 period: {{period}}
 labels.dedot: {{labels.dedot}}
 skip_major:
+{{#if skip_major}}
 {{#each skip_major}}
 - {{this}}
 {{/each}}

--- a/packages/docker/data_stream/diskio/agent/stream/stream.yml.hbs
+++ b/packages/docker/data_stream/diskio/agent/stream/stream.yml.hbs
@@ -5,3 +5,8 @@ hosts:
 {{/each}}
 period: {{period}}
 labels.dedot: {{labels.dedot}}
+skip_major:
+{{#each skip_major}}
+- {{this}}
+{{/each}}
+{{/if}}

--- a/packages/docker/data_stream/diskio/agent/stream/stream.yml.hbs
+++ b/packages/docker/data_stream/diskio/agent/stream/stream.yml.hbs
@@ -5,8 +5,8 @@ hosts:
 {{/each}}
 period: {{period}}
 labels.dedot: {{labels.dedot}}
-skip_major:
 {{#if skip_major}}
+skip_major:
 {{#each skip_major}}
 - {{this}}
 {{/each}}

--- a/packages/docker/data_stream/diskio/manifest.yml
+++ b/packages/docker/data_stream/diskio/manifest.yml
@@ -18,6 +18,13 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: skip_major
+        type: text
+        title: Skip major device numbers in disk usage calculations
+        multi: true
+        required: false
+        show_user: true
+        default: [9, 253]
       - name: labels.dedot
         type: bool
         title: De-Dot labels

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker Metrics
-version: 2.1.1
+version: 2.2.0
 release: ga
 description: Collect metrics from Docker instances with Elastic Agent.
 type: integration
@@ -20,7 +20,7 @@ categories:
   - containers
   - os_system
 conditions:
-  kibana.version: ^8.0.0
+  kibana.version: ^8.2.0
 policy_templates:
   - name: docker
     title: Docker metrics


### PR DESCRIPTION
## What does this PR do?

This adds A `skip_major` option, in line with what's now supported in metricbeat itself.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
