### PR TITLE
Deprecate s3 input in cloudwatch integration

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Deprecate s3 input in cloudwatch integration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3304
+    - description: Improve description for cloudwatch integration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3304
 - version: "1.14.8"
   changes:
     - description: Fix http.response.status_code to accept 000

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -3,9 +3,9 @@ type: logs
 streams:
   - input: aws-s3
     template_path: aws-s3.yml.hbs
-    title: AWS CloudWatch logs via S3
+    title: AWS CloudWatch logs via S3 (Deprecated)
     enabled: false
-    description: Collect AWS CloudWatch logs using s3 input
+    description: (Deprecated) Please use Custom AWS Logs integration instead
     vars:
       - name: visibility_timeout
         type: text

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.16.0
+version: 1.15.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.14.8
+version: 1.16.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration
@@ -127,13 +127,13 @@ policy_templates:
         type: image/png
   - name: cloudwatch
     title: AWS CloudWatch
-    description: Collect logs and metrics from Amazon CloudWatch with Elastic Agent
+    description: Use this integration to collect logs and metrics from Amazon CloudWatch with Elastic Agent, where no out of the box integration is available.
     data_streams:
       - cloudwatch_logs
       - cloudwatch_metrics
     inputs:
       - type: aws-s3
-        title: Collect logs from S3
+        title: Collect logs from S3 (Deprecated)
         description: Collecting logs using aws-s3 input
         input_group: logs
       - type: aws-cloudwatch


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to deprecate s3 input as an option in CloudWatch integration. Logs sent to CloudWatch can be ingested into elasticsearch directly via cloudwatch input. There is no need to send them to an S3 bucket and then to ealsticsearch.
<img width="717" alt="Screen Shot 2022-05-09 at 2 15 14 PM" src="https://user-images.githubusercontent.com/14081635/167490493-7fe50705-a72f-4c40-98e3-2ea994fff95b.png">


Also this PR also enhanced the description for cloudwatch integration.
<img width="1375" alt="Screen Shot 2022-05-09 at 1 26 42 PM" src="https://user-images.githubusercontent.com/14081635/167490672-8838f4ee-5718-42d0-8193-394bff8b685b.png">


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/3261
- 