### PR TITLE
[Synthetics] Add new monitor source field

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,8 @@
 # newer versions go on top
+- version: "0.9.3"
+  changes:
+    - description: Adds new monitor.source field for synthetics UI
+      type: enhancement
 - version: "0.9.2"
   changes:
     - description: Adds APM service name mappings

--- a/packages/synthetics/data_stream/browser/fields/common.yml
+++ b/packages/synthetics/data_stream/browser/fields/common.yml
@@ -72,4 +72,9 @@
       type: boolean
       description: >
         True if monitor is created with the Fleet integration UI
+    
+    - name: source
+      type: keyword
+      description: >
+        The source of this monitor configuration, usually either "ui", or "project"
 

--- a/packages/synthetics/data_stream/http/fields/common.yml
+++ b/packages/synthetics/data_stream/http/fields/common.yml
@@ -73,3 +73,8 @@
       description: >
         True if monitor is created with the Fleet integration UI
 
+    - name: source
+      type: keyword
+      description: >
+        The source of this monitor configuration, usually either "ui", or "project"
+

--- a/packages/synthetics/data_stream/tcp/fields/common.yml
+++ b/packages/synthetics/data_stream/tcp/fields/common.yml
@@ -73,3 +73,8 @@
       description: >
         True if monitor is created with the Fleet integration UI
 
+    - name: source
+      type: keyword
+      description: >
+        The source of this monitor configuration, usually either "ui", or "project"
+


### PR DESCRIPTION
This field will be used by the synthetics UI 

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
