### PR TITLE
[infoblox] Mark package as deprecated

### DIFF
--- a/packages/infoblox/changelog.yml
+++ b/packages/infoblox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.1"
+  changes:
+    - description: Mark package as deprecated. Please migrate to the infoblox_nios package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3286
 - version: "0.8.0"
   changes:
     - description: Update to ECS 8.2.0

--- a/packages/infoblox/docs/README.md
+++ b/packages/infoblox/docs/README.md
@@ -1,4 +1,7 @@
-# Infoblox integration
+# Infoblox integration (Deprecated)
+
+_This integration is deprecated. Please use one of the other Infoblox
+integrations that are specific to an Infoblox product._
 
 This integration is for Infoblox device's logs. It includes the following
 datasets for receiving logs over syslog or read from a file:

--- a/packages/infoblox/manifest.yml
+++ b/packages/infoblox/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: infoblox
 title: Infoblox Logs
 version: "0.8.1"
-description: Deprecated. Use a product specific Infoblox package instead.
+description: Deprecated. Use a product-specific Infoblox package instead.
 categories: ["network"]
 release: experimental
 license: basic

--- a/packages/infoblox/manifest.yml
+++ b/packages/infoblox/manifest.yml
@@ -1,8 +1,8 @@
 format_version: 1.0.0
 name: infoblox
-title: Infoblox NIOS Logs
-version: 0.8.0
-description: Collect NIOS logs from Infoblox devices with Elastic Agent.
+title: Infoblox Logs
+version: "0.8.1"
+description: Deprecated. Use a product specific Infoblox package instead.
 categories: ["network"]
 release: experimental
 license: basic


### PR DESCRIPTION
## What does this PR do?

There is a new integration specific to Infoblox NIOS. This package is now deprecated.

Relates #3129 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #3129 

## Screenshots

<img width="958" alt="Screen Shot 2022-05-05 at 14 11 24" src="https://user-images.githubusercontent.com/4565752/166986607-0b7c7806-b7f4-4214-bd21-3b91a2c62d33.png">
