### PR TITLE
[GCP] Add missing `cloud.provider` field to GCP datastreams

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.2"
+  changes:
+    - description: Add missing `cloud.provider` field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.6.1"
   changes:
     - description: Clarify the GCP privileges required by the Pub/Sub input.

--- a/packages/gcp/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/gcp/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -5,7 +5,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-beats"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -63,7 +64,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-beats"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -144,7 +146,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-beats"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -237,7 +240,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-beats"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -321,7 +325,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-siem"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -405,7 +410,8 @@
             "cloud": {
                 "project": {
                     "id": "foo"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -506,7 +512,8 @@
                 },
                 "project": {
                     "id": "foo"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -582,7 +589,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-siem"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -650,7 +658,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-siem"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -718,7 +727,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-siem"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -786,7 +796,8 @@
             "cloud": {
                 "project": {
                     "id": "elastic-siem"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -857,7 +868,8 @@
             "cloud": {
                 "project": {
                     "id": "project"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"
@@ -922,7 +934,8 @@
             "cloud": {
                 "project": {
                     "id": "project"
-                }
+                },
+                "provider": "gcp"
             },
             "ecs": {
                 "version": "8.2.0"

--- a/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,9 @@ processors:
   - set:
       field: event.kind
       value: event
+  - set:
+      field: cloud.provider
+      value: gcp
   - date:
       field: json.timestamp
       timezone: UTC

--- a/packages/gcp/data_stream/dns/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/gcp/data_stream/dns/_dev/test/pipeline/test-dns.log-expected.json
@@ -11,6 +11,7 @@
                 "project": {
                     "id": "project"
                 },
+                "provider": "gcp",
                 "region": "europe-west2"
             },
             "dns": {
@@ -85,6 +86,7 @@
                 "project": {
                     "id": "project"
                 },
+                "provider": "gcp",
                 "region": "europe-west2"
             },
             "dns": {
@@ -159,6 +161,7 @@
                 "project": {
                     "id": "project"
                 },
+                "provider": "gcp",
                 "region": "europe-west2"
             },
             "dns": {
@@ -259,6 +262,7 @@
                 "project": {
                     "id": "project"
                 },
+                "provider": "gcp",
                 "region": "europe-west2"
             },
             "dns": {
@@ -352,6 +356,7 @@
                 "project": {
                     "id": "project"
                 },
+                "provider": "gcp",
                 "region": "europe-west2"
             },
             "dns": {

--- a/packages/gcp/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,9 @@ processors:
   - set:
       field: event.kind
       value: event
+  - set:
+      field: cloud.provider
+      value: gcp
   - date:
       field: json.timestamp
       timezone: UTC

--- a/packages/gcp/data_stream/firewall/_dev/test/pipeline/test-firewall.log-expected.json
+++ b/packages/gcp/data_stream/firewall/_dev/test/pipeline/test-firewall.log-expected.json
@@ -7,6 +7,7 @@
                 "project": {
                     "id": "local-test"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -111,6 +112,7 @@
                 "project": {
                     "id": "local-test"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -215,6 +217,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -314,6 +317,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -408,6 +412,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -505,6 +510,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -600,6 +606,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -695,6 +702,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -792,6 +800,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -889,6 +898,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -986,6 +996,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -1083,6 +1094,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -1180,6 +1192,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -1277,6 +1290,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -1374,6 +1388,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -1473,6 +1488,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -1572,6 +1588,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1679,6 +1696,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1786,6 +1804,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1882,6 +1901,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1989,6 +2009,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -2096,6 +2117,7 @@
                 "project": {
                     "id": "test-beats"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {

--- a/packages/gcp/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -32,6 +32,9 @@ processors:
   - set:
       field: event.action
       value: firewall-rule
+  - set:
+      field: cloud.provider
+      value: gcp
   - rename:
       field: json.logName
       target_field: log.logger

--- a/packages/gcp/data_stream/vpcflow/_dev/test/pipeline/test-vpcflow.log-expected.json
+++ b/packages/gcp/data_stream/vpcflow/_dev/test/pipeline/test-vpcflow.log-expected.json
@@ -2,6 +2,9 @@
     "expected": [
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -88,6 +91,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -190,6 +194,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -287,6 +292,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.23",
                 "as": {
@@ -362,6 +370,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.117",
                 "as": {
@@ -438,6 +449,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -519,6 +533,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -621,6 +636,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -723,6 +739,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -825,6 +842,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -922,6 +940,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -1002,6 +1023,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1104,6 +1126,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1206,6 +1229,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1308,6 +1332,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1410,6 +1435,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1507,6 +1533,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.49.136.133",
                 "domain": "simianhacker-demo",
@@ -1588,6 +1617,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -1674,6 +1706,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1771,6 +1804,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -1857,6 +1893,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -1954,6 +1991,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -2035,6 +2075,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -2121,6 +2164,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -2218,6 +2262,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -2304,6 +2351,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -2406,6 +2454,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -2503,6 +2552,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:10.845Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -2584,6 +2636,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -2667,6 +2722,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -2764,6 +2820,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -2850,6 +2909,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -2952,6 +3012,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -3049,6 +3110,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -3135,6 +3199,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -3237,6 +3302,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -3334,6 +3400,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.117",
                 "as": {
@@ -3410,6 +3479,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -3496,6 +3568,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -3598,6 +3671,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -3695,6 +3769,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -3797,6 +3872,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -3899,6 +3975,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -4001,6 +4078,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -4098,6 +4176,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -4179,6 +4260,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -4260,6 +4344,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -4336,6 +4423,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -4417,6 +4507,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -4503,6 +4596,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -4605,6 +4699,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -4702,6 +4797,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -4799,6 +4895,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -4880,6 +4979,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -4961,6 +5063,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -5037,6 +5142,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.117",
                 "as": {
@@ -5113,6 +5221,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.165",
                 "as": {
@@ -5196,6 +5307,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -5298,6 +5410,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -5395,6 +5508,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:11.981Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -5476,6 +5592,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -5557,6 +5676,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -5643,6 +5765,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -5740,6 +5863,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -5821,6 +5947,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -5907,6 +6036,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -6004,6 +6134,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -6090,6 +6223,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -6192,6 +6326,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -6294,6 +6429,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -6396,6 +6532,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -6493,6 +6630,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -6579,6 +6719,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -6676,6 +6817,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -6762,6 +6906,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -6859,6 +7004,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -6940,6 +7088,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -7021,6 +7172,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -7102,6 +7256,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -7183,6 +7340,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -7264,6 +7424,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -7345,6 +7508,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -7431,6 +7597,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -7533,6 +7700,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -7630,6 +7798,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -7716,6 +7887,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -7813,6 +7985,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -7894,6 +8069,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -7975,6 +8153,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:13.921Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -8061,6 +8242,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -8163,6 +8345,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -8265,6 +8448,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -8367,6 +8551,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -8469,6 +8654,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -8566,6 +8752,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -8668,6 +8855,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -8770,6 +8958,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -8867,6 +9056,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -8969,6 +9159,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -9071,6 +9262,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -9173,6 +9365,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -9275,6 +9468,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -9377,6 +9571,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -9479,6 +9674,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -9581,6 +9777,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -9683,6 +9880,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -9780,6 +9978,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.453Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -9861,6 +10062,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.453Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -9947,6 +10151,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -10049,6 +10254,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -10151,6 +10357,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -10248,6 +10455,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.453Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -10334,6 +10544,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -10431,6 +10642,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.453Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -10512,6 +10726,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.453Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -10598,6 +10815,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -10700,6 +10918,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -10802,6 +11021,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -10899,6 +11119,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.453Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -10985,6 +11208,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -11087,6 +11311,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -11189,6 +11414,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -11291,6 +11517,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -11393,6 +11620,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -11495,6 +11723,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -11592,6 +11821,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -11673,6 +11905,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -11754,6 +11989,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -11835,6 +12073,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -11916,6 +12157,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -12002,6 +12246,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -12099,6 +12344,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -12177,6 +12425,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -12263,6 +12514,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -12360,6 +12612,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -12446,6 +12701,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -12540,6 +12796,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -12621,6 +12880,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -12707,6 +12969,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -12809,6 +13072,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -12906,6 +13170,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -12992,6 +13259,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -13094,6 +13362,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -13191,6 +13460,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:15.857Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -13274,6 +13546,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -13376,6 +13649,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -13470,6 +13744,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -13556,6 +13833,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -13650,6 +13928,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -13731,6 +14012,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -13817,6 +14101,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -13919,6 +14204,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -14016,6 +14302,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -14097,6 +14386,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -14191,6 +14481,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -14277,6 +14570,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -14369,6 +14663,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -14450,6 +14747,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -14531,6 +14831,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -14612,6 +14915,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.117",
                 "as": {
@@ -14693,6 +14999,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -14795,6 +15102,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -14894,6 +15202,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -14991,6 +15300,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -15072,6 +15384,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -15153,6 +15468,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:16.593Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -15239,6 +15557,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -15338,6 +15657,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -15440,6 +15760,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -15539,6 +15860,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -15638,6 +15960,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -15735,6 +16058,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -15832,6 +16156,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -15913,6 +16240,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -15986,6 +16316,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.117",
                 "as": {
@@ -16059,6 +16392,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -16140,6 +16476,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -16218,6 +16557,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -16299,6 +16641,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -16385,6 +16730,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -16482,6 +16828,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -16563,6 +16912,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -16644,6 +16996,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -16725,6 +17080,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -16806,6 +17164,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -16892,6 +17253,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -16989,6 +17351,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -17070,6 +17435,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -17151,6 +17519,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -17232,6 +17603,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -17313,6 +17687,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -17394,6 +17771,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -17475,6 +17855,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -17556,6 +17939,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.291Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -17639,6 +18025,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -17741,6 +18128,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -17843,6 +18231,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -17940,6 +18329,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -18026,6 +18418,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -18128,6 +18521,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -18230,6 +18624,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -18332,6 +18727,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -18429,6 +18825,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -18515,6 +18914,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -18617,6 +19017,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -18714,6 +19115,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.49.136.133",
                 "domain": "simianhacker-demo",
@@ -18795,6 +19199,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -18871,6 +19278,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.12",
                 "as": {
@@ -18951,6 +19361,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -19048,6 +19459,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -19134,6 +19548,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -19231,6 +19646,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -19317,6 +19735,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -19419,6 +19838,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -19511,6 +19931,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.117",
                 "as": {
@@ -19592,6 +20015,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -19694,6 +20118,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -19796,6 +20221,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -19898,6 +20324,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -19995,6 +20422,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -20081,6 +20511,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -20183,6 +20614,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -20285,6 +20717,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -20387,6 +20820,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -20489,6 +20923,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -20586,6 +21021,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -20672,6 +21110,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -20774,6 +21213,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -20876,6 +21316,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -20978,6 +21419,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -21080,6 +21522,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -21182,6 +21625,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -21284,6 +21728,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -21381,6 +21826,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.73.186.17",
                 "domain": "infraops-docker-data",
@@ -21461,6 +21909,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -21563,6 +22012,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -21665,6 +22115,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -21767,6 +22218,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -21864,6 +22316,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -21961,6 +22414,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.553Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -22047,6 +22503,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -22149,6 +22606,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -22251,6 +22709,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -22353,6 +22812,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -22450,6 +22910,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -22536,6 +22999,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -22638,6 +23102,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -22740,6 +23205,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -22842,6 +23308,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -22939,6 +23406,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -23020,6 +23490,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -23101,6 +23574,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -23182,6 +23658,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -23263,6 +23742,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -23344,6 +23826,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -23425,6 +23910,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -23511,6 +23999,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -23608,6 +24097,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -23689,6 +24181,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -23775,6 +24270,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -23872,6 +24368,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -23958,6 +24457,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -24060,6 +24560,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -24162,6 +24663,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -24264,6 +24766,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -24366,6 +24869,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -24463,6 +24967,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -24544,6 +25051,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -24625,6 +25135,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -24711,6 +25224,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -24808,6 +25322,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -24894,6 +25411,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -24991,6 +25509,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:17.763Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -25077,6 +25598,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-central1"
             },
             "destination": {
@@ -25174,6 +25696,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -25255,6 +25780,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.117",
                 "as": {
@@ -25336,6 +25864,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -25433,6 +25962,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -25509,6 +26041,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.117",
                 "as": {
@@ -25585,6 +26120,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -25666,6 +26204,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -25742,6 +26283,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -25823,6 +26367,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -25904,6 +26451,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "192.168.2.73",
                 "as": {
@@ -25982,6 +26532,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -26063,6 +26616,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -26144,6 +26700,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -26225,6 +26784,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -26306,6 +26868,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.13",
                 "as": {
@@ -26387,6 +26952,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.73.186.17",
                 "domain": "infraops-docker-data",
@@ -26465,6 +27033,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.139.99.242",
                 "domain": "elasticsearch",
@@ -26546,6 +27117,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "67.43.156.14",
                 "as": {
@@ -26624,6 +27198,9 @@
         },
         {
             "@timestamp": "2019-06-14T03:50:19.219Z",
+            "cloud": {
+                "provider": "gcp"
+            },
             "destination": {
                 "address": "10.87.40.76",
                 "domain": "kibana",
@@ -26707,6 +27284,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -26809,6 +27387,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {
@@ -26911,6 +27490,7 @@
                 "project": {
                     "id": "my-sample-project"
                 },
+                "provider": "gcp",
                 "region": "us-east1"
             },
             "destination": {

--- a/packages/gcp/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
@@ -37,6 +37,9 @@ processors:
       copy_from: json.insertId
       ignore_empty_value: true
       ignore_failure: true
+  - set:
+      field: cloud.provider
+      value: gcp
   - rename:
       field: json.logName
       target_field: log.logger

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: 1.6.1
+version: 1.6.2
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add missing `cloud.provider` field to GCP datastreams

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3270 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
