### PR TITLE
network_traffic: add config option to monitor processes

### DIFF
--- a/packages/network_traffic/_dev/build/docs/README.md
+++ b/packages/network_traffic/_dev/build/docs/README.md
@@ -53,6 +53,13 @@ filter, very little CPU is required to discard the packet. Network Packet Captur
 also uses the ports specified here to determine which parser to use for
 each packet.
 
+#### `monitor_processes`
+
+If this option is enabled then network traffic events will be enriched
+with information about the process associated with the events.
+
+The default value is false.
+
 #### `send_request`
 
 If this option is enabled, the raw message of the request (`request`

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Add option to monitor processes.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3456
 - version: "1.1.0"
   changes:
     - description: Add configuration documentation.

--- a/packages/network_traffic/data_stream/amqp/agent/stream/amqp.yml.hbs
+++ b/packages/network_traffic/data_stream/amqp/agent/stream/amqp.yml.hbs
@@ -39,6 +39,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/amqp/manifest.yml
+++ b/packages/network_traffic/data_stream/amqp/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [5672]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: max_body_length
         type: integer
         title: Max Body Length

--- a/packages/network_traffic/data_stream/cassandra/agent/stream/cassandra.yml.hbs
+++ b/packages/network_traffic/data_stream/cassandra/agent/stream/cassandra.yml.hbs
@@ -39,6 +39,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/cassandra/manifest.yml
+++ b/packages/network_traffic/data_stream/cassandra/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [9042]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: send_request
         type: bool
         title: Send Request

--- a/packages/network_traffic/data_stream/dhcpv4/agent/stream/dhcpv4.yml.hbs
+++ b/packages/network_traffic/data_stream/dhcpv4/agent/stream/dhcpv4.yml.hbs
@@ -18,6 +18,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/dhcpv4/manifest.yml
+++ b/packages/network_traffic/data_stream/dhcpv4/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [67, 68]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: keep_null
         type: bool
         title: Keep Null

--- a/packages/network_traffic/data_stream/dns/agent/stream/dns.yml.hbs
+++ b/packages/network_traffic/data_stream/dns/agent/stream/dns.yml.hbs
@@ -33,6 +33,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/dns/manifest.yml
+++ b/packages/network_traffic/data_stream/dns/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [53]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: include_authorities
         type: bool
         title: Include Authorities

--- a/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
+++ b/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
@@ -5,6 +5,10 @@ flows.timeout: '{{timeout}}'
 {{#if period}}
 flows.period: '{{period}}'
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/flow/manifest.yml
+++ b/packages/network_traffic/data_stream/flow/manifest.yml
@@ -7,6 +7,15 @@ streams:
     description: Track Network Flows
     template_path: flow.yml.hbs
     vars:
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: period
         type: text
         title: Period

--- a/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
@@ -75,6 +75,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/http/manifest.yml
+++ b/packages/network_traffic/data_stream/http/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [80, 8080, 8000, 5000, 8002]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: hide_keywords
         type: text
         title: Hide Keywords

--- a/packages/network_traffic/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/network_traffic/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -12,6 +12,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/icmp/manifest.yml
+++ b/packages/network_traffic/data_stream/icmp/manifest.yml
@@ -7,6 +7,15 @@ streams:
     description: Capture ICMP Traffic
     template_path: icmp.yml.hbs
     vars:
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: keep_null
         type: bool
         title: Keep Null

--- a/packages/network_traffic/data_stream/memcached/agent/stream/memcached.yml.hbs
+++ b/packages/network_traffic/data_stream/memcached/agent/stream/memcached.yml.hbs
@@ -39,6 +39,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/memcached/manifest.yml
+++ b/packages/network_traffic/data_stream/memcached/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [11211]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: parseunknown
         type: bool
         title: Parseunknown

--- a/packages/network_traffic/data_stream/mongodb/agent/stream/mongodb.yml.hbs
+++ b/packages/network_traffic/data_stream/mongodb/agent/stream/mongodb.yml.hbs
@@ -33,6 +33,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/mongodb/manifest.yml
+++ b/packages/network_traffic/data_stream/mongodb/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [27017]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: max_docs
         type: integer
         title: Max Docs

--- a/packages/network_traffic/data_stream/mysql/agent/stream/mysql.yml.hbs
+++ b/packages/network_traffic/data_stream/mysql/agent/stream/mysql.yml.hbs
@@ -27,6 +27,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/mysql/manifest.yml
+++ b/packages/network_traffic/data_stream/mysql/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [3306, 3307]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: send_request
         type: bool
         title: Send Request

--- a/packages/network_traffic/data_stream/nfs/agent/stream/nfs.yml.hbs
+++ b/packages/network_traffic/data_stream/nfs/agent/stream/nfs.yml.hbs
@@ -27,6 +27,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/nfs/manifest.yml
+++ b/packages/network_traffic/data_stream/nfs/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [2049]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: send_request
         type: bool
         title: Send Request

--- a/packages/network_traffic/data_stream/pgsql/agent/stream/pgsql.yml.hbs
+++ b/packages/network_traffic/data_stream/pgsql/agent/stream/pgsql.yml.hbs
@@ -27,6 +27,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/pgsql/manifest.yml
+++ b/packages/network_traffic/data_stream/pgsql/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [5432]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: send_request
         type: bool
         title: Send Request

--- a/packages/network_traffic/data_stream/redis/agent/stream/redis.yml.hbs
+++ b/packages/network_traffic/data_stream/redis/agent/stream/redis.yml.hbs
@@ -33,6 +33,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/redis/manifest.yml
+++ b/packages/network_traffic/data_stream/redis/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [6379]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: send_request
         type: bool
         title: Send Request

--- a/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
+++ b/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
@@ -24,6 +24,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/sip/manifest.yml
+++ b/packages/network_traffic/data_stream/sip/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [5060]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: parse_authorization
         type: bool
         title: Parse Authorization

--- a/packages/network_traffic/data_stream/thrift/agent/stream/thrift.yml.hbs
+++ b/packages/network_traffic/data_stream/thrift/agent/stream/thrift.yml.hbs
@@ -54,6 +54,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/thrift/manifest.yml
+++ b/packages/network_traffic/data_stream/thrift/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [9090]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: transport_type
         type: text
         title: Transport Type

--- a/packages/network_traffic/data_stream/tls/agent/stream/tls.yml.hbs
+++ b/packages/network_traffic/data_stream/tls/agent/stream/tls.yml.hbs
@@ -30,6 +30,10 @@ tags:
   - {{tag}}
 {{/each}}
 {{/if}}
+{{#if monitor_processes}}
+procs:
+  enabled: true
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/tls/manifest.yml
+++ b/packages/network_traffic/data_stream/tls/manifest.yml
@@ -14,6 +14,15 @@ streams:
         required: true
         show_user: true
         default: [443, 993, 995, 5223, 8443, 8883, 9243]
+      - name: monitor_processes
+        type: bool
+        title: Monitor Processes
+        description: |-
+          If this option is enabled then network traffic events will be enriched
+          with information about the process associated with the events.
+        show_user: true
+        multi: false
+        required: false
       - name: fingerprints
         type: text
         title: Fingerprints

--- a/packages/network_traffic/docs/README.md
+++ b/packages/network_traffic/docs/README.md
@@ -53,6 +53,13 @@ filter, very little CPU is required to discard the packet. Network Packet Captur
 also uses the ports specified here to determine which parser to use for
 each packet.
 
+#### `monitor_processes`
+
+If this option is enabled then network traffic events will be enriched
+with information about the process associated with the events.
+
+The default value is false.
+
 #### `send_request`
 
 If this option is enabled, the raw message of the request (`request`

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: 1.1.0
+version: 1.2.0
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This adds a config option to turn on process monitoring. It is off by default, but made a non-hidden option to bring it forward in user attention.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

- [ ] Relevant enablement code in packetbeat
    - https://github.com/elastic/beats/blob/72cea9866370bc16f871716a75357de329ca1b74/packetbeat/config/config.go#L35
    - https://github.com/elastic/beats/blob/72cea9866370bc16f871716a75357de329ca1b74/packetbeat/procs/config.go#L22-L27
    - https://github.com/elastic/beats/blob/72cea9866370bc16f871716a75357de329ca1b74/packetbeat/procs/procs.go#L132-L140
- [ ] Unused cmd_linegrep code in packetbeat — does not alter behaviour wrt filtering processes, just rewrites names.
    - https://github.com/elastic/beats/blob/72cea9866370bc16f871716a75357de329ca1b74/packetbeat/procs/procs.go#L270-L277

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

<img width="794" alt="Screen Shot 2022-06-02 at 09 07 42" src="https://user-images.githubusercontent.com/90160302/171518697-fbcca0f7-35d9-4e51-bc6c-4bcec29d5634.png">
<!-- Type of change
