### PR TITLE
[Azure Metrics] Move container_registry metrics from beats to integrations

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.8"
+  changes:
+    - description: Move container_registry metrics config from beats to integrations
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3629
 - version: "1.0.7"
   changes:
     - description: Move container_service metrics config from beats to integrations

--- a/packages/azure_metrics/data_stream/container_registry/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_registry/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["container_registry"]
+metricsets: ["monitor"]
 period: {{period}}
 {{#if client_id}}
 client_id: {{client_id}}
@@ -26,10 +26,44 @@ resources:
 {{#if resource_groups}}
     {{#each resource_groups}}
         - resource_group: "{{this}}"
+          resource_type: "Microsoft.ContainerRegistry/registries"
+          metrics:
+          - name: ["TotalPullCount", "SuccessfulPullCount", "TotalPushCount", "SuccessfulPushCount","RunDuration", "AgentPoolCPUTime"]
+            namespace: "Microsoft.ContainerRegistry/registries"
+            timegrain: "PT5M"
+          - name: ["StorageUsed"]
+            namespace: "Microsoft.ContainerRegistry/registries"
+            timegrain: "PT1H"        
     {{/each}}
 {{/if}}
 {{#if resource_ids}}
     {{#each resource_ids}}
         - resource_id: "{{this}}"
+          timegrain: "PT5M"
+          metrics:
+          - name: ["TotalPullCount", "SuccessfulPullCount", "TotalPushCount", "SuccessfulPushCount","RunDuration", "AgentPoolCPUTime"]
+            namespace: "Microsoft.ContainerRegistry/registries"
+            timegrain: "PT5M"
+          - name: ["StorageUsed"]
+            namespace: "Microsoft.ContainerRegistry/registries"
+            timegrain: "PT1H"
     {{/each}}
 {{/if}}
+
+{{!
+    When no resource group and resource ID are specified by the user, we want to 
+    collect metrics for all the resource groups in the subscription.
+}}
+
+{{#unless resource_ids }}
+    {{#unless resource_groups }}
+        - resource_query: "resourceType eq 'Microsoft.ContainerRegistry/registries'"
+          metrics:
+          - name: ["TotalPullCount", "SuccessfulPullCount", "TotalPushCount", "SuccessfulPushCount","RunDuration", "AgentPoolCPUTime"]
+            namespace: "Microsoft.ContainerRegistry/registries"
+            timegrain: "PT5M"
+          - name: ["StorageUsed"]
+            namespace: "Microsoft.ContainerRegistry/registries"
+            timegrain: "PT1H"       
+    {{/unless}}
+{{/unless}}

--- a/packages/azure_metrics/data_stream/container_registry/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure_metrics/data_stream/container_registry/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,14 @@
+---
+description: Pipeline for parsing azure container_registry metrics.
+processors:
+  - set:
+      field: ecs.version
+      value: "8.0.0"
+  - rename:
+      field: azure.metrics
+      target_field: azure.container_registry
+      ignore_missing: true
+on_failure:
+  - set:
+      field: error.message
+      value: '{{ _ingest.on_failure_message }}'

--- a/packages/azure_metrics/data_stream/container_registry/sample_event.json
+++ b/packages/azure_metrics/data_stream/container_registry/sample_event.json
@@ -52,7 +52,7 @@
     },
     "metricset": {
         "period": 300000,
-        "name": "container_registry"
+        "name": "monitor"
     },
     "event": {
         "duration": 938177400,

--- a/packages/azure_metrics/data_stream/container_registry/sample_event.json
+++ b/packages/azure_metrics/data_stream/container_registry/sample_event.json
@@ -1,24 +1,23 @@
 {
     "agent": {
-        "hostname": "docker-fleet-agent",
-        "name": "docker-fleet-agent",
-        "id": "6493df64-791a-4b55-b2e9-c5b1dd347fe7",
-        "ephemeral_id": "833a8afe-815e-4ed5-b7a1-bd0e30d626ed",
+        "name": "azure-vm",
+        "id": "2f167533-86cd-4751-b39f-a9dc7a155584",
         "type": "metricbeat",
-        "version": "7.14.0"
+        "ephemeral_id": "e221afb0-dd37-418e-93a2-34fd006dd0ea",
+        "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "6493df64-791a-4b55-b2e9-c5b1dd347fe7",
-        "version": "7.14.0",
+        "id": "2f167433-86cd-4751-b39f-a9cc7a155584",
+        "version": "8.3.0",
         "snapshot": true
     },
     "cloud": {
         "provider": "azure",
-        "region": "westeurope"
+        "region": "uksouth"
     },
-    "@timestamp": "2021-07-26T09:52:00.000Z",
+    "@timestamp": "2022-07-06T12:12:00.000Z",
     "ecs": {
-        "version": "1.10.0"
+        "version": "8.0.0"
     },
     "service": {
         "type": "azure"
@@ -29,46 +28,50 @@
         "dataset": "azure.container_registry"
     },
     "host": {
-        "hostname": "docker-fleet-agent",
+        "hostname": "azure-vm",
         "os": {
-            "kernel": "4.19.128-microsoft-standard",
+            "kernel": "3.10.0-1160.53.1.el7.x86_64",
             "codename": "Core",
             "name": "CentOS Linux",
-            "family": "redhat",
             "type": "linux",
+            "family": "redhat",
             "version": "7 (Core)",
             "platform": "centos"
         },
+        "containerized": false,
         "ip": [
-            "172.20.0.7"
+            "10.1.0.8",
+            "fe80::333:48ff:fe3f:2d92"
         ],
-        "containerized": true,
-        "name": "docker-fleet-agent",
-        "id": "d4845dae196bc2de62b7b208c215d5bc",
+        "name": "azure-vm",
+        "id": "09bbcdbd0f374f0e9fb660d89dad3a37",
         "mac": [
-            "02:42:ac:14:00:07"
+            "00:22:48:3f:2d:92"
         ],
         "architecture": "x86_64"
     },
     "metricset": {
-        "period": 300000,
+        "period": 60000,
         "name": "monitor"
     },
     "event": {
-        "duration": 938177400,
+        "duration": 549852712,
         "agent_id_status": "verified",
-        "ingested": "2021-07-26T10:02:19.107166500Z",
+        "ingested": "2022-07-06T12:17:38Z",
         "module": "azure",
         "dataset": "azure.container_registry"
     },
     "azure": {
-        "subscription_id": "70bd6e77-4b1e-4835-8896-db77b8eef364",
+        "subscription_id": "0e073ec1-c22f-4488-addf-da35ed609ccd",
         "timegrain": "PT5M",
         "resource": {
-            "name": "obstest",
-            "id": "/subscriptions/70bd6e77-4b1e-4835-8896-db77b8eef364/resourceGroups/obs-infrastructure/providers/Microsoft.ContainerRegistry/registries/obstest",
+            "name": "resource",
+            "id": "/subscriptions/0e073ec1-c22f-4388-adde-da35ed609ccd/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/resource",
             "type": "Microsoft.ContainerRegistry/registries",
-            "group": "obs-infrastructure"
+            "group": "rg",
+            "tags": {
+                "sometag": "somevalue"
+            }
         },
         "namespace": "Microsoft.ContainerRegistry/registries",
         "container_registry": {

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.7
+version: 1.0.8
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR is to move lightweight module configuration from Metricbeat into integrations.

Switch from "container_registry" to "monitor" metricset, add the metrics configuration from beats, and add an ingest pipeline to set the expected field names (`azure. container_registry.*` instead of `azure.metrics.*`).


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3594

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
