### PR TITLE
[Security Rules] Update security rules package to v7.16.3

### DIFF
--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -2,6 +2,16 @@
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
 - changes:
     - description: Release security rules update
+      link: https://github.com/elastic/integrations/pulls/0000
+      type: enhancement
+  version: 7.16.3
+- changes:
+    - description: Release security rules update
+      link: https://github.com/elastic/integrations/pulls/0000
+      type: enhancement
+  version: 7.16.3
+- changes:
+    - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/3556
       type: enhancement
   version: 7.16.3

--- a/packages/security_detection_engine/docs/README.md
+++ b/packages/security_detection_engine/docs/README.md
@@ -6,3 +6,5 @@ To download or update the rules, click **Settings** > **Install Prebuilt Securit
 Then [import](https://www.elastic.co/guide/en/security/master/rules-ui-management.html#load-prebuilt-rules)
 the rules into the Detection engine.
 
+## License Notice
+


### PR DESCRIPTION

## What does this PR do?
Update the Security Rules package to version 7.16.3.
Autogenerated from commit  https://github.com/elastic/detection-rules/tree/fafe1e0ab629095a5205b8d318f9ed17ed6ea0a3

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist
- Install the most recently release security rules in the Detection Engine
- Install the package
- Confirm the update is available in Kibana. Click "Update X rules" or "Install X rules"
- Look at the changes made after the install and confirm they are consistent

## How to test this PR locally
- Perform the above checklist, and use `package-storage` to build EPR from source

## Related issues
None

## Screenshots
None
