### PR TITLE
Use Git tag as ECS dependency

### DIFF
--- a/packages/1password/_dev/build/build.yml
+++ b/packages/1password/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/akamai/_dev/build/build.yml
+++ b/packages/akamai/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/apache_spark/_dev/build/build.yml
+++ b/packages/apache_spark/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.1
+    reference: git@v8.1.0

--- a/packages/atlassian_bitbucket/_dev/build/build.yml
+++ b/packages/atlassian_bitbucket/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/atlassian_confluence/_dev/build/build.yml
+++ b/packages/atlassian_confluence/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/atlassian_jira/_dev/build/build.yml
+++ b/packages/atlassian_jira/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/auditd/_dev/build/build.yml
+++ b/packages/auditd/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/auditd_manager/_dev/build/build.yml
+++ b/packages/auditd_manager/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/aws/_dev/build/build.yml
+++ b/packages/aws/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/aws_logs/_dev/build/build.yml
+++ b/packages/aws_logs/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/awsfargate/_dev/build/build.yml
+++ b/packages/awsfargate/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/azure/_dev/build/build.yml
+++ b/packages/azure/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/azure_application_insights/_dev/build/build.yml
+++ b/packages/azure_application_insights/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/azure_billing/_dev/build/build.yml
+++ b/packages/azure_billing/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/azure_metrics/_dev/build/build.yml
+++ b/packages/azure_metrics/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/barracuda/_dev/build/build.yml
+++ b/packages/barracuda/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/bluecoat/_dev/build/build.yml
+++ b/packages/bluecoat/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/carbon_black_cloud/_dev/build/build.yml
+++ b/packages/carbon_black_cloud/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/carbonblack_edr/_dev/build/build.yml
+++ b/packages/carbonblack_edr/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cassandra/_dev/build/build.yml
+++ b/packages/cassandra/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/cef/_dev/build/build.yml
+++ b/packages/cef/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/checkpoint/_dev/build/build.yml
+++ b/packages/checkpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco/_dev/build/build.yml
+++ b/packages/cisco/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/cisco_asa/_dev/build/build.yml
+++ b/packages/cisco_asa/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco_duo/_dev/build/build.yml
+++ b/packages/cisco_duo/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco_ftd/_dev/build/build.yml
+++ b/packages/cisco_ftd/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco_ios/_dev/build/build.yml
+++ b/packages/cisco_ios/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco_ise/_dev/build/build.yml
+++ b/packages/cisco_ise/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/cisco_meraki/_dev/build/build.yml
+++ b/packages/cisco_meraki/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco_nexus/_dev/build/build.yml
+++ b/packages/cisco_nexus/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco_secure_email_gateway/_dev/build/build.yml
+++ b/packages/cisco_secure_email_gateway/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco_secure_endpoint/_dev/build/build.yml
+++ b/packages/cisco_secure_endpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cisco_umbrella/_dev/build/build.yml
+++ b/packages/cisco_umbrella/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cloudflare/_dev/build/build.yml
+++ b/packages/cloudflare/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cockroachdb/_dev/build/build.yml
+++ b/packages/cockroachdb/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/crowdstrike/_dev/build/build.yml
+++ b/packages/crowdstrike/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cyberark/_dev/build/build.yml
+++ b/packages/cyberark/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/cyberarkpas/_dev/build/build.yml
+++ b/packages/cyberarkpas/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/cylance/_dev/build/build.yml
+++ b/packages/cylance/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/etcd/_dev/build/build.yml
+++ b/packages/etcd/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/f5/_dev/build/build.yml
+++ b/packages/f5/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/filestream/_dev/build/build.yml
+++ b/packages/filestream/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/fim/_dev/build/build.yml
+++ b/packages/fim/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/fireeye/_dev/build/build.yml
+++ b/packages/fireeye/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/fortinet/_dev/build/build.yml
+++ b/packages/fortinet/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/gcp/_dev/build/build.yml
+++ b/packages/gcp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/gcp_pubsub/_dev/build/build.yml
+++ b/packages/gcp_pubsub/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/github/_dev/build/build.yml
+++ b/packages/github/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/google_workspace/_dev/build/build.yml
+++ b/packages/google_workspace/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/hadoop/_dev/build/build.yml
+++ b/packages/hadoop/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/haproxy/_dev/build/build.yml
+++ b/packages/haproxy/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/hashicorp_vault/_dev/build/build.yml
+++ b/packages/hashicorp_vault/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/http_endpoint/_dev/build/build.yml
+++ b/packages/http_endpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/httpjson/_dev/build/build.yml
+++ b/packages/httpjson/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/imperva/_dev/build/build.yml
+++ b/packages/imperva/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/infoblox/_dev/build/build.yml
+++ b/packages/infoblox/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/infoblox_nios/_dev/build/build.yml
+++ b/packages/infoblox_nios/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/iptables/_dev/build/build.yml
+++ b/packages/iptables/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/juniper/_dev/build/build.yml
+++ b/packages/juniper/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/juniper_junos/_dev/build/build.yml
+++ b/packages/juniper_junos/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/juniper_netscreen/_dev/build/build.yml
+++ b/packages/juniper_netscreen/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/juniper_srx/_dev/build/build.yml
+++ b/packages/juniper_srx/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/kafka/_dev/build/build.yml
+++ b/packages/kafka/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/kafka_log/_dev/build/build.yml
+++ b/packages/kafka_log/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/keycloak/_dev/build/build.yml
+++ b/packages/keycloak/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/kubernetes/_dev/build/build.yml
+++ b/packages/kubernetes/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/m365_defender/_dev/build/build.yml
+++ b/packages/m365_defender/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/mattermost/_dev/build/build.yml
+++ b/packages/mattermost/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/microsoft/_dev/build/build.yml
+++ b/packages/microsoft/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/microsoft_defender_endpoint/_dev/build/build.yml
+++ b/packages/microsoft_defender_endpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/microsoft_dhcp/_dev/build/build.yml
+++ b/packages/microsoft_dhcp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/microsoft_sqlserver/_dev/build/build.yml
+++ b/packages/microsoft_sqlserver/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/mimecast/_dev/build/build.yml
+++ b/packages/mimecast/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/mongodb/_dev/build/build.yml
+++ b/packages/mongodb/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/mysql/_dev/build/build.yml
+++ b/packages/mysql/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/mysql_enterprise/_dev/build/build.yml
+++ b/packages/mysql_enterprise/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/nagios_xi/_dev/build/build.yml
+++ b/packages/nagios_xi/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.1
+    reference: git@v8.1.0

--- a/packages/nats/_dev/build/build.yml
+++ b/packages/nats/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/netflow/_dev/build/build.yml
+++ b/packages/netflow/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/netscout/_dev/build/build.yml
+++ b/packages/netscout/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/netskope/_dev/build/build.yml
+++ b/packages/netskope/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/network_traffic/_dev/build/build.yml
+++ b/packages/network_traffic/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/nginx/_dev/build/build.yml
+++ b/packages/nginx/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/nginx_ingress_controller/_dev/build/build.yml
+++ b/packages/nginx_ingress_controller/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/o365/_dev/build/build.yml
+++ b/packages/o365/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/okta/_dev/build/build.yml
+++ b/packages/okta/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/oracle/_dev/build/build.yml
+++ b/packages/oracle/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/oracle_weblogic/_dev/build/build.yml
+++ b/packages/oracle_weblogic/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/osquery/_dev/build/build.yml
+++ b/packages/osquery/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/panw/_dev/build/build.yml
+++ b/packages/panw/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/panw_cortex_xdr/_dev/build/build.yml
+++ b/packages/panw_cortex_xdr/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/pfsense/_dev/build/build.yml
+++ b/packages/pfsense/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/postgresql/_dev/build/build.yml
+++ b/packages/postgresql/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/proofpoint/_dev/build/build.yml
+++ b/packages/proofpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/pulse_connect_secure/_dev/build/build.yml
+++ b/packages/pulse_connect_secure/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/qnap_nas/_dev/build/build.yml
+++ b/packages/qnap_nas/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/rabbitmq/_dev/build/build.yml
+++ b/packages/rabbitmq/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/radware/_dev/build/build.yml
+++ b/packages/radware/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/redis/_dev/build/build.yml
+++ b/packages/redis/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/santa/_dev/build/build.yml
+++ b/packages/santa/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/snort/_dev/build/build.yml
+++ b/packages/snort/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/snyk/_dev/build/build.yml
+++ b/packages/snyk/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/sonicwall/_dev/build/build.yml
+++ b/packages/sonicwall/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/sonicwall_firewall/_dev/build/build.yml
+++ b/packages/sonicwall_firewall/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/sophos/_dev/build/build.yml
+++ b/packages/sophos/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/spring_boot/_dev/build/build.yml
+++ b/packages/spring_boot/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.1
+    reference: git@v8.1.0

--- a/packages/squid/_dev/build/build.yml
+++ b/packages/squid/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/stan/_dev/build/build.yml
+++ b/packages/stan/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/suricata/_dev/build/build.yml
+++ b/packages/suricata/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/system/_dev/build/build.yml
+++ b/packages/system/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/tcp/_dev/build/build.yml
+++ b/packages/tcp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/tenable_sc/_dev/build/build.yml
+++ b/packages/tenable_sc/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/ti_abusech/_dev/build/build.yml
+++ b/packages/ti_abusech/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/ti_anomali/_dev/build/build.yml
+++ b/packages/ti_anomali/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/ti_cybersixgill/_dev/build/build.yml
+++ b/packages/ti_cybersixgill/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/ti_misp/_dev/build/build.yml
+++ b/packages/ti_misp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/ti_otx/_dev/build/build.yml
+++ b/packages/ti_otx/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/ti_recordedfuture/_dev/build/build.yml
+++ b/packages/ti_recordedfuture/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/ti_threatq/_dev/build/build.yml
+++ b/packages/ti_threatq/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/tomcat/_dev/build/build.yml
+++ b/packages/tomcat/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/traefik/_dev/build/build.yml
+++ b/packages/traefik/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/udp/_dev/build/build.yml
+++ b/packages/udp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/websphere_application_server/_dev/build/build.yml
+++ b/packages/websphere_application_server/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/windows/_dev/build/build.yml
+++ b/packages/windows/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/winlog/_dev/build/build.yml
+++ b/packages/winlog/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/zeek/_dev/build/build.yml
+++ b/packages/zeek/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/zerofox/_dev/build/build.yml
+++ b/packages/zerofox/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/zookeeper/_dev/build/build.yml
+++ b/packages/zookeeper/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/zoom/_dev/build/build.yml
+++ b/packages/zoom/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/zscaler/_dev/build/build.yml
+++ b/packages/zscaler/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.0
+    reference: git@v8.0.0

--- a/packages/zscaler_zia/_dev/build/build.yml
+++ b/packages/zscaler_zia/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0

--- a/packages/zscaler_zpa/_dev/build/build.yml
+++ b/packages/zscaler_zpa/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.2
+    reference: git@v8.2.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR replaces ECS branch dependencies to Git tags. This is an outcome of the discussion [here](https://github.com/elastic/security-team/issues/3333). 
