### PR TITLE
[microsoft_dhcp] Fix value of event.type

### DIFF
--- a/packages/microsoft_dhcp/changelog.yml
+++ b/packages/microsoft_dhcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.2"
+  changes:
+    - description: Change event.type value from end to stop according to ECS
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/3406
 - version: "1.4.1"
   changes:
     - description: Format observer.mac as per ECS and add missing mappings for event.category, event.outcome, and event.type.

--- a/packages/microsoft_dhcp/data_stream/log/_dev/test/pipeline/test-logv6.log-expected.json
+++ b/packages/microsoft_dhcp/data_stream/log/_dev/test/pipeline/test-logv6.log-expected.json
@@ -67,7 +67,7 @@
                 "outcome": "success",
                 "timezone": "America/New_York",
                 "type": [
-                    "stop"
+                    "end"
                 ]
             },
             "log": {

--- a/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/dhcpv6.yml
+++ b/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/dhcpv6.yml
@@ -109,7 +109,7 @@ processors:
           category:
             - process
           type:
-            - stop
+            - end
         "11012":
           action: log-pause
           category:

--- a/packages/microsoft_dhcp/manifest.yml
+++ b/packages/microsoft_dhcp/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_dhcp
 title: Microsoft DHCP
-version: "1.4.1"
+version: "1.4.2"
 license: basic
 description: Collect logs from Microsoft DHCP with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Replaces unexpected value for `event.type` "stop" with "end".

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes https://github.com/elastic/integrations/issues/3406

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
