### PR TITLE
Oracle_30974: Ingest pipeline date parsing issue

### DIFF
--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Supporting the double digit date parsing in ingest pipeline for oracle logs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3318
 - version: "1.0.1"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Supporting the double digit date parsing in ingest pipeline for oracle logs
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/3318
+      link: https://github.com/elastic/integrations/pull/3337
 - version: "1.0.1"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/oracle/data_stream/database_audit/_dev/test/pipeline/test-oracle-database-audit.log
+++ b/packages/oracle/data_stream/database_audit/_dev/test/pipeline/test-oracle-database-audit.log
@@ -1,4 +1,4 @@
-Wed Oct  7 11:58:08 2020 -04:00
+Wed Oct 21 11:58:08 2020 -04:00
 LENGTH : '392'
 ACTION :[151] 'select /*+ opt_param('parallel_execution_enabled',
                                    'false') EXEC_FROM_DBMS_XPLAN */ * from gv$all_sql_plan where 1=0'

--- a/packages/oracle/data_stream/database_audit/_dev/test/pipeline/test-oracle-database-audit.log-expected.json
+++ b/packages/oracle/data_stream/database_audit/_dev/test/pipeline/test-oracle-database-audit.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2020-10-07T15:58:08.000Z",
+            "@timestamp": "2020-10-21T15:58:08.000Z",
             "ecs": {
                 "version": "8.0.0"
             },
@@ -9,7 +9,7 @@
                 "action": "database_audit",
                 "category": "database",
                 "kind": "event",
-                "original": "Wed Oct  7 11:58:08 2020 -04:00\nLENGTH : '392'\nACTION :[151] 'select /*+ opt_param('parallel_execution_enabled',\n                                   'false') EXEC_FROM_DBMS_XPLAN */ * from gv$all_sql_plan where 1=0'\nDATABASE USER:[1] '/'\nPRIVILEGE :[4] 'NONE'\nCLIENT USER:[0] ''\nCLIENT TERMINAL:[7] 'UNKNOWN'\nSTATUS:[1] '0'\nDBID:[10] '2824230686'\nSESSIONID:[1] '0'\nUSERHOST:[13] 'testlab.local'\nCLIENT ADDRESS:[0] ''\nACTION NUMBER:[1] '3'\n",
+                "original": "Wed Oct 21 11:58:08 2020 -04:00\nLENGTH : '392'\nACTION :[151] 'select /*+ opt_param('parallel_execution_enabled',\n                                   'false') EXEC_FROM_DBMS_XPLAN */ * from gv$all_sql_plan where 1=0'\nDATABASE USER:[1] '/'\nPRIVILEGE :[4] 'NONE'\nCLIENT USER:[0] ''\nCLIENT TERMINAL:[7] 'UNKNOWN'\nSTATUS:[1] '0'\nDBID:[10] '2824230686'\nSESSIONID:[1] '0'\nUSERHOST:[13] 'testlab.local'\nCLIENT ADDRESS:[0] ''\nACTION NUMBER:[1] '3'\n",
                 "outcome": "success",
                 "timezone": "-04:00",
                 "type": "access"

--- a/packages/oracle/data_stream/database_audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/oracle/data_stream/database_audit/elasticsearch/ingest_pipeline/default.yml
@@ -91,7 +91,7 @@ processors:
       field: tmp_timestamp
       target_field: "@timestamp"
       formats:
-        - EEE MMM  d HH:mm:ss uuuu XXX
+        - EEE MMM [ d][dd] HH:mm:ss uuuu XXX
   - grok:
       field: tmp_timestamp
       patterns:

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: oracle
 title: "Oracle"
-version: 1.0.1
+version: 1.0.2
 license: basic
 description: "Oracle Audit Log Integration"
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR parses a 2 digit month day format for the oracle's ingest pipeline


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

The test log file can be changed to a 2 month day. Without the change the particular changed log will not be parsed. With the change, the parsing of the 2 month day will happen successfully.




