### PR TITLE
Fix doc build (Azure Metrics)

### DIFF
--- a/packages/azure_metrics/_dev/build/docs/monitor.md
+++ b/packages/azure_metrics/_dev/build/docs/monitor.md
@@ -53,7 +53,7 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 
 `Resources`:: (_string_) Contains following options:
 
-`resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
+`resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format `/subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}`.
   Should return a list of resources.
 
 Users might have large number of resources they would like to gather metrics from. In order to reduce verbosity, they will have

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.5"
+  changes:
+    - description: Fix doc build
+      type: enhancement
+      link: TODO
 - version: "1.0.4"
   changes:
     - description: Update Readme

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix doc build
       type: enhancement
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/3528
 - version: "1.0.4"
   changes:
     - description: Update Readme

--- a/packages/azure_metrics/docs/monitor.md
+++ b/packages/azure_metrics/docs/monitor.md
@@ -53,7 +53,7 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 
 `Resources`:: (_string_) Contains following options:
 
-`resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format /subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}.
+`resource_id`:: (_[]string_) The fully qualified ID's of the resource, including the resource name and resource type. Has the format `/subscriptions/{guid}/resourceGroups/{resource-group-name}/providers/{resource-provider-namespace}/{resource-type}/{resource-name}`.
   Should return a list of resources.
 
 Users might have large number of resources they would like to gather metrics from. In order to reduce verbosity, they will have

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.4
+version: 1.0.5
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR fixes a `docs.elastic.co` documentation build error. Squiggly brackets must be escaped or in backticks.

## Related issues

* https://github.com/elastic/integrations/issues/3351.
