### PR TITLE
[httpjson] Remove conditional rendering based on oauth_id of auth options

### DIFF
--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.3"
+  changes:
+    - description: Fixes oauth2 config rendering
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.2.2"
   changes:
     - description: Fixes rendering issue for custom oauth2 scopes

--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fixes oauth2 config rendering
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/3518
 - version: "1.2.2"
   changes:
     - description: Fixes rendering issue for custom oauth2 scopes

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -14,6 +14,8 @@ auth.basic.password: {{password}}
 pipeline: {{pipeline}}
 {{/if}}
 
+{{#unless username}}
+{{#unless password}}
 {{#if oauth_id}}
 auth.oauth2.client.id: {{oauth_id}}
 {{/if}}
@@ -54,6 +56,8 @@ auth.oauth2.azure.resource: {{oauth_azure_resource}}
 auth.oauth2.endpoint_params: 
   {{oauth_endpoint_params}}
 {{/if}}
+{{/unless}}
+{{/unless}}
 
 request.url: {{request_url}}
 request.method: {{request_method}}

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -2,18 +2,18 @@ config_version: 2
 data_stream:
   dataset: {{data_stream.dataset}}
 interval: {{request_interval}}
-{{#unless oauth_id}}
+
 {{#if username}}
 auth.basic.user: {{username}}
 {{/if}}
 {{#if password}}
 auth.basic.password: {{password}}
 {{/if}}
-{{/unless}}
+
 {{#if pipeline}}
 pipeline: {{pipeline}}
 {{/if}}
-{{#if oauth_id}}
+
 {{#if oauth_id}}
 auth.oauth2.client.id: {{oauth_id}}
 {{/if}}
@@ -53,7 +53,6 @@ auth.oauth2.azure.resource: {{oauth_azure_resource}}
 {{#if oauth_endpoint_params}}
 auth.oauth2.endpoint_params: 
   {{oauth_endpoint_params}}
-{{/if}}
 {{/if}}
 
 request.url: {{request_url}}

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -3,7 +3,7 @@ name: httpjson
 title: Custom HTTPJSON Input
 description: Collect custom data from REST API's with Elastic Agent.
 type: integration
-version: 1.2.2
+version: 1.2.3
 release: ga
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Auth options were supedited to the existence of `oauth_id`, which made valid configs not rendered. Removing this will delegate the validation of the config to the input itself.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
