### PR TITLE
Fix links in changelogs

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -81,8 +81,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2022
+      link: https://github.com/elastic/integrations/pull/2022
 - version: "1.0.2"
   changes:
     - description: Update Title and Description.

--- a/packages/cyberark/changelog.yml
+++ b/packages/cyberark/changelog.yml
@@ -16,7 +16,7 @@
       link: https://github.com/elastic/integrations/pull/2023
     - description: Remove dash from title for consistency with brand.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR_PLACEHOLDER
+      link: https://github.com/elastic/integrations/pull/2004
 - version: "0.4.3"
   changes:
     - description: Update title and description.

--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -46,7 +46,7 @@
   changes:
     - description: Remove dash from title for consistency with brand.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR_PLACEHOLDER
+      link: https://github.com/elastic/integrations/pull/2004
 - version: "2.1.2"
   changes:
     - description: Update Title and Description.

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -33,8 +33,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2012
+      link: https://github.com/elastic/integrations/pull/2012
 - version: "1.1.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -8,20 +8,17 @@
   changes:
     - description: Fix missing ecs.version mapping
       type: bugfix
-      link: |
-        https://github.com/elastic/integrations/pull/2844
+      link: https://github.com/elastic/integrations/pull/2844
 - version: "1.3.0"
   changes:
     - description: Update compatibility of package to be compatible with 8.0.x
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2125
+      link: https://github.com/elastic/integrations/pull/2125
 - version: "1.2.2"
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2015
+      link: https://github.com/elastic/integrations/pull/2015
 - version: "1.2.1"
   changes:
     - description: Fix dashboard default filter
@@ -36,7 +33,7 @@
   changes:
     - description: Fix missing support for heartbeat metrics and logs
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/?
+      link: https://github.com/elastic/integrations/pull/1460
 - version: "1.1.0"
   changes:
     - description: Add mappings for all metrics and logs shipped by Elastic Agent and its sub processes.

--- a/packages/nats/changelog.yml
+++ b/packages/nats/changelog.yml
@@ -13,14 +13,12 @@
   changes:
     - description: Release nats package for v8.0.0
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2168
+      link: https://github.com/elastic/integrations/pull/2168
 - version: "1.1.2"
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2054
+      link: https://github.com/elastic/integrations/pull/2054
 - version: "1.1.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -33,14 +33,12 @@
   changes:
     - description: Release nginx package for v8.0.0
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2176
+      link: https://github.com/elastic/integrations/pull/2176
 - version: "1.1.2"
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2052
+      link: https://github.com/elastic/integrations/pull/2052
 - version: "1.1.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -23,14 +23,12 @@
   changes:
     - description: Release nginx_ingress_controller package for v8.0.0
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2192
+      link: https://github.com/elastic/integrations/pull/2192
 - version: "1.1.2"
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2053
+      link: https://github.com/elastic/integrations/pull/2053
 - version: "1.1.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -133,7 +133,7 @@
   changes:
     - description: Explicit mappings
       type: enhancement # can be one of: enhancement, bugfix, breaking-change
-      link: https://github.com/elastic/integrations/pull/902/files
+      link: https://github.com/elastic/integrations/pull/902
 - version: "0.1.0"
   changes:
     - description: initial release

--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -18,8 +18,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2051
+      link: https://github.com/elastic/integrations/pull/2051
 - version: "1.1.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -18,14 +18,12 @@
   changes:
     - description: Release prometheus package for v8.0.0
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2189
+      link: https://github.com/elastic/integrations/pull/2189
 - version: "0.6.1"
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2050
+      link: https://github.com/elastic/integrations/pull/2050
 - version: "0.6.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -18,8 +18,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2049
+      link: https://github.com/elastic/integrations/pull/2049
 - version: "1.1.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -18,8 +18,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2048
+      link: https://github.com/elastic/integrations/pull/2048
 - version: "1.1.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag

--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -7,7 +7,7 @@
   version: 1.0.2
 - changes:
     - description: Release security rules update
-      link: https://github.com/elastic/integrations/pulls/0000
+      link: https://github.com/elastic/integrations/pulls/3191
       type: enhancement
   version: 0.16.2
 - changes:

--- a/packages/snort/changelog.yml
+++ b/packages/snort/changelog.yml
@@ -52,5 +52,5 @@
 - version: "0.0.1"
   changes:
     - description: initial release
-      type: enhancement # can be one of: enhancement, bugfix, breaking-change
-      link: https://github.com/elastic/integrations/pull/XXX
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1575

--- a/packages/stan/changelog.yml
+++ b/packages/stan/changelog.yml
@@ -1,15 +1,14 @@
+# newer versions go on top
 - version: "1.3.0"
   changes:
     - description: Update to ECS 8.0
       type: enhancement
       link: https://github.com/elastic/integrations/pull/2511
-# newer versions go on top
 - version: "1.2.0"
   changes:
     - description: Release stan package for v8.0.0
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2171
+      link: https://github.com/elastic/integrations/pull/2171
 - version: "1.1.2"
   changes:
     - description: Uniform with guidelines

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -3,50 +3,42 @@
   changes:
     - description: Adds APM service name mappings
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2725
+      link: https://github.com/elastic/integrations/pull/2725
 - version: "0.9.1"
   changes:
     - description: Fix default values for monitor schedules
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2698
+      link: https://github.com/elastic/integrations/pull/2698
 - version: "0.9.0"
   changes:
     - description: Add run_once fields
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2609
+      link: https://github.com/elastic/integrations/pull/2609
 - version: "0.8.1"
   changes:
     - description: Add missing browser fields to the synthetics template
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2549
+      link: https://github.com/elastic/integrations/pull/2549
 - version: "0.8.0"
   changes:
     - description: Add index optimizations
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2319
+      link: https://github.com/elastic/integrations/pull/2319
 - version: "0.7.0"
   changes:
     - description: Add heartbeat enabled key
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2290
+      link: https://github.com/elastic/integrations/pull/2290
 - version: "0.6.0"
   changes:
     - description: Allow users to set throttling.
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2161
+      link: https://github.com/elastic/integrations/pull/2161
 - version: "0.5.0"
   changes:
     - description: Update compatibility of package to be compatible with 8.0.x
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2213
+      link: https://github.com/elastic/integrations/pull/2213
 - version: "0.4.2"
   changes:
     - description: Uniform with guidelines

--- a/packages/traefik/changelog.yml
+++ b/packages/traefik/changelog.yml
@@ -28,8 +28,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2047
+      link: https://github.com/elastic/integrations/pull/2047
 - version: "1.1.1"
   changes:
     - description: Fix logic that checks for the 'forwarded' tag

--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -18,8 +18,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2046
+      link: https://github.com/elastic/integrations/pull/2046
 - version: "1.1.0"
   changes:
     - description: Update to ECS 1.12.0

--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -28,8 +28,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2045
+      link: https://github.com/elastic/integrations/pull/2045
 - version: "1.0.2"
   changes:
     - description: Update Title and Description.

--- a/packages/zscaler/changelog.yml
+++ b/packages/zscaler/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Mark package as deprecated. Use the zscaler_zia package instead.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/2708
 - version: "0.5.0"
   changes:
     - description: Update to ECS 8.0.0
@@ -18,8 +18,7 @@
   changes:
     - description: Uniform with guidelines
       type: enhancement
-      link: |
-        https://github.com/elastic/integrations/pull/2044
+      link: https://github.com/elastic/integrations/pull/2044
 - version: "0.4.3"
   changes:
     - description: Update Title and Description.


### PR DESCRIPTION
Fix links in changelogs, required for package-spec 1.8.0 (https://github.com/elastic/package-spec/pull/324).