### PR TITLE
add container ID as part of Kubernetes Cotainer Logs filestream input

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.2"
+  changes:
+    - description: add container ID and pod name as part of Kubernetes Cotainer Logs filestream input
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3672
 - version: "1.21.1"
   changes:
     - description: improved the wording of the link to Kubernetes documentation

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -1,3 +1,4 @@
+id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
 paths:
 {{#each paths}}
   - {{this}}

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.21.1
+version: 1.21.2
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This is part of the fix for data duplication that happens when there
are multiple filestream inputs configured with the same ID.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

~~## Author's Checklist~~


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Relates https://github.com/elastic/beats/issues/31512

~~## Screenshots~~
