### PR TITLE
network_traffic: remove invalid value from event.category in SIP sample event

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.1"
+  changes:
+    - description: Remove invalid value from `event.category` in SIP data set.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3343
 - version: "0.10.0"
   changes:
     - description: Add configuration options for each protocol.

--- a/packages/network_traffic/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
@@ -21,6 +21,18 @@ processors:
 - uppercase:
     field: host.mac
     ignore_missing: true
+# Remove invalid "protocol" term added by packetbeat prior to v7.17.4/8.2.1.
+- script:
+    lang: painless
+    source: >
+        if (ctx.event?.category != null) {
+            for (int i=ctx.event.category.length-1; i>=0; i--) {
+                if (ctx.event.category[i] == "protocol") {
+                    ctx.event.category.remove(i);
+                }
+            }
+        }
+
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/sip/sample_event.json
+++ b/packages/network_traffic/data_stream/sip/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T08:32:14.536Z",
+    "@timestamp": "2022-05-13T07:10:35.715Z",
     "agent": {
-        "ephemeral_id": "ee3aeba6-2bd9-4a89-840a-32af72217a7a",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "008322ce-0d84-45f0-beaf-153cf4786013",
+        "id": "a82e5ec9-4d24-4491-8d66-470aa321ddae",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.0"
     },
     "client": {
         "ip": "10.0.2.20",
@@ -24,48 +24,47 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "a82e5ec9-4d24-4491-8d66-470aa321ddae",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.0"
     },
     "event": {
         "action": "sip-invite",
         "agent_id_status": "verified",
         "category": [
-            "network",
-            "protocol"
+            "network"
         ],
         "dataset": "network_traffic.sip",
         "duration": 0,
-        "end": "2022-03-09T08:32:14.536Z",
-        "ingested": "2022-03-09T08:32:15Z",
+        "end": "2022-05-13T07:10:35.715Z",
+        "ingested": "2022-05-13T07:10:39Z",
         "kind": "event",
         "original": "INVITE sip:test@10.0.2.15:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 10.0.2.20:5060;branch=z9hG4bK-2187-1-0\r\nFrom: \"DVI4/8000\" \u003csip:sipp@10.0.2.20:5060\u003e;tag=1\r\nTo: test \u003csip:test@10.0.2.15:5060\u003e\r\nCall-ID: 1-2187@10.0.2.20\r\nCSeq: 1 INVITE\r\nContact: sip:sipp@10.0.2.20:5060\r\nMax-Forwards: 70\r\nContent-Type: application/sdp\r\nContent-Length:   123\r\n\r\nv=0\r\no=- 42 42 IN IP4 10.0.2.20\r\ns=-\r\nc=IN IP4 10.0.2.20\r\nt=0 0\r\nm=audio 6000 RTP/AVP 5\r\na=rtpmap:5 DVI4/8000\r\na=recvonly\r\n",
         "sequence": 1,
-        "start": "2022-03-09T08:32:14.536Z",
+        "start": "2022-05-13T07:10:35.715Z",
         "type": [
             "info"
         ]
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "172.31.0.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-AC-1F-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "network": {

--- a/packages/network_traffic/docs/README.md
+++ b/packages/network_traffic/docs/README.md
@@ -3169,13 +3169,13 @@ An example event for `sip` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T08:32:14.536Z",
+    "@timestamp": "2022-05-13T07:10:35.715Z",
     "agent": {
-        "ephemeral_id": "ee3aeba6-2bd9-4a89-840a-32af72217a7a",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "008322ce-0d84-45f0-beaf-153cf4786013",
+        "id": "a82e5ec9-4d24-4491-8d66-470aa321ddae",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.0"
     },
     "client": {
         "ip": "10.0.2.20",
@@ -3194,48 +3194,47 @@ An example event for `sip` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "a82e5ec9-4d24-4491-8d66-470aa321ddae",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.0"
     },
     "event": {
         "action": "sip-invite",
         "agent_id_status": "verified",
         "category": [
-            "network",
-            "protocol"
+            "network"
         ],
         "dataset": "network_traffic.sip",
         "duration": 0,
-        "end": "2022-03-09T08:32:14.536Z",
-        "ingested": "2022-03-09T08:32:15Z",
+        "end": "2022-05-13T07:10:35.715Z",
+        "ingested": "2022-05-13T07:10:39Z",
         "kind": "event",
         "original": "INVITE sip:test@10.0.2.15:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 10.0.2.20:5060;branch=z9hG4bK-2187-1-0\r\nFrom: \"DVI4/8000\" \u003csip:sipp@10.0.2.20:5060\u003e;tag=1\r\nTo: test \u003csip:test@10.0.2.15:5060\u003e\r\nCall-ID: 1-2187@10.0.2.20\r\nCSeq: 1 INVITE\r\nContact: sip:sipp@10.0.2.20:5060\r\nMax-Forwards: 70\r\nContent-Type: application/sdp\r\nContent-Length:   123\r\n\r\nv=0\r\no=- 42 42 IN IP4 10.0.2.20\r\ns=-\r\nc=IN IP4 10.0.2.20\r\nt=0 0\r\nm=audio 6000 RTP/AVP 5\r\na=rtpmap:5 DVI4/8000\r\na=recvonly\r\n",
         "sequence": 1,
-        "start": "2022-03-09T08:32:14.536Z",
+        "start": "2022-05-13T07:10:35.715Z",
         "type": [
             "info"
         ]
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "172.31.0.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-AC-1F-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "network": {

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: 0.10.0
+version: 0.10.1
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This change removes an invalid value in the SIP data set.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

See https://github.com/elastic/integrations/issues/3016#issuecomment-1123638937

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #3329

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
