### PR TITLE
cyberarkpas: Make paths a multi string var

### DIFF
--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.2"
+  changes:
+    - description: Fix broken file paths configuration variable
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3497
 - version: "2.4.1"
   changes:
     - description: Update to readme. added link to vendor documentation

--- a/packages/cyberarkpas/data_stream/audit/manifest.yml
+++ b/packages/cyberarkpas/data_stream/audit/manifest.yml
@@ -10,7 +10,7 @@ streams:
       - name: paths
         type: text
         title: Paths
-        multi: false
+        multi: true
         required: false
         show_user: true
       - name: tags

--- a/packages/cyberarkpas/manifest.yml
+++ b/packages/cyberarkpas/manifest.yml
@@ -1,6 +1,6 @@
 name: cyberarkpas
 title: CyberArk Privileged Access Security Logs
-version: 2.4.1
+version: 2.4.2
 release: ga
 description: Collect audit logs from Cyberark Vault servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

The definition for the paths variable was missing the `multi` flag, preventing it to be used when setting up the integration in the UI, as it would never be an array.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).