### PR TITLE
windows: enrich user details from MemberSid where possible

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Use MemberSid to enrich for user name and domain where possible.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3707
 - version: "1.13.0"
   changes:
     - description: Added Processors for service datatstream.

--- a/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
@@ -21,7 +21,13 @@ include_xml: true
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if processors.length}}
 processors:
+  - translate_sid:
+      field: winlog.event_data.MemberSid
+      account_name_target: _user.name
+      domain_target: _user.domain
+      ignore_missing: true
+      ignore_failure: true
+{{#if processors.length}}
 {{processors}}
 {{/if}}

--- a/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/winlog.yml.hbs
@@ -24,8 +24,9 @@ publisher_pipeline.disable_host: true
 processors:
   - translate_sid:
       field: winlog.event_data.MemberSid
-      account_name_target: _user.name
-      domain_target: _user.domain
+      account_name_target: winlog.event_data._MemberUserName
+      domain_target: winlog.event_data._MemberDomain
+      account_type_target: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
 {{#if processors.length}}

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
@@ -13,6 +13,23 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "sysmon_operational" }}'
       if: ctx?.winlog?.channel != null && ctx?.winlog?.channel == "Microsoft-Windows-Sysmon/Operational"
+
+  # Get user details from the translate_sid processor enrichment
+  # if they are available and we don't already have them.
+  - rename:
+      field: _user.name
+      target_field: user.name
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: _user.domain
+      target_field: user.domain
+      ignore_failure: true
+      ignore_missing: true
+  - remove:
+      field: _user
+      ignore_missing: true
+
 on_failure:
   - set:
       field: "error.message"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
@@ -17,18 +17,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
-      field: _user.name
+      field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
-      field: _user.domain
+      field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
+  - append:
+      value: '{{{winlog.event_data._MemberAccountType}}}'
+      field: user.roles
+      ignore_failure: true
+      allow_duplicates: false
+      if: ctx.winlog?.event_data?._MemberAccountType != null
   - remove:
-      field: _user
+      field: winlog.event_data._MemberAccountType
       ignore_missing: true
+      ignore_failure: true
+      if: ctx.user?.roles != null && ctx.winlog?.event_data?._MemberAccountType != null && ctx.user.roles.contains(ctx.winlog.event_data._MemberAccountType)   
 
 on_failure:
   - set:

--- a/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
@@ -21,8 +21,9 @@ include_xml: true
 processors:
   - translate_sid:
       field: winlog.event_data.MemberSid
-      account_name_target: _user.name
-      domain_target: _user.domain
+      account_name_target: winlog.event_data._MemberUserName
+      domain_target: winlog.event_data._MemberDomain
+      account_type_target: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
 {{#if processors.length}}

--- a/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/winlog.yml.hbs
@@ -18,7 +18,13 @@ tags:
 {{#if preserve_original_event}}
 include_xml: true
 {{/if}}
-{{#if processors.length}}
 processors:
+  - translate_sid:
+      field: winlog.event_data.MemberSid
+      account_name_target: _user.name
+      domain_target: _user.domain
+      ignore_missing: true
+      ignore_failure: true
+{{#if processors.length}}
 {{processors}}
 {{/if}}

--- a/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
@@ -120,15 +120,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
-      field: _user.name
+      field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
-      field: _user.domain
+      field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
+  - append:
+      value: '{{{winlog.event_data._MemberAccountType}}}'
+      field: user.roles
+      ignore_failure: true
+      allow_duplicates: false
+      if: ctx.winlog?.event_data?._MemberAccountType != null
+  - remove:
+      field: winlog.event_data._MemberAccountType
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.user?.roles != null && ctx.winlog?.event_data?._MemberAccountType != null && ctx.user.roles.contains(ctx.winlog.event_data._MemberAccountType)   
 
   ## PowerShell fields.
 
@@ -414,7 +425,6 @@ processors:
   - remove:
       field:
         - _temp
-        - _user
         - winlog.event_data.param1
         - winlog.event_data.param2
         - winlog.event_data.param3

--- a/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
@@ -117,6 +117,18 @@ processors:
       ignore_failure: true
       allow_duplicates: false
       if: ctx?.user?.name != null
+  # Get user details from the translate_sid processor enrichment
+  # if they are available and we don't already have them.
+  - rename:
+      field: _user.name
+      target_field: user.name
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: _user.domain
+      target_field: user.domain
+      ignore_failure: true
+      ignore_missing: true
 
   ## PowerShell fields.
 
@@ -402,6 +414,7 @@ processors:
   - remove:
       field:
         - _temp
+        - _user
         - winlog.event_data.param1
         - winlog.event_data.param2
         - winlog.event_data.param3

--- a/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
@@ -20,9 +20,9 @@ include_xml: true
 {{/if}}
 processors:
   - translate_sid:
-      field: winlog.event_data.MemberSid
-      account_name_target: _user.name
-      domain_target: _user.domain
+      account_name_target: winlog.event_data._MemberUserName
+      domain_target:       winlog.event_data._MemberDomain
+      account_type_target: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
 {{#if processors.length}}

--- a/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
@@ -18,7 +18,13 @@ tags:
 {{#if preserve_original_event}}
 include_xml: true
 {{/if}}
-{{#if processors.length}}
 processors:
+  - translate_sid:
+      field: winlog.event_data.MemberSid
+      account_name_target: _user.name
+      domain_target: _user.domain
+      ignore_missing: true
+      ignore_failure: true
+{{#if processors.length}}
 {{processors}}
 {{/if}}

--- a/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
@@ -174,15 +174,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
-      field: _user.name
+      field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
-      field: _user.domain
+      field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
+  - append:
+      value: '{{{winlog.event_data._MemberAccountType}}}'
+      field: user.roles
+      ignore_failure: true
+      allow_duplicates: false
+      if: ctx.winlog?.event_data?._MemberAccountType != null
+  - remove:
+      field: winlog.event_data._MemberAccountType
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.user?.roles != null && ctx.winlog?.event_data?._MemberAccountType != null && ctx.user.roles.contains(ctx.winlog.event_data._MemberAccountType)   
 
   ## PowerShell fields.
 
@@ -472,7 +483,6 @@ processors:
   - remove:
       field:
         - _temp
-        - _user
         - winlog.event_data.SequenceNumber
         - winlog.event_data.User
         - winlog.event_data.ConnectedUser

--- a/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
@@ -171,6 +171,18 @@ processors:
       ignore_failure: true
       ignore_empty_value: true
       if: ctx?.source?.user != null
+  # Get user details from the translate_sid processor enrichment
+  # if they are available and we don't already have them.
+  - rename:
+      field: _user.name
+      target_field: user.name
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: _user.domain
+      target_field: user.domain
+      ignore_failure: true
+      ignore_missing: true
 
   ## PowerShell fields.
 
@@ -460,6 +472,7 @@ processors:
   - remove:
       field:
         - _temp
+        - _user
         - winlog.event_data.SequenceNumber
         - winlog.event_data.User
         - winlog.event_data.ConnectedUser

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
@@ -21,8 +21,9 @@ include_xml: true
 processors:
   - translate_sid:
       field: winlog.event_data.MemberSid
-      account_name_target: _user.name
-      domain_target: _user.domain
+      account_name_target: winlog.event_data._MemberUserName
+      domain_target: winlog.event_data._MemberDomain
+      account_type_target: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
 {{#if processors.length}}

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/winlog.yml.hbs
@@ -18,7 +18,13 @@ tags:
 {{#if preserve_original_event}}
 include_xml: true
 {{/if}}
-{{#if processors.length}}
 processors:
+  - translate_sid:
+      field: winlog.event_data.MemberSid
+      account_name_target: _user.name
+      domain_target: _user.domain
+      ignore_missing: true
+      ignore_failure: true
+{{#if processors.length}}
 {{processors}}
 {{/if}}

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -854,15 +854,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
-      field: _user.name
+      field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
-      field: _user.domain
+      field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
+  - append:
+      value: '{{{winlog.event_data._MemberAccountType}}}'
+      field: user.roles
+      ignore_failure: true
+      allow_duplicates: false
+      if: ctx.winlog?.event_data?._MemberAccountType != null
+  - remove:
+      field: winlog.event_data._MemberAccountType
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.user?.roles != null && ctx.winlog?.event_data?._MemberAccountType != null && ctx.user.roles.contains(ctx.winlog.event_data._MemberAccountType)   
 
 ## Sysmon fields
 
@@ -1211,7 +1222,6 @@ processors:
   - remove:
       field:
         - _temp
-        - _user
         - winlog.event_data.ProcessId
         - winlog.event_data.ParentProcessId
         - winlog.event_data.SourceProcessId

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -851,6 +851,18 @@ processors:
       ignore_failure: true
       ignore_empty_value: true
       if: ctx?._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
+  # Get user details from the translate_sid processor enrichment
+  # if they are available and we don't already have them.
+  - rename:
+      field: _user.name
+      target_field: user.name
+      ignore_failure: true
+      ignore_missing: true
+  - rename:
+      field: _user.domain
+      target_field: user.domain
+      ignore_failure: true
+      ignore_missing: true
 
 ## Sysmon fields
 
@@ -1199,6 +1211,7 @@ processors:
   - remove:
       field:
         - _temp
+        - _user
         - winlog.event_data.ProcessId
         - winlog.event_data.ParentProcessId
         - winlog.event_data.SourceProcessId

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.13.0
+version: 1.14.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This attempt to enrich user details from the event_data.MemberSid field if possible and the information is not othewise available.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3309

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
