### PR TITLE
[AWS] check if event.original exists before copying message field

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,6 +3,7 @@
   changes:
     - description: Improve support for event.original field from upstream forwarders.
       type: bugfix
+      link: https://github.com/elastic/integrations/pull/3682
 - version: "1.17.1"
   changes:
     - description: Fix misspelling of Log Stream Prefix variable in manifest for aws-cloudwatch input

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,8 @@
 # newer versions go on top
+- version: "1.17.2"
+  changes:
+    - description: Improve support for event.original field from upstream forwarders.
+      type: bugfix
 - version: "1.17.1"
   changes:
     - description: Fix misspelling of Log Stream Prefix variable in manifest for aws-cloudwatch input

--- a/packages/aws/data_stream/cloudfront_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudfront_logs/elasticsearch/ingest_pipeline/default.yml
@@ -21,6 +21,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
       field: event.original
       patterns:

--- a/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,13 @@ processors:
   - rename:
       field: message
       target_field: event.original
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
       if: ctx['@timestamp'] != null
       field: event.created

--- a/packages/aws/data_stream/ec2_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/ec2_logs/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
       field: event.original
       patterns:

--- a/packages/aws/data_stream/elb_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/elb_logs/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
       field: event.original
       # Classic ELB patterns documented in https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html

--- a/packages/aws/data_stream/firewall_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/firewall_logs/elasticsearch/ingest_pipeline/default.yml
@@ -8,6 +8,13 @@ processors:
   - rename:
       field: message
       target_field: event.original
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/aws/data_stream/route53_public_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/route53_public_logs/elasticsearch/ingest_pipeline/default.yml
@@ -21,6 +21,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
       field: event.original
       patterns:

--- a/packages/aws/data_stream/route53_resolver_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,13 @@ processors:
     field: message
     target_field: event.original
     ignore_missing: true
+    if: 'ctx.event?.original == null'
+    description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+- remove:
+    field: message
+    ignore_missing: true
+    if: 'ctx.event?.original != null'
+    description: 'The `message` field is no longer required if the document has an `event.original` field.'
 - json:
     field: event.original
     target_field: json

--- a/packages/aws/data_stream/s3access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/s3access/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
       field: event.original
       patterns:

--- a/packages/aws/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
       field: event.type
       value: connection

--- a/packages/aws/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
@@ -14,6 +14,13 @@ processors:
     field: message
     target_field: event.original
     ignore_missing: true
+    if: 'ctx.event?.original == null'
+    description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+- remove:
+    field: message
+    ignore_missing: true
+    if: 'ctx.event?.original != null'
+    description: 'The `message` field is no longer required if the document has an `event.original` field.'
 - json:
     field: event.original
     target_field: json

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.17.1
+version: 1.17.2
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Upstream event forwarders like Logstash can add their `event.original` field so we should add a check to see if `event.original` exists before copying `message` field to `event.original`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

