### PR TITLE
network_traffic: release as ga

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Release as GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/3355
 - version: "0.10.1"
   changes:
     - description: Remove invalid value from `event.category` in SIP data set.

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Release as GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxx
 - version: "0.10.1"
   changes:
     - description: Remove invalid value from `event.category` in SIP data set.

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,13 +1,13 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: 0.10.1
+version: 1.0.0
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
 categories:
   - web
-release: beta
+release: ga
 conditions:
   kibana.version: ^7.17.0 || ^8.0.0
 policy_templates:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

It moves the network packet capture integration to release:ga.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
