### PR TITLE
Fix misspelling of Log Stream Prefix variable in manifest for aws-clo…

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.1"
+  changes:
+    - description: Fix misspelling of Log Stream Prefix variable in manifest for aws-cloudwatch input
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.17.0"
   changes:
     - description: Added Redshift integration

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix misspelling of Log Stream Prefix variable in manifest for aws-cloudwatch input
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/3610
 - version: "1.17.0"
   changes:
     - description: Added Redshift integration

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -234,7 +234,7 @@ streams:
         required: false
         show_user: false
         description: A list of strings of log streams names that Filebeat collect log events from.
-      - name: log_streams_prefix
+      - name: log_stream_prefix
         type: text
         title: Log Stream Prefix
         multi: false

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -110,7 +110,7 @@ streams:
         required: false
         show_user: false
         description: A list of strings of log streams names that Filebeat collect log events from.
-      - name: log_streams_prefix
+      - name: log_stream_prefix
         type: text
         title: Log Stream Prefix
         multi: false

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -109,7 +109,7 @@ streams:
         required: false
         show_user: false
         description: A list of strings of log streams names that Filebeat collect log events from.
-      - name: log_streams_prefix
+      - name: log_stream_prefix
         type: text
         title: Log Stream Prefix
         multi: false

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -109,7 +109,7 @@ streams:
         required: false
         show_user: false
         description: A list of strings of log streams names that Filebeat collect log events from.
-      - name: log_streams_prefix
+      - name: log_stream_prefix
         type: text
         title: Log Stream Prefix
         multi: false

--- a/packages/aws/data_stream/firewall_logs/manifest.yml
+++ b/packages/aws/data_stream/firewall_logs/manifest.yml
@@ -109,7 +109,7 @@ streams:
         required: false
         show_user: false
         description: A list of strings of log streams names that Filebeat collect log events from.
-      - name: log_streams_prefix
+      - name: log_stream_prefix
         type: text
         title: Log Stream Prefix
         multi: false

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -109,7 +109,7 @@ streams:
         required: false
         show_user: false
         description: A list of strings of log streams names that Filebeat collect log events from.
-      - name: log_streams_prefix
+      - name: log_stream_prefix
         type: text
         title: Log Stream Prefix
         multi: false

--- a/packages/aws/data_stream/waf/manifest.yml
+++ b/packages/aws/data_stream/waf/manifest.yml
@@ -109,7 +109,7 @@ streams:
         required: false
         show_user: false
         description: A list of strings of log streams names that Filebeat collect log events from.
-      - name: log_streams_prefix
+      - name: log_stream_prefix
         type: text
         title: Log Stream Prefix
         multi: false

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.17.0
+version: 1.17.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.2.3"
+  changes:
+    - description: Fix misspelling of Log Stream Prefix variable in manifest for aws-cloudwatch input
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3610
 - version: "0.2.2"
   changes:
     - description: update readme file

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -42,7 +42,7 @@ streams:
         required: false
         show_user: false
         description: A list of strings of log streams names that Filebeat collect log events from.
-      - name: log_streams_prefix
+      - name: log_stream_prefix
         type: text
         title: Log Stream Prefix
         multi: false

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: 0.2.2
+version: 0.2.3
 release: beta
 license: basic
 categories:


### PR DESCRIPTION
…udwatch input

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
Bug
## What does this PR do?
Fix a type in manifest of aws integrations for cloudwatch logs input (`log_stream_prefix` vs `log_streams_prefix`)
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
Closes #3608 
## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
