### PR TITLE
[Azure Logs] Handle event.original from upstream forwarders

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.1.11"
+  changes:
+    - description: FIXME
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/999999999999 # FIXME: link to PR
 - version: "1.1.10"
   changes:
     - description: Update readme with links to Microsoft documentation

--- a/packages/azure/data_stream/activitylogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/activitylogs/elasticsearch/ingest_pipeline/default.yml
@@ -17,6 +17,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: azure.activitylogs

--- a/packages/azure/data_stream/auditlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/auditlogs/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: azure.auditlogs

--- a/packages/azure/data_stream/platformlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/platformlogs/elasticsearch/ingest_pipeline/default.yml
@@ -17,6 +17,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: azure.platformlogs

--- a/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
@@ -55,6 +55,14 @@ processors:
   - rename:
       field: message
       target_field: event.original
+      ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - rename:
       field: azure.signinlogs.resource_id
       target_field: azure.resource_id

--- a/packages/azure/data_stream/springcloudlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/springcloudlogs/elasticsearch/ingest_pipeline/default.yml
@@ -17,6 +17,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: azure.springcloudlogs

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 1.1.10
+version: 1.1.11
 release: ga
 description: This Elastic integration collects logs from Azure
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Upstream event forwarders like Logstash can add their `event.original` field, depending on the circumstances (specific
configurations or tool versions).

With the change, the pipeline will honor the `event.original` field over the message field, when it exists.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
