### PR TITLE
[system.auth] Split grok parsing, add tags/processors/preserve_original_event

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Separate grok parsing into stages and anchor the patterns in the system.auth pipeline.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4000
+      link: https://github.com/elastic/integrations/pull/3705
     - description: Add processors, tags, and preserve original event options to the system.auth data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4000
+      link: https://github.com/elastic/integrations/pull/3705
 - version: "1.17.0"
   changes:
     - description: Add processor and tag fields

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,9 +1,17 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Separate grok parsing into stages and anchor the patterns in the system.auth pipeline.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4000
+    - description: Add processors, tags, and preserve original event options to the system.auth data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4000
 - version: "1.17.0"
   changes:
     - description: Add processor and tag fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/3562
+      link: https://github.com/elastic/integrations/pull/3563
 - version: "1.16.2"
   changes:
     - description: Update documentation with additional context for new users.

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
@@ -193,7 +193,7 @@
             "host": {
                 "hostname": "precise32"
             },
-            "message": " vagrant : (command continued) '/etc/metricbeat/metricbeat.yml)",
+            "message": "vagrant : (command continued) '/etc/metricbeat/metricbeat.yml)",
             "process": {
                 "name": "sudo"
             },

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-multiline.log
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-multiline.log
@@ -1,0 +1,3 @@
+May 21 21:54:44 localhost foo[1234]: This message
+ spans multiple lines.
+May 21 21:54:45 localhost foo[1234]: Single-line message.

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-multiline.log-config.yml
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-multiline.log-config.yml
@@ -1,0 +1,5 @@
+fields:
+  event.timezone: "+0000"
+multiline:
+  # Pattern to match what is configured in log.yml.hbs.
+  first_line_pattern: '^[^\s]'

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-multiline.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-multiline.log-expected.json
@@ -1,0 +1,56 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-05-21T21:54:44.000Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "kind": "event",
+                "timezone": "+0000"
+            },
+            "host": {
+                "hostname": "localhost"
+            },
+            "message": "This message\n spans multiple lines.",
+            "process": {
+                "name": "foo",
+                "pid": 1234
+            },
+            "related": {
+                "hosts": [
+                    "localhost"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        },
+        {
+            "@timestamp": "2022-05-21T21:54:45.000Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "kind": "event",
+                "timezone": "+0000"
+            },
+            "host": {
+                "hostname": "localhost"
+            },
+            "message": "Single-line message.",
+            "process": {
+                "name": "foo",
+                "pid": 1234
+            },
+            "related": {
+                "hosts": [
+                    "localhost"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/auth/agent/stream/log.yml.hbs
+++ b/packages/system/data_stream/auth/agent/stream/log.yml.hbs
@@ -1,10 +1,27 @@
 paths:
 {{#each paths as |path i|}}
- - {{path}}
+  - {{path}}
 {{/each}}
 exclude_files: [".gz$"]
+
 multiline:
   pattern: "^\\s"
   match: after
+
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
+{{#each tags as |tag i|}}
+  - {{tag}}
+{{/each}}
+
+{{#contains "forwarded" tags}}
+publisher_pipeline.disable_host: true
+{{/contains}}
+
 processors:
-  - add_locale: ~
+- add_locale: ~
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -145,7 +145,7 @@ processors:
       if: ctx.system?.auth?.ssh?.event != null
       lang: painless
       source: >-
-        if (ctx.system.auth?.ssh.event == "Accepted") {
+        if (ctx.system.auth.ssh.event == "Accepted") {
           ctx.event.type = ["info"];
           ctx.event.category = ["authentication", "session"];
           ctx.event.action = "ssh_login";

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -10,23 +10,23 @@ processors:
           )*
         TIMESTAMP: (?:%{TIMESTAMP_ISO8601}|%{SYSLOGTIMESTAMP})
       patterns:
-        - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
           %{DATA:system.auth.ssh.event} %{DATA:system.auth.ssh.method} for (invalid user
           )?%{DATA:user.name} from %{IPORHOST:source.ip} port %{NUMBER:source.port:long}
           ssh2(: %{GREEDYDATA:system.auth.ssh.signature})?'
-        - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
           %{DATA:system.auth.ssh.event} user %{DATA:user.name} from %{IPORHOST:source.ip}'
-        - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
           Did not receive identification string from %{IPORHOST:system.auth.ssh.dropped_ip}'
-        - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
           \s*%{DATA:user.name} :( %{DATA:system.auth.sudo.error} ;)? TTY=%{DATA:system.auth.sudo.tty}
           ; PWD=%{DATA:system.auth.sudo.pwd} ; USER=%{DATA:system.auth.sudo.user} ; COMMAND=%{GREEDYDATA:system.auth.sudo.command}'
-        - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
           new group: name=%{DATA:group.name}, GID=%{NUMBER:group.id}'
-        - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
           new user: name=%{DATA:user.name}, UID=%{NUMBER:user.id}, GID=%{NUMBER:group.id},
           home=%{DATA:system.auth.useradd.home}, shell=%{DATA:system.auth.useradd.shell}$'
-        - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname}? %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname}? %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
           %{GREEDYMULTILINE:system.auth.message}'
   - remove:
       field: message

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -1,41 +1,47 @@
 ---
-description: Pipeline for parsing system authorisation/secure logs
+description: Pipeline for parsing system authorization and secure logs.
 processors:
-  - grok:
+  - set:
+      if: ctx.message != null
+      copy_from: message
+      field: event.original
+      override: false
+  - remove:
       field: message
       ignore_missing: true
+  - grok:
+      description: Grok the message header.
+      tag: grok-message-header
+      field: event.original
       pattern_definitions:
         GREEDYMULTILINE: |-
           (.|
           )*
         TIMESTAMP: (?:%{TIMESTAMP_ISO8601}|%{SYSLOGTIMESTAMP})
       patterns:
-        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-          %{DATA:system.auth.ssh.event} %{DATA:system.auth.ssh.method} for (invalid user
-          )?%{DATA:user.name} from %{IPORHOST:source.ip} port %{NUMBER:source.port:long}
-          ssh2(: %{GREEDYDATA:system.auth.ssh.signature})?'
-        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-          %{DATA:system.auth.ssh.event} user %{DATA:user.name} from %{IPORHOST:source.ip}'
-        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-          Did not receive identification string from %{IPORHOST:system.auth.ssh.dropped_ip}'
-        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-          \s*%{DATA:user.name} :( %{DATA:system.auth.sudo.error} ;)? TTY=%{DATA:system.auth.sudo.tty}
-          ; PWD=%{DATA:system.auth.sudo.pwd} ; USER=%{DATA:system.auth.sudo.user} ; COMMAND=%{GREEDYDATA:system.auth.sudo.command}'
-        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-          new group: name=%{DATA:group.name}, GID=%{NUMBER:group.id}'
-        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-          new user: name=%{DATA:user.name}, UID=%{NUMBER:user.id}, GID=%{NUMBER:group.id},
-          home=%{DATA:system.auth.useradd.home}, shell=%{DATA:system.auth.useradd.shell}$'
-        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname}? %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-          %{GREEDYMULTILINE:system.auth.message}'
-  - remove:
-      field: message
-  - rename:
-      field: system.auth.message
-      target_field: message
-      ignore_missing: true
-      if: ctx?.system?.auth?.message != null && ctx?.system?.auth?.message != ""
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname}? %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:%{SPACE}+%{GREEDYMULTILINE:_temp.message}$'
   - grok:
+      description: Grok specific auth messages.
+      tag: grok-specific-messages
+      field: _temp.message
+      ignore_missing: true
+      patterns:
+        - '^%{DATA:system.auth.ssh.event} %{DATA:system.auth.ssh.method} for (invalid user)?%{DATA:user.name} from %{IPORHOST:source.ip} port %{NUMBER:source.port:long} ssh2(: %{GREEDYDATA:system.auth.ssh.signature})?'
+        - '^%{DATA:system.auth.ssh.event} user %{DATA:user.name} from %{IPORHOST:source.ip}'
+        - '^Did not receive identification string from %{IPORHOST:system.auth.ssh.dropped_ip}'
+        - '^%{DATA:user.name} :( %{DATA:system.auth.sudo.error} ;)? TTY=%{DATA:system.auth.sudo.tty} ; PWD=%{DATA:system.auth.sudo.pwd} ; USER=%{DATA:system.auth.sudo.user} ; COMMAND=%{GREEDYDATA:system.auth.sudo.command}'
+        - '^new group: name=%{DATA:group.name}, GID=%{NUMBER:group.id}'
+        - '^new user: name=%{DATA:user.name}, UID=%{NUMBER:user.id}, GID=%{NUMBER:group.id}, home=%{DATA:system.auth.useradd.home}, shell=%{DATA:system.auth.useradd.shell}$'
+      on_failure:
+        - rename:
+            description: Leave the unmatched content in message.
+            field: _temp.message
+            target_field: message
+  - remove:
+      field: _temp
+  - grok:
+      description: Grok usernames from PAM messages.
+      tag: grok-pam-users
       field: message
       ignore_missing: true
       ignore_failure: true
@@ -43,7 +49,7 @@ processors:
         - 'for user \"?%{DATA:_temp.foruser}\"? by \"?%{DATA:_temp.byuser}\"?(?:\(uid=%{NUMBER:_temp.byuid}\))?$'
         - 'for user \"?%{DATA:_temp.foruser}\"?$'
         - 'by user \"?%{DATA:_temp.byuser}\"?$'
-      if: ctx?.message != null && ctx?.message != ""
+      if: ctx.message != null && ctx.message != ""
   - rename:
       field: _temp.byuser
       target_field: user.name
@@ -59,13 +65,13 @@ processors:
       target_field: user.name
       ignore_missing: true
       ignore_failure: true
-      if: ctx?.user?.name == null || ctx?.user?.name == ""
+      if: ctx.user?.name == null || ctx.user?.name == ""
   - rename:
       field: _temp.foruser
       target_field: user.effective.name
       ignore_missing: true
       ignore_failure: true
-      if: ctx?.user?.name != null
+      if: ctx.user?.name != null
   - remove:
       field: _temp
       ignore_missing: true
@@ -74,13 +80,17 @@ processors:
       target_field: user.effective.name
       type: string
       ignore_failure: true
-      if: ctx?.system?.auth?.sudo?.user != null
-  - set:
-      field: source.ip
-      value: '{{system.auth.ssh.dropped_ip}}'
-      ignore_empty_value: true
+      if: ctx.system?.auth?.sudo?.user != null
+  - convert:
+      field: system.auth.ssh.dropped_ip
+      target_field: source.ip
+      type: ip
+      ignore_missing: true
+      on_failure:
+        - remove:
+            field: system.auth.ssh.dropped_ip
   - date:
-      if: ctx.event.timezone == null
+      if: ctx.event?.timezone == null
       field: system.auth.timestamp
       target_field: '@timestamp'
       formats:
@@ -90,20 +100,20 @@ processors:
       on_failure:
         - append:
             field: error.message
-            value: '{{ _ingest.on_failure_message }}'
+            value: '{{{ _ingest.on_failure_message }}}'
   - date:
-      if: ctx.event.timezone != null
+      if: ctx.event?.timezone != null
       field: system.auth.timestamp
       target_field: '@timestamp'
       formats:
         - MMM  d HH:mm:ss
         - MMM dd HH:mm:ss
         - ISO8601
-      timezone: '{{ event.timezone }}'
+      timezone: '{{{ event.timezone }}}'
       on_failure:
         - append:
             field: error.message
-            value: '{{ _ingest.on_failure_message }}'
+            value: '{{{ _ingest.on_failure_message }}}'
   - remove:
       field: system.auth.timestamp
   - geoip:
@@ -135,7 +145,7 @@ processors:
       source: >-
         if (ctx.system.auth.ssh.event == "Accepted") {
           ctx.event.type = ["info"];
-          ctx.event.category = ["authentication","session"];
+          ctx.event.category = ["authentication", "session"];
           ctx.event.action = "ssh_login";
           ctx.event.outcome = "success";
         } else if (ctx.system.auth.ssh.event == "Invalid" || ctx.system.auth.ssh.event == "Failed") {
@@ -148,55 +158,60 @@ processors:
   - append:
       field: event.category
       value: iam
-      if: "ctx?.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)"
+      if: ctx.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)
   - set:
       field: event.outcome
       value: success
-      if: "ctx?.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)"
+      if: ctx.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)
   - append:
       field: event.type
       value: user
-      if: "ctx?.process?.name != null && ['useradd', 'userdel', 'usermod'].contains(ctx.process.name)"
+      if: ctx.process?.name != null && ['useradd', 'userdel', 'usermod'].contains(ctx.process.name)
   - append:
       field: event.type
       value: group
-      if: "ctx?.process?.name != null && ['groupadd', 'groupdel', 'groupmod'].contains(ctx.process.name)"
+      if: ctx.process?.name != null && ['groupadd', 'groupdel', 'groupmod'].contains(ctx.process.name)
   - append:
       field: event.type
       value: creation
-      if: "ctx?.process?.name != null && ['useradd', 'groupadd'].contains(ctx.process.name)"
+      if: ctx.process?.name != null && ['useradd', 'groupadd'].contains(ctx.process.name)
   - append:
       field: event.type
       value: deletion
-      if: "ctx?.process?.name != null && ['userdel', 'groupdel'].contains(ctx.process.name)"
+      if: ctx.process?.name != null && ['userdel', 'groupdel'].contains(ctx.process.name)
   - append:
       field: event.type
       value: change
-      if: "ctx?.process?.name != null && ['usermod', 'groupmod'].contains(ctx.process.name)"
+      if: ctx.process?.name != null && ['usermod', 'groupmod'].contains(ctx.process.name)
   - append:
       field: related.user
-      value: "{{user.name}}"
+      value: "{{{ user.name }}}"
       allow_duplicates: false
-      if: "ctx?.user?.name != null && ctx.user?.name != ''"
+      if: ctx.user?.name != null && ctx.user?.name != ''
   - append:
       field: related.user
-      value: "{{user.effective.name}}"
+      value: "{{{ user.effective.name }}}"
       allow_duplicates: false
-      if: "ctx?.user?.effective?.name != null && ctx.user?.effective?.name != ''"
+      if: ctx.user?.effective?.name != null && ctx.user?.effective?.name != ''
   - append:
       field: related.ip
-      value: "{{source.ip}}"
+      value: "{{{ source.ip }}}"
       allow_duplicates: false
-      if: "ctx?.source?.ip != null && ctx.source?.ip != ''"
+      if: ctx.source?.ip != null && ctx.source?.ip != ''
   - append:
       field: related.hosts
-      value: "{{host.hostname}}"
+      value: "{{{ host.hostname }}}"
       allow_duplicates: false
-      if: "ctx.host?.hostname != null && ctx.host?.hostname != ''"
+      if: ctx.host?.hostname != null && ctx.host?.hostname != ''
   - set:
       field: ecs.version
       value: 8.0.0
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
   - set:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -14,9 +14,7 @@ processors:
       tag: grok-message-header
       field: event.original
       pattern_definitions:
-        GREEDYMULTILINE: |-
-          (.|
-          )*
+        GREEDYMULTILINE: '(.|\n)*'
         TIMESTAMP: (?:%{TIMESTAMP_ISO8601}|%{SYSLOGTIMESTAMP})
       patterns:
         - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname}? %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:%{SPACE}+%{GREEDYMULTILINE:_temp.message}$'

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -119,7 +119,7 @@ processors:
   - geoip:
       field: source.ip
       target_field: source.geo
-      ignore_failure: true
+      ignore_missing: true
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
@@ -140,10 +140,12 @@ processors:
       field: event.kind
       value: event
   - script:
+      description: Add event.category/action/output to SSH events.
+      tag: script-categorize-ssh-event
+      if: ctx.system?.auth?.ssh?.event != null
       lang: painless
-      ignore_failure: true
       source: >-
-        if (ctx.system.auth.ssh.event == "Accepted") {
+        if (ctx.system.auth?.ssh.event == "Accepted") {
           ctx.event.type = ["info"];
           ctx.event.category = ["authentication", "session"];
           ctx.event.action = "ssh_login";
@@ -154,7 +156,6 @@ processors:
           ctx.event.action = "ssh_login";
           ctx.event.outcome = "failure";
         }
-
   - append:
       field: event.category
       value: iam

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -1,13 +1,10 @@
 ---
 description: Pipeline for parsing system authorization and secure logs.
 processors:
-  - set:
-      if: ctx.message != null
-      copy_from: message
-      field: event.original
-      override: false
-  - remove:
+  - rename:
+      if: ctx.event?.original == null
       field: message
+      target_field: event.original
       ignore_missing: true
   - grok:
       description: Grok the message header.

--- a/packages/system/data_stream/auth/manifest.yml
+++ b/packages/system/data_stream/auth/manifest.yml
@@ -13,6 +13,30 @@ streams:
         default:
           - /var/log/auth.log*
           - /var/log/secure*
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`.
+        type: bool
+        multi: false
+        default: false
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        required: true
+        show_user: false
+        default:
+          - hashicorp-vault-log
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata.  This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     template_path: log.yml.hbs
     title: System auth logs (log)
     description: Collect System auth logs using log input

--- a/packages/system/data_stream/auth/manifest.yml
+++ b/packages/system/data_stream/auth/manifest.yml
@@ -37,6 +37,7 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata.  This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     template_path: log.yml.hbs
     title: System auth logs (log)
     description: Collect System auth logs using log input

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.17.0
+version: 1.18.0
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This adds config options for tags, processors, and preserve original event to the system.auth data stream.

It improves the pipeline by splitting the main grok processor into two operations. First it groks the header common to all messages. Then the second grok extracts information from a specific set of messages. Previously all of the patterns in the single grok shared the same header so the the header was being parsed multiple times while trying to find a matching pattern. Additionally the patterns where not anchored so those were added.

I added a convert processor to check the `source.ip` for validity.

I added an `if` condition to the script processor to prevent `cannot access method/field [event] from a null def reference` errors that were being ignored with `ignore_failure: true`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Relates https://github.com/elastic/integrations/issues/2865


## Screenshots

<img width="644" alt="Screen Shot 2022-07-14 at 12 29 48" src="https://user-images.githubusercontent.com/4565752/179031741-3723163a-a9b0-499a-a0c2-ccb2a6b1b83d.png">

Before:

![logs-system auth-1 17 0-metrics](https://user-images.githubusercontent.com/4565752/179034964-5a88e682-0d56-4381-83ae-7e15128e3fd0.png)


After:

![logs-system auth-1 18 0-metrics](https://user-images.githubusercontent.com/4565752/179031589-2689f2a4-4f45-405b-b364-8922453505df.png)

