### PR TITLE
[aws] Fix invalid values for ECS fields

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.1"
+  changes:
+    - description: Fix invalid values for ECS fields in vpcflow
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3342
 - version: "1.16.0"
   changes:
     - description: Move VPN configuration file into integrations and add tag collection

--- a/packages/aws/data_stream/vpcflow/_dev/test/pipeline/test-extra-samples.log-expected.json
+++ b/packages/aws/data_stream/vpcflow/_dev/test/pipeline/test-extra-samples.log-expected.json
@@ -24,8 +24,8 @@
                     "country_iso_code": "NO",
                     "country_name": "Norway",
                     "location": {
-                        "lat": 62,
-                        "lon": 10
+                        "lat": 62.0,
+                        "lon": 10.0
                     }
                 },
                 "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
@@ -35,13 +35,13 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2016-10-31T11:37:00.000Z",
                 "kind": "event",
                 "original": "2 123456789010 eni-1235b8ca123456789 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6 34892 22 6 54 8855 1477913708 1477913820 ACCEPT OK",
-                "outcome": "allow",
+                "outcome": "success",
                 "start": "2016-10-31T11:35:08.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "network": {
                 "bytes": 8855,
@@ -65,8 +65,8 @@
                     "country_iso_code": "NO",
                     "country_name": "Norway",
                     "location": {
-                        "lat": 62,
-                        "lon": 10
+                        "lat": 62.0,
+                        "lon": 10.0
                     }
                 },
                 "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
@@ -97,12 +97,12 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2015-05-10T18:02:14.000Z",
                 "kind": "event",
                 "original": "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA",
                 "start": "2015-05-10T18:01:16.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "tags": [
                 "preserve_original_event"
@@ -128,12 +128,12 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2015-05-10T18:02:14.000Z",
                 "kind": "event",
                 "original": "2 123456789010 eni-89.160.20.1561aaaaaaaaa - - - - - - - 1431280876 1431280934 - SKIPDATA",
                 "start": "2015-05-10T18:01:16.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "tags": [
                 "preserve_original_event"
@@ -183,13 +183,13 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2014-12-14T04:07:50.000Z",
                 "kind": "event",
                 "original": "2 123456789010 eni-1235b8ca123456789 89.160.20.156 89.160.20.156 20641 22 6 20 4249 1418530010 1418530070 ACCEPT OK",
-                "outcome": "allow",
+                "outcome": "success",
                 "start": "2014-12-14T04:06:50.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "network": {
                 "bytes": 4249,
@@ -278,13 +278,13 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2014-12-14T04:07:50.000Z",
                 "kind": "event",
                 "original": "2 123456789010 eni-1235b8ca123456789 89.160.20.156 89.160.20.156 49761 3389 6 20 4249 1418530010 1418530070 REJECT OK",
-                "outcome": "deny",
+                "outcome": "failure",
                 "start": "2014-12-14T04:06:50.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "network": {
                 "bytes": 4249,
@@ -355,13 +355,13 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2015-05-29T16:32:22.000Z",
                 "kind": "event",
                 "original": "2 123456789010 eni-1235b8ca123456789 89.160.20.156 172.31.16.139 0 0 1 4 336 1432917027 1432917142 ACCEPT OK",
-                "outcome": "allow",
+                "outcome": "success",
                 "start": "2015-05-29T16:30:27.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "network": {
                 "bytes": 336,
@@ -450,13 +450,13 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2015-05-29T16:32:22.000Z",
                 "kind": "event",
                 "original": "2 123456789010 eni-1235b8ca123456789 172.31.16.139 89.160.20.156 0 0 1 4 336 1432917094 1432917142 REJECT OK",
-                "outcome": "deny",
+                "outcome": "failure",
                 "start": "2015-05-29T16:31:34.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "network": {
                 "bytes": 336,

--- a/packages/aws/data_stream/vpcflow/_dev/test/pipeline/test-tcp-flag-sequence.log-expected.json
+++ b/packages/aws/data_stream/vpcflow/_dev/test/pipeline/test-tcp-flag-sequence.log-expected.json
@@ -39,13 +39,13 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2019-08-26T19:48:53.000Z",
                 "kind": "event",
                 "original": "3 vpc-abcdefab012345678 subnet-aaaaaaaa012345678 i-01234567890123456 eni-1235b8ca123456789 123456789010 IPv4 89.160.20.156 10.0.0.62 43416 5001 89.160.20.156 10.0.0.62 6 568 8 1566848875 1566848933 ACCEPT 2 OK",
-                "outcome": "allow",
+                "outcome": "success",
                 "start": "2019-08-26T19:47:55.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "network": {
                 "bytes": 568,
@@ -116,12 +116,12 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2019-08-26T19:48:53.000Z",
                 "kind": "event",
                 "original": "3 vpc-abcdefab012345678 subnet-aaaaaaaa012345678 i-01234567890123456 eni-1235b8ca123456789 123456789010 - - - - - - - - - - 1566848875 1566848933 - - SKIPDATA",
                 "start": "2019-08-26T19:47:55.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "tags": [
                 "preserve_original_event"
@@ -153,12 +153,12 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2019-08-26T19:48:53.000Z",
                 "kind": "event",
                 "original": "3 vpc-abcdefab012345678 subnet-aaaaaaaa012345678 i-01234567890123456 eni-1235b8ca123456789 123456789010 - - - - - - - - - - 1566848875 1566848933 - - NODATA",
                 "start": "2019-08-26T19:47:55.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/aws/data_stream/vpcflow/_dev/test/pipeline/test-v5-all-fields.log-expected.json
+++ b/packages/aws/data_stream/vpcflow/_dev/test/pipeline/test-v5-all-fields.log-expected.json
@@ -45,13 +45,13 @@
                 "version": "8.0.0"
             },
             "event": {
-                "category": "network_traffic",
+                "category": "network",
                 "end": "2021-12-20T11:38:17.000Z",
                 "kind": "event",
                 "original": "5 64111117617 eni-069xxxxxb7a490 89.160.20.156 10.200.0.0 50041 33004 17 52 1 164000066 1640000297 REJECT OK vpc-09676f97xxxxxb8a7 subnet-02d645xxxxxxxdbc0 i-0axxxxxx1ad77 1 IPv4 89.160.20.156 10.200.0.80 us-east-1 use1-az5 - - AMAZON CLOUDFRONT ingress 1",
-                "outcome": "deny",
+                "outcome": "failure",
                 "start": "1975-03-14T03:34:26.000Z",
-                "type": "flow"
+                "type": "connection"
             },
             "network": {
                 "bytes": 1,

--- a/packages/aws/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
@@ -11,10 +11,10 @@ processors:
       ignore_missing: true
   - set:
       field: event.type
-      value: flow
+      value: connection
   - set:
       field: event.category
-      value: network_traffic
+      value: network
   - drop:
       if: 'ctx.event?.original.startsWith("version") || ctx.event?.original.startsWith("instance-id")'
   - script:
@@ -95,11 +95,11 @@ processors:
         handleMap(ctx.aws);
   - set:
       field: event.outcome
-      value: allow
+      value: success
       if: ctx.aws?.vpcflow?.action == "ACCEPT"
   - set:
       field: event.outcome
-      value: deny
+      value: failure
       if: ctx.aws?.vpcflow?.action == "REJECT"
   - rename:
       field: aws.vpcflow.srcaddr

--- a/packages/aws/data_stream/vpcflow/sample_event.json
+++ b/packages/aws/data_stream/vpcflow/sample_event.json
@@ -49,9 +49,9 @@
         "kind": "event",
         "start": "2016-10-31T11:35:08.000Z",
         "end": "2016-10-31T11:37:00.000Z",
-        "type": "flow",
-        "category": "network_traffic",
-        "outcome": "allow"
+        "type": "connection",
+        "category": "network",
+        "outcome": "success"
     },
     "aws": {
         "vpcflow": {

--- a/packages/aws/docs/vpcflow.md
+++ b/packages/aws/docs/vpcflow.md
@@ -184,9 +184,9 @@ An example event for `vpcflow` looks as following:
         "kind": "event",
         "start": "2016-10-31T11:35:08.000Z",
         "end": "2016-10-31T11:37:00.000Z",
-        "type": "flow",
-        "category": "network_traffic",
-        "outcome": "allow"
+        "type": "connection",
+        "category": "network",
+        "outcome": "success"
     },
     "aws": {
         "vpcflow": {

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.16.0
+version: 1.16.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix invalid values for ECS fields in AWS integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/3044