### PR TITLE
cisco_asa: fix handling of user parsing with sgt fields

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Fix handling of user parsing when SGT fields are present.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3650
+    - description: Fix handling of user parsing for 302013 and 302015 events.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3650
 - version: "2.5.0"
   changes:
     - description: Update package to ECS 8.3.0.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log
@@ -9,3 +9,6 @@ Oct 20 2019 15:42:53: %ASA-6-106100: access-list incoming permitted udp dmz2/127
 Oct 20 2019 15:42:54: %ASA-6-106100: access-list incoming permitted udp dmz2/127.2.3.4(56575)(LOCAL\\username) -> inside/127.3.4.5(53) hit-cnt 1 first hit [0x93d0e533, 0x578ef52f]
 Aug  6 2020 11:01:37: %ASA-session-3-106102: access-list dev_inward_client permitted udp for user redacted outside/10.123.123.20(49721) -> inside/10.223.223.40(53) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]
 Aug  6 2020 11:01:38: %ASA-1-106103: access-list filter denied icmp for user joe inside/10.1.2.3(64321) -> outside/81.2.69.144(8080) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]
+Jun 21 2022 11:47:08: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\alice, 123) to inside:89.160.20.112/9803 (89.160.20.112/9803) (bob)
+Jun 21 2022 11:47:08: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\alice) to inside:89.160.20.112/9803 (89.160.20.112/9803) (bob)
+Jun 21 2022 11:47:09: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\alice, 123) to inside:89.160.20.112/9803 (89.160.20.112/9803)(LOCAL\dave, 246) (bob)

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -811,6 +811,350 @@
             "user": {
                 "name": "joe"
             }
+        },
+        {
+            "@timestamp": "2022-06-21T11:47:08.000Z",
+            "cisco": {
+                "asa": {
+                    "connection_id": "7",
+                    "destination_interface": "inside",
+                    "mapped_destination_ip": "89.160.20.112",
+                    "mapped_destination_port": 9803,
+                    "mapped_source_ip": "81.2.69.142",
+                    "mapped_source_port": 3424,
+                    "source_interface": "outside",
+                    "source_user_security_group_tag": 123,
+                    "source_username": "LOCAL\\alice",
+                    "termination_user": "bob"
+                }
+            },
+            "destination": {
+                "address": "89.160.20.112",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "port": 9803
+            },
+            "ecs": {
+                "version": "8.3.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302015",
+                "kind": "event",
+                "original": "Jun 21 2022 11:47:08: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\\alice, 123) to inside:89.160.20.112/9803 (89.160.20.112/9803) (bob)",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "community_id": "1:797FALeb94mYDqvQDgC+6NRdALQ=",
+                "direction": "inbound",
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.142",
+                    "89.160.20.112"
+                ],
+                "user": [
+                    "alice"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142",
+                "port": 3424,
+                "user": {
+                    "name": "alice"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-06-21T11:47:08.000Z",
+            "cisco": {
+                "asa": {
+                    "connection_id": "7",
+                    "destination_interface": "inside",
+                    "mapped_destination_ip": "89.160.20.112",
+                    "mapped_destination_port": 9803,
+                    "mapped_source_ip": "81.2.69.142",
+                    "mapped_source_port": 3424,
+                    "source_interface": "outside",
+                    "source_username": "LOCAL\\alice",
+                    "termination_user": "bob"
+                }
+            },
+            "destination": {
+                "address": "89.160.20.112",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "port": 9803
+            },
+            "ecs": {
+                "version": "8.3.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302015",
+                "kind": "event",
+                "original": "Jun 21 2022 11:47:08: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\\alice) to inside:89.160.20.112/9803 (89.160.20.112/9803) (bob)",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "community_id": "1:797FALeb94mYDqvQDgC+6NRdALQ=",
+                "direction": "inbound",
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.142",
+                    "89.160.20.112"
+                ],
+                "user": [
+                    "alice"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142",
+                "port": 3424,
+                "user": {
+                    "name": "alice"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-06-21T11:47:09.000Z",
+            "cisco": {
+                "asa": {
+                    "connection_id": "7",
+                    "destination_interface": "inside",
+                    "destination_user_security_group_tag": 246,
+                    "destination_username": "LOCAL\\dave",
+                    "mapped_destination_ip": "89.160.20.112",
+                    "mapped_destination_port": 9803,
+                    "mapped_source_ip": "81.2.69.142",
+                    "mapped_source_port": 3424,
+                    "source_interface": "outside",
+                    "source_user_security_group_tag": 123,
+                    "source_username": "LOCAL\\alice",
+                    "termination_user": "bob"
+                }
+            },
+            "destination": {
+                "address": "89.160.20.112",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "port": 9803,
+                "user": {
+                    "name": "dave"
+                }
+            },
+            "ecs": {
+                "version": "8.3.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302015",
+                "kind": "event",
+                "original": "Jun 21 2022 11:47:09: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\\alice, 123) to inside:89.160.20.112/9803 (89.160.20.112/9803)(LOCAL\\dave, 246) (bob)",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "community_id": "1:797FALeb94mYDqvQDgC+6NRdALQ=",
+                "direction": "inbound",
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.142",
+                    "89.160.20.112"
+                ],
+                "user": [
+                    "dave",
+                    "alice"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142",
+                "port": 3424,
+                "user": {
+                    "name": "alice"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "dave"
+            }
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -5337,7 +5337,7 @@
                     "67.43.156.15"
                 ],
                 "user": [
-                    "user@domain.tld"
+                    "user"
                 ]
             },
             "source": {
@@ -5362,7 +5362,7 @@
                 "port": 12312,
                 "user": {
                     "domain": "domain.tld",
-                    "name": "user@domain.tld"
+                    "name": "user"
                 }
             },
             "tags": [
@@ -5491,7 +5491,7 @@
                 "ip": "175.16.199.1",
                 "user": {
                     "domain": "domain.tld",
-                    "name": "user@domain.tld"
+                    "name": "user"
                 }
             },
             "ecs": {
@@ -5532,7 +5532,7 @@
                     "175.16.199.1"
                 ],
                 "user": [
-                    "user@domain.tld"
+                    "user"
                 ]
             },
             "source": {
@@ -5552,14 +5552,14 @@
                 "ip": "67.43.156.15",
                 "user": {
                     "domain": "domain.tld",
-                    "name": "user@domain.tld"
+                    "name": "user"
                 }
             },
             "tags": [
                 "preserve_original_event"
             ],
             "user": {
-                "name": "user@domain.tld"
+                "name": "user"
             }
         },
         {

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -278,7 +278,7 @@ processors:
         - ^%{NOTSPACE:event.outcome} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{POSINT:source.port})?\s*(\(%{CISCO_USER:_temp_.cisco.source_username}\) )?dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{POSINT:destination.port})?%{DATA}by access-group "%{NOTSPACE:_temp_.cisco.list_id}"
       pattern_definitions:
         NOTCOLON: "[^:]*"
-        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?)
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106027'"
       field: "message"
@@ -350,10 +350,10 @@ processors:
       field: "message"
       description: "302013, 302015"
       patterns:
-        - Built %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} connection %{NUMBER:_temp_.cisco.connection_id} for %{NOTCOLON:_temp_.cisco.source_interface}:%{IP:source.address}/%{NUMBER:source.port} \(%{IP:_temp_.natsrcip}/%{NUMBER:_temp_.cisco.mapped_source_port}\)(\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{NUMBER:destination.port} \(%{NOTSPACE:_temp_.natdstip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\)(\(%{CISCO_USER:destination.user.name}\))?( \(%{CISCO_USER:_temp_.cisco.termination_user}\))?%{GREEDYDATA}
+        - Built %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} connection %{NUMBER:_temp_.cisco.connection_id} for %{NOTCOLON:_temp_.cisco.source_interface}:%{IP:source.address}/%{NUMBER:source.port} \(%{IP:_temp_.natsrcip}/%{NUMBER:_temp_.cisco.mapped_source_port}\)(\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{NUMBER:destination.port} \(%{NOTSPACE:_temp_.natdstip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\)(\(%{CISCO_USER:_temp_.cisco.destination_username}\))?( \(%{CISCO_USER:_temp_.cisco.termination_user}\))?%{GREEDYDATA}
       pattern_definitions:
         NOTCOLON: "[^:]*"
-        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?)
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
       if: "ctx._temp_.cisco.message_id == '303002'"
       field: "message"
@@ -367,7 +367,7 @@ processors:
         - Teardown %{DATA} %{NOTSPACE:network.transport} translation from %{NOTCOLON:_temp_.cisco.source_interface}:%{IP:source.address}/%{NUMBER:source.port}(\s*\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port} duration %{DURATION:_temp_.duration_hms}
       pattern_definitions:
         NOTCOLON: "[^:]*"
-        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?)
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
         DURATION: "%{INT}:%{MINUTE}:%{SECOND}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '302020'"
@@ -380,7 +380,7 @@ processors:
         ECSSOURCEIPORHOST: "(?:%{IP:source.address}|%{HOSTNAME:source.domain})"
         ECSDESTIPORHOST: "(?:%{IP:destination.address}|%{HOSTNAME:destination.domain})"
         MAPPEDSRC: "(?:%{DATA:_temp_.natsrcip}|%{HOSTNAME})"
-        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?)
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
       if: "ctx._temp_.cisco.message_id == '302022'"
       field: "message"
@@ -852,7 +852,7 @@ processors:
         ECSDESTIPORHOST: "(?:%{IP:destination.address}|%{HOSTNAME:destination.domain})"
         MAPPEDSRC: "(?:%{IPORHOST:_temp_.natsrcip}|%{HOSTNAME})"
         DURATION: "%{INT}:%{MINUTE}:%{SECOND}"
-        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?)
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
 
   #
   # Decode FTD's Security Event Syslog Messages
@@ -1397,6 +1397,36 @@ processors:
   #
   # Parse Source/Dest Username/Domain
   #
+  - grok:
+      field: "_temp_.cisco.source_username"
+      if: 'ctx?._temp_?.cisco?.source_username != null'
+      ignore_failure: true
+      patterns:
+        - '%{CISCO_DOMAIN_USER:_temp_.cisco.source_username}%{CISCO_SGT}'
+      pattern_definitions:
+        CISCO_DOMAIN_USER: (%{CISCO_DOMAIN})?%{CISCO_USER}
+        CISCO_SGT: (, *%{NUMBER:_temp_.cisco.source_user_security_group_tag})?
+        CISCO_USER: "%{USERNAME}(@%{HOSTNAME})?"
+        CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME}\\)?
+  - convert:
+      field: _temp_.cisco.source_user_security_group_tag
+      type: long
+      ignore_missing: true
+  - grok:
+      field: "_temp_.cisco.destination_username"
+      if: 'ctx?._temp_?.cisco?.destination_username != null'
+      ignore_failure: true
+      patterns:
+        - '%{CISCO_DOMAIN_USER:_temp_.cisco.destination_username}%{CISCO_SGT}'
+      pattern_definitions:
+        CISCO_DOMAIN_USER: (%{CISCO_DOMAIN})?%{CISCO_USER}
+        CISCO_SGT: (, *%{NUMBER:_temp_.cisco.destination_user_security_group_tag})?
+        CISCO_USER: "%{USERNAME}(@%{HOSTNAME})?"
+        CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME}\\)?
+  - convert:
+      field: _temp_.cisco.destination_user_security_group_tag
+      type: long
+      ignore_missing: true
   - set:
       field: source.user.name
       value: "{{{ _temp_.cisco.source_username }}}"
@@ -1410,19 +1440,20 @@ processors:
       if: 'ctx?.source?.user?.name != null'
       ignore_failure: true
       patterns:
-        - (%{CISCO_DOMAIN})?%{CISCO_USER:source.user.name}
+        - (%{CISCO_DOMAIN})?%{CISCO_USER}
       pattern_definitions:
-        CISCO_USER: "%{USERNAME}(@%{HOSTNAME:source.user.domain})?"
+        CISCO_USER: "%{USERNAME:source.user.name}(@%{HOSTNAME:source.user.domain})?"
         CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME:source.user.domain}\\)?
   - grok:
       field: "destination.user.name"
       if: 'ctx?.destination?.user?.name != null'
       ignore_failure: true
       patterns:
-        - (%{CISCO_DOMAIN})?%{CISCO_USER:destination.user.name}
+        - (%{CISCO_DOMAIN})?%{CISCO_USER}
       pattern_definitions:
-        CISCO_USER: "%{USERNAME}(@%{HOSTNAME:destination.user.domain})?"
+        CISCO_USER: "%{USERNAME:destination.user.name}(@%{HOSTNAME:destination.user.domain})?"
         CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME:destination.user.domain}\\)?
+
   #
   # Normalize protocol names
   #

--- a/packages/cisco_asa/data_stream/log/fields/fields.yml
+++ b/packages/cisco_asa/data_stream/log/fields/fields.yml
@@ -31,10 +31,20 @@
       description: >
         Name of the user that is the source for this event.
 
+    - name: source_user_security_group_tag
+      type: long
+      description: >
+        The Security Group Tag for the source user. Security Group Tag are 16-bit identifiers used to represent logical group privilege.
+
     - name: destination_username
       type: keyword
       description: >
         Name of the user that is the destination for this event.
+
+    - name: destination_user_security_group_tag
+      type: long
+      description: >
+        The Security Group Tag for the destination user. Security Group Tag are 16-bit identifiers used to represent logical group privilege.
 
     - name: mapped_source_ip
       type: ip
@@ -201,9 +211,3 @@
       type: keyword
       description: >-
         The message associated with SIP and Skinny VoIP events
-- name: syslog.facility.code
-  type: long
-  description: Syslog numeric facility of the event.
-- name: syslog.priority
-  type: long
-  description: Syslog priority of the event.

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -141,6 +141,7 @@ An example event for `log` looks as following:
 | cisco.asa.connection_type | The VPN connection type | keyword |
 | cisco.asa.dap_records | The assigned DAP records | keyword |
 | cisco.asa.destination_interface | Destination interface for the flow or event. | keyword |
+| cisco.asa.destination_user_security_group_tag | The Security Group Tag for the destination user. Security Group Tag are 16-bit identifiers used to represent logical group privilege. | long |
 | cisco.asa.destination_username | Name of the user that is the destination for this event. | keyword |
 | cisco.asa.icmp_code | ICMP code. | short |
 | cisco.asa.icmp_type | ICMP type. | short |
@@ -158,6 +159,7 @@ An example event for `log` looks as following:
 | cisco.asa.security | Cisco FTD security event fields. | flattened |
 | cisco.asa.session_type | Session type (for example, IPsec or UDP). | keyword |
 | cisco.asa.source_interface | Source interface for the flow or event. | keyword |
+| cisco.asa.source_user_security_group_tag | The Security Group Tag for the source user. Security Group Tag are 16-bit identifiers used to represent logical group privilege. | long |
 | cisco.asa.source_username | Name of the user that is the source for this event. | keyword |
 | cisco.asa.suffix | Optional suffix after %ASA identifier. | keyword |
 | cisco.asa.termination_initiator | Interface name of the side that initiated the teardown | keyword |
@@ -308,8 +310,6 @@ An example event for `log` looks as following:
 | source.user.group.name | Name of the group. | keyword |
 | source.user.name | Short name or login of the user. | keyword |
 | source.user.name.text | Multi-field of `source.user.name`. | match_only_text |
-| syslog.facility.code | Syslog numeric facility of the event. | long |
-| syslog.priority | Syslog priority of the event. | long |
 | tags | List of keywords used to tag each event. | keyword |
 | url.domain | Domain of the url, such as "www.elastic.co". In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732), the `[` and `]` characters should also be captured in the `domain` field. | keyword |
 | url.extension | The field contains the file extension from the original request url, excluding the leading dot. The file extension is only set if it exists, as not every url has a file extension. The leading period must not be included. For example, the value must be "png", not ".png". Note that when the file name has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz"). | keyword |

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.5.0"
+version: "2.5.1"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes handling of user parsing when there are SGT fields associated with the user and dissects the destination user from the domain in 302013 and 302015 events.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #elastic/beats#32009

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
