### PR TITLE
cisco_asa: remove invalid values from ECS fields

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.1"
+  changes:
+    - description: Ensure invalid event.outcome does not get recorded in event
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3354
 - version: "2.4.0"
   changes:
     - description: Add TCP input with TLS support

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -4682,12 +4682,13 @@
             "event": {
                 "action": "firewall-rule",
                 "category": [
-                    "network"
+                    "network",
+                    "intrusion_detection"
                 ],
                 "code": "338004",
                 "kind": "event",
                 "original": "Jan 14 2015 13:16:14: %ASA-4-338004: Dynamic Filter monitored blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.168.2.223/80 (192.168.2.223/80), destination 192.168.2.223 resolved from dynamic list: 192.168.2.223/255.255.255.255, threat-level: very-high, category: Malware",
-                "outcome": "monitored",
+                "outcome": "success",
                 "severity": 4,
                 "type": [
                     "info"

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1953,6 +1953,10 @@ processors:
         } else if (ctx?.event?.action.startsWith('connection-')) {
           ctx.event.type.add('connection');
         }
+        if (ctx.event.outcome == 'monitored') {
+          ctx.event.category.add('intrusion_detection');
+          ctx.event.outcome = 'success';
+        }
 
   - set:
       description: copy destination.user.name to user.name if it is not set

--- a/packages/cisco_asa/data_stream/log/sample_event.json
+++ b/packages/cisco_asa/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "147a5d91-18f7-4a75-9392-267d0d1f7e3b",
-        "id": "76622dbf-9aac-410d-ad3f-a1e99729e87f",
+        "ephemeral_id": "20ad3c57-e3e6-4064-a346-d303aa6d401e",
+        "id": "adecf804-775a-4deb-8b7f-486ddc33b19e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.2.0"
     },
     "cisco": {
         "asa": {
@@ -27,9 +27,9 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "76622dbf-9aac-410d-ad3f-a1e99729e87f",
+        "id": "adecf804-775a-4deb-8b7f-486ddc33b19e",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.0"
     },
     "event": {
         "action": "firewall-rule",
@@ -39,7 +39,7 @@
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2022-03-10T23:57:18Z",
+        "ingested": "2022-05-16T01:09:09Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
         "severity": 6,
@@ -52,12 +52,12 @@
         "hostname": "localhost"
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.32.7:40986"
+            "address": "192.168.160.4:44914"
         }
     },
     "network": {

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -17,11 +17,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "147a5d91-18f7-4a75-9392-267d0d1f7e3b",
-        "id": "76622dbf-9aac-410d-ad3f-a1e99729e87f",
+        "ephemeral_id": "20ad3c57-e3e6-4064-a346-d303aa6d401e",
+        "id": "adecf804-775a-4deb-8b7f-486ddc33b19e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.2.0"
     },
     "cisco": {
         "asa": {
@@ -43,9 +43,9 @@ An example event for `log` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "76622dbf-9aac-410d-ad3f-a1e99729e87f",
+        "id": "adecf804-775a-4deb-8b7f-486ddc33b19e",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.0"
     },
     "event": {
         "action": "firewall-rule",
@@ -55,7 +55,7 @@ An example event for `log` looks as following:
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2022-03-10T23:57:18Z",
+        "ingested": "2022-05-16T01:09:09Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
         "severity": 6,
@@ -68,12 +68,12 @@ An example event for `log` looks as following:
         "hostname": "localhost"
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.32.7:40986"
+            "address": "192.168.160.4:44914"
         }
     },
     "network": {

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: 2.4.0
+version: 2.4.1
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This removes invalid values from the event.outcome field.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #3344
- Relates #3016

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
