### PR TITLE
3276 metrics-elastic_agent mapping system.process.cpu.total.time.ms as a date

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,10 +1,9 @@
 # newer versions go on top
 - version: "1.3.2"
   changes:
-    - description: Fix some CPU elastic_agent_metrics mapping
+    - description: Fix some CPU elastic_agent_metrics mapping from date to long
       type: bugfix
-      link: |
-        https://github.com/elastic/integrations/pull/3284
+      link: https://github.com/elastic/integrations/pull/3284
 - version: "1.3.1"
   changes:
     - description: Fix missing ecs.version mapping

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Fix some CPU elastic_agent_metrics mapping
+      type: bugfix
+      link: |
+        https://github.com/elastic/integrations/pull/3284
 - version: "1.3.1"
   changes:
     - description: Fix missing ecs.version mapping

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
@@ -36,7 +36,7 @@
             The amount of CPU time the process spent in user space.
         - name: total.value
           type: long
-          metric_type: counter # is it really a counter? is it counter because it's a cumulative value?
+          metric_type: counter
           description: |
             The value of CPU usage since starting the process.
         - name: system.ticks
@@ -145,7 +145,7 @@
                 Number of times tasks in a cgroup have been throttled (that is, not allowed to run because they have exhausted all of the available time as specified by their quota).
             - name: stats.throttled.ns
               type: long
-              metric_type: counter # is it correct? ns as a counter?
+              metric_type: counter
               unit: nanos
               description: |
                 The total time duration (in nanoseconds) for which tasks in a cgroup have been throttled.
@@ -161,22 +161,22 @@
                 Path to the cgroup relative to the cgroup subsystem's mountpoint.
             - name: total.ns
               type: long
-              metric_type: counter # is it correct? ns as a counter?
+              metric_type: counter
               unit: nanos
               description: |
                 Total CPU time in nanoseconds consumed by all tasks in the cgroup.
             - name: stats.user.ns
               type: long
-              metric_type: counter # is it correct? ns as a counter?
+              metric_type: counter
               unit: nanos
               description: CPU time consumed by tasks in user mode.
             - name: stats.system.ns
               type: long
-              metric_type: counter # is it correct? ns as a counter?
+              metric_type: counter
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object # shouldn't it be long and nano?
+              type: object
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
@@ -36,7 +36,7 @@
             The amount of CPU time the process spent in user space.
         - name: total.value
           type: long
-          metric_type: counter
+          metric_type: counter # is it really a counter? is it counter because it's a cumulative value?
           description: |
             The value of CPU usage since starting the process.
         - name: system.ticks
@@ -50,15 +50,15 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
           description: |
             The time when the process was started.
         - name: user.time.ms
-          type: date
+          type: long
           description: |
             The time when the process was started.
         - name: system.time.ms
-          type: date
+          type: long
           description: |
             The time when the process was started.
     - name: memory
@@ -145,7 +145,7 @@
                 Number of times tasks in a cgroup have been throttled (that is, not allowed to run because they have exhausted all of the available time as specified by their quota).
             - name: stats.throttled.ns
               type: long
-              metric_type: counter
+              metric_type: counter # is it correct? ns as a counter?
               unit: nanos
               description: |
                 The total time duration (in nanoseconds) for which tasks in a cgroup have been throttled.
@@ -161,22 +161,22 @@
                 Path to the cgroup relative to the cgroup subsystem's mountpoint.
             - name: total.ns
               type: long
-              metric_type: counter
+              metric_type: counter # is it correct? ns as a counter?
               unit: nanos
               description: |
                 Total CPU time in nanoseconds consumed by all tasks in the cgroup.
             - name: stats.user.ns
               type: long
-              metric_type: counter
+              metric_type: counter # is it correct? ns as a counter?
               unit: nanos
               description: CPU time consumed by tasks in user mode.
             - name: stats.system.ns
               type: long
-              metric_type: counter
+              metric_type: counter # is it correct? ns as a counter?
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: object # shouldn't it be long and nano?
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.3.1
+version: 1.3.2
 release: ga
 description: Collect logs and metrics from Elastic Agents.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

It changes some of the CPU metrics mappings for the Elsatic Agent. They were `date`, when should be `long`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #3276

