### PR TITLE
iis_iis10_sdh: Accept IIS 10 Log Format

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Supporting a log format for IIS 10
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/3476
 - version: "0.9.0"
   changes:
     - description: Migrating the tile_map to map object in dashboard

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.0"
+  changes:
+    - description: Supporting a log format for IIS 10
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "0.9.0"
   changes:
     - description: Migrating the tile_map to map object in dashboard

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-75.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-75.log-expected.json
@@ -224,8 +224,8 @@
                     "country_iso_code": "NO",
                     "country_name": "Norway",
                     "location": {
-                        "lat": 62,
-                        "lon": 10
+                        "lat": 62.0,
+                        "lon": 10.0
                     }
                 },
                 "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"

--- a/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log
@@ -1,0 +1,3 @@
+2022-05-09 17:10:04 10.119.32.8 POST /civault/Cryptology/Cryptology.svc - 443 - 10.119.0.62 Mozilla/4.0+(compatible;+MSIE+7.0;+Windows+NT+10.0;+Win64;+x64;+Trident/7.0;+.NET4.0C;+.NET4.0E;+.NET+CLR+2.0.50727;+.NET+CLR+3.0.30729;+.NET+CLR+3.5.30729) - [apcvwp00049.corp.acxiom.net](https://apcvwp00049.corp.acxiom.net/) 200 0 0 26
+2022-05-08 01:26:01 10.119.32.8 POST /NamingServiceANSWS/ANSWS.svc - 443 - 10.119.38.250 - - itwebcert.acxiom.com 200 0 0 232
+2021-06-10 23:26:57 10.44.0.136 GET / - 80 - 10.46.208.5 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) check_for_cookie itweb.acx.co 200 0 0 23

--- a/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log
@@ -1,3 +1,3 @@
 2022-05-09 17:10:04 10.119.32.8 POST /civault/Cryptology/Cryptology.svc - 443 - 10.119.0.62 Mozilla/4.0+(compatible;+MSIE+7.0;+Windows+NT+10.0;+Win64;+x64;+Trident/7.0;+.NET4.0C;+.NET4.0E;+.NET+CLR+2.0.50727;+.NET+CLR+3.0.30729;+.NET+CLR+3.5.30729) - [apcvwp00049.corp.acxiom.net](https://apcvwp00049.corp.acxiom.net/) 200 0 0 26
 2022-05-08 01:26:01 10.119.32.8 POST /NamingServiceANSWS/ANSWS.svc - 443 - 10.119.38.250 - - itwebcert.acxiom.com 200 0 0 232
-2021-06-10 23:26:57 10.44.0.136 GET / - 80 - 10.46.208.5 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) check_for_cookie itweb.acx.co 200 0 0 23
+2021-06-10 23:26:57 10.44.0.136 GET / - 80 - 10.46.208.5 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) BIGipServerYAkgvoMHHYQAGkWEWadfsadfnyAqAere=27246369425.20480.0000 itweb.acx.co 200 0 0 23

--- a/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log-expected.json
@@ -141,7 +141,7 @@
                     "network"
                 ],
                 "kind": "event",
-                "original": "2021-06-10 23:26:57 10.44.0.136 GET / - 80 - 10.46.208.5 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) check_for_cookie itweb.acx.co 200 0 0 23",
+                "original": "2021-06-10 23:26:57 10.44.0.136 GET / - 80 - 10.46.208.5 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) BIGipServerYAkgvoMHHYQAGkWEWadfsadfnyAqAere=27246369425.20480.0000 itweb.acx.co 200 0 0 23",
                 "outcome": "success",
                 "type": [
                     "connection"
@@ -158,7 +158,7 @@
             },
             "iis": {
                 "access": {
-                    "cookie": "check_for_cookie",
+                    "cookie": "BIGipServerYAkgvoMHHYQAGkWEWadfsadfnyAqAere=27246369425.20480.0000",
                     "sub_status": 0,
                     "win32_status": 0
                 }

--- a/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log-expected.json
@@ -33,7 +33,8 @@
             },
             "iis": {
                 "access": {
-                    "sub_status": 0
+                    "sub_status": 0,
+                    "win32_status": 0
                 }
             },
             "related": {
@@ -101,7 +102,8 @@
             },
             "iis": {
                 "access": {
-                    "sub_status": 0
+                    "sub_status": 0,
+                    "win32_status": 0
                 }
             },
             "related": {
@@ -157,7 +159,8 @@
             "iis": {
                 "access": {
                     "cookie": "check_for_cookie",
-                    "sub_status": 0
+                    "sub_status": 0,
+                    "win32_status": 0
                 }
             },
             "related": {

--- a/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/tst-iis10-access.log-expected.json
@@ -1,0 +1,195 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-05-09T17:10:04.000Z",
+            "destination": {
+                "address": "10.119.32.8",
+                "ip": "10.119.32.8",
+                "port": 443
+            },
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "event": {
+                "category": [
+                    "web",
+                    "network"
+                ],
+                "kind": "event",
+                "original": "2022-05-09 17:10:04 10.119.32.8 POST /civault/Cryptology/Cryptology.svc - 443 - 10.119.0.62 Mozilla/4.0+(compatible;+MSIE+7.0;+Windows+NT+10.0;+Win64;+x64;+Trident/7.0;+.NET4.0C;+.NET4.0E;+.NET+CLR+2.0.50727;+.NET+CLR+3.0.30729;+.NET+CLR+3.5.30729) - [apcvwp00049.corp.acxiom.net](https://apcvwp00049.corp.acxiom.net/) 200 0 0 26",
+                "outcome": "success",
+                "type": [
+                    "connection"
+                ]
+            },
+            "http": {
+                "request": {
+                    "method": "POST",
+                    "referrer": "[apcvwp00049.corp.acxiom.net](https://apcvwp00049.corp.acxiom.net/)"
+                },
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "iis": {
+                "access": {
+                    "sub_status": 0
+                }
+            },
+            "related": {
+                "ip": [
+                    "10.119.0.62",
+                    "10.119.32.8"
+                ]
+            },
+            "source": {
+                "address": "10.119.0.62",
+                "ip": "10.119.0.62"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "extension": "svc",
+                "original": "/civault/Cryptology/Cryptology.svc",
+                "path": "/civault/Cryptology/Cryptology.svc"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Other"
+                },
+                "name": "IE",
+                "original": "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; Win64; x64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)",
+                "os": {
+                    "full": "Windows 10",
+                    "name": "Windows",
+                    "version": "10"
+                },
+                "version": "11.0"
+            }
+        },
+        {
+            "@timestamp": "2022-05-08T01:26:01.000Z",
+            "destination": {
+                "address": "10.119.32.8",
+                "ip": "10.119.32.8",
+                "port": 443
+            },
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "event": {
+                "category": [
+                    "web",
+                    "network"
+                ],
+                "kind": "event",
+                "original": "2022-05-08 01:26:01 10.119.32.8 POST /NamingServiceANSWS/ANSWS.svc - 443 - 10.119.38.250 - - itwebcert.acxiom.com 200 0 0 232",
+                "outcome": "success",
+                "type": [
+                    "connection"
+                ]
+            },
+            "http": {
+                "request": {
+                    "method": "POST",
+                    "referrer": "itwebcert.acxiom.com"
+                },
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "iis": {
+                "access": {
+                    "sub_status": 0
+                }
+            },
+            "related": {
+                "ip": [
+                    "10.119.38.250",
+                    "10.119.32.8"
+                ]
+            },
+            "source": {
+                "address": "10.119.38.250",
+                "ip": "10.119.38.250"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "extension": "svc",
+                "original": "/NamingServiceANSWS/ANSWS.svc",
+                "path": "/NamingServiceANSWS/ANSWS.svc"
+            }
+        },
+        {
+            "@timestamp": "2021-06-10T23:26:57.000Z",
+            "destination": {
+                "address": "10.44.0.136",
+                "ip": "10.44.0.136",
+                "port": 80
+            },
+            "ecs": {
+                "version": "1.12.0"
+            },
+            "event": {
+                "category": [
+                    "web",
+                    "network"
+                ],
+                "kind": "event",
+                "original": "2021-06-10 23:26:57 10.44.0.136 GET / - 80 - 10.46.208.5 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) check_for_cookie itweb.acx.co 200 0 0 23",
+                "outcome": "success",
+                "type": [
+                    "connection"
+                ]
+            },
+            "http": {
+                "request": {
+                    "method": "GET",
+                    "referrer": "itweb.acx.co"
+                },
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "iis": {
+                "access": {
+                    "cookie": "check_for_cookie",
+                    "sub_status": 0
+                }
+            },
+            "related": {
+                "ip": [
+                    "10.46.208.5",
+                    "10.44.0.136"
+                ]
+            },
+            "source": {
+                "address": "10.46.208.5",
+                "ip": "10.46.208.5"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "/",
+                "path": "/"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Other"
+                },
+                "name": "IE",
+                "original": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
+                "os": {
+                    "full": "Windows XP",
+                    "name": "Windows",
+                    "version": "XP"
+                },
+                "version": "8.0"
+            }
+        }
+    ]
+}

--- a/packages/iis/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/iis/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -18,10 +18,6 @@ processors:
       patterns:
         - '%{TIMESTAMP_ISO8601:iis.access.time} (?:-|%{IPORHOST:destination.address}) (?:-|%{WORD:http.request.method})
           (?:-|%{NOTSPACE:_temp_.url_path}) (?:-|%{NOTSPACE:_temp_.url_query}) (?:-|%{NUMBER:destination.port:long}) (?:-|%{NOTSPACE:user.name})
-          (?:-|%{IPORHOST:source.address}) (?:-|%{NOTSPACE:user_agent.original}) (?:-|%{NOTSPACE:iis.access.cookie}) (?:-|%{NOTSPACE:http.request.referrer})
-          (?:-|%{NUMBER:http.response.status_code:long}) (?:-|%{NUMBER:iis.access.sub_status:long})'
-        - '%{TIMESTAMP_ISO8601:iis.access.time} (?:-|%{IPORHOST:destination.address}) (?:-|%{WORD:http.request.method})
-          (?:-|%{NOTSPACE:_temp_.url_path}) (?:-|%{NOTSPACE:_temp_.url_query}) (?:-|%{NUMBER:destination.port:long}) (?:-|%{NOTSPACE:user.name})
           (?:-|%{IPORHOST:source.address}) (?:-|%{NOTSPACE:user_agent.original}) (?:-|%{NOTSPACE:http.request.referrer})
           (?:-|%{NUMBER:http.response.status_code:long}) (?:-|%{NUMBER:iis.access.sub_status:long})
           (?:-|%{NUMBER:iis.access.win32_status:long}) (?:-|%{NUMBER:_temp_.duration:long})( (?:-|%{IPORHOST:network.forwarded_ip}))?'
@@ -50,6 +46,11 @@ processors:
           (?:-|%{IPORHOST:source.address}) (?:-|%{NOTSPACE:user_agent.original}) (?:-|%{NUMBER:http.response.status_code:long})
           (?:-|%{NUMBER:iis.access.sub_status:long}) (?:-|%{NUMBER:iis.access.win32_status:long})
           (?:-|%{NUMBER:_temp_.duration:long})( (?:-|%{IPORHOST:network.forwarded_ip}))?'
+        - '%{TIMESTAMP_ISO8601:iis.access.time} (?:-|%{IPORHOST:destination.address}) (?:-|%{WORD:http.request.method})
+          (?:-|%{NOTSPACE:_temp_.url_path}) (?:-|%{NOTSPACE:_temp_.url_query}) (?:-|%{NUMBER:destination.port:long}) (?:-|%{NOTSPACE:user.name})
+          (?:-|%{IPORHOST:source.address}) (?:-|%{NOTSPACE:user_agent.original}) (?:-|%{NOTSPACE:iis.access.cookie}) (?:-|%{NOTSPACE:http.request.referrer})
+          (?:-|%{NUMBER:http.response.status_code:long}) (?:-|%{NUMBER:iis.access.sub_status:long})
+          (?:-|%{NUMBER:iis.access.win32_status:long}) (?:-|%{NUMBER:_temp_.duration:long})( (?:-|%{IPORHOST:network.forwarded_ip}))?'
   - uri_parts:
       field: _temp_.url_path
       ignore_failure: true

--- a/packages/iis/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/iis/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,10 @@ processors:
       patterns:
         - '%{TIMESTAMP_ISO8601:iis.access.time} (?:-|%{IPORHOST:destination.address}) (?:-|%{WORD:http.request.method})
           (?:-|%{NOTSPACE:_temp_.url_path}) (?:-|%{NOTSPACE:_temp_.url_query}) (?:-|%{NUMBER:destination.port:long}) (?:-|%{NOTSPACE:user.name})
+          (?:-|%{IPORHOST:source.address}) (?:-|%{NOTSPACE:user_agent.original}) (?:-|%{NOTSPACE:iis.access.cookie}) (?:-|%{NOTSPACE:http.request.referrer})
+          (?:-|%{NUMBER:http.response.status_code:long}) (?:-|%{NUMBER:iis.access.sub_status:long})'
+        - '%{TIMESTAMP_ISO8601:iis.access.time} (?:-|%{IPORHOST:destination.address}) (?:-|%{WORD:http.request.method})
+          (?:-|%{NOTSPACE:_temp_.url_path}) (?:-|%{NOTSPACE:_temp_.url_query}) (?:-|%{NUMBER:destination.port:long}) (?:-|%{NOTSPACE:user.name})
           (?:-|%{IPORHOST:source.address}) (?:-|%{NOTSPACE:user_agent.original}) (?:-|%{NOTSPACE:http.request.referrer})
           (?:-|%{NUMBER:http.response.status_code:long}) (?:-|%{NUMBER:iis.access.sub_status:long})
           (?:-|%{NUMBER:iis.access.win32_status:long}) (?:-|%{NUMBER:_temp_.duration:long})( (?:-|%{IPORHOST:network.forwarded_ip}))?'

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 0.9.0
+version: 0.10.0
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION

- Enhancement

## What does this PR do?

IIS Beats module doesn't support the below type of IIS 10 log format:

2018-12-31 12:02:53 10.44.0.136 GET / - 443 - 10.50.6.188 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - - 401 0 0 0

Gives the below error :

Provided Grok expressions do not match field value: [2021-06-10 23:26:57 10.44.0.136 GET / - 80 - 10.46.208.5 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - itweb.acx.co 200 0 0 23]

`This PR adds support for a log format for IIS 10 logs.` 
A new grok pattern was added that supports parsing cookie in the IIS 10 log. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Pipeline tests have been added for the new format of logs. 
Running elastic-package test pipeline should be good. 

- Closes https://github.com/elastic/beats/issues/31839
