### PR TITLE
[sophos.utm] Format {source,destination}.mac per ECS

### DIFF
--- a/packages/sophos/_dev/deploy/docker/sample_logs/sophos-utm-generated.log
+++ b/packages/sophos/_dev/deploy/docker/sample_logs/sophos-utm-generated.log
@@ -98,3 +98,5 @@
 2019:11:15-17:19:22 emvel4391.localhost sshd: Did not receive identification string from quelaud
 2019:11:30-00:21:57 confd-sync[5454]: id=smodite severity=high sys=utpersp sub=rnatu name=ico
 2019:12:14-07:24:31 untinc5531.www5.test sshd: error: Could not get shadow information for NOUSER
+2019:04:08-11:21:55 galaxy ulogd[5009]: id="2002" severity="info" sys="SecureNet" sub="packetfilter" name="Packet accepted" action="accept" fwrule="3000000014" initf="eth0" outitf="eth3" srcmac="00:50:56:c0:00:01" dstmac="00:0c:29:93:cc:85" srcip="192.168.168.1" dstip="172.30.30.1" proto="6" length="52" tos="0x00" prec="0x00" ttl="127" srcport="57051" dstport="51130" tcpflags="SYN"
+2019:04:08-11:22:05 gemini ulogd[8882]: id="2000" severity="info" sys="SecureNet" sub="packetfilter" name="Packet logged" action="log" fwrule="62003" initf="eth0" srcmac="00:0c:29:93:cc:a3" dstmac="00:0c:29:69:57:8b" srcip="192.168.168.1" dstip="172.30.30.1" proto="6" length="52" tos="0x00" prec="0x00" ttl="127" srcport="57096" dstport="51130" tcpflags="SYN"

--- a/packages/sophos/data_stream/utm/_dev/test/pipeline/test-packet-filter.json
+++ b/packages/sophos/data_stream/utm/_dev/test/pipeline/test-packet-filter.json
@@ -1,0 +1,115 @@
+{
+    "events": [
+        {
+            "@timestamp": "2019-04-08T11:21:55.000Z",
+            "agent": {
+                "ephemeral_id": "e311f248-bcfe-40fa-a92c-75047bac1b66",
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.1.3"
+            },
+            "data_stream": {
+                "dataset": "sophos.utm",
+                "namespace": "ep",
+                "type": "logs"
+            },
+            "destination": {
+                "ip": "172.30.30.1",
+                "mac": "00:0c:29:93:cc:85",
+                "port": 51130
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "elastic_agent": {
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "snapshot": false,
+                "version": "8.1.3"
+            },
+            "event": {
+                "code": "ulogd",
+                "dataset": "sophos.utm",
+                "original": "2019:04:08-11:21:55 galaxy ulogd[5009]: id=\"2002\" severity=\"info\" sys=\"SecureNet\" sub=\"packetfilter\" name=\"Packet accepted\" action=\"accept\" fwrule=\"3000000014\" initf=\"eth0\" outitf=\"eth3\" srcmac=\"00:50:56:c0:00:01\" dstmac=\"00:0c:29:93:cc:85\" srcip=\"192.168.168.1\" dstip=\"172.30.30.1\" proto=\"6\" length=\"52\" tos=\"0x00\" prec=\"0x00\" ttl=\"127\" srcport=\"57051\" dstport=\"51130\" tcpflags=\"SYN\"",
+                "timezone": "+00:00"
+            },
+            "host": {
+                "name": "galaxy"
+            },
+            "input": {
+                "type": "log"
+            },
+            "log": {
+                "file": {
+                    "path": "/tmp/service_logs/sophos-utm-generated.log"
+                },
+                "level": "info",
+                "offset": 24605
+            },
+            "message": "\"Packet",
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "eth3"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "eth0"
+                    }
+                },
+                "product": "UTM",
+                "type": "Firewall",
+                "vendor": "Sophos"
+            },
+            "process": {
+                "pid": 5009
+            },
+            "related": {
+                "ip": [
+                    "172.30.30.1",
+                    "192.168.168.1"
+                ]
+            },
+            "rsa": {
+                "internal": {
+                    "event_desc": "\"Packet",
+                    "messageid": "ulogd"
+                },
+                "investigations": {
+                    "ec_activity": "Scan",
+                    "ec_subject": "NetworkComm",
+                    "ec_theme": "TEV",
+                    "event_cat": 1901000000,
+                    "event_cat_name": "Other.Default"
+                },
+                "misc": {
+                    "policy_id": "3000000014",
+                    "rule": "2002",
+                    "severity": "info",
+                    "vsys": "SecureNet"
+                },
+                "network": {
+                    "alias_host": [
+                        "galaxy"
+                    ],
+                    "dinterface": "eth3",
+                    "network_service": "packetfilter",
+                    "sinterface": "eth0"
+                },
+                "time": {
+                    "event_time": "2019-04-08T11:21:55.000Z"
+                }
+            },
+            "source": {
+                "ip": "192.168.168.1",
+                "mac": "00:50:56:c0:00:01",
+                "port": 57051
+            },
+            "tags": [
+                "sophos-utm",
+                "forwarded"
+            ]
+        }
+    ]
+}

--- a/packages/sophos/data_stream/utm/_dev/test/pipeline/test-packet-filter.json-expected.json
+++ b/packages/sophos/data_stream/utm/_dev/test/pipeline/test-packet-filter.json-expected.json
@@ -1,0 +1,117 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2019-04-08T11:21:55.000Z",
+            "agent": {
+                "ephemeral_id": "e311f248-bcfe-40fa-a92c-75047bac1b66",
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.1.3"
+            },
+            "data_stream": {
+                "dataset": "sophos.utm",
+                "namespace": "ep",
+                "type": "logs"
+            },
+            "destination": {
+                "ip": "172.30.30.1",
+                "mac": "00-0C-29-93-CC-85",
+                "port": 51130
+            },
+            "ecs": {
+                "version": "8.2.0"
+            },
+            "elastic_agent": {
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "snapshot": false,
+                "version": "8.1.3"
+            },
+            "event": {
+                "code": "ulogd",
+                "dataset": "sophos.utm",
+                "original": "2019:04:08-11:21:55 galaxy ulogd[5009]: id=\"2002\" severity=\"info\" sys=\"SecureNet\" sub=\"packetfilter\" name=\"Packet accepted\" action=\"accept\" fwrule=\"3000000014\" initf=\"eth0\" outitf=\"eth3\" srcmac=\"00:50:56:c0:00:01\" dstmac=\"00:0c:29:93:cc:85\" srcip=\"192.168.168.1\" dstip=\"172.30.30.1\" proto=\"6\" length=\"52\" tos=\"0x00\" prec=\"0x00\" ttl=\"127\" srcport=\"57051\" dstport=\"51130\" tcpflags=\"SYN\"",
+                "timezone": "+00:00"
+            },
+            "host": {
+                "name": "galaxy"
+            },
+            "input": {
+                "type": "log"
+            },
+            "log": {
+                "file": {
+                    "path": "/tmp/service_logs/sophos-utm-generated.log"
+                },
+                "level": "info",
+                "offset": 24605
+            },
+            "message": "\"Packet",
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "eth3"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "eth0"
+                    }
+                },
+                "product": "UTM",
+                "type": "Firewall",
+                "vendor": "Sophos"
+            },
+            "process": {
+                "pid": 5009
+            },
+            "related": {
+                "hosts": [
+                    "galaxy"
+                ],
+                "ip": [
+                    "172.30.30.1",
+                    "192.168.168.1"
+                ]
+            },
+            "rsa": {
+                "internal": {
+                    "event_desc": "\"Packet",
+                    "messageid": "ulogd"
+                },
+                "investigations": {
+                    "ec_activity": "Scan",
+                    "ec_subject": "NetworkComm",
+                    "ec_theme": "TEV",
+                    "event_cat": 1901000000,
+                    "event_cat_name": "Other.Default"
+                },
+                "misc": {
+                    "policy_id": "3000000014",
+                    "rule": "2002",
+                    "severity": "info",
+                    "vsys": "SecureNet"
+                },
+                "network": {
+                    "alias_host": [
+                        "galaxy"
+                    ],
+                    "dinterface": "eth3",
+                    "network_service": "packetfilter",
+                    "sinterface": "eth0"
+                },
+                "time": {
+                    "event_time": "2019-04-08T11:21:55.000Z"
+                }
+            },
+            "source": {
+                "ip": "192.168.168.1",
+                "mac": "00-50-56-C0-00-01",
+                "port": 57051
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/default.yml
@@ -1,10 +1,26 @@
 ---
-description: Pipeline for Astaro Security Gateway
+description: Pipeline for Sophos UTM (formerly Astaro Security Gateway).
 
 processors:
   - set:
       field: ecs.version
       value: '8.2.0'
+  - gsub:
+      field: destination.mac
+      ignore_missing: true
+      pattern: '[:]'
+      replacement: '-'
+  - gsub:
+      field: source.mac
+      ignore_missing: true
+      pattern: '[:]'
+      replacement: '-'
+  - uppercase:
+      field: destination.mac
+      ignore_missing: true
+  - uppercase:
+      field: source.mac
+      ignore_missing: true
   # User agent
   - user_agent:
       field: user_agent.original


### PR DESCRIPTION
## What does this PR do?

Format the `{source,destination}.mac` field as per ECS (h[ttps://www.elastic.co/guide/en/ecs/current/ecs-observer.html#field-observer-mac](https://www.elastic.co/guide/en/ecs/current/ecs-source.html#field-source-mac)). 

> The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
