### PR TITLE
[Azure] Move container instance metrics from beats to integrations

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Move container_instance metrics config from beats to integrations
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9999999999
+      link: https://github.com/elastic/integrations/pull/3593
 - version: "1.0.5"
   changes:
     - description: Fix doc build

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.6"
+  changes:
+    - description: Move container_instance metrics config from beats to integrations
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999999999
 - version: "1.0.5"
   changes:
     - description: Fix doc build

--- a/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
@@ -34,7 +34,7 @@ resources:
             timegrain: "PT5M"
             dimensions:
             - name: "containerName"
-            value: "*"
+              value: "*"
           - name: ["NetworkBytesReceivedPerSecond", "NetworkBytesTransmittedPerSecond"]
             namespace: "Microsoft.ContainerInstance/containerGroups"
             ignore_unsupported: true

--- a/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
@@ -58,6 +58,12 @@ resources:
             timegrain: "PT5M"        
     {{/each}}
 {{/if}}
+
+{{!
+    When no resource group and resource ID are specified by the user, we want to 
+    collect metrics for all the resource groups in the subscription.
+}}
+
 {{#unless resource_ids }}
     {{#unless resource_groups }}
         - resource_query: "resourceType eq 'Microsoft.ContainerInstance/containerGroups'"

--- a/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["container_instance"]
+metricsets: ["monitor"]
 period: {{period}}
 {{#if client_id}}
 client_id: {{client_id}}
@@ -26,11 +26,52 @@ resources:
 {{#if resource_groups}}
     {{#each resource_groups}}
         - resource_group: "{{this}}"
+          resource_type: "Microsoft.ContainerInstance/containerGroups"
+          metrics:
+          - name: ["CpuUsage", "MemoryUsage"]
+            namespace: "Microsoft.ContainerInstance/containerGroups"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "containerName"
+            value: "*"
+          - name: ["NetworkBytesReceivedPerSecond", "NetworkBytesTransmittedPerSecond"]
+            namespace: "Microsoft.ContainerInstance/containerGroups"
+            ignore_unsupported: true
+            timegrain: "PT5M"        
     {{/each}}
 {{/if}}
 {{#if resource_ids}}
     {{#each resource_ids}}
         - resource_id: "{{this}}"
+          metrics:
+          - name: ["CpuUsage", "MemoryUsage"]
+            namespace: "Microsoft.ContainerInstance/containerGroups"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "containerName"
+              value: "*"
+          - name: ["NetworkBytesReceivedPerSecond", "NetworkBytesTransmittedPerSecond"]
+            namespace: "Microsoft.ContainerInstance/containerGroups"
+            ignore_unsupported: true
+            timegrain: "PT5M"        
     {{/each}}
 {{/if}}
-
+{{#unless resource_ids }}
+    {{#unless resource_groups }}
+        - resource_query: "resourceType eq 'Microsoft.ContainerInstance/containerGroups'"
+          metrics:
+          - name: ["CpuUsage", "MemoryUsage"]
+            namespace: "Microsoft.ContainerInstance/containerGroups"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "containerName"
+              value: "*"
+          - name: ["NetworkBytesReceivedPerSecond", "NetworkBytesTransmittedPerSecond"]
+            namespace: "Microsoft.ContainerInstance/containerGroups"
+            ignore_unsupported: true
+            timegrain: "PT5M"     
+    {{/unless}}
+{{/unless}}

--- a/packages/azure_metrics/data_stream/container_instance/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure_metrics/data_stream/container_instance/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,14 @@
+---
+description: Pipeline for parsing azure container_instance metrics.
+processors:
+  - set:
+      field: ecs.version
+      value: "8.0.0"
+  - rename:
+      field: azure.monitor
+      target_field: azure.container_instance
+      ignore_missing: true
+on_failure:
+  - set:
+      field: error.message
+      value: '{{ _ingest.on_failure_message }}'

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.5
+version: 1.0.6
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR is to move lightweight module configuration from Metricbeat into integrations.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md), and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related Issues

* Closes #3592