### PR TITLE
Try next elastic-package 0.48

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/elastic/go-sysinfo v1.7.1 // indirect
 	github.com/elastic/go-ucfg v0.8.4 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
-	github.com/elastic/package-spec v1.7.1 // indirect
+	github.com/elastic/package-spec v1.8.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
@@ -164,3 +164,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/elastic/elastic-package => github.com/elastic/elastic-package v0.48.1-0.20220512130958-590627003e63

--- a/go.mod
+++ b/go.mod
@@ -165,4 +165,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/elastic/elastic-package => github.com/elastic/elastic-package v0.48.1-0.20220512130958-590627003e63
+replace github.com/elastic/elastic-package => github.com/jsoriano/elastic-package v0.0.0-20220512161058-1eba589049f4

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/elastic/elastic-package v0.48.2 h1:sIF8Shfsu+J96bllzEMgc7BDhpaE2b4gCXziYwyNRXw=
-github.com/elastic/elastic-package v0.48.2/go.mod h1:tUXKdvUNGgV9myTfbeGmI4LNMUjuILAlXF8NfZNiCHw=
+github.com/elastic/elastic-package v0.48.1-0.20220512130958-590627003e63 h1:G5V88IG5ItR/N9lv/csEaFglfK6wA8NZQgfiLdIbCjQ=
+github.com/elastic/elastic-package v0.48.1-0.20220512130958-590627003e63/go.mod h1:lBtlDwcby/RiV57Ft9JbU1m2kc3ssUrIw6GypCrI8/0=
 github.com/elastic/go-elasticsearch/v7 v7.17.1 h1:49mHcHx7lpCL8cW1aioEwSEVKQF3s+Igi4Ye/QTWwmk=
 github.com/elastic/go-elasticsearch/v7 v7.17.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
@@ -427,8 +427,8 @@ github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUt
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
 github.com/elastic/package-registry v1.8.0 h1:c2nUbBZct3c2LZ6uw0HotB+11PmYM8xh0ynvyeuzFBY=
 github.com/elastic/package-registry v1.8.0/go.mod h1:zh8h1v9v2VYBQvlZK2KoD/uDJlYC7re5PLf4eDALEFA=
-github.com/elastic/package-spec v1.7.1 h1:Q2THMEnG4sRy+XSty16S2JLnVsROq4Ddo80WgQJzbo0=
-github.com/elastic/package-spec v1.7.1/go.mod h1:KzGTSDqCkdhmL1IFpOH2ZQNSSE9JEhNtndxU3ZrQilA=
+github.com/elastic/package-spec v1.8.1 h1:FOBODPtIrKsNSDuRMPy8zDmEj8A2/ZyevnlfwCKi+ms=
+github.com/elastic/package-spec v1.8.1/go.mod h1:KzGTSDqCkdhmL1IFpOH2ZQNSSE9JEhNtndxU3ZrQilA=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,6 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/elastic/elastic-package v0.48.1-0.20220512130958-590627003e63 h1:G5V88IG5ItR/N9lv/csEaFglfK6wA8NZQgfiLdIbCjQ=
-github.com/elastic/elastic-package v0.48.1-0.20220512130958-590627003e63/go.mod h1:lBtlDwcby/RiV57Ft9JbU1m2kc3ssUrIw6GypCrI8/0=
 github.com/elastic/go-elasticsearch/v7 v7.17.1 h1:49mHcHx7lpCL8cW1aioEwSEVKQF3s+Igi4Ye/QTWwmk=
 github.com/elastic/go-elasticsearch/v7 v7.17.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
@@ -809,6 +807,8 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jsoriano/elastic-package v0.0.0-20220512161058-1eba589049f4 h1:7jXOT7DAVNicVXX/udmScKqv4agIM8lkrdP6Ip+0RS8=
+github.com/jsoriano/elastic-package v0.0.0-20220512161058-1eba589049f4/go.mod h1:lBtlDwcby/RiV57Ft9JbU1m2kc3ssUrIw6GypCrI8/0=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=


### PR DESCRIPTION
Test current elastic-package master in CI before releasing a new version.

Most changes are related to https://github.com/elastic/package-spec/issues/331.