### PR TITLE
[httpjson] Adds missing  option for Google Oauth2

### DIFF
--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Adds missing `delegated_account` option for Google Oauth2
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/3256
 - version: "1.2.0"
   changes:
     - description: Update ECS to 8.2

--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.1"
+  changes:
+    - description: Adds missing `delegated_account` option for Google Oauth2
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.2.0"
   changes:
     - description: Update ECS to 8.2

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -41,6 +41,9 @@ auth.oauth2.google.credentials_json: '{{oauth_google_credentials_json}}'
 {{#if oauth_google_jwt_file}}
 auth.oauth2.google.jwt_file: {{oauth_google_jwt_file}}
 {{/if}}
+{{#if oauth_google_delegated_account}}
+auth.oauth2.google.delegated_account: {{oauth_google_delegated_account}}
+{{/if}}
 {{#if oauth_azure_tenant_id}}
 auth.oauth2.azure.tenant_id: {{oauth_azure_tenant_id}}
 {{/if}}

--- a/packages/httpjson/data_stream/generic/manifest.yml
+++ b/packages/httpjson/data_stream/generic/manifest.yml
@@ -273,6 +273,13 @@ streams:
         show_user: false
         multi: false
         required: false
+      - name: oauth_google_delegated_account
+        type: text
+        title: Oauth2 Google Delegated account
+        description: Email of the admin user used to access the API.
+        show_user: false
+        multi: false
+        required: false
       - name: oauth_azure_tenant_id
         type: text
         title: Oauth2 Azure Tenant ID

--- a/packages/httpjson/data_stream/generic/manifest.yml
+++ b/packages/httpjson/data_stream/generic/manifest.yml
@@ -276,7 +276,7 @@ streams:
       - name: oauth_google_delegated_account
         type: text
         title: Oauth2 Google Delegated account
-        description: Email of the admin user used to access the API.
+        description: Email of the delegated account used to create the credentials (usually an admin).
         show_user: false
         multi: false
         required: false

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -3,7 +3,7 @@ name: httpjson
 title: Custom HTTPJSON Input
 description: Collect custom data from REST API's with Elastic Agent.
 type: integration
-version: 1.2.0
+version: 1.2.1
 release: ga
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds missing option for the Google oauth2 config

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
