### PR TITLE
[Windows enhancement ]Added processor field for service data stream in windows package

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.12.5"
+- version: "1.13.0"
   changes:
     - description: Added Processors for service datatstream.
       type: enhancement

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.5"
+  changes:
+    - description: Added Processors for service datatstream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3618
 - version: "1.12.4"
   changes:
     - description: Update documentation with additional context for new users.

--- a/packages/windows/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/windows/data_stream/service/agent/stream/stream.yml.hbs
@@ -1,4 +1,7 @@
 metricsets: ["service"]
 condition: ${host.platform} == 'windows'
 period: {{period}}
-processors: {{processors}}
+processors:
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/windows/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/windows/data_stream/service/agent/stream/stream.yml.hbs
@@ -1,3 +1,4 @@
 metricsets: ["service"]
 condition: ${host.platform} == 'windows'
 period: {{period}}
+processors: {{processors}}

--- a/packages/windows/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/windows/data_stream/service/agent/stream/stream.yml.hbs
@@ -1,7 +1,7 @@
 metricsets: ["service"]
 condition: ${host.platform} == 'windows'
 period: {{period}}
-processors:
 {{#if processors}}
+processors:
 {{processors}}
 {{/if}}

--- a/packages/windows/data_stream/service/manifest.yml
+++ b/packages/windows/data_stream/service/manifest.yml
@@ -10,5 +10,12 @@ streams:
         required: true
         show_user: true
         default: 60s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: true
+        description: Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/metricbeat/current/filtering-and-enhancing-data.html) for details.
     title: Windows service metrics
     description: Collect Windows service metrics

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.12.4
+version: 1.12.5
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.12.5
+version: 1.13.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement


## What does this PR do?

This PR adds the [processors](https://www.elastic.co/guide/en/beats/metricbeat/current/filtering-and-enhancing-data.html) for the windows integration UI for windows service data stream, So that users can provide the processors input from the UI and filter out the services based on service display name or service state.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics and logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

- Clone the PR in windows machine.
- Build the integration using ```elastic-package``` commands
- Goto Integration page -> Search for windows -> Update to the latest package version
- Add the windows integration.
- Under the windows service metrics find the Processors yaml input box
- Specify the Processors for filtering the windows services.

## Related issues

- Closes [#2866](https://github.com/elastic/integrations/issues/2866)
- Closes [#2359](https://github.com/elastic/integrations/issues/2359)
