### PR TITLE
add threat_intel category to integrations

### DIFF
--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,12 +1,11 @@
 format_version: 1.0.0
 name: mimecast
 title: "Mimecast"
-version: "1.1.0"
+version: "1.1.1"
 license: basic
 description: "Collect logs from the Mimecast API with Elastic Agent."
 type: integration
-categories:
-  - security
+categories: ["security", "threat_intel"]
 release: ga
 conditions:
   kibana.version: "^8.3.0"

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,12 +1,12 @@
 name: ti_abusech
 title: AbuseCH
-version: "1.4.0"
+version: "1.4.1"
 release: ga
 description: Ingest threat intelligence indicators from URL Haus and Malware Bazaar feeds with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic
-categories: [security]
+categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.0.0
 icons:

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,12 +1,12 @@
 name: ti_anomali
 title: Anomali
-version: "1.4.0"
+version: "1.4.1"
 release: ga
 description: Ingest threat intelligence indicators from Anomali with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic
-categories: [security]
+categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.0.0
 icons:

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,12 +1,12 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.5.0"
+version: "1.5.1"
 release: ga
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic
-categories: ["security", "productivity"]
+categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.0.0
 policy_templates:

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,12 +1,12 @@
 name: ti_misp
 title: MISP
-version: "1.5.0"
+version: "1.5.1"
 release: ga
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic
-categories: [security]
+categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.0.0
 icons:

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,12 +1,12 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.4.0"
+version: "1.4.1"
 release: ga
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic
-categories: [security]
+categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.0.0
 icons:

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,12 +1,12 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "1.1.0"
+version: "1.1.1"
 release: ga
 description: Ingest threat intelligence indicators from Recorded Future risk lists with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic
-categories: [security]
+categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.0.0
 icons:

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,12 +1,12 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.4.0"
+version: "1.4.1"
 release: ga
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic
-categories: [security]
+categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.0.0
 icons:


### PR DESCRIPTION
## What does this PR do?

As a follow-on to https://github.com/elastic/package-spec/pull/366, this PR adds new `threat_intel` category to the relevant integrations:
 - Mimecast
 - AbuseCH
 - Anomali
 - Cybersixgill
 - MISP
 - AlienVault OTX
 - Recorded Future

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Relates to https://github.com/elastic/kibana/pull/135758, https://github.com/elastic/kibana/pull/136208
