### PR TITLE
[tcp/udp] Add option to parse syslog

### DIFF
--- a/packages/tcp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tcp/_dev/deploy/docker/docker-compose.yml
@@ -5,3 +5,13 @@ services:
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/test-tcp.log
+  test-tls:
+    image: docker.elastic.co/observability/stream:v0.6.1
+    volumes:
+      - ./sample_logs:/sample_logs:ro
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=tls --insecure /sample_logs/test-tcp.log
+  test-syslog:
+    image: docker.elastic.co/observability/stream:v0.6.1
+    volumes:
+      - ./sample_logs:/sample_logs:ro
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9517 -p=tcp /sample_logs/test-tcp.log

--- a/packages/tcp/_dev/deploy/docker/sample_logs/test-tcp.log
+++ b/packages/tcp/_dev/deploy/docker/sample_logs/test-tcp.log
@@ -1,1 +1,1 @@
-<134>1 2020-03-29T13:19:20Z testhostname testproductname 1930 - some longer testmessage. - a {2:2}.
+<134>1 2020-03-29T13:19:20Z testhostname testproductname 1930 - - some longer testmessage. - a {2:2}.

--- a/packages/tcp/changelog.yml
+++ b/packages/tcp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.0"
+  changes:
+    - description: Add syslog parsing option
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0001
 - version: "1.1.0"
   changes:
     - description: Update to ECS 8.2

--- a/packages/tcp/data_stream/generic/_dev/test/system/test-syslog-config.yml
+++ b/packages/tcp/data_stream/generic/_dev/test/system/test-syslog-config.yml
@@ -1,7 +1,8 @@
-service: test-tcp
+service: test-syslog
 service_notify_signal: SIGHUP
 input: tcp
 data_stream:
   vars:
     listen_address: 0.0.0.0
-    listen_port: 9515
+    listen_port: 9517
+    syslog: true

--- a/packages/tcp/data_stream/generic/_dev/test/system/test-tls-config.yml
+++ b/packages/tcp/data_stream/generic/_dev/test/system/test-tls-config.yml
@@ -1,0 +1,59 @@
+service: test-tls
+service_notify_signal: SIGHUP
+input: tcp
+data_stream:
+  vars:
+    listen_address: 0.0.0.0
+    listen_port: 9516
+    ssl: |
+      key: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDhCLvLsQAHufsN
+        U+u1x/CequAUphfXZqLhDo2Eo/holfBS0+ey4bnzPL6lS9NFL5JkLQA2gYESqsXU
+        /Ru8E76Az1egzMwT3TVAPLVU8NbrxBqeNiQa2m9wC37HQy4qC9OxL28LUoKtFjxS
+        cD1sa0oikXCJN1a3BSoAf9iiZ/dxz4WVfrNhrzq2JFXjravY84n5ujkZOg45Pg70
+        4vHOeg0rBbIoSNfjDUVZWjwC95K1BMN3msOTL9juv/EDa6BujqCxl+G1nY7JPFDL
+        SHWis65p+1AAa5xieYDb47vyJ0SSR7lEURTXZOkkM6k5JWfgkATEmGzRxPkOloIT
+        Xg9ag1OlAgMBAAECggEAEHfPJmzhj68wjB0kFr13AmWG2Hv/Kqg8KzQhbx+AwkaW
+        u7j+L70NGpvLZ9VQtLNyhxoz9cksZO1SZO/Q48aeHlcOFppmJN3/U6AdtQWa9M35
+        FLLpmX16wjxVHsfvzOvopgLOoYl8PqZt66qDFDgVyMnT7na6RdJ+7GJuvBPXq+Bc
+        vgThvAZitHSAOhnBFYmTMlBi6AzOMMsaFlgE3Xf9v3M0pAKItPRKMhXlC3MyvA/v
+        jgbra4Ib+0ryohggHheHB3bn3Jgv7iFKoW9OQSePVxacJ+kfr9H+No5g495URzqR
+        mx/96WCiv3rAh3ct8Sk/C4/3zMC8fUueDJIVjhgw0QKBgQD8NufLINNkIpBrLoCS
+        972oFEjZB2u6EusQ7X9raROqpaw26ZSu+zSHeIKCGQ93M3aRb3FpdGeOxgZ095MV
+        8a+nlh4stOvHj2Mm5YhTBDUavTC7o9aVR3Od5eTXUpHnaJpNI/uyIcKupeK1UJnV
+        UlBLeIwo/vJ1gsVrKMMAJkuKbwKBgQDkaWRRd0w2gUIbCTGf203BqXft0VdIiOW7
+        +gnkeaNHAf09XljzxMcQzrB8kG63aKVGbJffphEfzxtiJ+HRQVH+7QpKRhU/GHmu
+        +6OKkxTcxJm5zhoRFxcSi2wG4PWmUGJvc7ss1OJGcaOUxwocCepO7N/jfdDz9Uke
+        KnA+YWOdKwKBgQDteZkYlojT0QOgF8HyH5gQyUCqMKWLJ0LzxltiPCbLV4Dml1pq
+        w5Z7M8nWS1hXiTpLx93GSFc1hFkSCwYP9GfK6Lryp0sVtHnMZvTMDbseuSJImwRx
+        vDwtYQfugg1lEQWwOoBEAiu3m/PxernNtNprpU57T0nlwUK3GkM5QdWAuwKBgQCZ
+        ZF3GiANapzupxGbbH//8Cr9LqsafI7CEqMpz8WxBh4h16iJ6sq+tDeFgBe8UpOY5
+        gTwNKg1d+0w8guQYD3HtbWr3rlEeamVtqfiOW3ArQqyqJ0tCJuuLvK3zgKf35Qv2
+        JRaSaPT8sdxVUcXsRoxgLJu+vwPQke1koMN4YRbwuQKBgQDJiZ/WSeqa5oIqkXbn
+        hjm7RXKaf2oE1U/bNjdSFtdEP7T4vUvvr7Hq2f/jiBLtCE7w16PJjKx9iIq2+jMl
+        qIY43Sk9bdi5FxtYTHda0hwrbH274P+QVcVs5PXCT0TGktOleHGBlXaaPrxl9iCh
+        8tmmxZZYa5aQxEO/lxB9xQKaiQ==
+        -----END PRIVATE KEY-----
+      certificate: |
+        -----BEGIN CERTIFICATE-----
+        MIIDazCCAlOgAwIBAgIUW5TDu1tJMY2Oa7PsL+BQSmeWqz0wDQYJKoZIhvcNAQEL
+        BQAwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+        GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTEwMDEwNTAwMjNaFw0yMTEw
+        MDIwNTAwMjNaMEUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+        HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+        AQUAA4IBDwAwggEKAoIBAQDhCLvLsQAHufsNU+u1x/CequAUphfXZqLhDo2Eo/ho
+        lfBS0+ey4bnzPL6lS9NFL5JkLQA2gYESqsXU/Ru8E76Az1egzMwT3TVAPLVU8Nbr
+        xBqeNiQa2m9wC37HQy4qC9OxL28LUoKtFjxScD1sa0oikXCJN1a3BSoAf9iiZ/dx
+        z4WVfrNhrzq2JFXjravY84n5ujkZOg45Pg704vHOeg0rBbIoSNfjDUVZWjwC95K1
+        BMN3msOTL9juv/EDa6BujqCxl+G1nY7JPFDLSHWis65p+1AAa5xieYDb47vyJ0SS
+        R7lEURTXZOkkM6k5JWfgkATEmGzRxPkOloITXg9ag1OlAgMBAAGjUzBRMB0GA1Ud
+        DgQWBBRYUSKDHBBE9Q6fTeTqogicCxcXwDAfBgNVHSMEGDAWgBRYUSKDHBBE9Q6f
+        TeTqogicCxcXwDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBc
+        T8B+GpvPy9NQ700LsywRPY0L9IJCKiu6j3TP1tqqSPjAC/cg9ac+bFXuWOu7V+KJ
+        s09Q/pItq9SLX6UvnfRzTxu5lCBwwGX9cL131mTIu5SmFo7Eks+sorbiIarWDMoC
+        e+9An3GFpagW+YhOt4BdIM5lTqoeodzganDBsOUZI9aDAj2Yo5h2O7r6Wd12cb6T
+        mz8vMfB2eG8BxU20ZMfkdERWjiyXHOSBQqeqfkV8d9370gMu5RcJNcIgnbmTRdho
+        X3HJFiimZVaNjXATqmC/y2A1KXvJdamPLy3mGXkW2cFLoPCdK2OZFUHqiuc1bigA
+        qEf55SihFqErRMeURPPF
+        -----END CERTIFICATE-----

--- a/packages/tcp/data_stream/generic/agent/stream/tcp.yml.hbs
+++ b/packages/tcp/data_stream/generic/agent/stream/tcp.yml.hbs
@@ -37,5 +37,13 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 {{#if processors}}
 processors:
+{{#if syslog}}
+  - syslog:
+      {{syslog_options}}
+{{/if}}
 {{processors}}
+{{else if syslog}}
+processors:
+  - syslog:
+      {{syslog_options}}
 {{/if}}

--- a/packages/tcp/data_stream/generic/fields/ecs.yml
+++ b/packages/tcp/data_stream/generic/fields/ecs.yml
@@ -7,3 +7,21 @@
   description: The IP or DNS name of the source sending the UDP packet.
 - name: message
   external: ecs
+- name: log.syslog.appname
+  external: ecs
+- name: log.syslog.facility.code
+  external: ecs
+- name: log.syslog.facility.name
+  external: ecs
+- name: log.syslog.hostname
+  external: ecs
+- name: log.syslog.priority
+  external: ecs
+- name: log.syslog.procid
+  external: ecs
+- name: log.syslog.severity.code
+  external: ecs
+- name: log.syslog.severity.name
+  external: ecs
+- name: log.syslog.version
+  external: ecs

--- a/packages/tcp/data_stream/generic/manifest.yml
+++ b/packages/tcp/data_stream/generic/manifest.yml
@@ -88,3 +88,36 @@ streams:
         required: false
         multi: true
         show_user: true
+      - name: syslog
+        type: bool
+        title: Syslog Parsing
+        description: Enable the syslog parser to automatically parse syslog data.
+        required: false
+        show_user: true
+      - name: syslog_options
+        type: yaml
+        title: Syslog Configuration
+        description: i.e. field, format, time zone, etc. See [Syslog](https://www.elastic.co/guide/en/beats/filebeat/current/syslog.html) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          field: message
+          #format: auto
+          #timezone: Local
+      - name: ssl
+        type: yaml
+        title: SSL Configuration
+        description: i.e. certificate, keys, supported_protocols, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-server-config) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #certificate: |
+          #    -----BEGIN CERTIFICATE-----
+          #    ...
+          #    -----END CERTIFICATE-----
+          #key: |
+          #    -----BEGIN PRIVATE KEY-----
+          #    ...
+          #    -----END PRIVATE KEY-----

--- a/packages/tcp/manifest.yml
+++ b/packages/tcp/manifest.yml
@@ -3,10 +3,10 @@ name: tcp
 title: Custom TCP Logs
 description: Collect raw TCP data from listening TCP port with Elastic Agent.
 type: integration
-version: 1.1.0
+version: 1.2.0
 release: ga
 conditions:
-  kibana.version: "^7.16.0 || ^8.0.0"
+  kibana.version: "^8.2.1"
 license: basic
 categories:
   - custom

--- a/packages/udp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/udp/_dev/deploy/docker/docker-compose.yml
@@ -5,3 +5,8 @@ services:
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/test-udp.log
+  test-syslog:
+    image: docker.elastic.co/observability/stream:v0.6.1
+    volumes:
+      - ./sample_logs:/sample_logs:ro
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=udp /sample_logs/test-udp.log

--- a/packages/udp/_dev/deploy/docker/sample_logs/test-udp.log
+++ b/packages/udp/_dev/deploy/docker/sample_logs/test-udp.log
@@ -1,1 +1,1 @@
-<134>1 2020-03-29T13:19:20Z testhostname testproductname 1930 - some longer testmessage. - a {2:2}.
+<134>1 2020-03-29T13:19:20Z testhostname testproductname 1930 - - some longer testmessage. - a {2:2}.

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.0"
+  changes:
+    - description: Add syslog parsing option
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0001
 - version: "1.1.1"
   changes:
     - description: Fixing typo in readme

--- a/packages/udp/data_stream/generic/_dev/test/system/test-syslog-config.yml
+++ b/packages/udp/data_stream/generic/_dev/test/system/test-syslog-config.yml
@@ -1,7 +1,8 @@
-service: test-tcp
+service: test-syslog
 service_notify_signal: SIGHUP
-input: tcp
+input: udp
 data_stream:
   vars:
     listen_address: 0.0.0.0
-    listen_port: 9515
+    listen_port: 9516
+    syslog: true

--- a/packages/udp/data_stream/generic/agent/stream/udp.yml.hbs
+++ b/packages/udp/data_stream/generic/agent/stream/udp.yml.hbs
@@ -27,5 +27,13 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 {{#if processors}}
 processors:
+{{#if syslog}}
+  - syslog:
+      {{syslog_options}}
+{{/if}}
 {{processors}}
+{{else if syslog}}
+processors:
+  - syslog:
+      {{syslog_options}}
 {{/if}}

--- a/packages/udp/data_stream/generic/fields/ecs.yml
+++ b/packages/udp/data_stream/generic/fields/ecs.yml
@@ -7,3 +7,21 @@
   description: The IP or DNS name of the source sending the UDP packet.
 - name: message
   external: ecs
+- name: log.syslog.appname
+  external: ecs
+- name: log.syslog.facility.code
+  external: ecs
+- name: log.syslog.facility.name
+  external: ecs
+- name: log.syslog.hostname
+  external: ecs
+- name: log.syslog.priority
+  external: ecs
+- name: log.syslog.procid
+  external: ecs
+- name: log.syslog.severity.code
+  external: ecs
+- name: log.syslog.severity.name
+  external: ecs
+- name: log.syslog.version
+  external: ecs

--- a/packages/udp/data_stream/generic/manifest.yml
+++ b/packages/udp/data_stream/generic/manifest.yml
@@ -79,3 +79,20 @@ streams:
         required: false
         multi: true
         show_user: true
+      - name: syslog
+        type: bool
+        title: Syslog Parsing
+        description: Enable the syslog parser to automatically parse syslog data.
+        required: false
+        show_user: true
+      - name: syslog_options
+        type: yaml
+        title: Syslog Options
+        description: i.e. format, time zone, etc.
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          field: message
+          #format: auto
+          #timezone: Local

--- a/packages/udp/manifest.yml
+++ b/packages/udp/manifest.yml
@@ -3,10 +3,10 @@ name: udp
 title: Custom UDP Logs
 description: Collect raw UDP data from listening UDP port with Elastic Agent.
 type: integration
-version: 1.1.1
+version: 1.2.0
 release: ga
 conditions:
-  kibana.version: "^7.16.0 || ^8.0.0"
+  kibana.version: "^8.2.1"
 license: basic
 categories:
   - custom


### PR DESCRIPTION
## What does this PR do?

- Add option to parse syslog
- Fix sample logs to be properly formatted RFC 5424 messages
- Add syslog ECS field references
- Expose TLS in TCP integration
- Add system test for TCP/TLS
- Add system tests for syslog

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/tcp && elastic-package test
cd packages/udp && elastic-package test
```

## Related issues

- Closes #3212 

## Screenshots

![syslog-tcp](https://user-images.githubusercontent.com/90622908/175570313-4cc2a6b9-df08-46e4-af4e-f12131a45215.jpg)
![syslog-udp](https://user-images.githubusercontent.com/90622908/175570321-3982ca99-e1f6-45d6-81ac-4696881aca97.jpg)

