### PR TITLE
[sonicwall] Format {source,destination}.mac per ECS

### DIFF
--- a/packages/sonicwall/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sonicwall/_dev/deploy/docker/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   sonicwall-firewall-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.7.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash
     command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9536 -p=udp /sample_logs/sonicwall-firewall-*.log"
   sonicwall-firewall-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.7.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash

--- a/packages/sonicwall/changelog.yml
+++ b/packages/sonicwall/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.1"
+  changes:
+    - description: Format source.mac and destination.mac as per ECS.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3360
 - version: "0.8.0"
   changes:
     - description: Update to ECS 8.2.0

--- a/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-common-config.yml
+++ b/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,3 @@
-dynamic_fields:
-  event.ingested: ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-rsa2elk-output.json
+++ b/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-rsa2elk-output.json
@@ -1,0 +1,109 @@
+{
+    "events": [
+        {
+            "@timestamp": "2018-04-08T04:33:58.000Z",
+            "agent": {
+                "ephemeral_id": "4848b949-d929-46d0-9b02-5beed1da7691",
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.1.3"
+            },
+            "data_stream": {
+                "dataset": "sonicwall.firewall",
+                "namespace": "ep",
+                "type": "logs"
+            },
+            "destination": {
+                "ip": "10.246.0.167",
+                "mac": "01:00:5e:2c:22:06",
+                "port": 2189
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "elastic_agent": {
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "snapshot": false,
+                "version": "8.1.3"
+            },
+            "event": {
+                "action": "block",
+                "code": "utodita",
+                "dataset": "sonicwall.firewall",
+                "original": "id=utodita sn=aec time=\"2018-4-8 4:33:58\" fw=10.21.89.175 pri=medium c=diconse m=428 msg=\"elitse\" n=reseo src=10.71.238.250:41:lo3856 dst=10.246.0.167:2189:eth2632 srcMac= 01:00:5e:7c:42:0b dstMac=01:00:5e:2c:22:06 proto=icmp fw_action=\"block\"",
+                "timezone": "+00:00"
+            },
+            "host": {
+                "ip": "10.21.89.175"
+            },
+            "input": {
+                "type": "tcp"
+            },
+            "log": {
+                "level": "medium",
+                "source": {
+                    "address": "172.18.0.7:34140"
+                }
+            },
+            "message": "elitse",
+            "network": {
+                "protocol": "icmp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "eth2632"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "lo3856"
+                    }
+                },
+                "product": "Firewalls",
+                "type": "Firewall",
+                "vendor": "Sonicwall"
+            },
+            "related": {
+                "ip": [
+                    "10.71.238.250",
+                    "10.246.0.167",
+                    "10.21.89.175"
+                ]
+            },
+            "rsa": {
+                "internal": {
+                    "event_desc": "elitse",
+                    "messageid": "428"
+                },
+                "misc": {
+                    "action": [
+                        "block"
+                    ],
+                    "category": "diconse",
+                    "reference_id": "utodita",
+                    "serial_number": "aec",
+                    "severity": "medium"
+                },
+                "network": {
+                    "dinterface": "eth2632",
+                    "sinterface": "lo3856"
+                },
+                "time": {
+                    "date": "2018-4-8",
+                    "event_time": "2018-04-08T04:33:58.000Z"
+                }
+            },
+            "source": {
+                "ip": "10.71.238.250",
+                "mac": "01:00:5e:7c:42:0b",
+                "port": 41
+            },
+            "tags": [
+                "sonicwall-firewall",
+                "forwarded"
+            ]
+        }
+    ]
+}

--- a/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-rsa2elk-output.json-expected.json
+++ b/packages/sonicwall/data_stream/firewall/_dev/test/pipeline/test-rsa2elk-output.json-expected.json
@@ -1,0 +1,108 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2018-04-08T04:33:58.000Z",
+            "agent": {
+                "ephemeral_id": "4848b949-d929-46d0-9b02-5beed1da7691",
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.1.3"
+            },
+            "data_stream": {
+                "dataset": "sonicwall.firewall",
+                "namespace": "ep",
+                "type": "logs"
+            },
+            "destination": {
+                "ip": "10.246.0.167",
+                "mac": "01-00-5E-2C-22-06",
+                "port": 2189
+            },
+            "ecs": {
+                "version": "8.2.0"
+            },
+            "elastic_agent": {
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "snapshot": false,
+                "version": "8.1.3"
+            },
+            "event": {
+                "action": "block",
+                "code": "utodita",
+                "dataset": "sonicwall.firewall",
+                "original": "id=utodita sn=aec time=\"2018-4-8 4:33:58\" fw=10.21.89.175 pri=medium c=diconse m=428 msg=\"elitse\" n=reseo src=10.71.238.250:41:lo3856 dst=10.246.0.167:2189:eth2632 srcMac= 01:00:5e:7c:42:0b dstMac=01:00:5e:2c:22:06 proto=icmp fw_action=\"block\"",
+                "timezone": "+00:00"
+            },
+            "host": {
+                "ip": "10.21.89.175"
+            },
+            "input": {
+                "type": "tcp"
+            },
+            "log": {
+                "level": "medium",
+                "source": {
+                    "address": "172.18.0.7:34140"
+                }
+            },
+            "message": "elitse",
+            "network": {
+                "protocol": "icmp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "eth2632"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "lo3856"
+                    }
+                },
+                "product": "Firewalls",
+                "type": "Firewall",
+                "vendor": "Sonicwall"
+            },
+            "related": {
+                "ip": [
+                    "10.71.238.250",
+                    "10.246.0.167",
+                    "10.21.89.175"
+                ]
+            },
+            "rsa": {
+                "internal": {
+                    "event_desc": "elitse",
+                    "messageid": "428"
+                },
+                "misc": {
+                    "action": [
+                        "block"
+                    ],
+                    "category": "diconse",
+                    "reference_id": "utodita",
+                    "serial_number": "aec",
+                    "severity": "medium"
+                },
+                "network": {
+                    "dinterface": "eth2632",
+                    "sinterface": "lo3856"
+                },
+                "time": {
+                    "date": "2018-4-8",
+                    "event_time": "2018-04-08T04:33:58.000Z"
+                }
+            },
+            "source": {
+                "ip": "10.71.238.250",
+                "mac": "01-00-5E-7C-42-0B",
+                "port": 41
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/sonicwall/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sonicwall/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -5,6 +5,22 @@ processors:
   - set:
       field: ecs.version
       value: '8.2.0'
+  - gsub:
+      field: destination.mac
+      ignore_missing: true
+      pattern: '[:]'
+      replacement: '-'
+  - gsub:
+      field: source.mac
+      ignore_missing: true
+      pattern: '[:]'
+      replacement: '-'
+  - uppercase:
+      field: destination.mac
+      ignore_missing: true
+  - uppercase:
+      field: source.mac
+      ignore_missing: true
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/sonicwall/manifest.yml
+++ b/packages/sonicwall/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sonicwall
 title: Sonicwall-FW Logs
-version: 0.8.0
+version: "0.8.1"
 description: Collect logs from Sonicwall devices with Elastic Agent.
 categories: ["network", "security"]
 release: experimental


### PR DESCRIPTION


## What does this PR do?

Format the `{source,destination}.mac` field as per ECS (h[ttps://www.elastic.co/guide/en/ecs/current/ecs-observer.html#field-observer-mac](https://www.elastic.co/guide/en/ecs/current/ecs-source.html#field-source-mac)). 

> The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.
## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

