### PR TITLE
[cylance] Format host.mac per ECS

### DIFF
--- a/packages/cylance/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cylance/_dev/deploy/docker/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cylance-protect-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.7.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash
     command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9529 -p=udp /sample_logs/cylance-protect-*.log"
   cylance-protect-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.7.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash

--- a/packages/cylance/changelog.yml
+++ b/packages/cylance/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.1"
+  changes:
+    - description: Format host.mac as per ECS.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3368
 - version: "0.8.0"
   changes:
     - description: Update to ECS 8.2.0

--- a/packages/cylance/data_stream/protect/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cylance/data_stream/protect/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,3 @@
-dynamic_fields:
-  event.ingested: ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/cylance/data_stream/protect/_dev/test/pipeline/test-rsa2elk-output.json
+++ b/packages/cylance/data_stream/protect/_dev/test/pipeline/test-rsa2elk-output.json
@@ -1,0 +1,96 @@
+{
+    "events": [
+        {
+            "@timestamp": "2022-02-24T07:26:15.000Z",
+            "agent": {
+                "ephemeral_id": "354b040b-34b0-4afd-a65e-f9b5218ab48b",
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.1.3"
+            },
+            "data_stream": {
+                "dataset": "cylance.protect",
+                "namespace": "ep",
+                "type": "logs"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "elastic_agent": {
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "snapshot": false,
+                "version": "8.1.3"
+            },
+            "event": {
+                "action": "DeviceRemove",
+                "code": "CylancePROTECT",
+                "dataset": "cylance.protect",
+                "original": "24-Feb-2018 7:26:15 very-high idolor3916.www5.home tas \u003c\u003cautfugi\u003etasun 24T19:26:15.duntutla ntium4450.www5.localdomain CylancePROTECT Event Name:DeviceRemove, Device Name:vol, Agent Version:oremquel, IP Address: (10.22.94.10), MAC Address: (01:00:5e:ee:e8:77), Logged On Users: (ssusci), OS:animid, Zone Names:mpo",
+                "timezone": "+00:00"
+            },
+            "host": {
+                "mac": "01:00:5e:ee:e8:77",
+                "name": "ntium4450.www5.localdomain"
+            },
+            "input": {
+                "type": "log"
+            },
+            "log": {
+                "file": {
+                    "path": "/tmp/service_logs/cylance-protect-generated.log"
+                },
+                "offset": 14198
+            },
+            "observer": {
+                "product": "Protect",
+                "type": "Anti-Virus",
+                "vendor": "Cylance"
+            },
+            "related": {
+                "ip": [
+                    "10.22.94.10"
+                ],
+                "user": [
+                    "ssusci"
+                ]
+            },
+            "rsa": {
+                "db": {
+                    "index": "mpo"
+                },
+                "internal": {
+                    "messageid": "CylancePROTECT"
+                },
+                "investigations": {
+                    "event_cat": 1804020000,
+                    "event_cat_name": "Network.Devices.Removals"
+                },
+                "misc": {
+                    "OS": "animid",
+                    "event_type": "DeviceRemove",
+                    "node": "vol"
+                },
+                "network": {
+                    "alias_host": [
+                        "ntium4450.www5.localdomain"
+                    ],
+                    "eth_host": "01:00:5e:ee:e8:77"
+                },
+                "time": {
+                    "event_time": "2022-02-24T07:26:15.000Z"
+                }
+            },
+            "source": {
+                "ip": "10.22.94.10"
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "ssusci"
+            }
+        }
+    ]
+}

--- a/packages/cylance/data_stream/protect/_dev/test/pipeline/test-rsa2elk-output.json-expected.json
+++ b/packages/cylance/data_stream/protect/_dev/test/pipeline/test-rsa2elk-output.json-expected.json
@@ -1,0 +1,100 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-02-24T07:26:15.000Z",
+            "agent": {
+                "ephemeral_id": "354b040b-34b0-4afd-a65e-f9b5218ab48b",
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.1.3"
+            },
+            "data_stream": {
+                "dataset": "cylance.protect",
+                "namespace": "ep",
+                "type": "logs"
+            },
+            "ecs": {
+                "version": "8.2.0"
+            },
+            "elastic_agent": {
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "snapshot": false,
+                "version": "8.1.3"
+            },
+            "event": {
+                "action": "DeviceRemove",
+                "code": "CylancePROTECT",
+                "dataset": "cylance.protect",
+                "original": "24-Feb-2018 7:26:15 very-high idolor3916.www5.home tas \u003c\u003cautfugi\u003etasun 24T19:26:15.duntutla ntium4450.www5.localdomain CylancePROTECT Event Name:DeviceRemove, Device Name:vol, Agent Version:oremquel, IP Address: (10.22.94.10), MAC Address: (01:00:5e:ee:e8:77), Logged On Users: (ssusci), OS:animid, Zone Names:mpo",
+                "timezone": "+00:00"
+            },
+            "host": {
+                "mac": [
+                    "01-00-5E-EE-E8-77"
+                ],
+                "name": "ntium4450.www5.localdomain"
+            },
+            "input": {
+                "type": "log"
+            },
+            "log": {
+                "file": {
+                    "path": "/tmp/service_logs/cylance-protect-generated.log"
+                },
+                "offset": 14198
+            },
+            "observer": {
+                "product": "Protect",
+                "type": "Anti-Virus",
+                "vendor": "Cylance"
+            },
+            "related": {
+                "hosts": [
+                    "ntium4450.www5.localdomain"
+                ],
+                "ip": [
+                    "10.22.94.10"
+                ],
+                "user": [
+                    "ssusci"
+                ]
+            },
+            "rsa": {
+                "db": {
+                    "index": "mpo"
+                },
+                "internal": {
+                    "messageid": "CylancePROTECT"
+                },
+                "investigations": {
+                    "event_cat": 1804020000,
+                    "event_cat_name": "Network.Devices.Removals"
+                },
+                "misc": {
+                    "OS": "animid",
+                    "event_type": "DeviceRemove",
+                    "node": "vol"
+                },
+                "network": {
+                    "alias_host": [
+                        "ntium4450.www5.localdomain"
+                    ],
+                    "eth_host": "01:00:5e:ee:e8:77"
+                },
+                "time": {
+                    "event_time": "2022-02-24T07:26:15.000Z"
+                }
+            },
+            "source": {
+                "ip": "10.22.94.10"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "ssusci"
+            }
+        }
+    ]
+}

--- a/packages/cylance/data_stream/protect/_dev/test/system/test-udp-config.yml
+++ b/packages/cylance/data_stream/protect/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,6 @@ data_stream:
   vars:
     udp_host: 0.0.0.0
     udp_port: 9529
+    tags:
+      - forwarded
+      - preserve_original_event

--- a/packages/cylance/data_stream/protect/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cylance/data_stream/protect/elasticsearch/ingest_pipeline/default.yml
@@ -5,6 +5,20 @@ processors:
   - set:
       field: ecs.version
       value: '8.2.0'
+  - gsub:
+      field: host.mac
+      ignore_missing: true
+      pattern: '[:]'
+      replacement: '-'
+  - uppercase:
+      field: host.mac
+      ignore_missing: true
+  - script:
+      description: Convert host.mac to an array.
+      if: ctx.host?.mac != null && ctx.host.mac instanceof String
+      lang: painless
+      source:
+        ctx.host.mac = [ctx.host.mac];
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/cylance/data_stream/protect/sample_event.json
+++ b/packages/cylance/data_stream/protect/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2016-01-29T06:09:59.000Z",
     "agent": {
-        "ephemeral_id": "b747ad16-71f9-4ee3-80f1-e9c6e453cec1",
-        "id": "4e3f135a-d5f9-40b6-ae01-2c834ecbead0",
+        "ephemeral_id": "59f54338-3ade-4554-a66e-005e3f777eec",
+        "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.1.3"
     },
     "data_stream": {
         "dataset": "cylance.protect",
@@ -16,16 +16,17 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4e3f135a-d5f9-40b6-ae01-2c834ecbead0",
-        "snapshot": true,
-        "version": "8.0.0"
+        "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+        "snapshot": false,
+        "version": "8.1.3"
     },
     "event": {
         "action": "ZoneAdd",
         "agent_id_status": "verified",
         "code": "CylancePROTECT",
         "dataset": "cylance.protect",
-        "ingested": "2022-01-25T12:14:23Z",
+        "ingested": "2022-05-17T13:06:35Z",
+        "original": "29-January-2016 06:09:59 high boNemoe4402.www.invalid dolore \u003c\u003csequa\u003eabo 2016-1-29T6:09:59.squira nostrud4819.mail.test CylancePROTECT mqui nci [billoi] Event Type: AuditLog, Event Name: ZoneAdd, Message: Policy Assigned:orev; Devices: pisciv , User: uii umexe (estlabo)",
         "timezone": "+00:00"
     },
     "host": {
@@ -78,7 +79,7 @@
         }
     },
     "tags": [
-        "cylance-protect",
-        "forwarded"
+        "forwarded",
+        "preserve_original_event"
     ]
 }

--- a/packages/cylance/manifest.yml
+++ b/packages/cylance/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cylance
 title: CylanceProtect Logs
-version: 0.8.0
+version: "0.8.1"
 description: Collect logs from CylanceProtect devices with Elastic Agent.
 categories: ["security"]
 release: experimental


### PR DESCRIPTION
## What does this PR do?

Format the `host.mac` field as per ECS (https://www.elastic.co/guide/en/ecs/current/ecs-client.html#field-client-mac).

> The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.

The value also needed to be converted to an array.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
