### PR TITLE
Add processors and tags to all system data streams

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.0"
+  changes:
+    - description: Add processor and tag fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3562
 - version: "1.16.2"
   changes:
     - description: Update documentation with additional context for new users.

--- a/packages/system/data_stream/core/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/core/agent/stream/stream.yml.hbs
@@ -6,3 +6,13 @@ core.metrics:
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/core/manifest.yml
+++ b/packages/system/data_stream/core/manifest.yml
@@ -20,8 +20,20 @@ streams:
         show_user: true
         description: >
           How to report core metrics. Can be "percentages" or "ticks"
-
         default:
           - percentages
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: System core metrics
     description: Collect System core metrics

--- a/packages/system/data_stream/core/manifest.yml
+++ b/packages/system/data_stream/core/manifest.yml
@@ -20,6 +20,7 @@ streams:
         show_user: true
         description: >
           How to report core metrics. Can be "percentages" or "ticks"
+
         default:
           - percentages
       - name: tags

--- a/packages/system/data_stream/cpu/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/cpu/agent/stream/stream.yml.hbs
@@ -7,3 +7,13 @@ period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/cpu/manifest.yml
+++ b/packages/system/data_stream/cpu/manifest.yml
@@ -19,9 +19,21 @@ streams:
         show_user: true
         description: >
           How to report CPU metrics. Can be "percentages", "normalized_percentages", or "ticks"
-
         default:
           - percentages
           - normalized_percentages
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: System cpu metrics
     description: Collect System cpu metrics

--- a/packages/system/data_stream/cpu/manifest.yml
+++ b/packages/system/data_stream/cpu/manifest.yml
@@ -19,6 +19,7 @@ streams:
         show_user: true
         description: >
           How to report CPU metrics. Can be "percentages", "normalized_percentages", or "ticks"
+
         default:
           - percentages
           - normalized_percentages

--- a/packages/system/data_stream/diskio/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/diskio/agent/stream/stream.yml.hbs
@@ -7,3 +7,13 @@ period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/diskio/manifest.yml
+++ b/packages/system/data_stream/diskio/manifest.yml
@@ -19,6 +19,18 @@ streams:
         show_user: true
         description: >
           Provide a specific list of devices to monitor. By default, all devices are monitored.
-
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: System diskio metrics
     description: Collect System diskio metrics

--- a/packages/system/data_stream/diskio/manifest.yml
+++ b/packages/system/data_stream/diskio/manifest.yml
@@ -19,6 +19,7 @@ streams:
         show_user: true
         description: >
           Provide a specific list of devices to monitor. By default, all devices are monitored.
+
       - name: tags
         type: text
         title: Tags

--- a/packages/system/data_stream/filesystem/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/filesystem/agent/stream/stream.yml.hbs
@@ -7,3 +7,9 @@ filesystem.ignore_types: {{filesystem.ignore_types}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/filesystem/manifest.yml
+++ b/packages/system/data_stream/filesystem/manifest.yml
@@ -20,6 +20,7 @@ streams:
         show_user: true
         description: >
           The filesystem datastream will ignore any filesystems with a matching type as specified here. By default, this will exclude any filesystems marked as "nodev" in /proc/filesystems on linux.
+
       - name: tags
         type: text
         title: Tags

--- a/packages/system/data_stream/filesystem/manifest.yml
+++ b/packages/system/data_stream/filesystem/manifest.yml
@@ -12,18 +12,6 @@ streams:
         required: true
         show_user: true
         default: 1m
-      - name: processors
-        type: yaml
-        title: Processors
-        multi: false
-        required: true
-        show_user: true
-        description: >
-          Processors are used to reduce the number of fields in the exported event or to enhance the event with external metadata.
-
-        default: |
-          - drop_event.when.regexp:
-              system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
       - name: filesystem.ignore_types
         type: text
         title: List of filesystem types to ignore
@@ -32,6 +20,22 @@ streams:
         show_user: true
         description: >
           The filesystem datastream will ignore any filesystems with a matching type as specified here. By default, this will exclude any filesystems marked as "nodev" in /proc/filesystems on linux.
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: true
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with external metadata.
 
+        default: |
+          - drop_event.when.regexp:
+              system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
     title: System filesystem metrics
     description: Collect System filesystem metrics

--- a/packages/system/data_stream/fsstat/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/fsstat/agent/stream/stream.yml.hbs
@@ -4,3 +4,9 @@ processors: {{processors}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/fsstat/manifest.yml
+++ b/packages/system/data_stream/fsstat/manifest.yml
@@ -12,6 +12,11 @@ streams:
         required: true
         show_user: true
         default: 1m
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
       - name: processors
         type: yaml
         title: Processors

--- a/packages/system/data_stream/load/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/load/agent/stream/stream.yml.hbs
@@ -1,3 +1,13 @@
 metricsets: ["load"]
 condition: ${host.platform} != 'windows'
 period: {{period}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/load/manifest.yml
+++ b/packages/system/data_stream/load/manifest.yml
@@ -11,5 +11,19 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: System load metrics
     description: Collect System load metrics

--- a/packages/system/data_stream/load/manifest.yml
+++ b/packages/system/data_stream/load/manifest.yml
@@ -24,6 +24,5 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
     title: System load metrics
     description: Collect System load metrics

--- a/packages/system/data_stream/memory/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/memory/agent/stream/stream.yml.hbs
@@ -3,3 +3,13 @@ period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/memory/manifest.yml
+++ b/packages/system/data_stream/memory/manifest.yml
@@ -24,6 +24,5 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
     title: System memory metrics
     description: Collect System memory metrics

--- a/packages/system/data_stream/memory/manifest.yml
+++ b/packages/system/data_stream/memory/manifest.yml
@@ -11,5 +11,19 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: System memory metrics
     description: Collect System memory metrics

--- a/packages/system/data_stream/network/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/network/agent/stream/stream.yml.hbs
@@ -2,5 +2,15 @@ metricsets: ["network"]
 period: {{period}}
 network.interfaces:
 {{#each network.interfaces}}
-  - {{this}}
+- {{this}}
 {{/each}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/network/manifest.yml
+++ b/packages/system/data_stream/network/manifest.yml
@@ -19,6 +19,7 @@ streams:
         show_user: true
         description: >
           List of interfaces to monitor. Will monitor all by default.
+
       - name: tags
         type: text
         title: Tags
@@ -32,6 +33,5 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
     title: System network metrics
     description: Collect System network metrics

--- a/packages/system/data_stream/network/manifest.yml
+++ b/packages/system/data_stream/network/manifest.yml
@@ -19,6 +19,19 @@ streams:
         show_user: true
         description: >
           List of interfaces to monitor. Will monitor all by default.
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
     title: System network metrics
     description: Collect System network metrics

--- a/packages/system/data_stream/process/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/process/agent/stream/stream.yml.hbs
@@ -8,13 +8,23 @@ process.include_cpu_ticks: {{process.include_cpu_ticks}}
 {{#if process.env.whitelist}}
 process.env.whitelist:
 {{#each process.env.whitelist}}
-  - {{this}}
+- {{this}}
 {{/each}}
 {{/if}}
 processes:
 {{#each processes}}
-  - {{this}}
+- {{this}}
 {{/each}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
+{{/if}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
 {{/if}}

--- a/packages/system/data_stream/process/manifest.yml
+++ b/packages/system/data_stream/process/manifest.yml
@@ -94,6 +94,5 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
     title: System process metrics
     description: Collect System process metrics

--- a/packages/system/data_stream/process/manifest.yml
+++ b/packages/system/data_stream/process/manifest.yml
@@ -81,5 +81,19 @@ streams:
 
         default:
           - .*
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: System process metrics
     description: Collect System process metrics

--- a/packages/system/data_stream/process_summary/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/process_summary/agent/stream/stream.yml.hbs
@@ -3,3 +3,13 @@ period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/process_summary/manifest.yml
+++ b/packages/system/data_stream/process_summary/manifest.yml
@@ -12,5 +12,18 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: System process_summary metrics
     description: Collect System process_summary metrics

--- a/packages/system/data_stream/socket_summary/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/socket_summary/agent/stream/stream.yml.hbs
@@ -3,3 +3,13 @@ period: {{period}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}
 {{/if}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/socket_summary/manifest.yml
+++ b/packages/system/data_stream/socket_summary/manifest.yml
@@ -24,6 +24,5 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
     title: System socket_summary metrics
     description: Collect System socket_summary metrics

--- a/packages/system/data_stream/socket_summary/manifest.yml
+++ b/packages/system/data_stream/socket_summary/manifest.yml
@@ -11,5 +11,19 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: System socket_summary metrics
     description: Collect System socket_summary metrics

--- a/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
+++ b/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
@@ -8,3 +8,13 @@ multiline:
   match: after
 processors:
   - add_locale: ~
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/syslog/manifest.yml
+++ b/packages/system/data_stream/syslog/manifest.yml
@@ -13,6 +13,20 @@ streams:
         default:
           - /var/log/messages*
           - /var/log/syslog*
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     template_path: log.yml.hbs
     title: System syslog logs (log)
     description: Collect System syslog logs using log input

--- a/packages/system/data_stream/syslog/manifest.yml
+++ b/packages/system/data_stream/syslog/manifest.yml
@@ -26,7 +26,6 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
     template_path: log.yml.hbs
     title: System syslog logs (log)
     description: Collect System syslog logs using log input

--- a/packages/system/data_stream/uptime/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/uptime/agent/stream/stream.yml.hbs
@@ -1,2 +1,12 @@
 metricsets: ["uptime"]
 period: {{period}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}

--- a/packages/system/data_stream/uptime/manifest.yml
+++ b/packages/system/data_stream/uptime/manifest.yml
@@ -11,5 +11,19 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: System uptime metrics
     description: Collect System uptime metrics

--- a/packages/system/data_stream/uptime/manifest.yml
+++ b/packages/system/data_stream/uptime/manifest.yml
@@ -24,6 +24,5 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
     title: System uptime metrics
     description: Collect System uptime metrics

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.16.2
+version: 1.17.0
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fix for https://github.com/elastic/integrations/issues/2865
This adds a little drop-down config that adds `processors` and `tags` fields to all events in the system integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
