### PR TITLE
network_traffic: add mappings for process.* fields

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Add mappings for `process.*`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3515
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.3.0.

--- a/packages/network_traffic/data_stream/amqp/fields/beats.yml
+++ b/packages/network_traffic/data_stream/amqp/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/amqp/fields/beats.yml
+++ b/packages/network_traffic/data_stream/amqp/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/amqp/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/amqp/fields/ecs.yml
@@ -43,6 +43,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/amqp/sample_event.json
+++ b/packages/network_traffic/data_stream/amqp/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T07:37:02.033Z",
+    "@timestamp": "2022-06-28T23:30:50.532Z",
     "agent": {
-        "ephemeral_id": "ff9ccf25-9d67-46a5-b661-aa01e3db9b84",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "a929a7a7-1dba-4961-8b38-b7ef8ed7f1e2",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "amqp": {
         "auto-delete": false,
@@ -36,9 +36,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "amqp.queue.declare",
@@ -47,11 +47,11 @@
             "network"
         ],
         "dataset": "network_traffic.amqp",
-        "duration": 1325900,
-        "end": "2022-03-09T07:37:02.035Z",
-        "ingested": "2022-03-09T07:37:03Z",
+        "duration": 1407200,
+        "end": "2022-06-28T23:30:50.533Z",
+        "ingested": "2022-06-28T23:30:54Z",
         "kind": "event",
-        "start": "2022-03-09T07:37:02.033Z",
+        "start": "2022-06-28T23:30:50.532Z",
         "type": [
             "connection",
             "protocol"
@@ -59,23 +59,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "queue.declare",

--- a/packages/network_traffic/data_stream/cassandra/fields/beats.yml
+++ b/packages/network_traffic/data_stream/cassandra/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/cassandra/fields/beats.yml
+++ b/packages/network_traffic/data_stream/cassandra/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/cassandra/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/cassandra/fields/ecs.yml
@@ -41,6 +41,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/cassandra/sample_event.json
+++ b/packages/network_traffic/data_stream/cassandra/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T07:43:05.888Z",
+    "@timestamp": "2022-06-28T23:35:47.332Z",
     "agent": {
-        "ephemeral_id": "20d6eb94-1319-473d-9e2f-05621a4d2494",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "46bab0be-0856-406c-97e9-57a9158301fd",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "cassandra": {
         "request": {
@@ -56,9 +56,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -66,11 +66,11 @@
             "network"
         ],
         "dataset": "network_traffic.cassandra",
-        "duration": 131589500,
-        "end": "2022-03-09T07:43:06.019Z",
-        "ingested": "2022-03-09T07:43:09Z",
+        "duration": 131617200,
+        "end": "2022-06-28T23:35:47.464Z",
+        "ingested": "2022-06-28T23:35:50Z",
         "kind": "event",
-        "start": "2022-03-09T07:43:05.888Z",
+        "start": "2022-06-28T23:35:47.332Z",
         "type": [
             "connection",
             "protocol"
@@ -78,23 +78,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "network": {

--- a/packages/network_traffic/data_stream/dhcpv4/fields/beats.yml
+++ b/packages/network_traffic/data_stream/dhcpv4/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/dhcpv4/fields/beats.yml
+++ b/packages/network_traffic/data_stream/dhcpv4/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/dhcpv4/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/dhcpv4/fields/ecs.yml
@@ -41,6 +41,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/dhcpv4/sample_event.json
+++ b/packages/network_traffic/data_stream/dhcpv4/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T07:43:52.712Z",
+    "@timestamp": "2022-06-28T23:36:31.507Z",
     "agent": {
-        "ephemeral_id": "b98a43ba-d050-42e6-ab2f-2eba352e9cb0",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "6a85ac0c-2e83-40dd-a6e1-c0a248acd710",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 272,
@@ -44,9 +44,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -54,9 +54,9 @@
             "network"
         ],
         "dataset": "network_traffic.dhcpv4",
-        "ingested": "2022-03-09T07:43:53Z",
+        "ingested": "2022-06-28T23:36:32Z",
         "kind": "event",
-        "start": "2022-03-09T07:43:52.712Z",
+        "start": "2022-06-28T23:36:31.507Z",
         "type": [
             "connection",
             "protocol"
@@ -64,23 +64,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "network": {

--- a/packages/network_traffic/data_stream/dns/fields/beats.yml
+++ b/packages/network_traffic/data_stream/dns/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/dns/fields/beats.yml
+++ b/packages/network_traffic/data_stream/dns/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/dns/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/dns/fields/ecs.yml
@@ -77,6 +77,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/dns/sample_event.json
+++ b/packages/network_traffic/data_stream/dns/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T07:48:42.751Z",
+    "@timestamp": "2022-06-28T23:41:49.970Z",
     "agent": {
-        "ephemeral_id": "1d099984-2551-49e1-9e6a-c1dff964be0f",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "a41de8df-ad9b-45e1-9e6a-eeac1a007fa3",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 28,
@@ -85,9 +85,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -95,11 +95,11 @@
             "network"
         ],
         "dataset": "network_traffic.dns",
-        "duration": 68515700,
-        "end": "2022-03-09T07:48:42.819Z",
-        "ingested": "2022-03-09T07:48:43Z",
+        "duration": 68729900,
+        "end": "2022-06-28T23:41:50.039Z",
+        "ingested": "2022-06-28T23:41:51Z",
         "kind": "event",
-        "start": "2022-03-09T07:48:42.751Z",
+        "start": "2022-06-28T23:41:49.970Z",
         "type": [
             "connection",
             "protocol"
@@ -107,23 +107,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "QUERY",

--- a/packages/network_traffic/data_stream/flow/fields/beats.yml
+++ b/packages/network_traffic/data_stream/flow/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/flow/fields/beats.yml
+++ b/packages/network_traffic/data_stream/flow/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/flow/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/flow/fields/ecs.yml
@@ -41,6 +41,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/http/fields/beats.yml
+++ b/packages/network_traffic/data_stream/http/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/http/fields/beats.yml
+++ b/packages/network_traffic/data_stream/http/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/http/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/http/fields/ecs.yml
@@ -59,6 +59,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.hosts
 - external: ecs
   name: related.ip

--- a/packages/network_traffic/data_stream/http/sample_event.json
+++ b/packages/network_traffic/data_stream/http/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T07:54:42.031Z",
+    "@timestamp": "2022-06-28T23:47:52.462Z",
     "agent": {
-        "ephemeral_id": "822947c0-15fd-4278-ba0d-2cc64d687bb2",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "af51eb1c-712d-4702-ac11-ec9fb4eb6e90",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 211,
@@ -27,9 +27,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -37,11 +37,11 @@
             "network"
         ],
         "dataset": "network_traffic.http",
-        "duration": 141490400,
-        "end": "2022-03-09T07:54:42.172Z",
-        "ingested": "2022-03-09T07:54:43Z",
+        "duration": 140568500,
+        "end": "2022-06-28T23:47:52.602Z",
+        "ingested": "2022-06-28T23:47:55Z",
         "kind": "event",
-        "start": "2022-03-09T07:54:42.031Z",
+        "start": "2022-06-28T23:47:52.462Z",
         "type": [
             "connection",
             "protocol"
@@ -49,23 +49,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "http": {

--- a/packages/network_traffic/data_stream/icmp/fields/beats.yml
+++ b/packages/network_traffic/data_stream/icmp/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/icmp/fields/beats.yml
+++ b/packages/network_traffic/data_stream/icmp/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/icmp/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/icmp/fields/ecs.yml
@@ -41,6 +41,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/icmp/sample_event.json
+++ b/packages/network_traffic/data_stream/icmp/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T07:57:32.766Z",
+    "@timestamp": "2022-06-28T23:51:01.257Z",
     "agent": {
-        "ephemeral_id": "34e079a4-8dee-40db-a820-2296c225fbbe",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "8f36054a-c6a7-4611-b340-e0f09dc105cb",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 4,
@@ -24,9 +24,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -34,34 +34,34 @@
             "network"
         ],
         "dataset": "network_traffic.icmp",
-        "duration": 13336600,
-        "end": "2022-03-09T07:57:32.779Z",
-        "ingested": "2022-03-09T07:57:36Z",
+        "duration": 12420200,
+        "end": "2022-06-28T23:51:01.270Z",
+        "ingested": "2022-06-28T23:51:04Z",
         "kind": "event",
-        "start": "2022-03-09T07:57:32.766Z",
+        "start": "2022-06-28T23:51:01.257Z",
         "type": [
             "connection"
         ]
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "icmp": {

--- a/packages/network_traffic/data_stream/memcached/fields/beats.yml
+++ b/packages/network_traffic/data_stream/memcached/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/memcached/fields/beats.yml
+++ b/packages/network_traffic/data_stream/memcached/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/memcached/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/memcached/fields/ecs.yml
@@ -45,6 +45,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/memcached/sample_event.json
+++ b/packages/network_traffic/data_stream/memcached/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T08:09:26.564Z",
+    "@timestamp": "2022-06-29T00:03:53.173Z",
     "agent": {
-        "ephemeral_id": "53c3aab1-4c1d-4f33-87a9-1d1d4ce75205",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "99655ed9-2f0d-4598-954d-14b2fb979d4c",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "ip": "192.168.188.37",
@@ -25,9 +25,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -35,9 +35,9 @@
             "network"
         ],
         "dataset": "network_traffic.memcached",
-        "ingested": "2022-03-09T08:09:37Z",
+        "ingested": "2022-06-29T00:04:04Z",
         "kind": "event",
-        "start": "2022-03-09T08:09:26.564Z",
+        "start": "2022-06-29T00:03:53.173Z",
         "type": [
             "connection",
             "protocol"
@@ -46,23 +46,23 @@
     "event.action": "memcache.store",
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "memcache": {

--- a/packages/network_traffic/data_stream/mongodb/fields/beats.yml
+++ b/packages/network_traffic/data_stream/mongodb/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/mongodb/fields/beats.yml
+++ b/packages/network_traffic/data_stream/mongodb/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/mongodb/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/mongodb/fields/ecs.yml
@@ -41,6 +41,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/mongodb/sample_event.json
+++ b/packages/network_traffic/data_stream/mongodb/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T08:15:48.570Z",
+    "@timestamp": "2022-06-29T00:10:02.060Z",
     "agent": {
-        "ephemeral_id": "fafaeb02-c623-46a0-a3e0-72e035bd12ba",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "1b28af7e-1112-4544-805b-028d3d9fd21f",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 50,
@@ -26,9 +26,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -36,11 +36,11 @@
             "network"
         ],
         "dataset": "network_traffic.mongodb",
-        "duration": 1365900,
-        "end": "2022-03-09T08:15:48.571Z",
-        "ingested": "2022-03-09T08:15:49Z",
+        "duration": 1360700,
+        "end": "2022-06-29T00:10:02.061Z",
+        "ingested": "2022-06-29T00:10:05Z",
         "kind": "event",
-        "start": "2022-03-09T08:15:48.570Z",
+        "start": "2022-06-29T00:10:02.060Z",
         "type": [
             "connection",
             "protocol"
@@ -48,23 +48,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "find",

--- a/packages/network_traffic/data_stream/mysql/fields/beats.yml
+++ b/packages/network_traffic/data_stream/mysql/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/mysql/fields/beats.yml
+++ b/packages/network_traffic/data_stream/mysql/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/mysql/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/mysql/fields/ecs.yml
@@ -41,6 +41,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/mysql/sample_event.json
+++ b/packages/network_traffic/data_stream/mysql/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T08:20:44.667Z",
+    "@timestamp": "2022-06-29T00:14:38.122Z",
     "agent": {
-        "ephemeral_id": "43167926-7ebd-4acd-8216-daf3664fe286",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "b593f6e6-b815-46ae-bce4-0ae257977384",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 23,
@@ -26,9 +26,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -36,11 +36,11 @@
             "network"
         ],
         "dataset": "network_traffic.mysql",
-        "duration": 5532500,
-        "end": "2022-03-09T08:20:44.673Z",
-        "ingested": "2022-03-09T08:20:45Z",
+        "duration": 5606500,
+        "end": "2022-06-29T00:14:38.127Z",
+        "ingested": "2022-06-29T00:14:39Z",
         "kind": "event",
-        "start": "2022-03-09T08:20:44.667Z",
+        "start": "2022-06-29T00:14:38.122Z",
         "type": [
             "connection",
             "protocol"
@@ -48,23 +48,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "SELECT",

--- a/packages/network_traffic/data_stream/nfs/fields/beats.yml
+++ b/packages/network_traffic/data_stream/nfs/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/nfs/fields/beats.yml
+++ b/packages/network_traffic/data_stream/nfs/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/nfs/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/nfs/fields/ecs.yml
@@ -47,6 +47,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/nfs/sample_event.json
+++ b/packages/network_traffic/data_stream/nfs/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T08:24:00.569Z",
+    "@timestamp": "2022-06-29T00:18:10.093Z",
     "agent": {
-        "ephemeral_id": "62904593-11a1-4706-8487-78b14fb72c08",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "bdd76998-c3b1-4bc5-a61d-376e00170b20",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 208,
@@ -27,9 +27,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "nfs.CLOSE",
@@ -38,11 +38,11 @@
             "network"
         ],
         "dataset": "network_traffic.nfs",
-        "duration": 6573500,
-        "end": "2022-03-09T08:24:00.575Z",
-        "ingested": "2022-03-09T08:24:01Z",
+        "duration": 6469300,
+        "end": "2022-06-29T00:18:10.099Z",
+        "ingested": "2022-06-29T00:18:13Z",
         "kind": "event",
-        "start": "2022-03-09T08:24:00.569Z",
+        "start": "2022-06-29T00:18:10.093Z",
         "type": [
             "connection",
             "protocol"
@@ -51,23 +51,23 @@
     "group.id": 48,
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "host.hostname": "desycloud03.desy.de",

--- a/packages/network_traffic/data_stream/pgsql/fields/beats.yml
+++ b/packages/network_traffic/data_stream/pgsql/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/pgsql/fields/beats.yml
+++ b/packages/network_traffic/data_stream/pgsql/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/pgsql/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/pgsql/fields/ecs.yml
@@ -41,6 +41,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/pgsql/sample_event.json
+++ b/packages/network_traffic/data_stream/pgsql/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T08:29:39.675Z",
+    "@timestamp": "2022-06-29T00:22:14.651Z",
     "agent": {
-        "ephemeral_id": "1e05998c-1d97-426b-8d9e-f5f92c446612",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "26a40a58-254d-4daa-840f-1b17ac2c4f5d",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 34,
@@ -26,9 +26,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -36,11 +36,11 @@
             "network"
         ],
         "dataset": "network_traffic.pgsql",
-        "duration": 2568100,
-        "end": "2022-03-09T08:29:39.678Z",
-        "ingested": "2022-03-09T08:29:40Z",
+        "duration": 2559700,
+        "end": "2022-06-29T00:22:14.654Z",
+        "ingested": "2022-06-29T00:22:15Z",
         "kind": "event",
-        "start": "2022-03-09T08:29:39.675Z",
+        "start": "2022-06-29T00:22:14.651Z",
         "type": [
             "connection",
             "protocol"
@@ -48,23 +48,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "SELECT",

--- a/packages/network_traffic/data_stream/redis/fields/beats.yml
+++ b/packages/network_traffic/data_stream/redis/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/redis/fields/beats.yml
+++ b/packages/network_traffic/data_stream/redis/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/redis/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/redis/fields/ecs.yml
@@ -45,6 +45,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/redis/sample_event.json
+++ b/packages/network_traffic/data_stream/redis/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-03-09T08:30:57.254Z",
+    "@timestamp": "2022-06-29T00:23:34.687Z",
     "agent": {
-        "ephemeral_id": "b68277a8-8012-4ada-bbdd-6ce88a51c5ce",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "9c08996e-b0af-414a-a48a-64d90c5fb4ea",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 31,
@@ -26,9 +26,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "redis.set",
@@ -37,11 +37,11 @@
             "network"
         ],
         "dataset": "network_traffic.redis",
-        "duration": 1421600,
-        "end": "2022-03-09T08:30:57.256Z",
-        "ingested": "2022-03-09T08:30:58Z",
+        "duration": 1319100,
+        "end": "2022-06-29T00:23:34.688Z",
+        "ingested": "2022-06-29T00:23:35Z",
         "kind": "event",
-        "start": "2022-03-09T08:30:57.254Z",
+        "start": "2022-06-29T00:23:34.687Z",
         "type": [
             "connection",
             "protocol"
@@ -49,23 +49,23 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "SET",

--- a/packages/network_traffic/data_stream/sip/fields/beats.yml
+++ b/packages/network_traffic/data_stream/sip/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/sip/fields/beats.yml
+++ b/packages/network_traffic/data_stream/sip/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/sip/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/sip/fields/ecs.yml
@@ -55,6 +55,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.hosts
 - external: ecs
   name: related.ip

--- a/packages/network_traffic/data_stream/sip/sample_event.json
+++ b/packages/network_traffic/data_stream/sip/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-05-13T07:10:35.715Z",
+    "@timestamp": "2022-06-29T00:26:22.037Z",
     "agent": {
-        "ephemeral_id": "008322ce-0d84-45f0-beaf-153cf4786013",
-        "id": "a82e5ec9-4d24-4491-8d66-470aa321ddae",
+        "ephemeral_id": "2e09944f-2c6e-4ea1-9908-c23d2a8af731",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "client": {
         "ip": "10.0.2.20",
@@ -24,9 +24,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "a82e5ec9-4d24-4491-8d66-470aa321ddae",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "sip-invite",
@@ -36,14 +36,15 @@
         ],
         "dataset": "network_traffic.sip",
         "duration": 0,
-        "end": "2022-05-13T07:10:35.715Z",
-        "ingested": "2022-05-13T07:10:39Z",
+        "end": "2022-06-29T00:26:22.037Z",
+        "ingested": "2022-06-29T00:26:23Z",
         "kind": "event",
         "original": "INVITE sip:test@10.0.2.15:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 10.0.2.20:5060;branch=z9hG4bK-2187-1-0\r\nFrom: \"DVI4/8000\" \u003csip:sipp@10.0.2.20:5060\u003e;tag=1\r\nTo: test \u003csip:test@10.0.2.15:5060\u003e\r\nCall-ID: 1-2187@10.0.2.20\r\nCSeq: 1 INVITE\r\nContact: sip:sipp@10.0.2.20:5060\r\nMax-Forwards: 70\r\nContent-Type: application/sdp\r\nContent-Length:   123\r\n\r\nv=0\r\no=- 42 42 IN IP4 10.0.2.20\r\ns=-\r\nc=IN IP4 10.0.2.20\r\nt=0 0\r\nm=audio 6000 RTP/AVP 5\r\na=rtpmap:5 DVI4/8000\r\na=recvonly\r\n",
         "sequence": 1,
-        "start": "2022-05-13T07:10:35.715Z",
+        "start": "2022-06-29T00:26:22.037Z",
         "type": [
-            "info"
+            "info",
+            "protocol"
         ]
     },
     "host": {
@@ -51,10 +52,10 @@
         "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.31.0.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-AC-1F-00-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {

--- a/packages/network_traffic/data_stream/thrift/fields/beats.yml
+++ b/packages/network_traffic/data_stream/thrift/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/thrift/fields/beats.yml
+++ b/packages/network_traffic/data_stream/thrift/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/thrift/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/thrift/fields/ecs.yml
@@ -41,6 +41,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.bytes

--- a/packages/network_traffic/data_stream/thrift/sample_event.json
+++ b/packages/network_traffic/data_stream/thrift/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-05-23T10:59:35.668Z",
+    "@timestamp": "2022-06-29T00:28:33.760Z",
     "agent": {
-        "ephemeral_id": "016dcea4-c82a-4499-9069-e4e0ff6d04ff",
-        "id": "0488c467-eaa0-4733-a81a-326734926bc2",
+        "ephemeral_id": "714ec0d5-e654-462a-961d-003f2fc9113e",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 25,
@@ -26,9 +26,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "0488c467-eaa0-4733-a81a-326734926bc2",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -36,11 +36,11 @@
             "network"
         ],
         "dataset": "network_traffic.thrift",
-        "duration": 1275700,
-        "end": "2022-05-23T10:59:35.669Z",
-        "ingested": "2022-05-23T10:59:36Z",
+        "duration": 2979900,
+        "end": "2022-06-29T00:28:33.763Z",
+        "ingested": "2022-06-29T00:28:34Z",
         "kind": "event",
-        "start": "2022-05-23T10:59:35.668Z",
+        "start": "2022-06-29T00:28:33.760Z",
         "type": [
             "connection",
             "protocol"
@@ -51,10 +51,10 @@
         "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.224.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-E0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {

--- a/packages/network_traffic/data_stream/tls/fields/beats.yml
+++ b/packages/network_traffic/data_stream/tls/fields/beats.yml
@@ -58,31 +58,6 @@
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
-- name: process.name
-  type: keyword
-  description: >
-    The name of the process.
-
-- name: process.args
-  type: keyword
-  description: >
-    The command-line of the process.
-
-- name: process.executable
-  type: keyword
-  description: >
-    Absolute path to the process executable.
-
-- name: process.working_directory
-  type: keyword
-  description: >
-    The working directory of the process.
-
-- name: process.start
-  type: date
-  description: >
-    The time the process started.
-
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/tls/fields/beats.yml
+++ b/packages/network_traffic/data_stream/tls/fields/beats.yml
@@ -54,10 +54,35 @@
     VLAN identifier from the 802.1q frame. In case of a multi-tagged frame this field will be an array with the outer tag's VLAN identifier listed first.
 
 - name: type
+  type: keyword
   description: >
     The type of the transaction (for example, HTTP, MySQL, Redis, or RUM) or "flow" in case of flows.
 
+- name: process.name
   type: keyword
+  description: >
+    The name of the process.
+
+- name: process.args
+  type: keyword
+  description: >
+    The command-line of the process.
+
+- name: process.executable
+  type: keyword
+  description: >
+    Absolute path to the process executable.
+
+- name: process.working_directory
+  type: keyword
+  description: >
+    The working directory of the process.
+
+- name: process.start
+  type: date
+  description: >
+    The time the process started.
+
 - name: server.process.name
   type: keyword
   description: >

--- a/packages/network_traffic/data_stream/tls/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/tls/fields/ecs.yml
@@ -43,6 +43,16 @@
 - external: ecs
   name: network.type
 - external: ecs
+  name: process.name
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.working_directory
+- external: ecs
+  name: process.start
+- external: ecs
   name: related.ip
 - external: ecs
   name: related.hash

--- a/packages/network_traffic/data_stream/tls/sample_event.json
+++ b/packages/network_traffic/data_stream/tls/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-05-23T11:01:14.376Z",
+    "@timestamp": "2022-06-29T00:31:01.877Z",
     "agent": {
-        "ephemeral_id": "d7d5fdf6-998d-488e-bfb7-176a86d6860d",
-        "id": "0488c467-eaa0-4733-a81a-326734926bc2",
+        "ephemeral_id": "b97fc2e6-1b8c-4606-999e-34f4666385db",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "client": {
         "ip": "192.168.1.35",
@@ -25,9 +25,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "0488c467-eaa0-4733-a81a-326734926bc2",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -35,11 +35,11 @@
             "network"
         ],
         "dataset": "network_traffic.tls",
-        "duration": 365887700,
-        "end": "2022-05-23T11:01:14.741Z",
-        "ingested": "2022-05-23T11:01:17Z",
+        "duration": 367171900,
+        "end": "2022-06-29T00:31:02.244Z",
+        "ingested": "2022-06-29T00:31:03Z",
         "kind": "event",
-        "start": "2022-05-23T11:01:14.376Z",
+        "start": "2022-06-29T00:31:01.877Z",
         "type": [
             "connection",
             "protocol"
@@ -50,10 +50,10 @@
         "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.224.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-E0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -74,6 +74,9 @@
         "type": "ipv4"
     },
     "related": {
+        "hash": [
+            "e6573e91e6eb777c0933c5b8f97f10cd"
+        ],
         "ip": [
             "192.168.1.35",
             "93.184.216.34"

--- a/packages/network_traffic/docs/README.md
+++ b/packages/network_traffic/docs/README.md
@@ -209,6 +209,11 @@ The default value is 10s.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -377,6 +382,11 @@ Fields published for AMQP packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -686,6 +696,11 @@ Fields published for Apache Cassandra packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -947,6 +962,11 @@ Fields published for DHCPv4 packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -1215,6 +1235,11 @@ Fields published for DNS packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -1613,6 +1638,11 @@ Fields published for HTTP packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.hosts | All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
@@ -1881,6 +1911,11 @@ Fields published for ICMP packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -2168,6 +2203,11 @@ Fields published for Memcached packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -2418,6 +2458,11 @@ Fields published for MongoDB packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -2650,6 +2695,11 @@ Fields published for MySQL packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -2865,6 +2915,11 @@ Fields published for NFS packets.
 | nfs.version | NFS protocol version number. | long |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -3116,6 +3171,11 @@ Fields published for PostgreSQL packets.
 | pgsql.error_severity | The PostgreSQL error severity. | keyword |
 | pgsql.num_fields | If the SELECT query if successful, this field is set to the number of fields returned. | long |
 | pgsql.num_rows | If the SELECT query if successful, this field is set to the number of rows returned. | long |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -3331,6 +3391,11 @@ Fields published for Redis packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | redis.error | If the Redis command has resulted in an error, this field contains the error message returned by the Redis server. | keyword |
 | redis.return_value | The return value of the Redis command in a human readable format. | keyword |
@@ -3555,6 +3620,11 @@ Fields published for SIP packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.hosts | All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
@@ -4009,6 +4079,11 @@ Fields published for Thrift packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -4282,6 +4357,11 @@ Fields published for TLS packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
+| process.args | The command-line of the process. | keyword |
+| process.executable | Absolute path to the process executable. | keyword |
+| process.name | The name of the process. | keyword |
+| process.start | The time the process started. | date |
+| process.working_directory | The working directory of the process. | keyword |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.hash | All the hashes seen on your event. Populating this field, then using it to search for hashes can help in situations where you're unsure what the hash algorithm is (and therefore which key name to search). | keyword |
 | related.ip | All of the IPs seen on your event. | ip |

--- a/packages/network_traffic/docs/README.md
+++ b/packages/network_traffic/docs/README.md
@@ -209,11 +209,14 @@ The default value is 10s.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -382,11 +385,14 @@ Fields published for AMQP packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -411,13 +417,13 @@ An example event for `amqp` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T07:37:02.033Z",
+    "@timestamp": "2022-06-28T23:30:50.532Z",
     "agent": {
-        "ephemeral_id": "ff9ccf25-9d67-46a5-b661-aa01e3db9b84",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "a929a7a7-1dba-4961-8b38-b7ef8ed7f1e2",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "amqp": {
         "auto-delete": false,
@@ -448,9 +454,9 @@ An example event for `amqp` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "amqp.queue.declare",
@@ -459,11 +465,11 @@ An example event for `amqp` looks as following:
             "network"
         ],
         "dataset": "network_traffic.amqp",
-        "duration": 1325900,
-        "end": "2022-03-09T07:37:02.035Z",
-        "ingested": "2022-03-09T07:37:03Z",
+        "duration": 1407200,
+        "end": "2022-06-28T23:30:50.533Z",
+        "ingested": "2022-06-28T23:30:54Z",
         "kind": "event",
-        "start": "2022-03-09T07:37:02.033Z",
+        "start": "2022-06-28T23:30:50.532Z",
         "type": [
             "connection",
             "protocol"
@@ -471,23 +477,23 @@ An example event for `amqp` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "queue.declare",
@@ -696,11 +702,14 @@ Fields published for Apache Cassandra packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -725,13 +734,13 @@ An example event for `cassandra` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T07:43:05.888Z",
+    "@timestamp": "2022-06-28T23:35:47.332Z",
     "agent": {
-        "ephemeral_id": "20d6eb94-1319-473d-9e2f-05621a4d2494",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "46bab0be-0856-406c-97e9-57a9158301fd",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "cassandra": {
         "request": {
@@ -782,9 +791,9 @@ An example event for `cassandra` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -792,11 +801,11 @@ An example event for `cassandra` looks as following:
             "network"
         ],
         "dataset": "network_traffic.cassandra",
-        "duration": 131589500,
-        "end": "2022-03-09T07:43:06.019Z",
-        "ingested": "2022-03-09T07:43:09Z",
+        "duration": 131617200,
+        "end": "2022-06-28T23:35:47.464Z",
+        "ingested": "2022-06-28T23:35:50Z",
         "kind": "event",
-        "start": "2022-03-09T07:43:05.888Z",
+        "start": "2022-06-28T23:35:47.332Z",
         "type": [
             "connection",
             "protocol"
@@ -804,23 +813,23 @@ An example event for `cassandra` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "network": {
@@ -962,11 +971,14 @@ Fields published for DHCPv4 packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -991,13 +1003,13 @@ An example event for `dhcpv4` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T07:43:52.712Z",
+    "@timestamp": "2022-06-28T23:36:31.507Z",
     "agent": {
-        "ephemeral_id": "b98a43ba-d050-42e6-ab2f-2eba352e9cb0",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "6a85ac0c-2e83-40dd-a6e1-c0a248acd710",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 272,
@@ -1036,9 +1048,9 @@ An example event for `dhcpv4` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -1046,9 +1058,9 @@ An example event for `dhcpv4` looks as following:
             "network"
         ],
         "dataset": "network_traffic.dhcpv4",
-        "ingested": "2022-03-09T07:43:53Z",
+        "ingested": "2022-06-28T23:36:32Z",
         "kind": "event",
-        "start": "2022-03-09T07:43:52.712Z",
+        "start": "2022-06-28T23:36:31.507Z",
         "type": [
             "connection",
             "protocol"
@@ -1056,23 +1068,23 @@ An example event for `dhcpv4` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "network": {
@@ -1235,11 +1247,14 @@ Fields published for DNS packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -1264,13 +1279,13 @@ An example event for `dns` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T07:48:42.751Z",
+    "@timestamp": "2022-06-28T23:41:49.970Z",
     "agent": {
-        "ephemeral_id": "1d099984-2551-49e1-9e6a-c1dff964be0f",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "a41de8df-ad9b-45e1-9e6a-eeac1a007fa3",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 28,
@@ -1350,9 +1365,9 @@ An example event for `dns` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -1360,11 +1375,11 @@ An example event for `dns` looks as following:
             "network"
         ],
         "dataset": "network_traffic.dns",
-        "duration": 68515700,
-        "end": "2022-03-09T07:48:42.819Z",
-        "ingested": "2022-03-09T07:48:43Z",
+        "duration": 68729900,
+        "end": "2022-06-28T23:41:50.039Z",
+        "ingested": "2022-06-28T23:41:51Z",
         "kind": "event",
-        "start": "2022-03-09T07:48:42.751Z",
+        "start": "2022-06-28T23:41:49.970Z",
         "type": [
             "connection",
             "protocol"
@@ -1372,23 +1387,23 @@ An example event for `dns` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "QUERY",
@@ -1638,11 +1653,14 @@ Fields published for HTTP packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.hosts | All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
@@ -1679,13 +1697,13 @@ An example event for `http` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T07:54:42.031Z",
+    "@timestamp": "2022-06-28T23:47:52.462Z",
     "agent": {
-        "ephemeral_id": "822947c0-15fd-4278-ba0d-2cc64d687bb2",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "af51eb1c-712d-4702-ac11-ec9fb4eb6e90",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 211,
@@ -1707,9 +1725,9 @@ An example event for `http` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -1717,11 +1735,11 @@ An example event for `http` looks as following:
             "network"
         ],
         "dataset": "network_traffic.http",
-        "duration": 141490400,
-        "end": "2022-03-09T07:54:42.172Z",
-        "ingested": "2022-03-09T07:54:43Z",
+        "duration": 140568500,
+        "end": "2022-06-28T23:47:52.602Z",
+        "ingested": "2022-06-28T23:47:55Z",
         "kind": "event",
-        "start": "2022-03-09T07:54:42.031Z",
+        "start": "2022-06-28T23:47:52.462Z",
         "type": [
             "connection",
             "protocol"
@@ -1729,23 +1747,23 @@ An example event for `http` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "http": {
@@ -1911,11 +1929,14 @@ Fields published for ICMP packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -1940,13 +1961,13 @@ An example event for `icmp` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T07:57:32.766Z",
+    "@timestamp": "2022-06-28T23:51:01.257Z",
     "agent": {
-        "ephemeral_id": "34e079a4-8dee-40db-a820-2296c225fbbe",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "8f36054a-c6a7-4611-b340-e0f09dc105cb",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 4,
@@ -1965,9 +1986,9 @@ An example event for `icmp` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -1975,34 +1996,34 @@ An example event for `icmp` looks as following:
             "network"
         ],
         "dataset": "network_traffic.icmp",
-        "duration": 13336600,
-        "end": "2022-03-09T07:57:32.779Z",
-        "ingested": "2022-03-09T07:57:36Z",
+        "duration": 12420200,
+        "end": "2022-06-28T23:51:01.270Z",
+        "ingested": "2022-06-28T23:51:04Z",
         "kind": "event",
-        "start": "2022-03-09T07:57:32.766Z",
+        "start": "2022-06-28T23:51:01.257Z",
         "type": [
             "connection"
         ]
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "icmp": {
@@ -2203,11 +2224,14 @@ Fields published for Memcached packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -2232,13 +2256,13 @@ An example event for `memcached` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T08:09:26.564Z",
+    "@timestamp": "2022-06-29T00:03:53.173Z",
     "agent": {
-        "ephemeral_id": "53c3aab1-4c1d-4f33-87a9-1d1d4ce75205",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "99655ed9-2f0d-4598-954d-14b2fb979d4c",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "ip": "192.168.188.37",
@@ -2258,9 +2282,9 @@ An example event for `memcached` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -2268,9 +2292,9 @@ An example event for `memcached` looks as following:
             "network"
         ],
         "dataset": "network_traffic.memcached",
-        "ingested": "2022-03-09T08:09:37Z",
+        "ingested": "2022-06-29T00:04:04Z",
         "kind": "event",
-        "start": "2022-03-09T08:09:26.564Z",
+        "start": "2022-06-29T00:03:53.173Z",
         "type": [
             "connection",
             "protocol"
@@ -2279,23 +2303,23 @@ An example event for `memcached` looks as following:
     "event.action": "memcache.store",
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "memcache": {
@@ -2458,11 +2482,14 @@ Fields published for MongoDB packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -2487,13 +2514,13 @@ An example event for `mongodb` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T08:15:48.570Z",
+    "@timestamp": "2022-06-29T00:10:02.060Z",
     "agent": {
-        "ephemeral_id": "fafaeb02-c623-46a0-a3e0-72e035bd12ba",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "1b28af7e-1112-4544-805b-028d3d9fd21f",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 50,
@@ -2514,9 +2541,9 @@ An example event for `mongodb` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -2524,11 +2551,11 @@ An example event for `mongodb` looks as following:
             "network"
         ],
         "dataset": "network_traffic.mongodb",
-        "duration": 1365900,
-        "end": "2022-03-09T08:15:48.571Z",
-        "ingested": "2022-03-09T08:15:49Z",
+        "duration": 1360700,
+        "end": "2022-06-29T00:10:02.061Z",
+        "ingested": "2022-06-29T00:10:05Z",
         "kind": "event",
-        "start": "2022-03-09T08:15:48.570Z",
+        "start": "2022-06-29T00:10:02.060Z",
         "type": [
             "connection",
             "protocol"
@@ -2536,23 +2563,23 @@ An example event for `mongodb` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "find",
@@ -2695,11 +2722,14 @@ Fields published for MySQL packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -2724,13 +2754,13 @@ An example event for `mysql` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T08:20:44.667Z",
+    "@timestamp": "2022-06-29T00:14:38.122Z",
     "agent": {
-        "ephemeral_id": "43167926-7ebd-4acd-8216-daf3664fe286",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "b593f6e6-b815-46ae-bce4-0ae257977384",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 23,
@@ -2751,9 +2781,9 @@ An example event for `mysql` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -2761,11 +2791,11 @@ An example event for `mysql` looks as following:
             "network"
         ],
         "dataset": "network_traffic.mysql",
-        "duration": 5532500,
-        "end": "2022-03-09T08:20:44.673Z",
-        "ingested": "2022-03-09T08:20:45Z",
+        "duration": 5606500,
+        "end": "2022-06-29T00:14:38.127Z",
+        "ingested": "2022-06-29T00:14:39Z",
         "kind": "event",
-        "start": "2022-03-09T08:20:44.667Z",
+        "start": "2022-06-29T00:14:38.122Z",
         "type": [
             "connection",
             "protocol"
@@ -2773,23 +2803,23 @@ An example event for `mysql` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "SELECT",
@@ -2915,11 +2945,14 @@ Fields published for NFS packets.
 | nfs.version | NFS protocol version number. | long |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -2954,13 +2987,13 @@ An example event for `nfs` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T08:24:00.569Z",
+    "@timestamp": "2022-06-29T00:18:10.093Z",
     "agent": {
-        "ephemeral_id": "62904593-11a1-4706-8487-78b14fb72c08",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "bdd76998-c3b1-4bc5-a61d-376e00170b20",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 208,
@@ -2982,9 +3015,9 @@ An example event for `nfs` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "nfs.CLOSE",
@@ -2993,11 +3026,11 @@ An example event for `nfs` looks as following:
             "network"
         ],
         "dataset": "network_traffic.nfs",
-        "duration": 6573500,
-        "end": "2022-03-09T08:24:00.575Z",
-        "ingested": "2022-03-09T08:24:01Z",
+        "duration": 6469300,
+        "end": "2022-06-29T00:18:10.099Z",
+        "ingested": "2022-06-29T00:18:13Z",
         "kind": "event",
-        "start": "2022-03-09T08:24:00.569Z",
+        "start": "2022-06-29T00:18:10.093Z",
         "type": [
             "connection",
             "protocol"
@@ -3006,23 +3039,23 @@ An example event for `nfs` looks as following:
     "group.id": 48,
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "host.hostname": "desycloud03.desy.de",
@@ -3171,11 +3204,14 @@ Fields published for PostgreSQL packets.
 | pgsql.error_severity | The PostgreSQL error severity. | keyword |
 | pgsql.num_fields | If the SELECT query if successful, this field is set to the number of fields returned. | long |
 | pgsql.num_rows | If the SELECT query if successful, this field is set to the number of rows returned. | long |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -3200,13 +3236,13 @@ An example event for `pgsql` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T08:29:39.675Z",
+    "@timestamp": "2022-06-29T00:22:14.651Z",
     "agent": {
-        "ephemeral_id": "1e05998c-1d97-426b-8d9e-f5f92c446612",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "26a40a58-254d-4daa-840f-1b17ac2c4f5d",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 34,
@@ -3227,9 +3263,9 @@ An example event for `pgsql` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -3237,11 +3273,11 @@ An example event for `pgsql` looks as following:
             "network"
         ],
         "dataset": "network_traffic.pgsql",
-        "duration": 2568100,
-        "end": "2022-03-09T08:29:39.678Z",
-        "ingested": "2022-03-09T08:29:40Z",
+        "duration": 2559700,
+        "end": "2022-06-29T00:22:14.654Z",
+        "ingested": "2022-06-29T00:22:15Z",
         "kind": "event",
-        "start": "2022-03-09T08:29:39.675Z",
+        "start": "2022-06-29T00:22:14.651Z",
         "type": [
             "connection",
             "protocol"
@@ -3249,23 +3285,23 @@ An example event for `pgsql` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "SELECT",
@@ -3391,11 +3427,14 @@ Fields published for Redis packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | redis.error | If the Redis command has resulted in an error, this field contains the error message returned by the Redis server. | keyword |
 | redis.return_value | The return value of the Redis command in a human readable format. | keyword |
@@ -3422,13 +3461,13 @@ An example event for `redis` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-03-09T08:30:57.254Z",
+    "@timestamp": "2022-06-29T00:23:34.687Z",
     "agent": {
-        "ephemeral_id": "b68277a8-8012-4ada-bbdd-6ce88a51c5ce",
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "ephemeral_id": "9c08996e-b0af-414a-a48a-64d90c5fb4ea",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 31,
@@ -3449,9 +3488,9 @@ An example event for `redis` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "f789afb0-558d-48bd-b448-0fc838efd730",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "redis.set",
@@ -3460,11 +3499,11 @@ An example event for `redis` looks as following:
             "network"
         ],
         "dataset": "network_traffic.redis",
-        "duration": 1421600,
-        "end": "2022-03-09T08:30:57.256Z",
-        "ingested": "2022-03-09T08:30:58Z",
+        "duration": 1319100,
+        "end": "2022-06-29T00:23:34.688Z",
+        "ingested": "2022-06-29T00:23:35Z",
         "kind": "event",
-        "start": "2022-03-09T08:30:57.254Z",
+        "start": "2022-06-29T00:23:34.687Z",
         "type": [
             "connection",
             "protocol"
@@ -3472,23 +3511,23 @@ An example event for `redis` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.176.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-B0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.3 LTS (Focal Fossa)"
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
     },
     "method": "SET",
@@ -3620,11 +3659,14 @@ Fields published for SIP packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.hosts | All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
@@ -3727,13 +3769,13 @@ An example event for `sip` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-05-13T07:10:35.715Z",
+    "@timestamp": "2022-06-29T00:26:22.037Z",
     "agent": {
-        "ephemeral_id": "008322ce-0d84-45f0-beaf-153cf4786013",
-        "id": "a82e5ec9-4d24-4491-8d66-470aa321ddae",
+        "ephemeral_id": "2e09944f-2c6e-4ea1-9908-c23d2a8af731",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "client": {
         "ip": "10.0.2.20",
@@ -3752,9 +3794,9 @@ An example event for `sip` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "a82e5ec9-4d24-4491-8d66-470aa321ddae",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "sip-invite",
@@ -3764,14 +3806,15 @@ An example event for `sip` looks as following:
         ],
         "dataset": "network_traffic.sip",
         "duration": 0,
-        "end": "2022-05-13T07:10:35.715Z",
-        "ingested": "2022-05-13T07:10:39Z",
+        "end": "2022-06-29T00:26:22.037Z",
+        "ingested": "2022-06-29T00:26:23Z",
         "kind": "event",
         "original": "INVITE sip:test@10.0.2.15:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 10.0.2.20:5060;branch=z9hG4bK-2187-1-0\r\nFrom: \"DVI4/8000\" \u003csip:sipp@10.0.2.20:5060\u003e;tag=1\r\nTo: test \u003csip:test@10.0.2.15:5060\u003e\r\nCall-ID: 1-2187@10.0.2.20\r\nCSeq: 1 INVITE\r\nContact: sip:sipp@10.0.2.20:5060\r\nMax-Forwards: 70\r\nContent-Type: application/sdp\r\nContent-Length:   123\r\n\r\nv=0\r\no=- 42 42 IN IP4 10.0.2.20\r\ns=-\r\nc=IN IP4 10.0.2.20\r\nt=0 0\r\nm=audio 6000 RTP/AVP 5\r\na=rtpmap:5 DVI4/8000\r\na=recvonly\r\n",
         "sequence": 1,
-        "start": "2022-05-13T07:10:35.715Z",
+        "start": "2022-06-29T00:26:22.037Z",
         "type": [
-            "info"
+            "info",
+            "protocol"
         ]
     },
     "host": {
@@ -3779,10 +3822,10 @@ An example event for `sip` looks as following:
         "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.31.0.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-AC-1F-00-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -4079,11 +4122,14 @@ Fields published for Thrift packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | request | For text protocols, this is the request as seen on the wire (application layer only). For binary protocols this is our representation of the request. | text |
@@ -4112,13 +4158,13 @@ An example event for `thrift` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-05-23T10:59:35.668Z",
+    "@timestamp": "2022-06-29T00:28:33.760Z",
     "agent": {
-        "ephemeral_id": "016dcea4-c82a-4499-9069-e4e0ff6d04ff",
-        "id": "0488c467-eaa0-4733-a81a-326734926bc2",
+        "ephemeral_id": "714ec0d5-e654-462a-961d-003f2fc9113e",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "client": {
         "bytes": 25,
@@ -4139,9 +4185,9 @@ An example event for `thrift` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "0488c467-eaa0-4733-a81a-326734926bc2",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -4149,11 +4195,11 @@ An example event for `thrift` looks as following:
             "network"
         ],
         "dataset": "network_traffic.thrift",
-        "duration": 1275700,
-        "end": "2022-05-23T10:59:35.669Z",
-        "ingested": "2022-05-23T10:59:36Z",
+        "duration": 2979900,
+        "end": "2022-06-29T00:28:33.763Z",
+        "ingested": "2022-06-29T00:28:34Z",
         "kind": "event",
-        "start": "2022-05-23T10:59:35.668Z",
+        "start": "2022-06-29T00:28:33.760Z",
         "type": [
             "connection",
             "protocol"
@@ -4164,10 +4210,10 @@ An example event for `thrift` looks as following:
         "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.224.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-E0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -4357,11 +4403,14 @@ Fields published for TLS packets.
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |
 | params | The request parameters. For HTTP, these are the POST or GET parameters. For Thrift-RPC, these are the parameters from the request. | text |
 | path | The path the transaction refers to. For HTTP, this is the URL. For SQL databases, this is the table name. For key-value stores, this is the key. | keyword |
-| process.args | The command-line of the process. | keyword |
+| process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
-| process.name | The name of the process. | keyword |
+| process.executable.text | Multi-field of `process.executable`. | match_only_text |
+| process.name | Process name. Sometimes called program name or similar. | keyword |
+| process.name.text | Multi-field of `process.name`. | match_only_text |
 | process.start | The time the process started. | date |
 | process.working_directory | The working directory of the process. | keyword |
+| process.working_directory.text | Multi-field of `process.working_directory`. | match_only_text |
 | query | The query in a human readable format. For HTTP, it will typically be something like `GET /users/_search?name=test`. For MySQL, it is something like `SELECT id from users where name=test`. | keyword |
 | related.hash | All the hashes seen on your event. Populating this field, then using it to search for hashes can help in situations where you're unsure what the hash algorithm is (and therefore which key name to search). | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
@@ -4497,13 +4546,13 @@ An example event for `tls` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-05-23T11:01:14.376Z",
+    "@timestamp": "2022-06-29T00:31:01.877Z",
     "agent": {
-        "ephemeral_id": "d7d5fdf6-998d-488e-bfb7-176a86d6860d",
-        "id": "0488c467-eaa0-4733-a81a-326734926bc2",
+        "ephemeral_id": "b97fc2e6-1b8c-4606-999e-34f4666385db",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "name": "docker-fleet-agent",
         "type": "packetbeat",
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "client": {
         "ip": "192.168.1.35",
@@ -4523,9 +4572,9 @@ An example event for `tls` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "0488c467-eaa0-4733-a81a-326734926bc2",
+        "id": "827ce6a9-85bd-4e07-9a7a-4896c17144cd",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -4533,11 +4582,11 @@ An example event for `tls` looks as following:
             "network"
         ],
         "dataset": "network_traffic.tls",
-        "duration": 365887700,
-        "end": "2022-05-23T11:01:14.741Z",
-        "ingested": "2022-05-23T11:01:17Z",
+        "duration": 367171900,
+        "end": "2022-06-29T00:31:02.244Z",
+        "ingested": "2022-06-29T00:31:03Z",
         "kind": "event",
-        "start": "2022-05-23T11:01:14.376Z",
+        "start": "2022-06-29T00:31:01.877Z",
         "type": [
             "connection",
             "protocol"
@@ -4548,10 +4597,10 @@ An example event for `tls` looks as following:
         "containerized": false,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "192.168.224.7"
+            "192.168.48.7"
         ],
         "mac": [
-            "02-42-C0-A8-E0-07"
+            "02-42-C0-A8-30-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -4572,6 +4621,9 @@ An example event for `tls` looks as following:
         "type": "ipv4"
     },
     "related": {
+        "hash": [
+            "e6573e91e6eb777c0933c5b8f97f10cd"
+        ],
         "ip": [
             "192.168.1.35",
             "93.184.216.34"

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.4.0"
+version: "1.4.1"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds mappings for `process.*` fields at the root level.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] I have added the fields to all the data streams and not just the 4 that were noted in the issue since the beat field.yml includes `process.*` in the common set.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3512 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
