### PR TITLE
fix ECS schema on system/auth package

### DIFF
--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
@@ -470,10 +470,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -708,10 +708,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -923,10 +923,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -1346,10 +1346,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -1669,10 +1669,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -1758,10 +1758,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -2890,10 +2890,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -3205,10 +3205,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -4255,10 +4255,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth.log-expected.json
@@ -12,10 +12,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -66,10 +66,10 @@
                     "session"
                 ],
                 "kind": "event",
-                "outcome": "authentication success",
+                "outcome": "success",
                 "timezone": "+0000",
                 "type": [
-                    "success",
+                    "access",
                     "info"
                 ]
             },
@@ -118,7 +118,7 @@
                     "authentication"
                 ],
                 "kind": "event",
-                "outcome": "authentication failure",
+                "outcome": "failure",
                 "timezone": "+0000",
                 "type": [
                     "denied",
@@ -168,7 +168,7 @@
                     "authentication"
                 ],
                 "kind": "event",
-                "outcome": "authentication failure",
+                "outcome": "failure",
                 "timezone": "+0000",
                 "type": [
                     "denied",

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-secure-rhel7.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-secure-rhel7.log-expected.json
@@ -11,7 +11,7 @@
                     "authentication"
                 ],
                 "kind": "event",
-                "outcome": "authentication failure",
+                "outcome": "failure",
                 "timezone": "+0000",
                 "type": [
                     "denied",

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -134,15 +134,15 @@ processors:
       ignore_failure: true
       source: >-
         if (ctx.system.auth.ssh.event == "Accepted") {
-          ctx.event.type = ["success", "info"];
+          ctx.event.type = ["access", "info"];
           ctx.event.category = ["authentication","session"];
           ctx.event.action = "ssh_login";
-          ctx.event.outcome = "authentication success";
+          ctx.event.outcome = "success";
         } else if (ctx.system.auth.ssh.event == "Invalid" || ctx.system.auth.ssh.event == "Failed") {
           ctx.event.type = ["denied", "info"];
           ctx.event.category = ["authentication"];
           ctx.event.action = "ssh_login";
-          ctx.event.outcome = "authentication failure";
+          ctx.event.outcome = "failure";
         }
 
   - append:


### PR DESCRIPTION
## What does this PR do?

This commit fixes the ECS schema on system/auth package.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

~~## Author's Checklist~~
## How to test this PR locally

```shell
go mod edit -replace github.com/elastic/elastic-package=github.com/jsoriano/elastic-package@check-allowed-values
go mod tidy
go run github.com/elastic/elastic-package test
cd packages/system/data_stream/auth

elastic-package stack up -d -v
eval "$(elastic-package stack shellinit)"

go run github.com/elastic/elastic-package test pipeline -d auth
```
## Related issues

- Fixes elastic#3051

~~## Screenshots~~
