### PR TITLE
cisco_ftd: remove invalid values from ECS fields

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove invalid values from ECS fields
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/3344
 - version: "2.2.0"
   changes:
     - description: Add TCP input with TLS support

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.1"
+  changes:
+    - description: Remove invalid values from ECS fields
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/xxxx
 - version: "2.2.0"
   changes:
     - description: Add TCP input with TLS support

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -4669,12 +4669,13 @@
             "event": {
                 "action": "firewall-rule",
                 "category": [
-                    "network"
+                    "network",
+                    "intrusion_detection"
                 ],
                 "code": "338004",
                 "kind": "event",
                 "original": "Jan 14 2015 13:16:14: %FTD-4-338004: Dynamic Filter monitored blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.168.2.223/80 (192.168.2.225/80), destination 192.168.2.223 resolved from dynamic list: 192.168.2.223/255.255.255.255, threat-level: very-high, category: Malware",
-                "outcome": "monitored",
+                "outcome": "success",
                 "severity": 4,
                 "type": [
                     "info"

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-connection.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-connection.log-expected.json
@@ -1118,7 +1118,7 @@
                 "code": "430002",
                 "kind": "event",
                 "original": "2019-08-16T09:35:15Z firepower  %FTD-1-430002: AccessControlRuleAction: Block, SrcIP: 10.0.100.30, DstIP: 10.0.1.20, ICMPType: Echo Request, ICMPCode: No Code, Protocol: icmp, IngressInterface: output, EgressInterface: input, IngressZone: output-zone, EgressZone: input-zone, ACPolicy: default, AccessControlRuleName: Block-inbound-ICMP, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, InitiatorPackets: 0, ResponderPackets: 0, InitiatorBytes: 0, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity",
-                "outcome": "block",
+                "outcome": "success",
                 "severity": 1,
                 "type": [
                     "connection",
@@ -1241,7 +1241,7 @@
                 "end": "2019-08-14T15:09:41.000Z",
                 "kind": "event",
                 "original": "Aug 14 2019 15:09:41 siem-ftd  %FTD-1-430003: AccessControlRuleAction: Block, AccessControlRuleReason: File Block, SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41544, DstPort: 8000, Protocol: tcp, IngressInterface: input, EgressInterface: output, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, UserAgent: curl/7.58.0, Client: cURL, ClientVersion: 7.58.0, ApplicationProtocol: HTTP, ConnectionDuration: 1, FileCount: 1, InitiatorPackets: 4, ResponderPackets: 7, InitiatorBytes: 365, ResponderBytes: 1927, NAPPolicy: Balanced Security and Connectivity, HTTPResponse: 200, ReferencedHost: 10.0.100.30:8000, URL: http://10.0.100.30:8000/eicar_com.zip",
-                "outcome": "block",
+                "outcome": "success",
                 "severity": 1,
                 "start": "2019-08-14T15:09:40.000Z",
                 "type": [

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1816,7 +1816,12 @@ processors:
             ctx.event.type.add('denied');
           }
           if (ctx.event.outcome == 'block') {
+            ctx.event.outcome = 'success';
             ctx.event.type.add('denied');
+          }
+          if (ctx.event.outcome == 'monitored') {
+            ctx.event.category.add('intrusion_detection');
+            ctx.event.outcome = 'success';
           }
         }
 

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ftd
 title: Cisco FTD
-version: 2.2.0
+version: 2.2.1
 license: basic
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This removes invalid values from the event.outcome field. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3328

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
