### PR TITLE
Publish package to the Package Storage v2

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -105,11 +105,12 @@ pipeline {
                               sh(label: 'Configure Git user.email', script: 'git config --global user.email "elasticmachine@users.noreply.github.com"')
                               sh(label: "Publish integration: ${it}", script: '../../build/elastic-package publish -v --fork=false')
                             }
+                          }
 
                             // Publish package to the Package Storage v2
                             sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
                             packageStoragePublish('../../build/packages')
-                          }
+
                         }
                       } finally {
                         dir("${BASE_DIR}") {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
 
                             // Publish package to the Package Storage v2
                             sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
-                            packageStoragePublish('../../build/packages')
+                            packageStoragePublish(it, '../../build/packages')
 
                         }
                       } finally {
@@ -307,12 +307,12 @@ def archiveArtifactsSafe(remotePath, artifacts) {
     pattern: artifacts)
 }
 
-def packageStoragePublish(builtPackagesPath) {
-  signUnpublishedArtifactsWithElastic(builtPackagesPath)
+def packageStoragePublish(jobName, builtPackagesPath) {
+  signUnpublishedArtifactsWithElastic(jobName, builtPackagesPath)
   uploadUnpublishedToPackageStorage(builtPackagesPath)
 }
 
-def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
+def signUnpublishedArtifactsWithElastic(jobName, builtPackagesPath) {
   def unpublished = false
   dir(builtPackagesPath) {
     findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
@@ -322,7 +322,7 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
       }
 
       unpublished = true
-      googleStorageUpload(bucket: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
+      googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}/${jobName}",
         credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
         pattern: '*.zip',
         sharedPublicly: false,
@@ -338,11 +338,11 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
     triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
       job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
       token: TOKEN,
-      parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+      parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}/${jobName}",
       useCrumbCache: false,
       useJobInfoCache: false)
   }
-  googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
+  googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/${jobName}/*",
     credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
     localDirectory: builtPackagesPath + '/',
     pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
@@ -382,5 +382,6 @@ def isAlreadyPublished(packageZip) {
   def responseCode = httpRequest(method: "HEAD",
     url: "https://package-storage.elastic.co/artifacts/packages/${packageZip}",
     response_code_only: true)
+  echo "EPR HTTP status code for ${packageZip}: ${responseCode}"
   return responseCode == 200
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,6 +22,19 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
     JOB_GCS_EXT_CREDENTIALS = 'beats-ci-gcs-plugin-file-credentials'
     STACK_VERSION = "${params.stackVersion}"
+
+    // Signing
+    JOB_SIGNING_CREDENTIALS = 'sign-artifacts-with-gpg-job'
+    INFRA_SIGNING_BUCKET_NAME = 'internal-ci-artifacts'
+    INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER = "${env.REPO_BUILD_TAG}/signed-artifacts"
+    INFRA_SIGNING_BUCKET_ARTIFACTS_PATH = "gs://${env.INFRA_SIGNING_BUCKET_NAME}/${env.REPO_BUILD_TAG}"
+    INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH = "gs://${env.INFRA_SIGNING_BUCKET_NAME}/${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}"
+
+    // Publishing
+    INTERNAL_CI_JOB_GCS_CREDENTIALS = 'internal-ci-gcs-plugin'
+    PACKAGE_STORAGE_UPLOADER_CREDENTIALS = 'upload-package-to-package-storage'
+    PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT = 'secret/gce/elastic-bekitzur/service-account/package-storage-uploader'
+    PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH = "gs://elastic-bekitzur-package-storage-internal/queue-publishing/${env.REPO_BUILD_TAG}"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -92,6 +105,10 @@ pipeline {
                               sh(label: 'Configure Git user.email', script: 'git config --global user.email "elasticmachine@users.noreply.github.com"')
                               sh(label: "Publish integration: ${it}", script: '../../build/elastic-package publish -v --fork=false')
                             }
+
+                            // Publish package to the Package Storage v2
+                            sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
+                            packageStoragePublish('../../build/packages')
                           }
                         }
                       } finally {
@@ -286,4 +303,82 @@ def archiveArtifactsSafe(remotePath, artifacts) {
     bucket: "gs://${JOB_GCS_BUCKET_INTERNAL}/${env.JOB_NAME}-${env.BUILD_ID}/${remotePath}",
     credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
     pattern: artifacts)
+}
+
+def packageStoragePublish(builtPackagesPath) {
+  signUnpublishedArtifactsWithElastic(builtPackagesPath)
+  uploadUnpublishedToPackageStorage(builtPackagesPath)
+}
+
+def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
+  def unpublished = false
+  dir(builtPackagesPath) {
+    findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
+      def packageZip = it
+      if (isAlreadyPublished(packageZip)) {
+        return
+      }
+
+      unpublished = true
+      googleStorageUpload(bucket: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
+        credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+        pattern: '*.zip',
+        sharedPublicly: false,
+        showInline: true)
+    }
+  }
+
+  if (!unpublished) {
+    return
+  }
+
+  withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
+    triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+      job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
+      token: TOKEN,
+      parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+      useCrumbCache: false,
+      useJobInfoCache: false)
+  }
+  googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
+    credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+    localDirectory: builtPackagesPath + '/',
+    pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
+    sh(label: 'Rename .asc to .sig', script: 'for f in ' + builtPackagesPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
+}
+
+def uploadUnpublishedToPackageStorage(builtPackagesPath) {
+  dir(builtPackagesPath) {
+    withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
+      withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
+        findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
+          def packageZip = it
+          if (isAlreadyPublished(packageZip)) {
+            return
+          }
+
+          sh(label: 'Upload package .zip file', script: "gsutil cp ${packageZip} ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
+          sh(label: 'Upload package .sig file', script: "gsutil cp ${packageZip}.sig ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
+
+          triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+            job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
+            token: TOKEN,
+            parameters: """
+              dry_run=true
+              gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
+              gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
+              """,
+              useCrumbCache: true,
+              useJobInfoCache: true)
+        }
+      }
+    }
+  }
+}
+
+def isAlreadyPublished(packageZip) {
+  def responseCode = httpRequest(method: "HEAD",
+    url: "https://package-storage.elastic.co/artifacts/packages/${packageZip}",
+    response_code_only: true)
+  return responseCode == 200
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -320,13 +320,13 @@ def packageStoragePublish() {
     unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
     useElasticPackage()
 
-    // FIXME Build only unpublished files (need to read version from manifest.yml)
+    // Build only unpublished files (need to read version from manifest.yml)
     dir("${BASE_DIR}/packages") {
       findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
         dir("${it}") {
-          def manifest = readYaml(file: "${it}/manifest.yml")
-          if (manifest != null && manifest["name"] != null && manifest["version"] != null) {
-            def packageZip = manifest["name"] + "-" + manifest["version"] + ".zip"
+          def manifest = readYaml(file: "manifest.yml")
+          if (manifest != null && manifest["version"] != null) {
+            def packageZip = it + "-" + manifest["version"] + ".zip"
             if (isAlreadyPublished(packageZip)) {
               return
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -321,7 +321,6 @@ def packageStoragePublish(jobName, builtPackagesPath) {
         pattern: '*.zip',
         sharedPublicly: false,
         showInline: true)
-      }
       withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
         triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
           job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -107,11 +107,6 @@ pipeline {
                               sh(label: "Publish integration: ${it}", script: '../../build/elastic-package publish -v --fork=false')
                             }
                           }
-
-                            // Publish package to the Package Storage v2
-                            sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
-                            packageStoragePublish(it, '../../build/packages')
-
                         }
                       } finally {
                         dir("${BASE_DIR}") {
@@ -139,6 +134,7 @@ pipeline {
   post {
     always {
       publishCoverageReports()
+      packageStoragePublish()
     }
     cleanup {
       notifyBuildResult(prComment: true)
@@ -307,8 +303,15 @@ def archiveArtifactsSafe(remotePath, artifacts) {
     pattern: artifacts)
 }
 
-def packageStoragePublish(jobName, builtPackagesPath) {
-  dir(builtPackagesPath) {
+def packageStoragePublish() {
+  //if (env.BRANCH_NAME != 'main') {
+  //  echo "packageStoragePublish: not a main branch, nothing will be published"
+  //  return
+  //}
+  dir("${BASE_DIR}/packages") {
+    sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
+  }
+  dir("${BASE_DIR}/build/packages") {
     findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
       def packageZip = it
       if (isAlreadyPublished(packageZip)) {
@@ -316,7 +319,7 @@ def packageStoragePublish(jobName, builtPackagesPath) {
       }
 
       // Sign package before publishing
-      googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}/${jobName}",
+      googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
         credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
         pattern: '*.zip',
         sharedPublicly: false,
@@ -325,11 +328,11 @@ def packageStoragePublish(jobName, builtPackagesPath) {
         triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
           job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
           token: TOKEN,
-          parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}/${jobName}",
+          parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
           useCrumbCache: false,
           useJobInfoCache: false)
       }
-      googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/${jobName}/*",
+      googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
         credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
         localDirectory: builtPackagesPath + '/',
         pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -325,7 +325,7 @@ def packageStoragePublish() {
         dir("${it}") {
           sh(label: "Build integration as zip: ${it}", script: """
             PATH=${env.WORKSPACE}/${BASE_DIR}/build:${env.PATH}
-            elastic-package build -v --zip""")
+            elastic-package build --zip""")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,6 +61,13 @@ pipeline {
         stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
       }
     }
+    stage('T') {
+      steps {
+        script {
+          packageStoragePublish()
+        }
+      }
+    }
     stage('Check Go sources') {
       steps {
         dir("${BASE_DIR}"){
@@ -312,13 +319,21 @@ def packageStoragePublish() {
     deleteDir()
     unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
     useElasticPackage()
+
+    // Build all integrations
+    def integrations = []
     dir("${BASE_DIR}/packages") {
       findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
-        dir("${BASE_DIR}/packages/${it}") {
-          sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
-        }
+        integrations += it
       }
     }
+    integrations.each { it ->
+      dir("${it}") {
+        sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
+      }
+    }
+
+    // Start publishing procedure
     dir("${BASE_DIR}/build/packages") {
       findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
         def packageZip = it

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -328,8 +328,8 @@ def packageStoragePublish() {
       }
     }
     integrations.each { integration ->
-      dir("${integration}") {
-        sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
+      dir("${BASE_DIR}/packages/${integration}") {
+        sh(label: "Build integration as zip: ${integration}", script: '../../build/elastic-package build -v --zip')
       }
     }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -308,12 +308,6 @@ def archiveArtifactsSafe(remotePath, artifacts) {
 }
 
 def packageStoragePublish(jobName, builtPackagesPath) {
-  signUnpublishedArtifactsWithElastic(jobName, builtPackagesPath)
-  uploadUnpublishedToPackageStorage(builtPackagesPath)
-}
-
-def signUnpublishedArtifactsWithElastic(jobName, builtPackagesPath) {
-  def unpublished = false
   dir(builtPackagesPath) {
     findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
       def packageZip = it
@@ -321,47 +315,32 @@ def signUnpublishedArtifactsWithElastic(jobName, builtPackagesPath) {
         return
       }
 
-      unpublished = true
+      // Sign package before publishing
       googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}/${jobName}",
         credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
         pattern: '*.zip',
         sharedPublicly: false,
         showInline: true)
-    }
-  }
+      }
+      withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
+        triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+          job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
+          token: TOKEN,
+          parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}/${jobName}",
+          useCrumbCache: false,
+          useJobInfoCache: false)
+      }
+      googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/${jobName}/*",
+        credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+        localDirectory: builtPackagesPath + '/',
+        pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
+      sh(label: 'Rename .asc to .sig', script: 'for f in ' + builtPackagesPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
 
-  if (!unpublished) {
-    return
-  }
-
-  withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
-    triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
-      job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
-      token: TOKEN,
-      parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}/${jobName}",
-      useCrumbCache: false,
-      useJobInfoCache: false)
-  }
-  googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/${jobName}/*",
-    credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-    localDirectory: builtPackagesPath + '/',
-    pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
-    sh(label: 'Rename .asc to .sig', script: 'for f in ' + builtPackagesPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
-}
-
-def uploadUnpublishedToPackageStorage(builtPackagesPath) {
-  dir(builtPackagesPath) {
-    withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
-      withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
-        findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
-          def packageZip = it
-          if (isAlreadyPublished(packageZip)) {
-            return
-          }
-
+      // Publish package
+      withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
+        withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
           sh(label: 'Upload package .zip file', script: "gsutil cp ${packageZip} ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
           sh(label: 'Upload package .sig file', script: "gsutil cp ${packageZip}.sig ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
-
           triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
             job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
             token: TOKEN,
@@ -370,8 +349,8 @@ def uploadUnpublishedToPackageStorage(builtPackagesPath) {
               gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
               gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
               """,
-              useCrumbCache: true,
-              useJobInfoCache: true)
+            useCrumbCache: true,
+            useJobInfoCache: true)
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -313,7 +313,11 @@ def packageStoragePublish() {
     unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
     useElasticPackage()
     dir("${BASE_DIR}/packages") {
-      sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
+      findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
+        dir("${BASE_DIR}/packages/${it}") {
+          sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
+        }
+      }
     }
     dir("${BASE_DIR}/build/packages") {
       findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -326,9 +326,9 @@ def packageStoragePublish() {
             }
           }
 
-          sh(label: "Build integration as zip: ${it}", script: """
-            PATH=${env.WORKSPACE}/${BASE_DIR}/build:${env.PATH}
-            elastic-package build --zip""")
+          withEnv(["PATH=${env.WORKSPACE}/${BASE_DIR}/build:${env.PATH}"]) {
+            sh(label: "Build integration as zip: ${it}", script: "elastic-package build --zip")
+          }
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -340,24 +340,26 @@ def packageStoragePublish() {
     }
 
     // Sign unpublished packages
-    googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
-      credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-      pattern: '*.zip',
-      sharedPublicly: false,
-      showInline: true)
-    withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
-      triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
-        job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
-        token: TOKEN,
-        parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
-        useCrumbCache: false,
-        useJobInfoCache: false)
+    dir("${BASE_DIR}/build/packages") {
+      googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+        credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+        pattern: '*.zip',
+        sharedPublicly: false,
+        showInline: true)
+      withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
+        triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+          job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
+          token: TOKEN,
+          parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+          useCrumbCache: false,
+          useJobInfoCache: false)
+      }
+      googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
+        credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+        localDirectory: '.',
+        pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
+        sh(label: 'Rename .asc to .sig', script: 'for f in *.asc; do mv "$f" "${f%.asc}.sig"; done')
     }
-    googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
-      credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-      localDirectory: builtPackagesPath + '/',
-      pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
-      sh(label: 'Rename .asc to .sig', script: 'for f in ' + builtPackagesPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
 
     // Publish packages with signatures. Only packages with generated signatures haven't been published yet.
     withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
@@ -389,6 +391,8 @@ def isAlreadyPublished(packageZip) {
   def responseCode = httpRequest(method: "HEAD",
     url: "https://package-storage.elastic.co/artifacts/packages/${packageZip}",
     response_code_only: true)
-  echo "EPR HTTP status code for ${packageZip}: ${responseCode}"
+  if (responseCode != 200) {
+    echo "Package Registry HTTP status code for ${packageZip}: ${responseCode}"
+  }
   return responseCode == 200
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -320,9 +320,18 @@ def packageStoragePublish() {
     unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
     useElasticPackage()
 
+    // FIXME Build only unpublished files (need to read version from manifest.yml)
     dir("${BASE_DIR}/packages") {
       findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
         dir("${it}") {
+          def manifest = readYaml(file: "${it}/manifest.yml")
+          if (manifest != null && manifest["name"] != null && manifest["version"] != null) {
+            def packageZip = manifest["name"] + "-" + manifest["version"] + ".zip"
+            if (isAlreadyPublished(packageZip)) {
+              return
+            }
+          }
+
           sh(label: "Build integration as zip: ${it}", script: """
             PATH=${env.WORKSPACE}/${BASE_DIR}/build:${env.PATH}
             elastic-package build --zip""")
@@ -330,46 +339,42 @@ def packageStoragePublish() {
       }
     }
 
-    // Start publishing procedure
-    dir("${BASE_DIR}/build/packages") {
-      findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
-        def packageZip = it
-        if (isAlreadyPublished(packageZip)) {
-          return
-        }
+    // Sign unpublished packages
+    googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+      credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+      pattern: '*.zip',
+      sharedPublicly: false,
+      showInline: true)
+    withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
+      triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+        job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
+        token: TOKEN,
+        parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+        useCrumbCache: false,
+        useJobInfoCache: false)
+    }
+    googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
+      credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+      localDirectory: builtPackagesPath + '/',
+      pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
+      sh(label: 'Rename .asc to .sig', script: 'for f in ' + builtPackagesPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
 
-        // Sign package before publishing
-        googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
-          credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-          pattern: '*.zip',
-          sharedPublicly: false,
-          showInline: true)
-        withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
-          triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
-            job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
-            token: TOKEN,
-            parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
-            useCrumbCache: false,
-            useJobInfoCache: false)
-        }
-        googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
-          credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-          localDirectory: builtPackagesPath + '/',
-          pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
-        sh(label: 'Rename .asc to .sig', script: 'for f in ' + builtPackagesPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
-
-        // Publish package
-        withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
-          withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
+    // Publish packages with signatures. Only packages with generated signatures haven't been published yet.
+    withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
+      withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
+        dir("${BASE_DIR}/build/packages") {
+          findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
+            def packageZip = it
+            def packageZipSig = packageZip + ".sig"
             sh(label: 'Upload package .zip file', script: "gsutil cp ${packageZip} ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
-            sh(label: 'Upload package .sig file', script: "gsutil cp ${packageZip}.sig ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
+            sh(label: 'Upload package .sig file', script: "gsutil cp ${packageZipSig} ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
             triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
               job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
               token: TOKEN,
               parameters: """
                 dry_run=true
                 gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
-                gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
+                gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZipSig}
                 """,
               useCrumbCache: true,
               useJobInfoCache: true)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,13 +61,6 @@ pipeline {
         stashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
       }
     }
-    stage('T') {
-      steps {
-        script {
-          packageStoragePublish()
-        }
-      }
-    }
     stage('Check Go sources') {
       steps {
         dir("${BASE_DIR}"){
@@ -312,10 +305,11 @@ def archiveArtifactsSafe(remotePath, artifacts) {
 
 def packageStoragePublish() {
   stage('Publish to Package Storage v2') {
-    //if (env.BRANCH_NAME != 'main') {
-    //  echo "packageStoragePublish: not a main branch, nothing will be published"
-    //  return
-    //}
+    if (env.BRANCH_NAME != 'main') {
+      echo "packageStoragePublish: not the main branch, nothing will be published"
+      return
+    }
+
     deleteDir()
     unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
     useElasticPackage()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     CREATED_DATE = "${new Date().getTime()}"
     ENVIRONMENT = "ci"
     REPO = 'integrations'
+    REPO_BUILD_TAG = "${env.REPO}/${env.BUILD_TAG}"
     BASE_DIR = "src/github.com/elastic/${REPO}"
     GITHUB_TOKEN_CREDENTIALS = "2a9602aa-ab9f-4e52-baf3-b71ca88469c7"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -327,8 +327,8 @@ def packageStoragePublish() {
         integrations += it
       }
     }
-    integrations.each { it ->
-      dir("${it}") {
+    integrations.each { integration ->
+      dir("${integration}") {
         sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -304,55 +304,60 @@ def archiveArtifactsSafe(remotePath, artifacts) {
 }
 
 def packageStoragePublish() {
-  //if (env.BRANCH_NAME != 'main') {
-  //  echo "packageStoragePublish: not a main branch, nothing will be published"
-  //  return
-  //}
-  dir("${BASE_DIR}/packages") {
-    sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
-  }
-  dir("${BASE_DIR}/build/packages") {
-    findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
-      def packageZip = it
-      if (isAlreadyPublished(packageZip)) {
-        return
-      }
+  stage('Publish to Package Storage v2') {
+    //if (env.BRANCH_NAME != 'main') {
+    //  echo "packageStoragePublish: not a main branch, nothing will be published"
+    //  return
+    //}
+    deleteDir()
+    unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+    useElasticPackage()
+    dir("${BASE_DIR}/packages") {
+      sh(label: "Build integration as zip: ${it}", script: '../../build/elastic-package build -v --zip')
+    }
+    dir("${BASE_DIR}/build/packages") {
+      findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
+        def packageZip = it
+        if (isAlreadyPublished(packageZip)) {
+          return
+        }
 
-      // Sign package before publishing
-      googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
-        credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-        pattern: '*.zip',
-        sharedPublicly: false,
-        showInline: true)
-      withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
-        triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
-          job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
-          token: TOKEN,
-          parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
-          useCrumbCache: false,
-          useJobInfoCache: false)
-      }
-      googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
-        credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-        localDirectory: builtPackagesPath + '/',
-        pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
-      sh(label: 'Rename .asc to .sig', script: 'for f in ' + builtPackagesPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
-
-      // Publish package
-      withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
-        withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
-          sh(label: 'Upload package .zip file', script: "gsutil cp ${packageZip} ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
-          sh(label: 'Upload package .sig file', script: "gsutil cp ${packageZip}.sig ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
+        // Sign package before publishing
+        googleStorageUpload(bucket: "${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+          credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+          pattern: '*.zip',
+          sharedPublicly: false,
+          showInline: true)
+        withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
           triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
-            job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
+            job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
             token: TOKEN,
-            parameters: """
-              dry_run=true
-              gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
-              gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
-              """,
-            useCrumbCache: true,
-            useJobInfoCache: true)
+            parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+            useCrumbCache: false,
+            useJobInfoCache: false)
+        }
+        googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
+          credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+          localDirectory: builtPackagesPath + '/',
+          pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
+        sh(label: 'Rename .asc to .sig', script: 'for f in ' + builtPackagesPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
+
+        // Publish package
+        withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
+          withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
+            sh(label: 'Upload package .zip file', script: "gsutil cp ${packageZip} ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
+            sh(label: 'Upload package .sig file', script: "gsutil cp ${packageZip}.sig ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
+            triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+              job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
+              token: TOKEN,
+              parameters: """
+                dry_run=true
+                gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
+                gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
+                """,
+              useCrumbCache: true,
+              useJobInfoCache: true)
+          }
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -368,7 +368,7 @@ def packageStoragePublish() {
               job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
               token: TOKEN,
               parameters: """
-                dry_run=true
+                dry_run=false
                 gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
                 gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZipSig}
                 """,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -320,16 +320,13 @@ def packageStoragePublish() {
     unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
     useElasticPackage()
 
-    // Build all integrations
-    def integrations = []
     dir("${BASE_DIR}/packages") {
       findFiles()?.findAll{ !it.name.endsWith('@tmp') }?.collect{ it.name }?.sort()?.each {
-        integrations += it
-      }
-    }
-    integrations.each { integration ->
-      dir("${BASE_DIR}/packages/${integration}") {
-        sh(label: "Build integration as zip: ${integration}", script: '../../build/elastic-package build -v --zip')
+        dir("${it}") {
+          sh(label: "Build integration as zip: ${it}", script: """
+            PATH=${env.WORKSPACE}/${BASE_DIR}/build:${env.PATH}
+            elastic-package build -v --zip""")
+        }
       }
     }
 


### PR DESCRIPTION
Issue: https://github.com/elastic/ingest-dev/issues/1119

This PR modifies the Jenkins CI pipeline to publish packages to Package Storage v2.

Unfortunately, we can't run sign&publish for every package due to the DoS effect/fail2ban, but we need to prepare packages in a batch to pass them to the Elastic signing job.  

As a result of running the CI job, all packages stored in Integrations will be pushed to the v2 storage.

