### PR TITLE
[carbon_black_cloud] Fix invalid value for event.outcome

### DIFF
--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Change event.outcome value from failure to failed according to ECS
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/3407
 - version: "1.0.0"
   changes:
     - description: Make GA

--- a/packages/carbon_black_cloud/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/carbon_black_cloud/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -93,7 +93,7 @@
                 "id": "28xxxxxxxxxx8ac7bd",
                 "kind": "event",
                 "original": "{\"orgName\":\"cb-xxxx-xxxxx.com\",\"requestUrl\":null,\"eventTime\":1644509082441,\"eventId\":\"28xxxxxxxxxx8ac7bd\",\"loginName\":\"GXXXXX7ANL\",\"flagged\":true,\"clientIp\":\"175.16.199.1\",\"verbose\":false,\"description\":\"Login failed\"}",
-                "outcome": "failed",
+                "outcome": "failure",
                 "reason": "Login failed"
             },
             "organization": {

--- a/packages/carbon_black_cloud/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/carbon_black_cloud/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -26,7 +26,7 @@ processors:
       value: success
   - set: 
       field: event.outcome
-      value: failed
+      value: failure
       if: ctx?.json?.flagged == true
   - rename: 
       field: json.description

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: 1.0.0
+version: 1.0.1
 license: basic
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Replaces `failed` with `failure` in `event.outcome`, according to ECS.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #3407