### PR TITLE
suricata: add SNI to related.hosts for TLS events

### DIFF
--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add Server Name Indication to related.hosts for TLS events.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/3665
 - version: "2.2.0"
   changes:
     - description: Update package to ECS 8.3.0.

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -4,6 +4,9 @@
     - description: Add Server Name Indication to related.hosts for TLS events.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/3665
+    - description: Render host.mac hardware addresses according to ECS.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3665
 - version: "2.2.0"
   changes:
     - description: Update package to ECS 8.3.0.

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Add Server Name Indication to related.hosts for TLS events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.2.0"
   changes:
     - description: Update package to ECS 8.3.0.

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-alerts.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-alerts.log-expected.json
@@ -2499,6 +2499,9 @@
                     "0993626a07ad09e1ce91293be7aa5721",
                     "d92325c876e7279f4eb8c62415e3a6b7"
                 ],
+                "hosts": [
+                    "hostname.domain.net"
+                ],
                 "ip": [
                     "10.126.2.140",
                     "10.232.0.237"
@@ -2613,6 +2616,9 @@
                     "363FEE2A1CFADEADBEEF4299CFA9B09101EBA9CC",
                     "391231ba5675e42807b9e1f457b2614e",
                     "3f1ea03f5822e8021b60cc3e4b233181"
+                ],
+                "hosts": [
+                    "host.domain.net"
                 ],
                 "ip": [
                     "10.137.3.54",

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-small.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-small.log-expected.json
@@ -94,6 +94,9 @@
                 "transport": "tcp"
             },
             "related": {
+                "hosts": [
+                    "l2.io"
+                ],
                 "ip": [
                     "192.168.86.85",
                     "192.168.156.70"
@@ -632,6 +635,9 @@
                 "hash": [
                     "6AFFACA65F8A05E7A98C7629B908C769ADDC7247"
                 ],
+                "hosts": [
+                    "p33-btmmdns.icloud.com"
+                ],
                 "ip": [
                     "192.168.86.85",
                     "89.160.20.112"
@@ -1053,6 +1059,9 @@
             "related": {
                 "hash": [
                     "44d502d471cfdb99c59bdfb0f220e5a8"
+                ],
+                "hosts": [
+                    "www.example.com"
                 ],
                 "ip": [
                     "192.168.50.1"

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
@@ -666,4 +666,4 @@ processors:
 on_failure:
   - set:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
@@ -60,6 +60,19 @@ processors:
       field: destination.mac
       ignore_missing: true
 
+  # Format host.mac addresses.
+  - script:
+      lang: painless
+      if: ctx.host?.mac != null
+      source:
+        def fixup(ArrayList macs) {
+          for (def i = 0; i < macs.length; i++) {
+            macs[i] = macs[i].replace(':','-').toUpperCase();
+          }
+          return macs;
+        }
+        ctx.host['mac'] = fixup(ctx.host?.mac);
+
   - rename:
       field: suricata.eve.src_ip
       target_field: source.address

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns-answer-v1.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns-answer-v1.yml
@@ -36,4 +36,4 @@ processors:
 on_failure:
   - set:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns-answer-v2.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns-answer-v2.yml
@@ -39,4 +39,4 @@ processors:
 on_failure:
   - set:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/dns.yml
@@ -4,15 +4,15 @@ description: Pipeline for Suricata DNS Events
 processors:
   - set:
       field: dns.id
-      value: '{{suricata.eve.dns.id}}'
+      value: '{{{suricata.eve.dns.id}}}'
       ignore_empty_value: true
   - set:
       field: dns.response_code
-      value: '{{suricata.eve.dns.rcode}}'
+      value: '{{{suricata.eve.dns.rcode}}}'
       ignore_empty_value: true
   - set:
       field: dns.type
-      value: '{{suricata.eve.dns.type}}'
+      value: '{{{suricata.eve.dns.type}}}'
       ignore_empty_value: true
   - set:
       # V2 events always include the query data.
@@ -20,7 +20,7 @@ processors:
         ctx?.dns?.type == "query" ||
         ctx?.suricata?.eve?.dns?.version == 2
       field: dns.question.name
-      value: '{{suricata.eve.dns.rrname}}'
+      value: '{{{suricata.eve.dns.rrname}}}'
       ignore_empty_value: true
   - set:
       # V2 events always include the query data.
@@ -28,7 +28,7 @@ processors:
         ctx?.dns?.type == "query" ||
         ctx?.suricata?.eve?.dns?.version == 2
       field: dns.question.type
-      value: '{{suricata.eve.dns.rrtype}}'
+      value: '{{{suricata.eve.dns.rrtype}}}'
       ignore_empty_value: true
   - pipeline:
       if: >-
@@ -47,7 +47,7 @@ processors:
         append:
           field: related.ip
           value:
-            - '{{_ingest._value}}'
+            - '{{{_ingest._value}}}'
           allow_duplicates: false
   - script:
       if: ctx?.dns?.question?.registered_domain != null
@@ -90,4 +90,4 @@ processors:
 on_failure:
   - set:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/tls.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/tls.yml
@@ -23,7 +23,7 @@ processors:
   # Subject
   - set:
       field: tls.server.subject
-      value: '{{suricata.eve.tls.subject}}'
+      value: '{{{suricata.eve.tls.subject}}}'
       ignore_empty_value: true
   - kv:
       field: suricata.eve.tls.subject
@@ -58,7 +58,7 @@ processors:
   # Issuer
   - set:
       field: tls.server.issuer
-      value: '{{suricata.eve.tls.issuerdn}}'
+      value: '{{{suricata.eve.tls.issuerdn}}}'
       ignore_empty_value: true
   - gsub:
       field: suricata.eve.tls.issuerdn
@@ -103,7 +103,7 @@ processors:
       ignore_missing: true
   - set:
       field: tls.server.hash.sha1
-      value: '{{suricata.eve.tls.fingerprint}}'
+      value: '{{{suricata.eve.tls.fingerprint}}}'
       ignore_empty_value: true
   - uppercase:
       field: tls.server.hash.sha1
@@ -122,11 +122,11 @@ processors:
       if: "ctx?.tls?.server?.hash?.sha1 != null"
   - set:
       field: tls.client.server_name
-      value: '{{suricata.eve.tls.sni}}'
+      value: '{{{suricata.eve.tls.sni}}}'
       ignore_empty_value: true
   - set:
       field: destination.domain
-      value: '{{suricata.eve.tls.sni}}'
+      value: '{{{suricata.eve.tls.sni}}}'
       ignore_empty_value: true
   - append:
       field: related.hosts
@@ -135,23 +135,23 @@ processors:
       allow_duplicates: false
   - set:
       field: tls.server.ja3s
-      value: '{{suricata.eve.tls.ja3s.hash}}'
+      value: '{{{suricata.eve.tls.ja3s.hash}}}'
       ignore_empty_value: true
   - set:
       field: tls.client.ja3
-      value: '{{suricata.eve.tls.ja3.hash}}'
+      value: '{{{suricata.eve.tls.ja3.hash}}}'
       ignore_empty_value: true
   - set:
       field: tls.server.certificate
-      value: '{{suricata.eve.tls.certificate}}'
+      value: '{{{suricata.eve.tls.certificate}}}'
       ignore_empty_value: true
   - set:
       field: tls.server.certificate_chain
-      value: '{{suricata.eve.tls.chain}}'
+      value: '{{{suricata.eve.tls.chain}}}'
       ignore_empty_value: true
   - set:
       field: tls.server.x509.serial_number
-      value: '{{suricata.eve.tls.serial}}'
+      value: '{{{suricata.eve.tls.serial}}}'
       ignore_empty_value: true
   - gsub:
       field: tls.server.x509.serial_number
@@ -172,11 +172,11 @@ processors:
       if: ctx.suricata?.eve?.tls?.notbefore != null
   - set:
       field: tls.server.x509.not_after
-      value: '{{tls.server.not_after}}'
+      value: '{{{tls.server.not_after}}}'
       ignore_empty_value: true
   - set:
       field: tls.server.x509.not_before
-      value: '{{tls.server.not_before}}'
+      value: '{{{tls.server.not_before}}}'
       ignore_empty_value: true
   - remove:
       field:
@@ -186,4 +186,4 @@ processors:
 on_failure:
   - set:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/tls.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/tls.yml
@@ -128,6 +128,11 @@ processors:
       field: destination.domain
       value: '{{suricata.eve.tls.sni}}'
       ignore_empty_value: true
+  - append:
+      field: related.hosts
+      value: '{{{suricata.eve.tls.sni}}}'
+      if: ctx.suricata?.eve?.tls?.sni != null && ctx.suricata.eve.tls.sni != ""
+      allow_duplicates: false
   - set:
       field: tls.server.ja3s
       value: '{{suricata.eve.tls.ja3s.hash}}'

--- a/packages/suricata/data_stream/eve/sample_event.json
+++ b/packages/suricata/data_stream/eve/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2018-07-05T19:01:09.820Z",
     "agent": {
-        "ephemeral_id": "5087d9af-5bd8-452b-90e2-96bb9c5e4770",
-        "id": "b1d83907-ff3e-464a-b79a-cf843f6f0bba",
+        "ephemeral_id": "1766b03e-b9fd-4e5b-9c37-bb972c55d7c5",
+        "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.2.3"
     },
     "data_stream": {
         "dataset": "suricata.eve",
@@ -14,24 +14,25 @@
     },
     "destination": {
         "address": "192.168.253.112",
+        "ip": "192.168.253.112",
         "port": 22
     },
     "ecs": {
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "b1d83907-ff3e-464a-b79a-cf843f6f0bba",
+        "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "network"
         ],
-        "created": "2022-01-03T01:09:30.084Z",
+        "created": "2022-07-08T01:02:15.499Z",
         "dataset": "suricata.eve",
-        "ingested": "2022-01-03T01:09:31Z",
+        "ingested": "2022-07-08T01:02:16Z",
         "kind": "event",
         "type": [
             "protocol"
@@ -47,12 +48,14 @@
         "offset": 0
     },
     "network": {
+        "community_id": "1:NLm1MbaBR6humQxEQI2Ai7h/XiI=",
         "protocol": "ssh",
         "transport": "tcp"
     },
     "related": {
         "ip": [
-            "192.168.86.85"
+            "192.168.86.85",
+            "192.168.253.112"
         ]
     },
     "source": {

--- a/packages/suricata/docs/README.md
+++ b/packages/suricata/docs/README.md
@@ -17,11 +17,11 @@ An example event for `eve` looks as following:
 {
     "@timestamp": "2018-07-05T19:01:09.820Z",
     "agent": {
-        "ephemeral_id": "5087d9af-5bd8-452b-90e2-96bb9c5e4770",
-        "id": "b1d83907-ff3e-464a-b79a-cf843f6f0bba",
+        "ephemeral_id": "01b06085-bdec-4eda-9816-aee2080bfe18",
+        "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.2.3"
     },
     "data_stream": {
         "dataset": "suricata.eve",
@@ -30,24 +30,25 @@ An example event for `eve` looks as following:
     },
     "destination": {
         "address": "192.168.253.112",
+        "ip": "192.168.253.112",
         "port": 22
     },
     "ecs": {
         "version": "8.3.0"
     },
     "elastic_agent": {
-        "id": "b1d83907-ff3e-464a-b79a-cf843f6f0bba",
+        "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.2.3"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "network"
         ],
-        "created": "2022-01-03T01:09:30.084Z",
+        "created": "2022-07-08T00:57:26.903Z",
         "dataset": "suricata.eve",
-        "ingested": "2022-01-03T01:09:31Z",
+        "ingested": "2022-07-08T00:57:27Z",
         "kind": "event",
         "type": [
             "protocol"
@@ -63,12 +64,14 @@ An example event for `eve` looks as following:
         "offset": 0
     },
     "network": {
+        "community_id": "1:NLm1MbaBR6humQxEQI2Ai7h/XiI=",
         "protocol": "ssh",
         "transport": "tcp"
     },
     "related": {
         "ip": [
-            "192.168.86.85"
+            "192.168.86.85",
+            "192.168.253.112"
         ]
     },
     "source": {

--- a/packages/suricata/docs/README.md
+++ b/packages/suricata/docs/README.md
@@ -17,7 +17,7 @@ An example event for `eve` looks as following:
 {
     "@timestamp": "2018-07-05T19:01:09.820Z",
     "agent": {
-        "ephemeral_id": "01b06085-bdec-4eda-9816-aee2080bfe18",
+        "ephemeral_id": "1766b03e-b9fd-4e5b-9c37-bb972c55d7c5",
         "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -46,9 +46,9 @@ An example event for `eve` looks as following:
         "category": [
             "network"
         ],
-        "created": "2022-07-08T00:57:26.903Z",
+        "created": "2022-07-08T01:02:15.499Z",
         "dataset": "suricata.eve",
-        "ingested": "2022-07-08T00:57:27Z",
+        "ingested": "2022-07-08T01:02:16Z",
         "kind": "event",
         "type": [
             "protocol"

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata Events
-version: "2.2.0"
+version: "2.3.0"
 release: ga
 description: Collect and parse event logs from Suricata instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This adds the SNI host to `related.hosts` when the event is a TLS event and cleans up some template invocations.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Related to the original issue, I confirmed that when `forwarded` is not set as a tag, the host information is present in events. It is not possible with current testing infrastructure to test this AFAICS. ~~Note that the MAC address [populated by libbeat](https://www.elastic.co/guide/en/beats/filebeat/current/add-host-metadata.html#add-host-metadata) does not conform to the ECS docs.~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3521 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
