### PR TITLE
[M365_Defender] Update duplication for redirect type events

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.4"
+  changes:
+    - description: Update duplication handling to also support Redirect type alerts
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3194
 - version: "1.0.3"
   changes:
     - description: Add duplication handling in ingest pipeline

--- a/packages/m365_defender/data_stream/log/_dev/test/pipeline/test-m365-defender-empty-ndjson.log-expected.json
+++ b/packages/m365_defender/data_stream/log/_dev/test/pipeline/test-m365-defender-empty-ndjson.log-expected.json
@@ -1,37 +1,5 @@
 {
     "expected": [
-        {
-            "@timestamp": "2021-04-12T11:18:30.4033333Z",
-            "cloud": {
-                "provider": "azure"
-            },
-            "ecs": {
-                "version": "8.2.0"
-            },
-            "event": {
-                "category": [
-                    "host"
-                ],
-                "created": "2021-04-12T11:18:28.86Z",
-                "kind": "alert",
-                "original": "{\"incidentId\":1111,\"redirectIncidentId\":1107,\"incidentName\":\"Impossible travel activity involving one user\",\"createdTime\":\"2021-04-12T11:18:28.86Z\",\"lastUpdateTime\":\"2021-04-12T11:18:30.4033333Z\",\"assignedTo\":null,\"classification\":\"Unknown\",\"determination\":\"NotAvailable\",\"status\":\"Redirected\",\"severity\":\"UnSpecified\",\"tags\":[],\"comments\":[],\"alerts\":[]}",
-                "timezone": "UTC"
-            },
-            "m365_defender": {
-                "classification": "Unknown",
-                "determination": "NotAvailable",
-                "incidentId": "1111",
-                "redirectIncidentId": "1107",
-                "status": "Redirected"
-            },
-            "message": "Impossible travel activity involving one user",
-            "observer": {
-                "product": "365 Defender",
-                "vendor": "Microsoft"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        }
+        null
     ]
 }

--- a/packages/m365_defender/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -11,6 +11,9 @@ processors:
   - json:
       field: event.original
       target_field: json
+  - drop:
+      description: Drops duplicated events without alerts
+      if: ctx.json?.status == 'Redirected'
   - remove:
       field:
         - json.alerts

--- a/packages/m365_defender/data_stream/log/sample_event.json
+++ b/packages/m365_defender/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-09-06T12:07:55.32Z",
     "agent": {
-        "ephemeral_id": "1ebfd048-e749-4ff2-96be-5b4aeb0f86e3",
-        "id": "a7b26a39-38e4-4f22-91d4-c27b8a1f18b2",
+        "ephemeral_id": "c642e33c-9a0b-4d7b-8be4-0baa5bbbb9c5",
+        "id": "66ee0cf6-0f3a-4a85-bb44-eb9ba0cc0863",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.1.0"
     },
     "cloud": {
         "provider": "azure"
@@ -19,9 +19,9 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "a7b26a39-38e4-4f22-91d4-c27b8a1f18b2",
+        "id": "66ee0cf6-0f3a-4a85-bb44-eb9ba0cc0863",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.1.0"
     },
     "event": {
         "action": "InitialAccess",
@@ -34,7 +34,7 @@
         "duration": 0,
         "end": "2020-09-06T12:04:00Z",
         "id": "faf8edc936-85f8-a603-b800-08d8525cf099",
-        "ingested": "2022-04-26T07:37:34Z",
+        "ingested": "2022-05-17T07:46:27Z",
         "kind": "alert",
         "provider": "OfficeATP",
         "severity": 1,

--- a/packages/m365_defender/docs/README.md
+++ b/packages/m365_defender/docs/README.md
@@ -26,11 +26,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2020-09-06T12:07:55.32Z",
     "agent": {
-        "ephemeral_id": "1ebfd048-e749-4ff2-96be-5b4aeb0f86e3",
-        "id": "a7b26a39-38e4-4f22-91d4-c27b8a1f18b2",
+        "ephemeral_id": "c642e33c-9a0b-4d7b-8be4-0baa5bbbb9c5",
+        "id": "66ee0cf6-0f3a-4a85-bb44-eb9ba0cc0863",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.1.0"
     },
     "cloud": {
         "provider": "azure"
@@ -44,9 +44,9 @@ An example event for `log` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "a7b26a39-38e4-4f22-91d4-c27b8a1f18b2",
+        "id": "66ee0cf6-0f3a-4a85-bb44-eb9ba0cc0863",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.1.0"
     },
     "event": {
         "action": "InitialAccess",
@@ -59,7 +59,7 @@ An example event for `log` looks as following:
         "duration": 0,
         "end": "2020-09-06T12:04:00Z",
         "id": "faf8edc936-85f8-a603-b800-08d8525cf099",
-        "ingested": "2022-04-26T07:37:34Z",
+        "ingested": "2022-05-17T07:46:27Z",
         "kind": "alert",
         "provider": "OfficeATP",
         "severity": 1,

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: m365_defender
 title: M365 Defender Logs
-version: 1.0.3
+version: 1.0.4
 description: Collect logs from M365 Defender API with Elastic Agent.
 categories:
   - "network"


### PR DESCRIPTION
## What does this PR do?

Events with status type of "Redirect" is events created when an incident is updated, however without any information, alerts or ID's, so it bypasses duplication handling, this PR ensures those empty events are also dropped.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


