### PR TITLE
Adding Prometheus under Kubernetes category menu

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adding Prometheus under Kubernetes category menu
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/3662
+      link: https://github.com/elastic/integrations/pull/3670
 - version: "0.10.0"
   changes:
     - description: Hide some configuration for remote_write data_stream; Add leader election for collector and query data_streams

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.1"
+  changes:
+    - description: Adding Prometheus under Kubernetes category menu
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3662
 - version: "0.10.0"
   changes:
     - description: Hide some configuration for remote_write data_stream; Add leader election for collector and query data_streams

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,13 +1,14 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus Metrics
-version: 0.10.0
+version: 0.10.1
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
 categories:
   - monitoring
   - datastore
+  - kubernetes
 release: experimental
 conditions:
   kibana.version: "^7.14.0 || ^8.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Adding Prometheus under Kubernetes category menu

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


