### PR TITLE
CSP - Update kibana version constrain

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.13"
+  changes:
+    - description: Update Kibana version constrain
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3505
 - version: "0.0.12"
   changes:
     - description: Add new rule templates

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - kubernetes
 release: experimental
 conditions:
-  kibana.version: "^8.3.0"
+  kibana.version: "^8.4.0"
 screenshots:
   - src: /img/dashboard.png
     title: Dashboard page

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "CIS Kubernetes Benchmark"
-version: 0.0.12
+version: 0.0.13
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Currently, we can only constrain an integration to a Kibana version.
Even though an old version of the elastic agent can run with newer versions of the Elastic stack it's still worth limiting the newer versions of the Integration to Kibana 8.4, which narrows down the possibility of running with the wrong cloudbeat version.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Relates: https://github.com/elastic/package-spec/issues/165#issuecomment-1153753218


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
