### PR TITLE
[fortinet.forimanager] - Format {source,destination}.mac per ECS

### DIFF
--- a/packages/fortinet/data_stream/fortimanager/_dev/test/pipeline/test-rsa2elk-output.json
+++ b/packages/fortinet/data_stream/fortimanager/_dev/test/pipeline/test-rsa2elk-output.json
@@ -1,0 +1,172 @@
+{
+    "events": [
+        {
+            "@timestamp": "2019-11-30T12:21:57.000Z",
+            "_id": null,
+            "_index": "logs-fortinet.fortimanager-ep",
+            "_version": -4,
+            "_version_type": "internal",
+            "agent": {
+                "ephemeral_id": "d4a51898-1ffd-4a5b-ad3c-32c04ddd4eb2",
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.1.3"
+            },
+            "data_stream": {
+                "dataset": "fortinet.fortimanager",
+                "namespace": "ep",
+                "type": "logs"
+            },
+            "destination": {
+                "bytes": 4714,
+                "ip": "10.139.144.75",
+                "port": 5037
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "elastic_agent": {
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "snapshot": false,
+                "version": "8.1.3"
+            },
+            "event": {
+                "action": "block",
+                "code": "rchitec",
+                "dataset": "fortinet.fortimanager",
+                "original": "logver=siu date=2019-11-30 time=12:21:57 log_id=inrepr devid=cero devname=ita logid=xercitat type=meumfug subtype=umt level=very-high vd=laparia srcip=10.195.87.127 srcport=760 srcintf=lo3094 dstip=10.52.118.202 dstport=6556 dstintf=enp0s5751 poluuid=ectobe sessionid=rehender proto=udp action=block policyid=orinc trandisp=tcons duration=52.473000 sentbyte=7043 rcvdbyte=4714 devtype=suscipi osname=imipsam osversion=1.4674 mastersrcmac=hilm srcmac=01:00:5e:73:ca:c1 crscore=54.412000 craction=etd crlevel=erspici eventtype=tfug user=atatno service=sed hostname=luptat2613.internal.localhost profile=olupt reqtype=mipsum url=https://www.example.net/Maloru/lapariat.htm?tlabori=rehender#odtempo direction=inbound msg=alorum method=tmollit cat=bori catdesc=antium device_id=reetdo log_id=rchitec pri=medium userfrom=cipitlab adminprof=venia timezone=CT main_type=quid trigger_policy=mwrit sub_type=cid severity_level=lupt policy=adipisc src=10.182.124.88 src_port=116 dst=10.139.144.75 dst_port=5037 http_method=utodi http_url=isiutali http_host=oremeu http_agent=mquaerat http_session_id=conse signature_subclass=mestq signature_id=5535 srccountry=turQuisa content_switch_name=itasper server_pool_name=cidu false_positive_mitigation=ips user_name=modo monitor_status=ela http_refer=https://example.org/unti/niamqu.html?ris=veli#giatnu http_version=tanimide dev_id=ectetur threat_weight=umexer history_threat_weight=nim threat_level=nisiuta ftp_mode=cipitla ftp_cmd=ditautf cipher_suite=oluptasn msg_id=madmin",
+                "timezone": "+00:00"
+            },
+            "host": {
+                "name": "luptat2613.internal.localhost"
+            },
+            "http": {
+                "request": {
+                    "referrer": "https://example.org/unti/niamqu.html?ris=veli#giatnu"
+                }
+            },
+            "input": {
+                "type": "log"
+            },
+            "log": {
+                "file": {
+                    "path": "/tmp/service_logs/fortinet-fortimanager.log"
+                },
+                "level": "medium",
+                "offset": 103183
+            },
+            "message": "alorum",
+            "network": {
+                "bytes": 11757,
+                "direction": "inbound"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "enp0s5751"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "lo3094"
+                    }
+                },
+                "product": "FortiManager",
+                "type": "Configuration",
+                "vendor": "Fortinet",
+                "version": "1.4674"
+            },
+            "related": {
+                "hosts": [
+                    "oremeu",
+                    "ita"
+                ],
+                "ip": [
+                    "10.182.124.88",
+                    "10.139.144.75"
+                ],
+                "user": [
+                    "modo"
+                ]
+            },
+            "rsa": {
+                "internal": {
+                    "event_desc": "alorum",
+                    "messageid": "generic_fortinetmgr"
+                },
+                "investigations": {
+                    "event_vcat": "tfug"
+                },
+                "misc": {
+                    "OS": "imipsam",
+                    "action": [
+                        "block",
+                        "utodi"
+                    ],
+                    "category": "cid",
+                    "client": "mquaerat",
+                    "context": "tcons",
+                    "event_source": "ita",
+                    "event_type": "meumfug",
+                    "fcatnum": "bori",
+                    "filter": "antium",
+                    "hardware_id": "reetdo",
+                    "log_session_id": "conse",
+                    "policy_id": "orinc",
+                    "policy_name": "adipisc",
+                    "reference_id": "rchitec",
+                    "rule_name": "olupt",
+                    "severity": "medium",
+                    "sig_id": 5535,
+                    "version": "1.4674",
+                    "vsys": "laparia"
+                },
+                "network": {
+                    "alias_host": [
+                        "luptat2613.internal.localhost"
+                    ],
+                    "dinterface": "enp0s5751",
+                    "network_service": "sed",
+                    "sinterface": "lo3094"
+                },
+                "threat": {
+                    "threat_desc": "nisiuta"
+                },
+                "time": {
+                    "duration_time": 52.473,
+                    "event_time": "2019-11-30T12:21:57.000Z",
+                    "timezone": "CT"
+                },
+                "web": {
+                    "reputation_num": 54.412,
+                    "web_ref_domain": "oremeu"
+                }
+            },
+            "rule": {
+                "name": "olupt"
+            },
+            "source": {
+                "bytes": 7043,
+                "geo": {
+                    "country_name": "turQuisa"
+                },
+                "ip": "10.182.124.88",
+                "mac": "01:00:5e:73:ca:c1",
+                "port": 116
+            },
+            "tags": [
+                "preserve_original_event",
+                "fortinet-fortimanager",
+                "forwarded"
+            ],
+            "url": {
+                "original": "https://www.example.net/Maloru/lapariat.htm?tlabori=rehender#odtempo",
+                "query": "isiutali"
+            },
+            "user": {
+                "name": "modo"
+            }
+        }
+    ]
+}

--- a/packages/fortinet/data_stream/fortimanager/_dev/test/pipeline/test-rsa2elk-output.json-expected.json
+++ b/packages/fortinet/data_stream/fortimanager/_dev/test/pipeline/test-rsa2elk-output.json-expected.json
@@ -1,0 +1,175 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2019-11-30T12:21:57.000Z",
+            "agent": {
+                "ephemeral_id": "d4a51898-1ffd-4a5b-ad3c-32c04ddd4eb2",
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "name": "docker-fleet-agent",
+                "type": "filebeat",
+                "version": "8.1.3"
+            },
+            "data_stream": {
+                "dataset": "fortinet.fortimanager",
+                "namespace": "ep",
+                "type": "logs"
+            },
+            "destination": {
+                "bytes": 4714,
+                "ip": "10.139.144.75",
+                "port": 5037
+            },
+            "ecs": {
+                "version": "8.2.0"
+            },
+            "elastic_agent": {
+                "id": "de9c1b8e-5967-4715-bc22-6f9dd52f6cc2",
+                "snapshot": false,
+                "version": "8.1.3"
+            },
+            "event": {
+                "action": "block",
+                "code": "rchitec",
+                "dataset": "fortinet.fortimanager",
+                "original": "logver=siu date=2019-11-30 time=12:21:57 log_id=inrepr devid=cero devname=ita logid=xercitat type=meumfug subtype=umt level=very-high vd=laparia srcip=10.195.87.127 srcport=760 srcintf=lo3094 dstip=10.52.118.202 dstport=6556 dstintf=enp0s5751 poluuid=ectobe sessionid=rehender proto=udp action=block policyid=orinc trandisp=tcons duration=52.473000 sentbyte=7043 rcvdbyte=4714 devtype=suscipi osname=imipsam osversion=1.4674 mastersrcmac=hilm srcmac=01:00:5e:73:ca:c1 crscore=54.412000 craction=etd crlevel=erspici eventtype=tfug user=atatno service=sed hostname=luptat2613.internal.localhost profile=olupt reqtype=mipsum url=https://www.example.net/Maloru/lapariat.htm?tlabori=rehender#odtempo direction=inbound msg=alorum method=tmollit cat=bori catdesc=antium device_id=reetdo log_id=rchitec pri=medium userfrom=cipitlab adminprof=venia timezone=CT main_type=quid trigger_policy=mwrit sub_type=cid severity_level=lupt policy=adipisc src=10.182.124.88 src_port=116 dst=10.139.144.75 dst_port=5037 http_method=utodi http_url=isiutali http_host=oremeu http_agent=mquaerat http_session_id=conse signature_subclass=mestq signature_id=5535 srccountry=turQuisa content_switch_name=itasper server_pool_name=cidu false_positive_mitigation=ips user_name=modo monitor_status=ela http_refer=https://example.org/unti/niamqu.html?ris=veli#giatnu http_version=tanimide dev_id=ectetur threat_weight=umexer history_threat_weight=nim threat_level=nisiuta ftp_mode=cipitla ftp_cmd=ditautf cipher_suite=oluptasn msg_id=madmin",
+                "timezone": "+00:00"
+            },
+            "host": {
+                "name": "luptat2613.internal.localhost"
+            },
+            "http": {
+                "request": {
+                    "referrer": "https://example.org/unti/niamqu.html?ris=veli#giatnu"
+                }
+            },
+            "input": {
+                "type": "log"
+            },
+            "log": {
+                "file": {
+                    "path": "/tmp/service_logs/fortinet-fortimanager.log"
+                },
+                "level": "medium",
+                "offset": 103183
+            },
+            "message": "alorum",
+            "network": {
+                "bytes": 11757,
+                "direction": "inbound"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "enp0s5751"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "lo3094"
+                    }
+                },
+                "product": "FortiManager",
+                "type": "Configuration",
+                "vendor": "Fortinet",
+                "version": "1.4674"
+            },
+            "related": {
+                "hosts": [
+                    "oremeu",
+                    "ita",
+                    "luptat2613.internal.localhost"
+                ],
+                "ip": [
+                    "10.182.124.88",
+                    "10.139.144.75"
+                ],
+                "user": [
+                    "modo"
+                ]
+            },
+            "rsa": {
+                "internal": {
+                    "event_desc": "alorum",
+                    "messageid": "generic_fortinetmgr"
+                },
+                "investigations": {
+                    "event_vcat": "tfug"
+                },
+                "misc": {
+                    "OS": "imipsam",
+                    "action": [
+                        "block",
+                        "utodi"
+                    ],
+                    "category": "cid",
+                    "client": "mquaerat",
+                    "context": "tcons",
+                    "event_source": "ita",
+                    "event_type": "meumfug",
+                    "fcatnum": "bori",
+                    "filter": "antium",
+                    "hardware_id": "reetdo",
+                    "log_session_id": "conse",
+                    "policy_id": "orinc",
+                    "policy_name": "adipisc",
+                    "reference_id": "rchitec",
+                    "rule_name": "olupt",
+                    "severity": "medium",
+                    "sig_id": 5535,
+                    "version": "1.4674",
+                    "vsys": "laparia"
+                },
+                "network": {
+                    "alias_host": [
+                        "luptat2613.internal.localhost"
+                    ],
+                    "dinterface": "enp0s5751",
+                    "network_service": "sed",
+                    "sinterface": "lo3094"
+                },
+                "threat": {
+                    "threat_desc": "nisiuta"
+                },
+                "time": {
+                    "duration_time": 52.473,
+                    "event_time": "2019-11-30T12:21:57.000Z",
+                    "timezone": "CT"
+                },
+                "web": {
+                    "reputation_num": 54.412,
+                    "web_ref_domain": "oremeu"
+                }
+            },
+            "rule": {
+                "name": "olupt"
+            },
+            "source": {
+                "bytes": 7043,
+                "geo": {
+                    "country_name": "turQuisa"
+                },
+                "ip": "10.182.124.88",
+                "mac": "01-00-5E-73-CA-C1",
+                "port": 116
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "www.example.net",
+                "extension": "htm",
+                "fragment": "odtempo",
+                "original": "https://www.example.net/Maloru/lapariat.htm?tlabori=rehender#odtempo",
+                "path": "/Maloru/lapariat.htm",
+                "query": [
+                    "isiutali",
+                    "tlabori=rehender"
+                ],
+                "scheme": "https"
+            },
+            "user": {
+                "name": "modo"
+            }
+        }
+    ]
+}

--- a/packages/fortinet/data_stream/fortimanager/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet/data_stream/fortimanager/elasticsearch/ingest_pipeline/default.yml
@@ -5,6 +5,22 @@ processors:
   - set:
       field: ecs.version
       value: '8.2.0'
+  - gsub:
+      field: destination.mac
+      ignore_missing: true
+      pattern: '[:]'
+      replacement: '-'
+  - gsub:
+      field: source.mac
+      ignore_missing: true
+      pattern: '[:]'
+      replacement: '-'
+  - uppercase:
+      field: destination.mac
+      ignore_missing: true
+  - uppercase:
+      field: source.mac
+      ignore_missing: true
   # User agent
   - user_agent:
       field: user_agent.original


### PR DESCRIPTION
## What does this PR do?

Format the `{source,destination}.mac` field as per ECS (h[ttps://www.elastic.co/guide/en/ecs/current/ecs-observer.html#field-observer-mac](https://www.elastic.co/guide/en/ecs/current/ecs-source.html#field-source-mac)). 

> The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

