### PR TITLE
Move container_service metrics from beats to integrations

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Move container_service metrics config from beats to integrations
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9999999999999 # FIXME: link to PR
+      link: https://github.com/elastic/integrations/pull/3627
 - version: "1.0.6"
   changes:
     - description: Move container_instance metrics config from beats to integrations

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.7"
+  changes:
+    - description: Move container_service metrics config from beats to integrations
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999999999999 # FIXME: link to PR
 - version: "1.0.6"
   changes:
     - description: Move container_instance metrics config from beats to integrations

--- a/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["container_service"]
+metricsets: ["monitor"]
 period: {{period}}
 {{#if client_id}}
 client_id: {{client_id}}
@@ -26,10 +26,91 @@ resources:
 {{#if resource_groups}}
     {{#each resource_groups}}
         - resource_group: "{{this}}"
+          resource_type: "Microsoft.ContainerService/managedClusters"
+          metrics:
+          - name: ["kube_node_status_condition"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "node"
+              value: "*"
+            - name: "status"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_node_status_allocatable_cpu_cores", "kube_node_status_allocatable_memory_bytes"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"        
     {{/each}}
 {{/if}}
 {{#if resource_ids}}
     {{#each resource_ids}}
         - resource_id: "{{this}}"
+          metrics:
+          - name: ["kube_node_status_condition"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "node"
+              value: "*"
+            - name: "status"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_node_status_allocatable_cpu_cores", "kube_node_status_allocatable_memory_bytes"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"
     {{/each}}
 {{/if}}
+
+{{!
+    When no resource group and resource ID are specified by the user, we want to 
+    collect metrics for all the resource groups in the subscription.
+}}
+
+{{#unless resource_ids }}
+    {{#unless resource_groups }}
+        - resource_query: "resourceType eq 'Microsoft.ContainerService/managedClusters'"
+          metrics:
+          - name: ["kube_node_status_condition"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "node"
+              value: "*"
+            - name: "status"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_node_status_allocatable_cpu_cores", "kube_node_status_allocatable_memory_bytes"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"          
+    {{/unless}}
+{{/unless}}

--- a/packages/azure_metrics/data_stream/container_service/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure_metrics/data_stream/container_service/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,14 @@
+---
+description: Pipeline for parsing azure container_service metrics.
+processors:
+  - set:
+      field: ecs.version
+      value: "8.0.0"
+  - rename:
+      field: azure.metrics
+      target_field: azure.container_service
+      ignore_missing: true
+on_failure:
+  - set:
+      field: error.message
+      value: '{{ _ingest.on_failure_message }}'

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.6
+version: 1.0.7
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR is to move lightweight module configuration from Metricbeat into integrations.

Switch from "container_service" to "monitor" metricset, add the metrics configuration from beats, and add an ingest pipeline to set the expected field names (`azure.container_service.*` instead of `azure.metrics.*`).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3595 3595

