### PR TITLE
[crowdstrike] Format source.mac per ECS in FDR

### DIFF
--- a/packages/crowdstrike/data_stream/falcon/fields/agent.yml
+++ b/packages/crowdstrike/data_stream/falcon/fields/agent.yml
@@ -63,10 +63,7 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
       level: extended
       type: keyword
@@ -131,12 +128,7 @@
       ignore_above: 1024
       description: Host mac addresses.
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      external: ecs
     - name: os.family
       level: extended
       type: keyword

--- a/packages/crowdstrike/data_stream/falcon/fields/beats.yml
+++ b/packages/crowdstrike/data_stream/falcon/fields/beats.yml
@@ -8,5 +8,4 @@
   type: long
   description: Offset of the entry in the log file.
 - name: log.file.path
-  type: keyword
-  description: Path to the log file.
+  external: ecs

--- a/packages/crowdstrike/data_stream/falcon/fields/ecs.yml
+++ b/packages/crowdstrike/data_stream/falcon/fields/ecs.yml
@@ -60,8 +60,6 @@
   external: ecs
 - name: destination.port
   external: ecs
-- name: host.name
-  external: ecs
 - name: file.hash.sha1
   external: ecs
 - name: file.hash.sha256
@@ -93,6 +91,4 @@
 - name: related.hash
   external: ecs
 - name: tags
-  external: ecs
-- name: container.id
   external: ecs

--- a/packages/crowdstrike/data_stream/falcon/sample_event.json
+++ b/packages/crowdstrike/data_stream/falcon/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-02-12T21:29:10.710Z",
     "agent": {
-        "ephemeral_id": "9060b4e5-b568-47b0-9a7b-62121df53ec9",
-        "id": "c53ddea2-61ac-4643-8676-0c70ebf51c91",
+        "ephemeral_id": "cc9fb403-5b26-4fe7-aefc-41666b9f4575",
+        "id": "ca0beb8d-9522-4450-8af7-3cb7f3d8c478",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.2.0"
     },
     "crowdstrike": {
         "event": {
@@ -55,9 +55,9 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "c53ddea2-61ac-4643-8676-0c70ebf51c91",
+        "id": "ca0beb8d-9522-4450-8af7-3cb7f3d8c478",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.2.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -65,7 +65,7 @@
             "authentication"
         ],
         "dataset": "crowdstrike.falcon",
-        "ingested": "2021-12-30T05:13:25Z",
+        "ingested": "2022-05-09T16:35:19Z",
         "kind": "event",
         "original": "{\n    \"metadata\": {\n        \"customerIDString\": \"8f69fe9e-b995-4204-95ad-44f9bcf75b6b\",\n        \"offset\": 0,\n        \"eventType\": \"AuthActivityAuditEvent\",\n        \"eventCreationTime\": 1581542950710,\n        \"version\": \"1.0\"\n    },\n    \"event\": {\n        \"UserId\": \"api-client-id:1234567890abcdefghijklmnopqrstuvwxyz\",\n        \"UserIp\": \"10.10.0.8\",\n        \"OperationName\": \"streamStarted\",\n        \"ServiceName\": \"Crowdstrike Streaming API\",\n        \"Success\": true,\n        \"UTCTimestamp\": 1581542950,\n        \"AuditKeyValues\": [\n            {\n                \"Key\": \"APIClientID\",\n                \"ValueString\": \"1234567890abcdefghijklmnopqr\"\n            },\n            {\n                \"Key\": \"partition\",\n                \"ValueString\": \"0\"\n            },\n            {\n                \"Key\": \"offset\",\n                \"ValueString\": \"-1\"\n            },\n            {\n                \"Key\": \"appId\",\n                \"ValueString\": \"siem-connector-v2.0.0\"\n            },\n            {\n                \"Key\": \"eventType\",\n                \"ValueString\": \"[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]\"\n            }\n        ]\n    }\n}",
         "outcome": "success",

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
@@ -1355,7 +1355,7 @@
                     }
                 },
                 "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "mac": "6e-9e-e0-1f-6d-7d"
+                "mac": "6E-9E-E0-1F-6D-7D"
             },
             "tags": [
                 "preserve_original_event"
@@ -2279,7 +2279,7 @@
                     }
                 },
                 "ip": "67.43.156.14",
-                "mac": "0e-d6-ff-ff-ff-63"
+                "mac": "0E-D6-FF-FF-FF-63"
             },
             "tags": [
                 "preserve_original_event"
@@ -2457,7 +2457,7 @@
                     }
                 },
                 "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
-                "mac": "c2-27-b0-27-83-0f"
+                "mac": "C2-27-B0-27-83-0F"
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -900,6 +900,9 @@ processors:
       field: crowdstrike.PhysicalAddress
       target_field: source.mac
       ignore_missing: true
+  - uppercase:
+      field: source.mac
+      ignore_missing: true
   - rename:
       field: crowdstrike.DownloadServer
       target_field: server.address

--- a/packages/crowdstrike/data_stream/fdr/fields/ecs.yml
+++ b/packages/crowdstrike/data_stream/fdr/fields/ecs.yml
@@ -133,6 +133,8 @@
 - external: ecs
   name: process.command_line
 - external: ecs
+  name: process.end
+- external: ecs
   name: process.entity_id
 - external: ecs
   name: process.executable

--- a/packages/crowdstrike/data_stream/fdr/fields/ecs.yml
+++ b/packages/crowdstrike/data_stream/fdr/fields/ecs.yml
@@ -12,10 +12,8 @@
   name: destination.geo.country_iso_code
 - external: ecs
   name: destination.geo.country_name
-- description: Longitude and latitude.
-  level: core
+- external: ecs
   name: destination.geo.location
-  type: geo_point
 - external: ecs
   name: destination.geo.region_iso_code
 - external: ecs
@@ -192,10 +190,8 @@
   name: source.geo.country_iso_code
 - external: ecs
   name: source.geo.country_name
-- description: Longitude and latitude.
-  level: core
+- external: ecs
   name: source.geo.location
-  type: geo_point
 - external: ecs
   name: source.geo.region_iso_code
 - external: ecs

--- a/packages/crowdstrike/data_stream/fdr/fields/fields.yml
+++ b/packages/crowdstrike/data_stream/fdr/fields/fields.yml
@@ -593,5 +593,3 @@
       type: keyword
     - name: WindowFlags
       type: keyword
-- name: process.end
-  type: date

--- a/packages/crowdstrike/data_stream/fdr/sample_event.json
+++ b/packages/crowdstrike/data_stream/fdr/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-11-08T09:58:32.519Z",
     "agent": {
-        "ephemeral_id": "33b3f217-19d7-4071-bb17-5dd3176d549d",
-        "id": "c53ddea2-61ac-4643-8676-0c70ebf51c91",
+        "ephemeral_id": "8cb3a21e-5542-440a-a909-8a2f161001ba",
+        "id": "ca0beb8d-9522-4450-8af7-3cb7f3d8c478",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.2.0"
     },
     "crowdstrike": {
         "ConfigStateHash": "1763245019",
@@ -34,9 +34,9 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "c53ddea2-61ac-4643-8676-0c70ebf51c91",
+        "id": "ca0beb8d-9522-4450-8af7-3cb7f3d8c478",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.2.0"
     },
     "event": {
         "action": "RansomwareOpenFile",
@@ -47,7 +47,7 @@
         "created": "2020-11-08T17:07:22.091Z",
         "dataset": "crowdstrike.fdr",
         "id": "ffffffff-1111-11eb-9756-06fe7f8f682f",
-        "ingested": "2021-12-30T05:14:09Z",
+        "ingested": "2022-05-09T16:39:37Z",
         "kind": "alert",
         "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"1016182570608\",\"ContextThreadId\":\"37343520154472\",\"ContextTimeStamp\":\"1604829512.519\",\"DesiredAccess\":\"1179785\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00\",\"FileObject\":\"18446670458156489088\",\"Information\":\"1\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"16777312\",\"ShareAccess\":\"5\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user11\\\\Downloads\\\\file.pptx\",\"aid\":\"ffffffffac4148947ed68497e89f3308\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RansomwareOpenFile\",\"id\":\"ffffffff-1111-11eb-9756-06fe7f8f682f\",\"name\":\"RansomwareOpenFileV4\",\"timestamp\":\"1604855242091\"}",
         "outcome": "success",

--- a/packages/crowdstrike/docs/README.md
+++ b/packages/crowdstrike/docs/README.md
@@ -182,7 +182,7 @@ Contains endpoint data and CrowdStrike Falcon platform audit data forwarded from
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
-| log.file.path | Path to the log file. | keyword |
+| log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.flags | Flags for the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
@@ -227,11 +227,11 @@ An example event for `falcon` looks as following:
 {
     "@timestamp": "2020-02-12T21:29:10.710Z",
     "agent": {
-        "ephemeral_id": "9060b4e5-b568-47b0-9a7b-62121df53ec9",
-        "id": "c53ddea2-61ac-4643-8676-0c70ebf51c91",
+        "ephemeral_id": "cc9fb403-5b26-4fe7-aefc-41666b9f4575",
+        "id": "ca0beb8d-9522-4450-8af7-3cb7f3d8c478",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.2.0"
     },
     "crowdstrike": {
         "event": {
@@ -281,9 +281,9 @@ An example event for `falcon` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "c53ddea2-61ac-4643-8676-0c70ebf51c91",
+        "id": "ca0beb8d-9522-4450-8af7-3cb7f3d8c478",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.2.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -291,7 +291,7 @@ An example event for `falcon` looks as following:
             "authentication"
         ],
         "dataset": "crowdstrike.falcon",
-        "ingested": "2021-12-30T05:13:25Z",
+        "ingested": "2022-05-09T16:35:19Z",
         "kind": "event",
         "original": "{\n    \"metadata\": {\n        \"customerIDString\": \"8f69fe9e-b995-4204-95ad-44f9bcf75b6b\",\n        \"offset\": 0,\n        \"eventType\": \"AuthActivityAuditEvent\",\n        \"eventCreationTime\": 1581542950710,\n        \"version\": \"1.0\"\n    },\n    \"event\": {\n        \"UserId\": \"api-client-id:1234567890abcdefghijklmnopqrstuvwxyz\",\n        \"UserIp\": \"10.10.0.8\",\n        \"OperationName\": \"streamStarted\",\n        \"ServiceName\": \"Crowdstrike Streaming API\",\n        \"Success\": true,\n        \"UTCTimestamp\": 1581542950,\n        \"AuditKeyValues\": [\n            {\n                \"Key\": \"APIClientID\",\n                \"ValueString\": \"1234567890abcdefghijklmnopqr\"\n            },\n            {\n                \"Key\": \"partition\",\n                \"ValueString\": \"0\"\n            },\n            {\n                \"Key\": \"offset\",\n                \"ValueString\": \"-1\"\n            },\n            {\n                \"Key\": \"appId\",\n                \"ValueString\": \"siem-connector-v2.0.0\"\n            },\n            {\n                \"Key\": \"eventType\",\n                \"ValueString\": \"[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]\"\n            }\n        ]\n    }\n}",
         "outcome": "success",
@@ -837,7 +837,7 @@ and/or `session_token`.
 | process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | wildcard |
 | process.command_line.text | Multi-field of `process.command_line`. | match_only_text |
-| process.end |  | date |
+| process.end | The time the process ended. | date |
 | process.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
 | process.executable.text | Multi-field of `process.executable`. | match_only_text |
@@ -903,11 +903,11 @@ An example event for `fdr` looks as following:
 {
     "@timestamp": "2020-11-08T09:58:32.519Z",
     "agent": {
-        "ephemeral_id": "33b3f217-19d7-4071-bb17-5dd3176d549d",
-        "id": "c53ddea2-61ac-4643-8676-0c70ebf51c91",
+        "ephemeral_id": "8cb3a21e-5542-440a-a909-8a2f161001ba",
+        "id": "ca0beb8d-9522-4450-8af7-3cb7f3d8c478",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.2.0"
     },
     "crowdstrike": {
         "ConfigStateHash": "1763245019",
@@ -936,9 +936,9 @@ An example event for `fdr` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "c53ddea2-61ac-4643-8676-0c70ebf51c91",
+        "id": "ca0beb8d-9522-4450-8af7-3cb7f3d8c478",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.2.0"
     },
     "event": {
         "action": "RansomwareOpenFile",
@@ -949,7 +949,7 @@ An example event for `fdr` looks as following:
         "created": "2020-11-08T17:07:22.091Z",
         "dataset": "crowdstrike.fdr",
         "id": "ffffffff-1111-11eb-9756-06fe7f8f682f",
-        "ingested": "2021-12-30T05:14:09Z",
+        "ingested": "2022-05-09T16:39:37Z",
         "kind": "alert",
         "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"1016182570608\",\"ContextThreadId\":\"37343520154472\",\"ContextTimeStamp\":\"1604829512.519\",\"DesiredAccess\":\"1179785\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00\",\"FileObject\":\"18446670458156489088\",\"Information\":\"1\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"16777312\",\"ShareAccess\":\"5\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user11\\\\Downloads\\\\file.pptx\",\"aid\":\"ffffffffac4148947ed68497e89f3308\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RansomwareOpenFile\",\"id\":\"ffffffff-1111-11eb-9756-06fe7f8f682f\",\"name\":\"RansomwareOpenFileV4\",\"timestamp\":\"1604855242091\"}",
         "outcome": "success",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Format the `source.mac` field as per ECS (h[ttps://www.elastic.co/guide/en/ecs/current/ecs-observer.html#field-observer-mac](https://www.elastic.co/guide/en/ecs/current/ecs-source.html#field-source-mac)). 

> The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.

Also cleanup field mappings:

- fdr: Use ECS process.end, source.geo.location, destination.geo.location.
- falcon: Use ECS log.file.path.
- falcon: Remove duplicated field definitions.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

