### PR TITLE
fim: Make GA and compatible with 8.2.0

### DIFF
--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: "Make GA and compatible with 8.2"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3389
 - version: "0.1.0"
   changes:
     - description: Initial version

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,9 +1,9 @@
 format_version: 1.0.0
 name: fim
 title: "File Integrity Monitoring"
-version: 0.1.0
+version: 1.0.0
 license: basic
-release: beta
+release: ga
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."
 type: integration
 categories:
@@ -11,7 +11,7 @@ categories:
   - os_system
   - security
 conditions:
-  kibana.version: "^8.3.0"
+  kibana.version: "^8.2.0"
 icons:
   - src: /img/sample-logo.svg
     title: Sample logo


### PR DESCRIPTION
## What does this PR do?

Releases the auditbeat-based `fim` package as GA and makes it compatible with 8.2.0.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
