### PR TITLE
cisco_duo: fix invalid values for event.outcome

### DIFF
--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Fix invalid value for `event.outcome` in auth data set
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/xxxx
 - version: "1.2.1"
   changes:
     - description: Added link to Duo documentation

--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix invalid value for `event.outcome` in auth data set
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/3333
 - version: "1.2.1"
   changes:
     - description: Added link to Duo documentation

--- a/packages/cisco_duo/data_stream/auth/_dev/test/pipeline/test-auth.log-expected.json
+++ b/packages/cisco_duo/data_stream/auth/_dev/test/pipeline/test-auth.log-expected.json
@@ -410,7 +410,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"89.160.20.156\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"89.160.20.156\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:20:54.700050+00:00\",\"ood_software\":null,\"reason\":\"user_marked_fraud\",\"result\":\"fraud\",\"timestamp\":1627024854,\"txid\":\"78e1a910-350b-4226-828b-edb0ac2f2e3c\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_marked_fraud",
                 "type": "info"
             },
@@ -528,7 +528,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"89.160.20.156\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"89.160.20.156\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },
@@ -630,7 +630,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"89.160.20.112:1234\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"192.168.225.254:4321\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },
@@ -741,7 +741,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },
@@ -843,7 +843,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"[2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6]:1234\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"[2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6]:4321\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },
@@ -946,7 +946,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6#1234\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6#4321\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },
@@ -1049,7 +1049,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6p1234\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6p4321\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },
@@ -1152,7 +1152,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6:1234\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6:4321\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },
@@ -1255,7 +1255,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6 port 1234\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6 port 4321\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },
@@ -1358,7 +1358,7 @@
                 "category": "authentication",
                 "kind": "event",
                 "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"92.0.4515.107\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6.1234\",\"is_encryption_enabled\":\"unknown\",\"is_firewall_enabled\":\"unknown\",\"is_password_set\":\"unknown\",\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Windows\",\"os_version\":\"10\"},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Duo Access Gateway Launcher\"},\"auth_device\":{\"ip\":\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6.4321\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"+91 12345 12345\"},\"email\":\"\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2021-07-23T07:19:34.702203+00:00\",\"ood_software\":null,\"reason\":\"user_mistake\",\"result\":\"denied\",\"timestamp\":1627024774,\"txid\":\"e22120cd-7388-424f-aa0a-b60cad42d8f3\",\"user\":{\"groups\":[\"AD Sync\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway\"}}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "user_mistake",
                 "type": "info"
             },

--- a/packages/cisco_duo/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -32,7 +32,7 @@ processors:
       value: event
   - set:
       field: event.outcome
-      value: failed
+      value: failure
   - set:
       field: event.outcome
       value: success

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_duo
 title: Cisco Duo
-version: 1.2.1
+version: 1.2.2
 license: basic
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes an invalid value in event.outcome for the auth data set.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

See https://github.com/elastic/integrations/issues/3016#issuecomment-1123638937

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3328

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
