### PR TITLE
jjbb: ignore builds if the target branch has changed

### DIFF
--- a/.ci/jobs/integrations.yml
+++ b/.ci/jobs/integrations.yml
@@ -25,7 +25,7 @@
                 ignore-tags-newer-than: -1
             - regular-branches: true
             - change-request:
-                ignore-target-only-changes: false
+                ignore-target-only-changes: true
           clean:
             after: true
             before: true
@@ -40,4 +40,4 @@
             timeout: 100
           timeout: '15'
           use-author: true
-          wipe-workspace: 'True'
+          wipe-workspace: true


### PR DESCRIPTION
### What

<img width="946" alt="image" src="https://user-images.githubusercontent.com/2871786/169250139-9e6da702-63cf-4d2b-908b-8ca297e85b8d.png">


### Why

It was reported that PRs get triggered again if there was a change in their PR description.
The GitHub webhook event is sent and processed by jenkins, since Jenkins verifies the target branch has changed then it triggers a new build.


### Further details

This is the configuration we apply by default as stated in https://github.com/elastic/apm-pipeline-library/blob/c13c74b24da047d29da2a628b7645fe55dda1da7/.ci/jobs/apm-test-pipeline-mbp.yml#L54-L57