### PR TITLE
gcp: remove gcp.audit.* fields duplicated in ECS fields

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,10 +1,15 @@
 # newer versions go on top
-- version: 2.1.0
+- version: "2.2.0"
+  changes:
+    - description: Remove fields duplicated in ECS fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3609
+- version: "2.1.0"
   changes:
     - description: restore compatibility with 7.17 release track
       type: enhancement
       link: foobar
-- version: 2.0.0
+- version: "2.0.0"
   changes:
     - description: |
         Move configurations to support metrics. This change is breaking, as it moves

--- a/packages/gcp/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/gcp/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -34,9 +34,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx@xxx.xxx"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -44,13 +41,11 @@
                             "resource": "projects/elastic-beats"
                         }
                     ],
-                    "method_name": "GetResourceBillingInfo",
                     "request": {
                         "@type": "type.googleapis.com/google.internal.cloudbilling.billingaccount.v1.GetResourceBillingInfoRequest",
                         "resourceName": "projects/189716325846"
                     },
                     "resource_name": "projects/elastic-beats",
-                    "service_name": "cloudbilling.googleapis.com",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -102,9 +97,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx@xxx.xxx"
-                    },
                     "authorization_info": [
                         {
                             "granted": false,
@@ -116,13 +108,9 @@
                             }
                         }
                     ],
-                    "method_name": "beta.compute.machineTypes.aggregatedList",
                     "num_response_items": 71,
                     "request": {
                         "@type": "type.googleapis.com/compute.machineTypes.aggregatedList"
-                    },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:71.0) Gecko/20100101 Firefox/71.0,gzip(gfe),gzip(gfe)"
                     },
                     "resource_location": {
                         "current_locations": [
@@ -130,7 +118,6 @@
                         ]
                     },
                     "resource_name": "projects/elastic-beats/global/machineTypes",
-                    "service_name": "compute.googleapis.com",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -195,9 +182,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx@xxx.xxx"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -209,13 +193,9 @@
                             }
                         }
                     ],
-                    "method_name": "beta.compute.instances.aggregatedList",
                     "num_response_items": 61,
                     "request": {
                         "@type": "type.googleapis.com/compute.instances.aggregatedList"
-                    },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:71.0) Gecko/20100101 Firefox/71.0,gzip(gfe),gzip(gfe)"
                     },
                     "resource_location": {
                         "current_locations": [
@@ -235,7 +215,6 @@
                         "kind": "Status",
                         "status_value": "Success"
                     },
-                    "service_name": "compute.googleapis.com",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -296,9 +275,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx@xxx.xxx"
-                    },
                     "authorization_info": [
                         {
                             "permission": "compute.instances.list",
@@ -309,13 +285,9 @@
                             }
                         }
                     ],
-                    "method_name": "beta.compute.instances.aggregatedList",
                     "num_response_items": 61,
                     "request": {
                         "@type": "type.googleapis.com/compute.instances.aggregatedList"
-                    },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:71.0) Gecko/20100101 Firefox/71.0,gzip(gfe),gzip(gfe)"
                     },
                     "resource_location": {
                         "current_locations": [
@@ -323,7 +295,6 @@
                         ]
                     },
                     "resource_name": "projects/elastic-beats/global/instances",
-                    "service_name": "compute.googleapis.com",
                     "status": {
                         "code": 7,
                         "message": "PERMISSION_DENIED"
@@ -392,9 +363,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "system:serviceaccount:cert-manager:cert-manager-webhook"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -409,7 +377,6 @@
                     "logentry_operation": {
                         "id": "5555555-6349-45d2-b905-fc607e6c5d3b"
                     },
-                    "method_name": "io.k8s.authorization.v1beta1.subjectaccessreviews.create",
                     "request": {
                         "@type": "authorization.k8s.io/v1beta1.SubjectAccessReview",
                         "apiVersion": "authorization.k8s.io/v1beta1",
@@ -429,9 +396,6 @@
                         "status": {
                             "allowed": false
                         }
-                    },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "webhook/v0.0.0 (linux/amd64) kubernetes/$Format"
                     },
                     "response": {
                         "@type": "authorization.k8s.io/v1beta1.SubjectAccessReview",
@@ -454,7 +418,6 @@
                             "reason": "RBAC: allowed by ClusterRoleBinding \"system:discovery\" of ClusterRole \"system:discovery\" to Group \"system:authenticated\""
                         }
                     },
-                    "service_name": "k8s.io",
                     "status": {
                         "code": 0
                     },
@@ -530,9 +493,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "user@mycompany.com"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -547,7 +507,6 @@
                     "logentry_operation": {
                         "id": "operation-1596664766354-5ac287c395484-fa3923bd-543e018e"
                     },
-                    "method_name": "v1.compute.images.insert",
                     "request": {
                         "@type": "type.googleapis.com/compute.images.insert",
                         "family": "windows-server-2016",
@@ -564,9 +523,6 @@
                             "source": "https://storage.googleapis.com/storage/v1/b/foo/o/windows-server-2016-v20200805.tar.gz"
                         },
                         "sourceType": "RAW"
-                    },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "google-cloud-sdk gcloud/290.0.1 command/gcloud.compute.images.create invocation-id/032752ad0fa44b4ea951951d2deef6a3 environment/None environment-version/None interactive/True from-script/False python/2.7.17 term/xterm-256color (Macintosh; Intel Mac OS X 19.6.0),gzip(gfe)"
                     },
                     "resource_location": {
                         "current_locations": [
@@ -589,7 +545,6 @@
                         "targetLink": "https://www.googleapis.com/compute/v1/projects/foo/global/images/windows-server-2016-v20200805",
                         "user": "user@mycompany.com"
                     },
-                    "service_name": "compute.googleapis.com",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -666,21 +621,13 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "user@mycompany.com"
-                    },
                     "logentry_operation": {
                         "id": "operation-1596646123456-5ac2438b775f6-f8ca1382-e70b6831"
                     },
-                    "method_name": "beta.compute.instances.stop",
                     "request": {
                         "@type": "type.googleapis.com/compute.instances.stop"
                     },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:79.0) Gecko/20100101 Firefox/79.0,gzip(gfe),gzip(gfe)"
-                    },
                     "resource_name": "projects/foo/zones/us-central1-a/instances/win10-test",
-                    "service_name": "compute.googleapis.com",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -757,9 +704,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx@xxx.xxx"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -770,11 +714,6 @@
                     "labels": {
                         "authorization.k8s.io/decision": "allow"
                     },
-                    "method_name": "io.k8s.core.v1.nodes.list",
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "GoogleCloudConsole"
-                    },
-                    "service_name": "k8s.io",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -842,9 +781,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx@xxx.xxx"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -857,11 +793,6 @@
                         "k8s.io/deprecated": "true",
                         "k8s.io/removed-release": "1.22"
                     },
-                    "method_name": "io.k8s.extensions.v1beta1.ingresses.list",
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "GoogleCloudConsole"
-                    },
-                    "service_name": "k8s.io",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -930,9 +861,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "system:anonymous"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -944,11 +872,6 @@
                         "authorization.k8s.io/decision": "allow",
                         "authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"system:public-info-viewer\" of ClusterRole \"system:public-info-viewer\" to Group \"system:unauthenticated\""
                     },
-                    "method_name": "io.k8s.get",
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "kube-probe/1.19+"
-                    },
-                    "service_name": "k8s.io",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -1015,9 +938,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "system:serviceaccount:kube-system:generic-garbage-collector"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -1029,11 +949,6 @@
                         "authorization.k8s.io/decision": "allow",
                         "authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"system:discovery\" of ClusterRole \"system:discovery\" to Group \"system:authenticated\""
                     },
-                    "method_name": "io.k8s.get",
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "kube-controller-manager/v1.19.8 (linux/amd64) kubernetes/4f6f69f/system:serviceaccount:kube-system:generic-garbage-collector"
-                    },
-                    "service_name": "k8s.io",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -1102,10 +1017,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx@xxx.xxx",
-                        "principal_subject": "sub"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -1113,17 +1024,12 @@
                             "resource": "projects/project"
                         }
                     ],
-                    "method_name": "google.iam.admin.v1.ListServiceAccounts",
                     "request": {
                         "@type": "type.googleapis.com/google.iam.admin.v1.ListServiceAccountsRequest",
                         "name": "projects/project",
                         "page_token": "cg:FFFFFF"
                     },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "google-api-go-client/0.5,gzip(gfe)"
-                    },
                     "resource_name": "projects/project",
-                    "service_name": "iam.googleapis.com",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -1178,9 +1084,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx@xxx.xxx"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -1198,7 +1101,6 @@
                     "logentry_operation": {
                         "id": "924fbbf6-1982-4173-9355-3fca0ab7b0ee"
                     },
-                    "method_name": "io.k8s.authorization.v1beta1.subjectaccessreviews.create",
                     "request": {
                         "@type": "authorization.k8s.io/v1beta1.SubjectAccessReview",
                         "apiVersion": "authorization.k8s.io/v1beta1",
@@ -1218,9 +1120,6 @@
                         "status": {
                             "allowed": false
                         }
-                    },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "metrics-server/v0.0.0 (linux/amd64) kubernetes/$Format"
                     },
                     "response": {
                         "@type": "authorization.k8s.io/v1beta1.SubjectAccessReview",
@@ -1254,7 +1153,6 @@
                             "reason": "RBAC: allowed by ClusterRoleBinding \"system:discovery\" of ClusterRole \"system:discovery\" to Group \"system:authenticated\""
                         }
                     },
-                    "service_name": "k8s.io",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -1337,9 +1235,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "system:addon-manager"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -1350,7 +1245,6 @@
                     "labels": {
                         "authorization.k8s.io/decision": "allow"
                     },
-                    "method_name": "io.k8s.apps.v1.deployments.patch",
                     "request": {
                         "@type": "k8s.io/Patch",
                         "spec": {
@@ -1388,9 +1282,6 @@
                                 }
                             }
                         }
-                    },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "kubectl/v1.20.2 (linux/amd64) kubernetes/faecb19"
                     },
                     "response": {
                         "@type": "apps.k8s.io/v1.Deployment",
@@ -1642,7 +1533,6 @@
                             "updatedReplicas": 6
                         }
                     },
-                    "service_name": "k8s.io",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -1716,30 +1606,21 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "service-150691754250@container-engine-robot.iam.gserviceaccount.com",
-                        "principal_subject": "serviceAccount:service-150691754250@container-engine-robot.iam.gserviceaccount.com"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
                             "permission": "container.clusters.get"
                         }
                     ],
-                    "method_name": "google.container.v1.ClusterManager.GetCluster",
                     "request": {
                         "@type": "type.googleapis.com/google.container.v1alpha1.GetClusterRequest",
                         "name": "projects/elastic-product/locations/us-central1-a/clusters/demo-elastic-co"
-                    },
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "google-api-go-client/0.5 cluster-autoscaler,gzip(gfe)"
                     },
                     "resource_location": {
                         "current_locations": [
                             "us-central1-a"
                         ]
                     },
-                    "service_name": "container.googleapis.com",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },
@@ -1804,9 +1685,6 @@
             },
             "gcp": {
                 "audit": {
-                    "authentication_info": {
-                        "principal_email": "xxx-compute@developer.gserviceaccount.com"
-                    },
                     "authorization_info": [
                         {
                             "granted": true,
@@ -1814,17 +1692,12 @@
                             "resource": "projects/_/buckets/dataflow-staging-us-central1-xxx/objects/staging/xxx.jar"
                         }
                     ],
-                    "method_name": "storage.objects.get",
-                    "request_metadata": {
-                        "caller_supplied_user_agent": "BigstoreFile BigstoreIO (cr/xxx) "
-                    },
                     "resource_location": {
                         "current_locations": [
                             "us-central1"
                         ]
                     },
                     "resource_name": "projects/_/buckets/dataflow-staging-us-central1-xxx/objects/staging/jfxrt-xxx.jar",
-                    "service_name": "storage.googleapis.com",
                     "type": "type.googleapis.com/google.cloud.audit.AuditLog"
                 }
             },

--- a/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -127,15 +127,24 @@ processors:
       target_field: gcp.audit.authentication_info.authority_selector
       ignore_missing: true
 
-# TODO remove - duplicated in client.user.email and client.user.id
-  - set:
+  - rename:
       field: gcp.audit.authentication_info.principal_email
-      copy_from: client.user.email
-      if: ctx.client?.user?.email != null
-  - set:
+      target_field: client.user.email
+      if: ctx.client?.user?.email == null
+      ignore_missing: true
+  - remove:
+      field: gcp.audit.authentication_info.principal_email
+      if: ctx.client?.user?.email == ctx.gcp?.audit?.authentication_info?.principal_email
+      ignore_missing: true
+  - rename:
       field: gcp.audit.authentication_info.principal_subject
-      copy_from: client.user.id
-      if: ctx.client?.user?.id != null
+      target_field: client.user.id
+      if: ctx.client?.user?.id == null
+      ignore_missing: true
+  - remove:
+      field: gcp.audit.authentication_info.principal_subject
+      if: ctx.client?.user?.id == ctx.gcp?.audit?.authentication_info?.principal_subject
+      ignore_missing: true
 ##
 # AuthorizationInfo
 # .protoPayload.authorizationInfo
@@ -174,15 +183,10 @@ processors:
       field: json.protoPayload.requestMetadata.callerIp
       target_field: source.ip
       ignore_missing: true
-  # TODO remove - duplicated in useragent
   - rename:
       field: json.protoPayload.requestMetadata.callerSuppliedUserAgent
-      target_field: gcp.audit.request_metadata.caller_supplied_user_agent
+      target_field: user_agent.original
       ignore_missing: true
-  - set:
-      field: user_agent.original
-      value: "{{gcp.audit.request_metadata.caller_supplied_user_agent}}"
-      if: ctx?.gcp?.audit?.request_metadata?.caller_supplied_user_agent != null
   - user_agent:
       field: user_agent.original
       ignore_missing: true
@@ -224,12 +228,8 @@ processors:
 # TODO remove duplicate protoPayload.methodName
   - rename:
       field: json.protoPayload.methodName
-      target_field: gcp.audit.method_name
+      target_field: event.action
       ignore_missing: true
-  - set:
-      field: event.action
-      value: "{{gcp.audit.method_name}}"
-      if: ctx?.gcp?.audit?.method_name != null
   - convert:
       field: json.protoPayload.numResponseItems
       target_field: gcp.audit.num_response_items
@@ -261,15 +261,15 @@ processors:
       field: json.protoPayload.resourceLocation.currentLocations
       target_field: gcp.audit.resource_location.current_locations
       ignore_missing: true
-# TODO remove duplicate json.protoPayload.serviceName
   - rename:
       field: json.protoPayload.serviceName
       target_field: gcp.audit.service_name
       ignore_missing: true
-  - set:
-      field: service.name
-      value: "{{gcp.audit.service_name}}"
-      if: ctx?.gcp?.audit?.service_name != null
+  - rename:
+      field: gcp.audit.service_name
+      target_field: service.name
+      if: ctx.service?.name == null
+      ignore_missing: true
 ##
 # .protoPayload.Status
 # https://cloud.google.com/logging/docs/reference/audit/auditlog/rest/Shared.Types/AuditLog#Status

--- a/packages/gcp/data_stream/audit/sample_event.json
+++ b/packages/gcp/data_stream/audit/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2019-12-19T00:44:25.051Z",
     "agent": {
-        "ephemeral_id": "15ffa48e-049a-4ead-9716-cea0236748c4",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "9edf0b6c-05b7-451e-83ad-13b2a23bf4e5",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "client": {
         "user": {
@@ -28,9 +27,9 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "beta.compute.instances.aggregatedList",
@@ -39,10 +38,10 @@
             "network",
             "configuration"
         ],
-        "created": "2022-05-20T07:25:00.534Z",
+        "created": "2022-06-28T02:45:52.230Z",
         "dataset": "gcp.audit",
         "id": "yonau2dg2zi",
-        "ingested": "2022-05-20T07:25:01Z",
+        "ingested": "2022-06-28T02:45:53Z",
         "kind": "event",
         "outcome": "success",
         "provider": "data_access",
@@ -53,9 +52,6 @@
     },
     "gcp": {
         "audit": {
-            "authentication_info": {
-                "principal_email": "xxx@xxx.xxx"
-            },
             "authorization_info": [
                 {
                     "granted": true,
@@ -67,13 +63,9 @@
                     }
                 }
             ],
-            "method_name": "beta.compute.instances.aggregatedList",
             "num_response_items": 61,
             "request": {
                 "@type": "type.googleapis.com/compute.instances.aggregatedList"
-            },
-            "request_metadata": {
-                "caller_supplied_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:71.0) Gecko/20100101 Firefox/71.0,gzip(gfe),gzip(gfe)"
             },
             "resource_location": {
                 "current_locations": [
@@ -91,9 +83,8 @@
                     "uid": "2beff34a-945f-11ea-bacf-42010a80007f"
                 },
                 "kind": "Status",
-                "status": "Success"
+                "status_value": "Success"
             },
-            "service_name": "compute.googleapis.com",
             "type": "type.googleapis.com/google.cloud.audit.AuditLog"
         }
     },

--- a/packages/gcp/data_stream/dns/sample_event.json
+++ b/packages/gcp/data_stream/dns/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2022-01-23T09:16:05.341Z",
     "agent": {
-        "ephemeral_id": "0d2f83ac-67e6-454f-84eb-859aa503167a",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "0b86920e-9dac-4b22-91c8-e594b22a00b4",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "europe-west2-a",
@@ -50,16 +49,16 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-05-20T07:25:43.755Z",
+        "created": "2022-06-28T02:46:41.230Z",
         "dataset": "gcp.dns",
         "id": "vwroyze8pg7y",
-        "ingested": "2022-05-20T07:25:44Z",
+        "ingested": "2022-06-28T02:46:42Z",
         "kind": "event",
         "outcome": "success"
     },

--- a/packages/gcp/data_stream/firewall/sample_event.json
+++ b/packages/gcp/data_stream/firewall/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2019-10-30T13:52:42.191Z",
     "agent": {
-        "ephemeral_id": "1f7633a7-3410-4684-bb55-14b0bd0e2bd4",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "da5a2e43-d26c-4ee3-bbf3-ad9d9ab853ec",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "us-east1-b",
@@ -31,18 +30,18 @@
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "firewall-rule",
         "agent_id_status": "verified",
         "category": "network",
-        "created": "2022-05-20T07:26:27.445Z",
+        "created": "2022-06-28T02:47:26.097Z",
         "dataset": "gcp.firewall",
         "id": "1f21ciqfpfssuo",
-        "ingested": "2022-05-20T07:26:28Z",
+        "ingested": "2022-06-28T02:47:27Z",
         "kind": "event",
         "type": "connection"
     },

--- a/packages/gcp/data_stream/vpcflow/sample_event.json
+++ b/packages/gcp/data_stream/vpcflow/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2019-06-14T03:50:10.845Z",
     "agent": {
-        "ephemeral_id": "10bb82a5-c0e6-4aed-8589-003f734a7183",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "cb760ad9-6bf9-465b-9022-e5de8df2ba82",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "us-east1-b",
@@ -22,41 +21,29 @@
         "type": "logs"
     },
     "destination": {
-        "address": "67.43.156.14",
-        "as": {
-            "number": 35908
-        },
+        "address": "10.139.99.242",
         "domain": "elasticsearch",
-        "geo": {
-            "continent_name": "Asia",
-            "country_iso_code": "BT",
-            "country_name": "Bhutan",
-            "location": {
-                "lat": 27.5,
-                "lon": 90.5
-            }
-        },
-        "ip": "67.43.156.14",
+        "ip": "10.139.99.242",
         "port": 9200
     },
     "ecs": {
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "network",
-        "created": "2022-05-20T07:27:09.739Z",
+        "created": "2022-06-28T02:48:14.443Z",
         "dataset": "gcp.vpcflow",
-        "end": "2019-06-14T03:49:51.821308944Z",
-        "id": "ut8lbrffooxyp",
-        "ingested": "2022-05-20T07:27:10Z",
+        "end": "2019-06-14T03:49:51.821056075Z",
+        "id": "ut8lbrffooxz5",
+        "ingested": "2022-06-28T02:48:15Z",
         "kind": "event",
-        "start": "2019-06-14T03:40:08.469099728Z",
+        "start": "2019-06-14T03:40:20.510622432Z",
         "type": "connection"
     },
     "gcp": {
@@ -85,9 +72,9 @@
             }
         },
         "vpcflow": {
-            "reporter": "SRC",
+            "reporter": "DEST",
             "rtt": {
-                "ms": 3
+                "ms": 201
             }
         }
     },
@@ -98,28 +85,40 @@
         "logger": "projects/my-sample-project/logs/compute.googleapis.com%2Fvpc_flows"
     },
     "network": {
-        "bytes": 15169,
-        "community_id": "1:NAY9D1IuyJAG+Hm34t3LIlP6/4c=",
+        "bytes": 11773,
+        "community_id": "1:FYaJFSEAKLcBCMFoT6sR5TMHf/s=",
         "direction": "internal",
         "iana_number": "6",
         "name": "default",
-        "packets": 92,
+        "packets": 94,
         "transport": "tcp",
         "type": "ipv4"
     },
     "related": {
         "ip": [
-            "10.87.40.76",
-            "67.43.156.14"
+            "67.43.156.13",
+            "10.139.99.242"
         ]
     },
     "source": {
-        "address": "10.87.40.76",
-        "bytes": 15169,
+        "address": "67.43.156.13",
+        "as": {
+            "number": 35908
+        },
+        "bytes": 11773,
         "domain": "kibana",
-        "ip": "10.87.40.76",
-        "packets": 92,
-        "port": 33880
+        "geo": {
+            "continent_name": "Asia",
+            "country_iso_code": "BT",
+            "country_name": "Bhutan",
+            "location": {
+                "lat": 27.5,
+                "lon": 90.5
+            }
+        },
+        "ip": "67.43.156.13",
+        "packets": 94,
+        "port": 33576
     },
     "tags": [
         "forwarded",

--- a/packages/gcp/docs/README.md
+++ b/packages/gcp/docs/README.md
@@ -323,12 +323,11 @@ An example event for `audit` looks as following:
 {
     "@timestamp": "2019-12-19T00:44:25.051Z",
     "agent": {
-        "ephemeral_id": "15ffa48e-049a-4ead-9716-cea0236748c4",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "9edf0b6c-05b7-451e-83ad-13b2a23bf4e5",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "client": {
         "user": {
@@ -350,9 +349,9 @@ An example event for `audit` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "beta.compute.instances.aggregatedList",
@@ -361,10 +360,10 @@ An example event for `audit` looks as following:
             "network",
             "configuration"
         ],
-        "created": "2022-05-20T07:25:00.534Z",
+        "created": "2022-06-28T02:45:52.230Z",
         "dataset": "gcp.audit",
         "id": "yonau2dg2zi",
-        "ingested": "2022-05-20T07:25:01Z",
+        "ingested": "2022-06-28T02:45:53Z",
         "kind": "event",
         "outcome": "success",
         "provider": "data_access",
@@ -375,9 +374,6 @@ An example event for `audit` looks as following:
     },
     "gcp": {
         "audit": {
-            "authentication_info": {
-                "principal_email": "xxx@xxx.xxx"
-            },
             "authorization_info": [
                 {
                     "granted": true,
@@ -389,13 +385,9 @@ An example event for `audit` looks as following:
                     }
                 }
             ],
-            "method_name": "beta.compute.instances.aggregatedList",
             "num_response_items": 61,
             "request": {
                 "@type": "type.googleapis.com/compute.instances.aggregatedList"
-            },
-            "request_metadata": {
-                "caller_supplied_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:71.0) Gecko/20100101 Firefox/71.0,gzip(gfe),gzip(gfe)"
             },
             "resource_location": {
                 "current_locations": [
@@ -413,9 +405,8 @@ An example event for `audit` looks as following:
                     "uid": "2beff34a-945f-11ea-bacf-42010a80007f"
                 },
                 "kind": "Status",
-                "status": "Success"
+                "status_value": "Success"
             },
-            "service_name": "compute.googleapis.com",
             "type": "type.googleapis.com/google.cloud.audit.AuditLog"
         }
     },
@@ -585,12 +576,11 @@ An example event for `firewall` looks as following:
 {
     "@timestamp": "2019-10-30T13:52:42.191Z",
     "agent": {
-        "ephemeral_id": "1f7633a7-3410-4684-bb55-14b0bd0e2bd4",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "da5a2e43-d26c-4ee3-bbf3-ad9d9ab853ec",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "us-east1-b",
@@ -615,18 +605,18 @@ An example event for `firewall` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "firewall-rule",
         "agent_id_status": "verified",
         "category": "network",
-        "created": "2022-05-20T07:26:27.445Z",
+        "created": "2022-06-28T02:47:26.097Z",
         "dataset": "gcp.firewall",
         "id": "1f21ciqfpfssuo",
-        "ingested": "2022-05-20T07:26:28Z",
+        "ingested": "2022-06-28T02:47:27Z",
         "kind": "event",
         "type": "connection"
     },
@@ -834,12 +824,11 @@ An example event for `vpcflow` looks as following:
 {
     "@timestamp": "2019-06-14T03:50:10.845Z",
     "agent": {
-        "ephemeral_id": "10bb82a5-c0e6-4aed-8589-003f734a7183",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "cb760ad9-6bf9-465b-9022-e5de8df2ba82",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "us-east1-b",
@@ -855,41 +844,29 @@ An example event for `vpcflow` looks as following:
         "type": "logs"
     },
     "destination": {
-        "address": "67.43.156.14",
-        "as": {
-            "number": 35908
-        },
+        "address": "10.139.99.242",
         "domain": "elasticsearch",
-        "geo": {
-            "continent_name": "Asia",
-            "country_iso_code": "BT",
-            "country_name": "Bhutan",
-            "location": {
-                "lat": 27.5,
-                "lon": 90.5
-            }
-        },
-        "ip": "67.43.156.14",
+        "ip": "10.139.99.242",
         "port": 9200
     },
     "ecs": {
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "network",
-        "created": "2022-05-20T07:27:09.739Z",
+        "created": "2022-06-28T02:48:14.443Z",
         "dataset": "gcp.vpcflow",
-        "end": "2019-06-14T03:49:51.821308944Z",
-        "id": "ut8lbrffooxyp",
-        "ingested": "2022-05-20T07:27:10Z",
+        "end": "2019-06-14T03:49:51.821056075Z",
+        "id": "ut8lbrffooxz5",
+        "ingested": "2022-06-28T02:48:15Z",
         "kind": "event",
-        "start": "2019-06-14T03:40:08.469099728Z",
+        "start": "2019-06-14T03:40:20.510622432Z",
         "type": "connection"
     },
     "gcp": {
@@ -918,9 +895,9 @@ An example event for `vpcflow` looks as following:
             }
         },
         "vpcflow": {
-            "reporter": "SRC",
+            "reporter": "DEST",
             "rtt": {
-                "ms": 3
+                "ms": 201
             }
         }
     },
@@ -931,28 +908,40 @@ An example event for `vpcflow` looks as following:
         "logger": "projects/my-sample-project/logs/compute.googleapis.com%2Fvpc_flows"
     },
     "network": {
-        "bytes": 15169,
-        "community_id": "1:NAY9D1IuyJAG+Hm34t3LIlP6/4c=",
+        "bytes": 11773,
+        "community_id": "1:FYaJFSEAKLcBCMFoT6sR5TMHf/s=",
         "direction": "internal",
         "iana_number": "6",
         "name": "default",
-        "packets": 92,
+        "packets": 94,
         "transport": "tcp",
         "type": "ipv4"
     },
     "related": {
         "ip": [
-            "10.87.40.76",
-            "67.43.156.14"
+            "67.43.156.13",
+            "10.139.99.242"
         ]
     },
     "source": {
-        "address": "10.87.40.76",
-        "bytes": 15169,
+        "address": "67.43.156.13",
+        "as": {
+            "number": 35908
+        },
+        "bytes": 11773,
         "domain": "kibana",
-        "ip": "10.87.40.76",
-        "packets": 92,
-        "port": 33880
+        "geo": {
+            "continent_name": "Asia",
+            "country_iso_code": "BT",
+            "country_name": "Bhutan",
+            "location": {
+                "lat": 27.5,
+                "lon": 90.5
+            }
+        },
+        "ip": "67.43.156.13",
+        "packets": 94,
+        "port": 33576
     },
     "tags": [
         "forwarded",
@@ -1057,12 +1046,11 @@ An example event for `dns` looks as following:
 {
     "@timestamp": "2022-01-23T09:16:05.341Z",
     "agent": {
-        "ephemeral_id": "0d2f83ac-67e6-454f-84eb-859aa503167a",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "0b86920e-9dac-4b22-91c8-e594b22a00b4",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "europe-west2-a",
@@ -1106,16 +1094,16 @@ An example event for `dns` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-05-20T07:25:43.755Z",
+        "created": "2022-06-28T02:46:41.230Z",
         "dataset": "gcp.dns",
         "id": "vwroyze8pg7y",
-        "ingested": "2022-05-20T07:25:44Z",
+        "ingested": "2022-06-28T02:46:42Z",
         "kind": "event",
         "outcome": "success"
     },

--- a/packages/gcp/docs/audit.md
+++ b/packages/gcp/docs/audit.md
@@ -147,12 +147,11 @@ An example event for `audit` looks as following:
 {
     "@timestamp": "2019-12-19T00:44:25.051Z",
     "agent": {
-        "ephemeral_id": "15ffa48e-049a-4ead-9716-cea0236748c4",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "9edf0b6c-05b7-451e-83ad-13b2a23bf4e5",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "client": {
         "user": {
@@ -174,9 +173,9 @@ An example event for `audit` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "beta.compute.instances.aggregatedList",
@@ -185,10 +184,10 @@ An example event for `audit` looks as following:
             "network",
             "configuration"
         ],
-        "created": "2022-05-20T07:25:00.534Z",
+        "created": "2022-06-28T02:45:52.230Z",
         "dataset": "gcp.audit",
         "id": "yonau2dg2zi",
-        "ingested": "2022-05-20T07:25:01Z",
+        "ingested": "2022-06-28T02:45:53Z",
         "kind": "event",
         "outcome": "success",
         "provider": "data_access",
@@ -199,9 +198,6 @@ An example event for `audit` looks as following:
     },
     "gcp": {
         "audit": {
-            "authentication_info": {
-                "principal_email": "xxx@xxx.xxx"
-            },
             "authorization_info": [
                 {
                     "granted": true,
@@ -213,13 +209,9 @@ An example event for `audit` looks as following:
                     }
                 }
             ],
-            "method_name": "beta.compute.instances.aggregatedList",
             "num_response_items": 61,
             "request": {
                 "@type": "type.googleapis.com/compute.instances.aggregatedList"
-            },
-            "request_metadata": {
-                "caller_supplied_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:71.0) Gecko/20100101 Firefox/71.0,gzip(gfe),gzip(gfe)"
             },
             "resource_location": {
                 "current_locations": [
@@ -237,9 +229,8 @@ An example event for `audit` looks as following:
                     "uid": "2beff34a-945f-11ea-bacf-42010a80007f"
                 },
                 "kind": "Status",
-                "status": "Success"
+                "status_value": "Success"
             },
-            "service_name": "compute.googleapis.com",
             "type": "type.googleapis.com/google.cloud.audit.AuditLog"
         }
     },

--- a/packages/gcp/docs/dns.md
+++ b/packages/gcp/docs/dns.md
@@ -96,12 +96,11 @@ An example event for `dns` looks as following:
 {
     "@timestamp": "2022-01-23T09:16:05.341Z",
     "agent": {
-        "ephemeral_id": "0d2f83ac-67e6-454f-84eb-859aa503167a",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "0b86920e-9dac-4b22-91c8-e594b22a00b4",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "europe-west2-a",
@@ -145,16 +144,16 @@ An example event for `dns` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-05-20T07:25:43.755Z",
+        "created": "2022-06-28T02:46:41.230Z",
         "dataset": "gcp.dns",
         "id": "vwroyze8pg7y",
-        "ingested": "2022-05-20T07:25:44Z",
+        "ingested": "2022-06-28T02:46:42Z",
         "kind": "event",
         "outcome": "success"
     },

--- a/packages/gcp/docs/firewall.md
+++ b/packages/gcp/docs/firewall.md
@@ -133,12 +133,11 @@ An example event for `firewall` looks as following:
 {
     "@timestamp": "2019-10-30T13:52:42.191Z",
     "agent": {
-        "ephemeral_id": "1f7633a7-3410-4684-bb55-14b0bd0e2bd4",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "da5a2e43-d26c-4ee3-bbf3-ad9d9ab853ec",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "us-east1-b",
@@ -163,18 +162,18 @@ An example event for `firewall` looks as following:
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "action": "firewall-rule",
         "agent_id_status": "verified",
         "category": "network",
-        "created": "2022-05-20T07:26:27.445Z",
+        "created": "2022-06-28T02:47:26.097Z",
         "dataset": "gcp.firewall",
         "id": "1f21ciqfpfssuo",
-        "ingested": "2022-05-20T07:26:28Z",
+        "ingested": "2022-06-28T02:47:27Z",
         "kind": "event",
         "type": "connection"
     },

--- a/packages/gcp/docs/vpcflow.md
+++ b/packages/gcp/docs/vpcflow.md
@@ -130,12 +130,11 @@ An example event for `vpcflow` looks as following:
 {
     "@timestamp": "2019-06-14T03:50:10.845Z",
     "agent": {
-        "ephemeral_id": "10bb82a5-c0e6-4aed-8589-003f734a7183",
-        "hostname": "docker-fleet-agent",
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "ephemeral_id": "cb760ad9-6bf9-465b-9022-e5de8df2ba82",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "cloud": {
         "availability_zone": "us-east1-b",
@@ -151,41 +150,29 @@ An example event for `vpcflow` looks as following:
         "type": "logs"
     },
     "destination": {
-        "address": "67.43.156.14",
-        "as": {
-            "number": 35908
-        },
+        "address": "10.139.99.242",
         "domain": "elasticsearch",
-        "geo": {
-            "continent_name": "Asia",
-            "country_iso_code": "BT",
-            "country_name": "Bhutan",
-            "location": {
-                "lat": 27.5,
-                "lon": 90.5
-            }
-        },
-        "ip": "67.43.156.14",
+        "ip": "10.139.99.242",
         "port": 9200
     },
     "ecs": {
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "df142714-8028-4ef0-a80c-4eb03051c084",
+        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "network",
-        "created": "2022-05-20T07:27:09.739Z",
+        "created": "2022-06-28T02:48:14.443Z",
         "dataset": "gcp.vpcflow",
-        "end": "2019-06-14T03:49:51.821308944Z",
-        "id": "ut8lbrffooxyp",
-        "ingested": "2022-05-20T07:27:10Z",
+        "end": "2019-06-14T03:49:51.821056075Z",
+        "id": "ut8lbrffooxz5",
+        "ingested": "2022-06-28T02:48:15Z",
         "kind": "event",
-        "start": "2019-06-14T03:40:08.469099728Z",
+        "start": "2019-06-14T03:40:20.510622432Z",
         "type": "connection"
     },
     "gcp": {
@@ -214,9 +201,9 @@ An example event for `vpcflow` looks as following:
             }
         },
         "vpcflow": {
-            "reporter": "SRC",
+            "reporter": "DEST",
             "rtt": {
-                "ms": 3
+                "ms": 201
             }
         }
     },
@@ -227,28 +214,40 @@ An example event for `vpcflow` looks as following:
         "logger": "projects/my-sample-project/logs/compute.googleapis.com%2Fvpc_flows"
     },
     "network": {
-        "bytes": 15169,
-        "community_id": "1:NAY9D1IuyJAG+Hm34t3LIlP6/4c=",
+        "bytes": 11773,
+        "community_id": "1:FYaJFSEAKLcBCMFoT6sR5TMHf/s=",
         "direction": "internal",
         "iana_number": "6",
         "name": "default",
-        "packets": 92,
+        "packets": 94,
         "transport": "tcp",
         "type": "ipv4"
     },
     "related": {
         "ip": [
-            "10.87.40.76",
-            "67.43.156.14"
+            "67.43.156.13",
+            "10.139.99.242"
         ]
     },
     "source": {
-        "address": "10.87.40.76",
-        "bytes": 15169,
+        "address": "67.43.156.13",
+        "as": {
+            "number": 35908
+        },
+        "bytes": 11773,
         "domain": "kibana",
-        "ip": "10.87.40.76",
-        "packets": 92,
-        "port": 33880
+        "geo": {
+            "continent_name": "Asia",
+            "country_iso_code": "BT",
+            "country_name": "Bhutan",
+            "location": {
+                "lat": 27.5,
+                "lon": 90.5
+            }
+        },
+        "ip": "67.43.156.13",
+        "packets": 94,
+        "port": 33576
     },
     "tags": [
         "forwarded",

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: 2.1.0
+version: "2.2.0"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This resolves a set of TODOs by removing duplicated fields.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3397

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
