### PR TITLE
First draft of CloudWatch edits

### DIFF
--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -6,7 +6,7 @@ The AWS CloudWatch integration allows you to monitor [AWS CloudWatch](https://aw
 
 Use the AWS CloudWatch integration to collect metrics and logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs and metrics when troubleshooting an issue.
 
-For example, you could use the data from this integration to detect anomalous behavior in your environments. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs and metrics, such as the the source of the behavior, and more.
+For example, you could use the data from this integration to detect anomalous behavior in your environments. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs and metrics, such as the source of the behavior, and more.
 
 ## Data streams
 

--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -16,7 +16,7 @@ The AWS CloudWatch integration collects two types of data streams: logs and metr
 The log data stream includes the CloudWatch log message along with contextual information. See more details in the [Logs](#logs-reference).
 
 **Metrics** give you insight into the state of AWS CloudWatch.
-Metric data streams collected by the AWS CloudWatch integration include The cloud account name or alias used to identify different entities in a multi-tenant environment and more. See more details in the [Metrics](#metrics-reference).
+The metric data stream includes the metrics that are returned from a CloudWatch API query along with contextual information. See more details in the [Metrics](#metrics-reference).
 
 ## Requirements
 

--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -1,8 +1,6 @@
 # AWS CloudWatch
 
-## Overview
-
-The AWS CloudWatch integration allows you to monitor [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). AWS CloudWatch is a monitoring and observability service built for DevOps engineers, developers, site reliability engineers (SREs), IT managers, and product owners. CloudWatch provides you with data and actionable insights to monitor your applications, respond to system-wide performance changes, and optimize resource utilization.
+The AWS CloudWatch integration allows you to monitor [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). AWS CloudWatch is a service that provides data and insights for monitoring applications, and changes to system performance. It can also be used for optimizing the use of resources.
 
 Use the AWS CloudWatch integration to collect metrics and logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs and metrics when troubleshooting an issue.
 

--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -42,7 +42,7 @@ For step-by-step instructions on how to set up an integration, see the
 
 ## Logs reference
 
-The `cloudwatch` dataset collects CloudWatch logs. Users can use Amazon 
+The `cloudwatch` data stream collects CloudWatch logs. Users can use Amazon 
 CloudWatch logs to monitor, store, and access log files from different sources. 
 Export logs from log groups to an Amazon S3 bucket which has SQS notification 
 setup already.

--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -1,6 +1,46 @@
-# cloudwatch
+# AWS CloudWatch
 
-## Logs
+## Overview
+
+The AWS CloudWatch integration allows you to monitor [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). AWS CloudWatch is a monitoring and observability service built for DevOps engineers, developers, site reliability engineers (SREs), IT managers, and product owners. CloudWatch provides you with data and actionable insights to monitor your applications, respond to system-wide performance changes, and optimize resource utilization.
+
+Use the AWS CloudWatch integration to Use the AWS Cloudwatch to collect metrics and logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs and metrics when troubleshooting an issue.
+
+For example, you could use the data from this integration to detect anomalous behavior in your environments. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs and metrics, such as the the source of the behavior, and more.
+
+## Data streams
+
+The AWS CloudWatch integration collects two types of data streams: logs and metrics.
+
+**Logs** help you keep a record of events happening in AWS CloudWatch.
+Log data streams collected by the AWS CloudWatch integration include The cloud account or organization id used to identify different entities in a multi-tenant environment and more. See more details in the [Logs](#logs-reference).
+
+**Metrics** give you insight into the state of AWS CloudWatch.
+Metric data streams collected by the AWS CloudWatch integration include The cloud account name or alias used to identify different entities in a multi-tenant environment and more. See more details in the [Metrics](#metrics-reference).
+
+## Requirements
+
+You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
+You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
+
+ Before using any AWS integration you will need:
+
+ * **AWS Credentials** to connect with your AWS account.
+ * **AWS Permissions** to make sure the user you're using to connect has permission to share the relevant data.
+
+ For more details about these requirements, see the **AWS** integration documentation.
+
+## Setup
+
+ Use this integration if you only need to collect data from the AWS CloudWatch service.
+
+ If you want to collect data from two or more AWS services, consider using the **AWS** integration.
+ When you configure the AWS integration, you can collect data from as many AWS services as you'd like.
+
+For step-by-step instructions on how to set up an integration, see the
+[Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+
+## Logs reference
 
 The `cloudwatch` dataset collects CloudWatch logs. Users can use Amazon 
 CloudWatch logs to monitor, store, and access log files from different sources. 
@@ -11,7 +51,7 @@ setup already.
 
 {{event "cloudwatch_logs"}}
 
-## Metrics
+## Metrics reference
 
 {{event "cloudwatch_metrics"}}
 

--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -4,7 +4,7 @@
 
 The AWS CloudWatch integration allows you to monitor [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). AWS CloudWatch is a monitoring and observability service built for DevOps engineers, developers, site reliability engineers (SREs), IT managers, and product owners. CloudWatch provides you with data and actionable insights to monitor your applications, respond to system-wide performance changes, and optimize resource utilization.
 
-Use the AWS CloudWatch integration to Use the AWS Cloudwatch to collect metrics and logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs and metrics when troubleshooting an issue.
+Use the AWS CloudWatch integration to collect metrics and logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs and metrics when troubleshooting an issue.
 
 For example, you could use the data from this integration to detect anomalous behavior in your environments. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs and metrics, such as the the source of the behavior, and more.
 

--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -13,7 +13,7 @@ For example, you could use the data from this integration to detect anomalous be
 The AWS CloudWatch integration collects two types of data streams: logs and metrics.
 
 **Logs** help you keep a record of events happening in AWS CloudWatch.
-Log data streams collected by the AWS CloudWatch integration include The cloud account or organization id used to identify different entities in a multi-tenant environment and more. See more details in the [Logs](#logs-reference).
+The log data stream includes the CloudWatch log message along with contextual information. See more details in the [Logs](#logs-reference).
 
 **Metrics** give you insight into the state of AWS CloudWatch.
 Metric data streams collected by the AWS CloudWatch integration include The cloud account name or alias used to identify different entities in a multi-tenant environment and more. See more details in the [Metrics](#metrics-reference).

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.1"
+  changes:
+    - description: First draft AWS CloudWatch integration documentation
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3614
 - version: "1.17.0"
   changes:
     - description: Added Redshift integration

--- a/packages/aws/docs/cloudwatch.md
+++ b/packages/aws/docs/cloudwatch.md
@@ -1,22 +1,20 @@
 # AWS CloudWatch
 
-## Overview
+The AWS CloudWatch integration allows you to monitor [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). AWS CloudWatch is a service that provides data and insights for monitoring applications, and changes to system performance. It can also be used for optimizing the use of resources.
 
-The AWS CloudWatch integration allows you to monitor [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). AWS CloudWatch is a monitoring and observability service built for DevOps engineers, developers, site reliability engineers (SREs), IT managers, and product owners. CloudWatch provides you with data and actionable insights to monitor your applications, respond to system-wide performance changes, and optimize resource utilization.
+Use the AWS CloudWatch integration to collect metrics and logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs and metrics when troubleshooting an issue.
 
-Use the AWS CloudWatch integration to Use the AWS Cloudwatch to collect metrics and logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs and metrics when troubleshooting an issue.
-
-For example, you could use the data from this integration to detect anomalous behavior in your environments. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs and metrics, such as the the source of the behavior, and more.
+For example, you could use the data from this integration to detect anomalous behavior in your environments. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs and metrics, such as the source of the behavior, and more.
 
 ## Data streams
 
 The AWS CloudWatch integration collects two types of data streams: logs and metrics.
 
 **Logs** help you keep a record of events happening in AWS CloudWatch.
-Log data streams collected by the AWS CloudWatch integration include The cloud account or organization id used to identify different entities in a multi-tenant environment and more. See more details in the [Logs](#logs-reference).
+The log data stream includes the CloudWatch log message along with contextual information. See more details in the [Logs](#logs-reference).
 
 **Metrics** give you insight into the state of AWS CloudWatch.
-Metric data streams collected by the AWS CloudWatch integration include The cloud account name or alias used to identify different entities in a multi-tenant environment and more. See more details in the [Metrics](#metrics-reference).
+The metric data stream includes the metrics that are returned from a CloudWatch API query along with contextual information. See more details in the [Metrics](#metrics-reference).
 
 ## Requirements
 
@@ -42,7 +40,7 @@ For step-by-step instructions on how to set up an integration, see the
 
 ## Logs reference
 
-The `cloudwatch` dataset collects CloudWatch logs. Users can use Amazon 
+The `cloudwatch` data stream collects CloudWatch logs. Users can use Amazon 
 CloudWatch logs to monitor, store, and access log files from different sources. 
 Export logs from log groups to an Amazon S3 bucket which has SQS notification 
 setup already.

--- a/packages/aws/docs/cloudwatch.md
+++ b/packages/aws/docs/cloudwatch.md
@@ -1,6 +1,46 @@
-# cloudwatch
+# AWS CloudWatch
 
-## Logs
+## Overview
+
+The AWS CloudWatch integration allows you to monitor [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). AWS CloudWatch is a monitoring and observability service built for DevOps engineers, developers, site reliability engineers (SREs), IT managers, and product owners. CloudWatch provides you with data and actionable insights to monitor your applications, respond to system-wide performance changes, and optimize resource utilization.
+
+Use the AWS CloudWatch integration to Use the AWS Cloudwatch to collect metrics and logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs and metrics when troubleshooting an issue.
+
+For example, you could use the data from this integration to detect anomalous behavior in your environments. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs and metrics, such as the the source of the behavior, and more.
+
+## Data streams
+
+The AWS CloudWatch integration collects two types of data streams: logs and metrics.
+
+**Logs** help you keep a record of events happening in AWS CloudWatch.
+Log data streams collected by the AWS CloudWatch integration include The cloud account or organization id used to identify different entities in a multi-tenant environment and more. See more details in the [Logs](#logs-reference).
+
+**Metrics** give you insight into the state of AWS CloudWatch.
+Metric data streams collected by the AWS CloudWatch integration include The cloud account name or alias used to identify different entities in a multi-tenant environment and more. See more details in the [Metrics](#metrics-reference).
+
+## Requirements
+
+You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
+You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
+
+ Before using any AWS integration you will need:
+
+ * **AWS Credentials** to connect with your AWS account.
+ * **AWS Permissions** to make sure the user you're using to connect has permission to share the relevant data.
+
+ For more details about these requirements, see the **AWS** integration documentation.
+
+## Setup
+
+ Use this integration if you only need to collect data from the AWS CloudWatch service.
+
+ If you want to collect data from two or more AWS services, consider using the **AWS** integration.
+ When you configure the AWS integration, you can collect data from as many AWS services as you'd like.
+
+For step-by-step instructions on how to set up an integration, see the
+[Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+
+## Logs reference
 
 The `cloudwatch` dataset collects CloudWatch logs. Users can use Amazon 
 CloudWatch logs to monitor, store, and access log files from different sources. 
@@ -83,7 +123,7 @@ An example event for `cloudwatch` looks as following:
 }
 ```
 
-## Metrics
+## Metrics reference
 
 An example event for `cloudwatch` looks as following:
 

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.17.0
+version: 1.17.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

From https://github.com/elastic/integrations/issues/3572:

>In https://github.com/elastic/integrations/pull/3308 we updated docs for two AWS integrations to align with the new documentation guidelines and establish the relationship between the AWS integration/package ("AWS") and integrations for individual AWS services (for example, "AWS CloudFront").
>
>Now we should update the docs for all AWS integrations for individual services to follow the same format as the updated "AWS CloudFront" integration docs.

This PR adds more context for the AWS CloudWatch integration including:

- [x] Adds context to the "Overview" including a link to the relevant AWS page and an example
- [x] Lists the types of "Data streams" for the service
- [x] "Requirements" points back to "AWS" for detailed information on credentials and permissions
- [x] "Requirements" includes any other service-specific requirements
- [x] "Setup" establishes a relationship between the AWS integration/package ("AWS") and this integration
- [x] Includes "Reference" sections

## For the reviewer

<!-- anything to highlight for the reviewer -->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Review by docs team 
- [ ] Review by integrations team

## Related issues

- https://github.com/elastic/integrations/issues/3572