### PR TITLE
Mandate SVG logo in docs

### DIFF
--- a/docs/generic_guidelines.md
+++ b/docs/generic_guidelines.md
@@ -92,7 +92,7 @@ Integration packages should provide out-of-the-box dashboards.
 
 #### Content for elastic.co/integrations
 
-Each integration will be listed on the public website elastic.co/integrations and the package registry will serve as the source of truth. As a result, our docs and screenshots should be high quality to showcase the integration. Please ensure to use `svg` for logs and `png` for all other images. Any additional branding material should be reviewed, e.g.:
+Each integration will be listed on the public website elastic.co/integrations and the package registry will serve as the source of truth. As a result, our docs and screenshots should be high quality to showcase the integration. Please ensure to use `svg` for the logo and `png` for all other images. Any additional branding material should be reviewed, e.g.:
 
 - logo format and quality
 - permission to use logos and trademarks

--- a/docs/generic_guidelines.md
+++ b/docs/generic_guidelines.md
@@ -92,7 +92,7 @@ Integration packages should provide out-of-the-box dashboards.
 
 #### Content for elastic.co/integrations
 
-Each integration will be listed on the public website elastic.co/integrations and the package registry will serve as the source of truth. As a result, our docs and screenshots should be high quality to showcase the integration. Any additional branding material should be reviewed, e.g.:
+Each integration will be listed on the public website elastic.co/integrations and the package registry will serve as the source of truth. As a result, our docs and screenshots should be high quality to showcase the integration. Please ensure to use `svg` for logs and `png` for all other images. Any additional branding material should be reviewed, e.g.:
 
 - logo format and quality
 - permission to use logos and trademarks


### PR DESCRIPTION
Add guidance on image format to mandate `svg` for logos since `png` may crash Kibana. `png` is fine for other images, this only applies to the integration logo.

## What does this PR do?

Updated the generic guidelines to mandate use of `svg` images for Integration logo after observing that `png` crashes the Integrations browser

## Checklist

*this is a change to docs, not a new integration*

- [x] ~I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.~
- [x] ~I have verified that all data streams collect metrics or logs.~
- [x] ~I have added an entry to my package's `changelog.yml` file.~
- [x] ~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Author's Checklist

## How to test this PR locally

## Related issues

## Screenshots

