### PR TITLE
[Cloud Posture] add benchmark id to rule template

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.19"
+  changes:
+    - description: update rule benchmark field to include an id
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3654
 - version: "0.0.18"
   changes:
     - description: enhance integration to support eks

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.0.19"
   changes:
-    - description: update rule benchmark field to include an id
+    - description: Update rule benchmark field to include an id
       type: enhancement
       link: https://github.com/elastic/integrations/pull/3654
 - version: "0.0.18"

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -5,13 +5,13 @@ streams:
     title: K8s CIS Compliance
     description: |
       Check CIS Benchmark compliance
-      ###### only a single benchmark can be enabled. default is K8s CIS.
+      ###### Only a single benchmark can be enabled. Default is K8s CIS.
   - input: cloudbeat/eks
     enabled: false
     title: CIS Amazon EKS Compliance
     description: |
       Check CIS Amazon Benchmark compliance
-      ###### only a single benchmark can be enabled. default is K8s CIS.
+      ###### Only a single benchmark can be enabled. Default is K8s CIS.
     vars:
       - name: access_key_id
         type: text

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -3,11 +3,15 @@ type: logs
 streams:
   - input: cloudbeat/vanilla
     title: K8s CIS Compliance
-    description: Check CIS Benchmark compliance
+    description: |
+      Check CIS Benchmark compliance
+      ###### only a single benchmark can be enabled. default is K8s CIS.
   - input: cloudbeat/eks
     enabled: false
     title: CIS Amazon EKS Compliance
-    description: Check CIS Amazon Benchmark compliance
+    description: |
+      Check CIS Amazon Benchmark compliance
+      ###### only a single benchmark can be enabled. default is K8s CIS.
     vars:
       - name: access_key_id
         type: text

--- a/packages/cloud_security_posture/kibana/csp_rule_template/0434fc0b-4b72-5a73-8bee-8c8c40345165.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/0434fc0b-4b72-5a73-8bee-8c8c40345165.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_18"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/058dd742-d183-57c8-9115-16ab34615037.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/058dd742-d183-57c8-9115-16ab34615037.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_20"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/07361e5e-0142-57ce-8e42-d6ebd5110d2e.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/07361e5e-0142-57ce-8e42-d6ebd5110d2e.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_19"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/0cd77c44-7420-5cac-a366-821b44bf819e.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/0cd77c44-7420-5cac-a366-821b44bf819e.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_16"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/0e3755af-d150-504f-80db-3a5bb1094c4e.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/0e3755af-d150-504f-80db-3a5bb1094c4e.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_32"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/140866d3-af45-58a5-9984-cfa9f9498809.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/140866d3-af45-58a5-9984-cfa9f9498809.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_15"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/1727f238-cf56-52bb-86ed-ddf0c141eebc.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/1727f238-cf56-52bb-86ed-ddf0c141eebc.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_6"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/192af64f-4521-584c-ae84-5c7ad8a11597.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/192af64f-4521-584c-ae84-5c7ad8a11597.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_1_10"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/1a5c8f4f-fc22-5c1e-b7e1-affa0f03edf0.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/1a5c8f4f-fc22-5c1e-b7e1-affa0f03edf0.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_12"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/1d3a468f-78ca-54ff-a43c-0d205ad832b7.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/1d3a468f-78ca-54ff-a43c-0d205ad832b7.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_3"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/1d4fadeb-808b-55cb-80db-fe01409e4ebc.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/1d4fadeb-808b-55cb-80db-fe01409e4ebc.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_8"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/1f4cc187-dedb-553d-b41f-8e26682415b5.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/1f4cc187-dedb-553d-b41f-8e26682415b5.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_5"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/248339e7-4a2c-598b-954e-b676176f0e49.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/248339e7-4a2c-598b-954e-b676176f0e49.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_15"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/271a6cd7-9498-5bc1-bac4-8d58f7b46e96.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/271a6cd7-9498-5bc1-bac4-8d58f7b46e96.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_29"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/272d95bf-8e18-5a8e-b8b0-76d220de9664.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/272d95bf-8e18-5a8e-b8b0-76d220de9664.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_14"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/2b399496-f79d-5533-8a86-4ea00b95e3bd.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/2b399496-f79d-5533-8a86-4ea00b95e3bd.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_1_5"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/307e747c-5998-5bf8-a8e3-d24aab71e558.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/307e747c-5998-5bf8-a8e3-d24aab71e558.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_2"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/3b0587fb-01a3-50c2-9d3d-6675f376d509.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/3b0587fb-01a3-50c2-9d3d-6675f376d509.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_2"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/3b9e7a41-95c8-5262-8643-c0e15d2eb8c7.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/3b9e7a41-95c8-5262-8643-c0e15d2eb8c7.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_24"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/3be1207a-0cfe-5dbd-abde-97e50421466d.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/3be1207a-0cfe-5dbd-abde-97e50421466d.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_1_5"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/3e07507c-31ba-5d01-800f-cfb8c0a09787.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/3e07507c-31ba-5d01-800f-cfb8c0a09787.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_11"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/3f2a98b2-26a6-52bf-97ad-68ef81df953c.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/3f2a98b2-26a6-52bf-97ad-68ef81df953c.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_14"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/41e05dea-5fdd-50a7-9149-5be11cd8a63e.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/41e05dea-5fdd-50a7-9149-5be11cd8a63e.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_4"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/428bd666-2825-532e-a484-0f31ea5db0f9.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/428bd666-2825-532e-a484-0f31ea5db0f9.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_20"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/43af3bd9-c0b8-5f06-b1c0-8a1295983524.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/43af3bd9-c0b8-5f06-b1c0-8a1295983524.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_2_3"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/46d69440-3946-50f6-83b3-a0987551afa2.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/46d69440-3946-50f6-83b3-a0987551afa2.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_12"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/4caf31ec-2fe2-5337-b1e1-9cbf498de17f.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/4caf31ec-2fe2-5337-b1e1-9cbf498de17f.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_25"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/54fabe1f-8eb5-5015-82b5-30db926064c0.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/54fabe1f-8eb5-5015-82b5-30db926064c0.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_4_2"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/55983039-6973-57a9-9ed2-fb577c0be1f6.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/55983039-6973-57a9-9ed2-fb577c0be1f6.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_4"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/576f7a4e-bfec-5e1e-9b41-92212823e83d.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/576f7a4e-bfec-5e1e-9b41-92212823e83d.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_27"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/5867e0c0-71c5-5f21-8c9c-621a160bfbd9.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/5867e0c0-71c5-5f21-8c9c-621a160bfbd9.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_18"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/58b41542-b102-5c9a-81fb-89aa5bc0fcb8.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/58b41542-b102-5c9a-81fb-89aa5bc0fcb8.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_8"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/59f978f4-c825-578a-bc21-ab5f395c5cd9.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/59f978f4-c825-578a-bc21-ab5f395c5cd9.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_2_6"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/5c060a65-bbc5-5af4-9a42-338717937ec4.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/5c060a65-bbc5-5af4-9a42-338717937ec4.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_5"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/5ee652ed-952d-57d3-8643-87f95d046f25.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/5ee652ed-952d-57d3-8643-87f95d046f25.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_21"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/63ea14ed-b605-5fe1-b35d-6b254f16d8ab.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/63ea14ed-b605-5fe1-b35d-6b254f16d8ab.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_4_1"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/655e7d25-f5a9-547f-847c-70ee6c1ca801.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/655e7d25-f5a9-547f-847c-70ee6c1ca801.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_1_9"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/6664c1b8-05f2-5872-a516-4b2c3c36d2d7.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/6664c1b8-05f2-5872-a516-4b2c3c36d2d7.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_1"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/66cf51af-50b4-5570-be5b-afe549fafd62.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/66cf51af-50b4-5570-be5b-afe549fafd62.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_5"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/670e64f4-c52c-5efa-b0dd-6dce8175e4c0.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/670e64f4-c52c-5efa-b0dd-6dce8175e4c0.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_2_1"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/6c8f1b4a-9e41-5fdb-b4bf-57b850ea1d29.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/6c8f1b4a-9e41-5fdb-b4bf-57b850ea1d29.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_2"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/6cfcb087-18c7-5cb1-95fd-0dc074f48766.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/6cfcb087-18c7-5cb1-95fd-0dc074f48766.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_16"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/7037cf42-1f9b-5064-afde-e74a69cf96eb.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/7037cf42-1f9b-5064-afde-e74a69cf96eb.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_1_6"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/7295eff3-3d9d-5032-8552-bcce9cba8a26.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/7295eff3-3d9d-5032-8552-bcce9cba8a26.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_2_4"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/743de18a-f988-55e3-b6a9-0b692d1e25fb.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/743de18a-f988-55e3-b6a9-0b692d1e25fb.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_1_6"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/74a82a38-4266-59f0-9ed0-39ef03bc72d1.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/74a82a38-4266-59f0-9ed0-39ef03bc72d1.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_9"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/772a42c5-4652-5610-858d-01ef23bd6290.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/772a42c5-4652-5610-858d-01ef23bd6290.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_17"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/780ac02f-e0f5-537c-98ba-354ae5873a81.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/780ac02f-e0f5-537c-98ba-354ae5873a81.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_19"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/811f3dd3-7fbc-5141-83b7-724730ec158d.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/811f3dd3-7fbc-5141-83b7-724730ec158d.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_7"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/81a89547-86b3-5538-a6c4-c33aae82a8ae.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/81a89547-86b3-5538-a6c4-c33aae82a8ae.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_6"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/81efecae-af9e-5630-9ef0-1947aa17e376.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/81efecae-af9e-5630-9ef0-1947aa17e376.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_3_5"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/827e1022-2702-55c4-aa65-3315517bb6c0.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/827e1022-2702-55c4-aa65-3315517bb6c0.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_1_2"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/8371e3cb-c8a3-5b4c-876a-3c68b995d30b.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/8371e3cb-c8a3-5b4c-876a-3c68b995d30b.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_3"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/861cb7eb-4db7-58c2-b849-19c2437c97f2.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/861cb7eb-4db7-58c2-b849-19c2437c97f2.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_21"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/8832517d-74ba-5191-8b2b-3bbc81f6f970.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/8832517d-74ba-5191-8b2b-3bbc81f6f970.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_4"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/8c46796a-9b8d-585b-8c01-48cde4eff2ec.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/8c46796a-9b8d-585b-8c01-48cde4eff2ec.json
@@ -23,7 +23,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_1_3"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/8dad2026-5cfd-5398-ba90-9c329ae6b2ca.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/8dad2026-5cfd-5398-ba90-9c329ae6b2ca.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_9"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/9144ba59-0a3e-59fb-b96e-e3f73e7aaf66.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/9144ba59-0a3e-59fb-b96e-e3f73e7aaf66.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_1_1"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/95868b0f-4f1a-5af1-846e-93725abc9c18.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/95868b0f-4f1a-5af1-846e-93725abc9c18.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_12"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/9a584e20-2a45-598e-b7ee-1148740f3085.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/9a584e20-2a45-598e-b7ee-1148740f3085.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_6"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/9ad692c7-e8ee-5633-ac83-d7911467c2c0.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/9ad692c7-e8ee-5633-ac83-d7911467c2c0.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_13"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/9ed65e6a-550a-5960-b86d-ab3449c407c0.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/9ed65e6a-550a-5960-b86d-ab3449c407c0.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_26"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/a082f4e6-67d7-56c4-9764-42db2030a552.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/a082f4e6-67d7-56c4-9764-42db2030a552.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_1"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/a406209b-2765-5d90-91ba-4e872802c450.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/a406209b-2765-5d90-91ba-4e872802c450.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_3"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/a6194f98-6534-5308-9683-1adb4914cc46.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/a6194f98-6534-5308-9683-1adb4914cc46.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_2_2"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/a75f69ac-866e-5fbe-b9ce-b5a2a8c20834.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/a75f69ac-866e-5fbe-b9ce-b5a2a8c20834.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_3_6"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/b26d85f5-ac08-535f-8b5d-8e461a0cf679.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/b26d85f5-ac08-535f-8b5d-8e461a0cf679.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_2_5"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/b2d85ce5-e820-580d-98ba-a7e3ac83eeb3.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/b2d85ce5-e820-580d-98ba-a7e3ac83eeb3.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_7"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/bbe88e70-e917-5e9d-8993-3b5dd61a56c9.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/bbe88e70-e917-5e9d-8993-3b5dd61a56c9.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_6"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/c03358d0-05d0-54a9-b079-7c6991b2bc41.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/c03358d0-05d0-54a9-b079-7c6991b2bc41.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_23"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/c3c56d62-e217-5a77-aba0-124b1dfb3d2c.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/c3c56d62-e217-5a77-aba0-124b1dfb3d2c.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_8"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/c978fb31-5706-5bdf-93fb-7cb84a35c63c.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/c978fb31-5706-5bdf-93fb-7cb84a35c63c.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_2"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/cfcc0315-7d89-5b9c-ab1a-eaf860e8942f.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/cfcc0315-7d89-5b9c-ab1a-eaf860e8942f.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_5_2_10"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/d44fc5e7-7275-5d07-88a7-f1f8fc2f73c2.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/d44fc5e7-7275-5d07-88a7-f1f8fc2f73c2.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_10"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/d4942f42-b0b7-5fab-9d43-bfcf3373ac57.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/d4942f42-b0b7-5fab-9d43-bfcf3373ac57.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_8"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/d8682dfd-f8ab-5f9f-b10f-6225b9b46560.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/d8682dfd-f8ab-5f9f-b10f-6225b9b46560.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_11"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/d94918af-be06-5d3c-b880-6d9d0f23a1e7.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/d94918af-be06-5d3c-b880-6d9d0f23a1e7.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_11"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/db3446ed-5542-59b0-a9e3-499814d5bde3.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/db3446ed-5542-59b0-a9e3-499814d5bde3.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_5"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/dc91f4c4-4f0e-59ba-a0e1-96e996736787.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/dc91f4c4-4f0e-59ba-a0e1-96e996736787.json
@@ -22,7 +22,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_10"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/ddf0a2b1-5b54-5960-a749-89f351dcc04b.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/ddf0a2b1-5b54-5960-a749-89f351dcc04b.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_7"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/e14db7eb-4c21-5f97-826a-391266a92ced.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/e14db7eb-4c21-5f97-826a-391266a92ced.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_17"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/e48fe269-49e1-56da-85f8-b52c9a47d918.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/e48fe269-49e1-56da-85f8-b52c9a47d918.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_3_4"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/e60a7027-cdd7-5a35-afa2-f7a8be2dc845.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/e60a7027-cdd7-5a35-afa2-f7a8be2dc845.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_28"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/eb641843-bd10-5ec5-9a37-7b6a70feb6e0.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/eb641843-bd10-5ec5-9a37-7b6a70feb6e0.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_22"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/ed33b6ba-d276-5b5c-9cdc-85b62de52be1.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/ed33b6ba-d276-5b5c-9cdc-85b62de52be1.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_2_9"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/ed431503-ac95-5312-a02b-cf9b51778ad4.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/ed431503-ac95-5312-a02b-cf9b51778ad4.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_3_2"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/f0d72b13-5130-5045-b94d-bc8d7e00b7fc.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/f0d72b13-5130-5045-b94d-bc8d7e00b7fc.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_3_7"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/f59951c7-ec2f-52b1-96d7-a7777badc2a7.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/f59951c7-ec2f-52b1-96d7-a7777badc2a7.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_3_3"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/f5d3c40c-d915-56d7-b4c4-33d863201c9f.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/f5d3c40c-d915-56d7-b4c4-33d863201c9f.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_4"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/f8239b9d-dbc4-51ee-a4c7-2896ad3b102e.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/f8239b9d-dbc4-51ee-a4c7-2896ad3b102e.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_7"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/f9d84d7f-a741-5f2a-a454-704554380bca.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/f9d84d7f-a741-5f2a-a454-704554380bca.json
@@ -24,7 +24,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_4_2_13"
         }

--- a/packages/cloud_security_posture/kibana/csp_rule_template/fa54a7f6-30ac-5c16-9f7c-a156c78cf96a.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/fa54a7f6-30ac-5c16-9f7c-a156c78cf96a.json
@@ -25,7 +25,8 @@
             ],
             "benchmark": {
                 "name": "CIS Kubernetes V1.23",
-                "version": "v1.0.0"
+                "version": "v1.0.0",
+                "id": "cis_k8s"
             },
             "rego_rule_id": "cis_1_1_13"
         }

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "CIS Kubernetes Benchmark"
-version: 0.0.18
+version: 0.0.19
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
 type: integration


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

this PR uses the newly introduced `benchmark.id` property and assigns every existing rule templates to use `cis_k8s` as its benchmark id. 
when EKS rule templates are introduced, they should be added with their benchmark id property set to `cis_eks`


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~~I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] ~~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~



<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


## How to test this PR locally

1. use local package registry
   - setup `xpack.fleet.registryUrl: 'http://localhost:8080'` in `kibana.dev.yml` 
   - pull this PR [integrations PR](https://github.com/elastic/integrations/pull/3654) 
   - add an `eks`  rule
      - copy-paste a `cis_k8s` rule
      - change its `id` so it's unique (replace a single char)
      - change the `benchmark.id` to `cis_eks` 
   - run `elastic-package build && elastic-package stack up -v -s package-registry`  
2. add a CIS integration per benchmark and verify the number of rules is `92` for `cis_k8s` and `1` for `cis_eks` 
  
 example:
![Screen Shot 2022-07-11 at 16 06 55](https://user-images.githubusercontent.com/20814186/178271181-e0acfd22-7c73-4765-aff1-0a8b671f1caf.png)



<!-- Recommended
## Related issues
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->




<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
