### PR TITLE
Add verbose/daemon to package-registry recycle command

### DIFF
--- a/docs/developer_workflow_design_build_test_integration.md
+++ b/docs/developer_workflow_design_build_test_integration.md
@@ -78,7 +78,7 @@ elastic-package build
 ... and recycle the package-registry Docker container (run from inside of the integration directory):
 
 ```bash
-elastic-package stack up --services package-registry
+elastic-package stack up -v -d --services package-registry
 ```
 
 Once the container is recycled, you can refresh the Fleet UI and Kibana will pick up updated packages.


### PR DESCRIPTION
## What does this PR do?

Adds verbose/daemon to package-registry recycle command in dev docs.

Without this it's unclear if the job is hanging or just taking a long time to download layers for rebuild.

Rebuild grabs ~1GB of layers which takes 13 minutes on my connection.

## Checklist

- ~~I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.~~
- ~~I have verified that all data streams collect metrics or logs.~~
- ~~I have added an entry to my package's `changelog.yml` file.~~
- ~~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~

## How to test this PR locally

Read and follow the modified doc

## Related issues

None

## Screenshots

![Screen Shot 2022-05-20 at 15 07 16](https://user-images.githubusercontent.com/690/169463680-9bec0a49-e8ef-4dae-9e45-38cff28a6e13.png)
