### PR TITLE
Add configuration required for cloudbeat logs, metrics

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.3"
+  changes:
+    - description: Add configuration for cloudbeat logs and metrics.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3378
 - version: "1.3.2"
   changes:
     - description: Fix some CPU elastic_agent_metrics mapping from date to long

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/agent.yml
@@ -1,0 +1,141 @@
+- name: cloud
+  title: Cloud
+  group: 2
+  description: Fields related to the cloud or infrastructure the events are coming from.
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
+  type: group
+  fields:
+    - name: account.id
+      type: keyword
+      ignore_above: 1024
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
+    - name: availability_zone
+      type: keyword
+      ignore_above: 1024
+      description: Availability zone in which this host is running.
+    - name: instance.id
+      type: keyword
+      ignore_above: 1024
+      description: Instance ID of the host machine.
+    - name: instance.name
+      type: keyword
+      ignore_above: 1024
+      description: Instance name of the host machine.
+    - name: machine.type
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the host machine.
+    - name: provider
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
+    - name: region
+      type: keyword
+      ignore_above: 1024
+      description: Region in which this host is running.
+    - name: project.id
+      type: keyword
+      description: Name of the project in Google Cloud.
+    - name: image.id
+      type: keyword
+      description: Image ID for the cloud instance.
+- name: container
+  title: Container
+  group: 2
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Unique container id.
+    - name: image.name
+      type: keyword
+      ignore_above: 1024
+      description: Name of the image the container was built on.
+    - name: labels
+      type: object
+      object_type: keyword
+      description: Image labels.
+    - name: name
+      type: keyword
+      ignore_above: 1024
+      description: Container name.
+- name: host
+  title: Host
+  group: 2
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
+  type: group
+  fields:
+    - name: architecture
+      type: keyword
+      ignore_above: 1024
+      description: Operating system architecture.
+    - name: domain
+      type: keyword
+      ignore_above: 1024
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
+      default_field: false
+    - name: hostname
+      type: keyword
+      ignore_above: 1024
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+    - name: ip
+      type: ip
+      description: Host ip addresses.
+    - name: mac
+      type: keyword
+      ignore_above: 1024
+      description: Host mac addresses.
+    - name: name
+      type: keyword
+      ignore_above: 1024
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+    - name: os.family
+      type: keyword
+      ignore_above: 1024
+      description: OS family (such as redhat, debian, freebsd, windows).
+    - name: os.kernel
+      type: keyword
+      ignore_above: 1024
+      description: Operating system kernel version as a raw string.
+    - name: os.name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: Operating system name, without the version.
+    - name: os.platform
+      type: keyword
+      ignore_above: 1024
+      description: Operating system platform (such centos, ubuntu, windows).
+    - name: os.version
+      type: keyword
+      ignore_above: 1024
+      description: Operating system version as a raw string.
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+    - name: containerized
+      type: boolean
+      description: >
+        If the host is a container.
+
+    - name: os.build
+      type: keyword
+      description: >
+        OS build information.
+
+    - name: os.codename
+      type: keyword
+      description: >
+        OS codename, if any.
+

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/base-fields.yml
@@ -1,0 +1,15 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: "@timestamp"
+  type: date
+  description: Event timestamp.
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/ecs.yml
@@ -1,0 +1,6 @@
+- external: ecs
+  name: ecs.version
+- external: ecs
+  name: log.level
+- external: ecs
+  name: message

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -1,0 +1,20 @@
+- name: elastic_agent
+  title: Elastic Agent
+  description: Fields related to the Elastic Agents
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Elastic Agent id.
+    - name: process
+      type: keyword
+      ignore_above: 1024
+      description: Process run by the Elastic Agent.
+    - name: snapshot
+      type: boolean
+      description: Is the agent running from a snapshot build
+    - name: version
+      type: keyword
+      ignore_above: 1024
+      description: Elastic agent version.

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/manifest.yml
@@ -1,0 +1,7 @@
+title: Elastic Agent
+dataset: elastic_agent.cloudbeat
+type: logs
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
@@ -1,0 +1,141 @@
+- name: cloud
+  title: Cloud
+  group: 2
+  description: Fields related to the cloud or infrastructure the events are coming from.
+  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
+  type: group
+  fields:
+    - name: account.id
+      type: keyword
+      ignore_above: 1024
+      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
+    - name: availability_zone
+      type: keyword
+      ignore_above: 1024
+      description: Availability zone in which this host is running.
+    - name: instance.id
+      type: keyword
+      ignore_above: 1024
+      description: Instance ID of the host machine.
+    - name: instance.name
+      type: keyword
+      ignore_above: 1024
+      description: Instance name of the host machine.
+    - name: machine.type
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the host machine.
+    - name: provider
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
+    - name: region
+      type: keyword
+      ignore_above: 1024
+      description: Region in which this host is running.
+    - name: project.id
+      type: keyword
+      description: Name of the project in Google Cloud.
+    - name: image.id
+      type: keyword
+      description: Image ID for the cloud instance.
+- name: container
+  title: Container
+  group: 2
+  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Unique container id.
+    - name: image.name
+      type: keyword
+      ignore_above: 1024
+      description: Name of the image the container was built on.
+    - name: labels
+      type: object
+      object_type: keyword
+      description: Image labels.
+    - name: name
+      type: keyword
+      ignore_above: 1024
+      description: Container name.
+- name: host
+  title: Host
+  group: 2
+  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
+  type: group
+  fields:
+    - name: architecture
+      type: keyword
+      ignore_above: 1024
+      description: Operating system architecture.
+    - name: domain
+      type: keyword
+      ignore_above: 1024
+      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
+      default_field: false
+    - name: hostname
+      type: keyword
+      ignore_above: 1024
+      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+    - name: ip
+      type: ip
+      description: Host ip addresses.
+    - name: mac
+      type: keyword
+      ignore_above: 1024
+      description: Host mac addresses.
+    - name: name
+      type: keyword
+      ignore_above: 1024
+      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+    - name: os.family
+      type: keyword
+      ignore_above: 1024
+      description: OS family (such as redhat, debian, freebsd, windows).
+    - name: os.kernel
+      type: keyword
+      ignore_above: 1024
+      description: Operating system kernel version as a raw string.
+    - name: os.name
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: Operating system name, without the version.
+    - name: os.platform
+      type: keyword
+      ignore_above: 1024
+      description: Operating system platform (such centos, ubuntu, windows).
+    - name: os.version
+      type: keyword
+      ignore_above: 1024
+      description: Operating system version as a raw string.
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+    - name: containerized
+      type: boolean
+      description: >
+        If the host is a container.
+
+    - name: os.build
+      type: keyword
+      description: >
+        OS build information.
+
+    - name: os.codename
+      type: keyword
+      description: >
+        OS codename, if any.
+

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: "@timestamp"
+  type: date
+  description: Event timestamp.

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-fields.yml
@@ -1,0 +1,81 @@
+- name: beat.type
+  descripion: Beat type.
+  type: keyword
+- name: beat.stats
+  description: Beat stats
+  type: group
+  fields:
+    - name: libbeat
+      type: group
+      description: >
+        Fields common to all Beats
+
+      fields:
+        - name: output
+          type: group
+          description: >
+            Output stats
+
+          fields:
+            - name: events
+              type: group
+              description: >
+                Event counters
+
+              fields:
+                - name: acked
+                  type: long
+                  description: >
+                    Number of events acknowledged
+
+                - name: active
+                  type: long
+                  description: >
+                    Number of active events
+
+                - name: batches
+                  type: long
+                  description: >
+                    Number of event batches
+
+                - name: dropped
+                  type: long
+                  description: >
+                    Number of events dropped
+
+                - name: duplicates
+                  type: long
+                  description: >
+                    Number of events duplicated
+
+                - name: failed
+                  type: long
+                  description: >
+                    Number of events failed
+
+                - name: toomany
+                  type: long
+                  description: >
+                    Number of too many events
+
+                - name: total
+                  type: long
+                  description: >
+                    Total number of events
+
+            - name: write
+              type: group
+              description: >
+                Write stats
+
+              fields:
+                - name: bytes
+                  type: long
+                  description: >
+                    Number of bytes written
+
+                - name: errors
+                  type: long
+                  description: >
+                    Number of write errors
+

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/ecs.yml
@@ -1,0 +1,2 @@
+- external: ecs
+  name: ecs.version

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
@@ -1,0 +1,414 @@
+- name: elastic_agent
+  title: Elastic Agent
+  description: Fields related to the Elastic Agents
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Elastic Agent id.
+    - name: process
+      type: keyword
+      ignore_above: 1024
+      description: Process run by the Elastic Agent.
+    - name: snapshot
+      type: boolean
+      description: Is the agent running from a snapshot build
+    - name: version
+      type: keyword
+      ignore_above: 1024
+      description: Elastic agent version.
+- name: system.process
+  type: group
+  fields:
+    - name: cpu
+      type: group
+      fields:
+        - name: user.ticks
+          type: long
+          metric_type: counter
+          description: |
+            The amount of CPU time the process spent in user space.
+        - name: total.value
+          type: long
+          metric_type: counter
+          description: |
+            The value of CPU usage since starting the process.
+        - name: system.ticks
+          type: long
+          metric_type: counter
+          description: |
+            The amount of CPU time the process spent in kernel space.
+        - name: total.ticks
+          type: long
+          metric_type: counter
+          description: |
+            The total CPU time spent by the process.
+        - name: total.time.ms
+          type: date
+          description: |
+            The time when the process was started.
+        - name: user.time.ms
+          type: date
+          description: |
+            The time when the process was started.
+        - name: system.time.ms
+          type: date
+          description: |
+            The time when the process was started.
+    - name: memory
+      type: group
+      fields:
+        - name: size
+          type: long
+          format: bytes
+          unit: byte
+          metric_type: gauge
+          description: |
+            The total virtual memory the process has. On Windows this represents the Commit Charge (the total amount of memory that the memory manager has committed for a running process) value in bytes for this process.
+    - name: fd
+      type: group
+      fields:
+        - name: open
+          type: long
+          metric_type: gauge
+          description: The number of file descriptors open by the process.
+        - name: limit.soft
+          type: long
+          metric_type: gauge
+          description: |
+            The soft limit on the number of file descriptors opened by the process. The soft limit can be changed by the process at any time.
+        - name: limit.hard
+          type: long
+          metric_type: gauge
+          description: |
+            The hard limit on the number of file descriptors opened by the process. The hard limit can only be raised by root.
+    - name: cgroup
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          description: |
+            The ID common to all cgroups associated with this task. If there isn't a common ID used by all cgroups this field will be absent.
+        - name: path
+          type: keyword
+          description: |
+            The path to the cgroup relative to the cgroup subsystem's mountpoint. If there isn't a common path used by all cgroups this field will be absent.
+        - name: cpu
+          type: group
+          fields:
+            - name: id
+              type: keyword
+              description: ID of the cgroup.
+            - name: path
+              type: keyword
+              description: |
+                Path to the cgroup relative to the cgroup subsystem's mountpoint.
+            - name: cfs.period.us
+              type: long
+              unit: micros
+              description: |
+                Period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated.
+            - name: cfs.quota.us
+              type: long
+              unit: micros
+              description: |
+                Total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by cfs.period.us).
+            - name: cfs.shares
+              type: long
+              description: |
+                An integer value that specifies a relative share of CPU time available to the tasks in a cgroup. The value specified in the cpu.shares file must be 2 or higher.
+            - name: rt.period.us
+              type: long
+              unit: micros
+              description: |
+                Period of time in microseconds for how regularly a cgroup's access to CPU resources is reallocated.
+            - name: rt.runtime.us
+              type: long
+              unit: micros
+              description: |
+                Period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources.
+            - name: stats.periods
+              type: long
+              metric_type: counter
+              description: |
+                Number of period intervals (as specified in cpu.cfs.period.us) that have elapsed.
+            - name: stats.throttled.periods
+              type: long
+              metric_type: counter
+              description: |
+                Number of times tasks in a cgroup have been throttled (that is, not allowed to run because they have exhausted all of the available time as specified by their quota).
+            - name: stats.throttled.ns
+              type: long
+              metric_type: counter
+              unit: nanos
+              description: |
+                The total time duration (in nanoseconds) for which tasks in a cgroup have been throttled.
+        - name: cpuacct
+          type: group
+          fields:
+            - name: id
+              type: keyword
+              description: ID of the cgroup.
+            - name: path
+              type: keyword
+              description: |
+                Path to the cgroup relative to the cgroup subsystem's mountpoint.
+            - name: total.ns
+              type: long
+              metric_type: counter
+              unit: nanos
+              description: |
+                Total CPU time in nanoseconds consumed by all tasks in the cgroup.
+            - name: stats.user.ns
+              type: long
+              metric_type: counter
+              unit: nanos
+              description: CPU time consumed by tasks in user mode.
+            - name: stats.system.ns
+              type: long
+              metric_type: counter
+              unit: nanos
+              description: CPU time consumed by tasks in user (kernel) mode.
+            - name: percpu
+              type: object
+              description: |
+                CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
+        - name: memory
+          type: group
+          fields:
+            - name: id
+              type: keyword
+              description: ID of the cgroup.
+            - name: path
+              type: keyword
+              description: |
+                Path to the cgroup relative to the cgroup subsystem's mountpoint.
+            - name: mem.usage.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Total memory usage by processes in the cgroup (in bytes).
+            - name: mem.usage.max.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum memory used by processes in the cgroup (in bytes).
+            - name: mem.limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
+            - name: mem.failures
+              type: long
+              description: |
+                The number of times that the memory limit (mem.limit.bytes) was reached.
+            - name: memsw.usage.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The sum of current memory usage plus swap space used by processes in the cgroup (in bytes).
+            - name: memsw.usage.max.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount of memory and swap space used by processes in the cgroup (in bytes).
+            - name: memsw.limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount for the sum of memory and swap usage that tasks in the cgroup are allowed to use.
+            - name: memsw.failures
+              type: long
+              unit: byte
+              metric_type: gauge
+              description: |
+                The number of times that the memory plus swap space limit (memsw.limit.bytes) was reached.
+            - name: kmem.usage.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Total kernel memory usage by processes in the cgroup (in bytes).
+            - name: kmem.usage.max.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum kernel memory used by processes in the cgroup (in bytes).
+            - name: kmem.limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount of kernel memory that tasks in the cgroup are allowed to use.
+            - name: kmem.failures
+              type: long
+              metric_type: counter
+              description: |
+                The number of times that the memory limit (kmem.limit.bytes) was reached.
+            - name: kmem_tcp.usage.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Total memory usage for TCP buffers in bytes.
+            - name: kmem_tcp.usage.max.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum memory used for TCP buffers by processes in the cgroup (in bytes).
+            - name: kmem_tcp.limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount of memory for TCP buffers that tasks in the cgroup are allowed to use.
+            - name: kmem_tcp.failures
+              type: long
+              metric_type: counter
+              description: |
+                The number of times that the memory limit (kmem_tcp.limit.bytes) was reached.
+            - name: stats.active_anon.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Anonymous and swap cache on active least-recently-used (LRU) list, including tmpfs (shmem), in bytes.
+            - name: stats.active_file.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: File-backed memory on active LRU list, in bytes.
+            - name: stats.cache.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: Page cache, including tmpfs (shmem), in bytes.
+            - name: stats.hierarchical_memory_limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Memory limit for the hierarchy that contains the memory cgroup, in bytes.
+            - name: stats.hierarchical_memsw_limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Memory plus swap limit for the hierarchy that contains the memory cgroup, in bytes.
+            - name: stats.inactive_anon.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Anonymous and swap cache on inactive LRU list, including tmpfs (shmem), in bytes
+            - name: stats.inactive_file.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                File-backed memory on inactive LRU list, in bytes.
+            - name: stats.mapped_file.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Size of memory-mapped mapped files, including tmpfs (shmem), in bytes.
+            - name: stats.page_faults
+              type: long
+              metric_type: counter
+              description: |
+                Number of times that a process in the cgroup triggered a page fault.
+            - name: stats.major_page_faults
+              type: long
+              metric_type: counter
+              description: |
+                Number of times that a process in the cgroup triggered a major fault. "Major" faults happen when the kernel actually has to read the data from disk.
+            - name: stats.pages_in
+              type: long
+              metric_type: counter
+              description: |
+                Number of pages paged into memory. This is a counter.
+            - name: stats.pages_out
+              type: long
+              metric_type: counter
+              description: |
+                Number of pages paged out of memory. This is a counter.
+            - name: stats.rss.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Anonymous and swap cache (includes transparent hugepages), not including tmpfs (shmem), in bytes.
+            - name: stats.rss_huge.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Number of bytes of anonymous transparent hugepages.
+            - name: stats.swap.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Swap usage, in bytes.
+            - name: stats.unevictable.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Memory that cannot be reclaimed, in bytes.
+        - name: blkio
+          type: group
+          fields:
+            - name: id
+              type: keyword
+              description: ID of the cgroup.
+            - name: path
+              type: keyword
+              description: |
+                Path to the cgroup relative to the cgroup subsystems mountpoint.
+            - name: total.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Total number of bytes transferred to and from all block devices by processes in the cgroup.
+            - name: total.ios
+              type: long
+              metric_type: counter
+              description: |
+                Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/manifest.yml
@@ -1,0 +1,7 @@
+title: Elastic Agent
+dataset: elastic_agent.cloudbeat
+type: metrics
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.3.2
+version: 1.3.3
 release: ga
 description: Collect logs and metrics from Elastic Agents.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Required configuration changes to avoid permission errors when Agent-managed filebeat tries to create the `logs-elastic_agent.cloudbeat-*` index on ES. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Configuration files look appropriate.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Build the `elastic_agent` and `cloud_security_posture` packages, bring the stack up along with the [associated changes on Kibana](https://github.com/elastic/kibana/pull/132452). Running an Agent with the CIS integration added should show the option for cloudbeat logs on the logs page, as shown in the screenshot.

## Screenshots

![Screenshot 2022-05-18 at 7 38 08 PM](https://user-images.githubusercontent.com/9020112/169096223-475d14ae-46e8-40ab-8740-55c28b9d3263.png)

