### PR TITLE
[elasticsearch] Add `scope` configuration option for metricsets

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Add `scope` configuration option for metricsets
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.2.2"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `scope` configuration option for metricsets
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/3275
 - version: "0.2.2"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+scope: {{scope}}
 {{#if username}}
 username: {{username}}
 {{/if}}

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 0.2.2
+version: 0.3.0
 release: experimental
 description: Elasticsearch Integration
 type: integration
@@ -48,5 +48,16 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+          - name: scope
+            type: text
+            title: Scope
+            description: |
+              By default, scope is set to node and each entry in the hosts list indicates a distinct node in an Elasticsearch cluster. 
+              If you set scope to cluster then each entry in the hosts list indicates a single endpoint for a distinct Elasticsearch cluster (for example, a load-balancing proxy fronting the cluster). 
+              You should use scope: cluster if the cluster has dedicated master nodes, and configure the endpoint in the hosts list not to direct requests to the dedicated master nodes.
+            multi: false
+            required: true
+            show_user: false
+            default: node
 owner:
   github: elastic/infra-monitoring-ui

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -51,11 +51,8 @@ policy_templates:
           - name: scope
             type: text
             title: Scope
-            description: |
-              Options are `node` or `cluster`.
-              By default, scope is set to node and each entry in the hosts list indicates a distinct node in an Elasticsearch cluster. 
-              If the scope is set to cluster then each entry in the hosts list indicates a single endpoint for a distinct Elasticsearch cluster (for example, a load-balancing proxy fronting the cluster). 
-              Cluster should be used if the cluster has dedicated master nodes, and configure the endpoint in the hosts list not to direct requests to the dedicated master nodes.
+            description: >-
+              Options are `node` or `cluster`. By default, scope is set to node and each entry in the hosts list indicates a distinct node in an Elasticsearch cluster.  If the scope is set to cluster then each entry in the hosts list indicates a single endpoint for a distinct Elasticsearch cluster (for example, a load-balancing proxy fronting the cluster).  Cluster should be used if the cluster has dedicated master nodes, and configure the endpoint in the hosts list not to direct requests to the dedicated master nodes.
             multi: false
             required: true
             show_user: false

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -52,9 +52,10 @@ policy_templates:
             type: text
             title: Scope
             description: |
+              Options are `node` or `cluster`.
               By default, scope is set to node and each entry in the hosts list indicates a distinct node in an Elasticsearch cluster. 
-              If you set scope to cluster then each entry in the hosts list indicates a single endpoint for a distinct Elasticsearch cluster (for example, a load-balancing proxy fronting the cluster). 
-              You should use scope: cluster if the cluster has dedicated master nodes, and configure the endpoint in the hosts list not to direct requests to the dedicated master nodes.
+              If the scope is set to cluster then each entry in the hosts list indicates a single endpoint for a distinct Elasticsearch cluster (for example, a load-balancing proxy fronting the cluster). 
+              Cluster should be used if the cluster has dedicated master nodes, and configure the endpoint in the hosts list not to direct requests to the dedicated master nodes.
             multi: false
             required: true
             show_user: false


### PR DESCRIPTION
## What does this PR do?

Add `scope` configuration option for metricsets

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3255

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
