### PR TITLE
[cisco_umbrella] Enrich DNS fields

### DIFF
--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Enrich DNS fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.1.0"
   changes:
     - description: Update package to ECS 8.3.0.

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enrich DNS fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/3712
 - version: "1.1.0"
   changes:
     - description: Update package to ECS 8.3.0.

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log
@@ -1,3 +1,3 @@
-"2020-07-23 23:49:54","elasticuser","elasticuser2,some other identity","192.168.1.1","81.2.69.144","Allowed","1 (A)","NOERROR","elastic.co.","Software/Technology,Business Services,Application","Test Policy Name","SomeIdentityType",""
+"2020-07-23 23:49:54","elasticuser","elasticuser2,some other identity","192.168.1.1","81.2.69.144","Allowed","1 (A)","NOERROR","www.elastic.co.","Software/Technology,Business Services,Application","Test Policy Name","SomeIdentityType",""
 "2020-07-23 23:50:25","elasticuser","elasticuser2,some other identity","192.168.1.1","67.43.156.12","Blocked","1 (A)","NOERROR","elastic.co.","Chat,Instant Messaging,Block List,Application","Test Policy Name","SomeIdentityType","BlockedCategories"
 "2021-05-14 19:39:58","elastic_machine","elastic_machine,Elastic User (ElasticUser@elastic.co)","67.43.156.12","81.2.69.144","Allowed","1 (A)","NOERROR","elastic.co.","Infrastructure","Roaming Computers","Roaming Computers,AD Users",""

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
@@ -19,7 +19,10 @@
             },
             "dns": {
                 "question": {
-                    "name": "elastic.co.",
+                    "name": "www.elastic.co",
+                    "registered_domain": "elastic.co",
+                    "subdomain": "www",
+                    "top_level_domain": "co",
                     "type": "1 (A)"
                 },
                 "response_code": "NOERROR",
@@ -31,7 +34,7 @@
             "event": {
                 "action": "dns-request-Allowed",
                 "category": "network",
-                "original": "\"2020-07-23 23:49:54\",\"elasticuser\",\"elasticuser2,some other identity\",\"192.168.1.1\",\"81.2.69.144\",\"Allowed\",\"1 (A)\",\"NOERROR\",\"elastic.co.\",\"Software/Technology,Business Services,Application\",\"Test Policy Name\",\"SomeIdentityType\",\"\"",
+                "original": "\"2020-07-23 23:49:54\",\"elasticuser\",\"elasticuser2,some other identity\",\"192.168.1.1\",\"81.2.69.144\",\"Allowed\",\"1 (A)\",\"NOERROR\",\"www.elastic.co.\",\"Software/Technology,Business Services,Application\",\"Test Policy Name\",\"SomeIdentityType\",\"\"",
                 "type": [
                     "allowed",
                     "connection"
@@ -49,7 +52,7 @@
             },
             "related": {
                 "hosts": [
-                    "elastic.co."
+                    "www.elastic.co"
                 ],
                 "ip": [
                     "192.168.1.1",
@@ -93,7 +96,9 @@
             },
             "dns": {
                 "question": {
-                    "name": "elastic.co.",
+                    "name": "elastic.co",
+                    "registered_domain": "elastic.co",
+                    "top_level_domain": "co",
                     "type": "1 (A)"
                 },
                 "response_code": "NOERROR",
@@ -123,7 +128,7 @@
             },
             "related": {
                 "hosts": [
-                    "elastic.co."
+                    "elastic.co"
                 ],
                 "ip": [
                     "192.168.1.1",
@@ -161,7 +166,9 @@
             },
             "dns": {
                 "question": {
-                    "name": "elastic.co.",
+                    "name": "elastic.co",
+                    "registered_domain": "elastic.co",
+                    "top_level_domain": "co",
                     "type": "1 (A)"
                 },
                 "response_code": "NOERROR",
@@ -191,7 +198,7 @@
             },
             "related": {
                 "hosts": [
-                    "elastic.co."
+                    "elastic.co"
                 ],
                 "ip": [
                     "67.43.156.12",

--- a/packages/cisco_umbrella/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_umbrella/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -34,7 +34,12 @@ processors:
         - cisco.umbrella.identity_types
         - cisco.umbrella.blocked_categories
       if: ctx?.log?.file?.path.contains('dnslogs')
-
+  - gsub:
+      description: Strip tailing dot from DNS names.
+      field: dns.question.name
+      pattern: '\.$'
+      replacement: ''
+      ignore_missing: true
   - set:
       field: observer.type
       value: dns
@@ -191,11 +196,12 @@ processors:
       if: ctx?.cisco?.umbrella?.action != null
   - registered_domain:
       field: dns.question.name
-      target_field: dns.question.registered_domain
-      target_etld_field: dns.question.top_level_domain
-      target_subdomain_field: dns.question.sudomain
+      target_field: dns.question
       ignore_missing: true
       ignore_failure: true
+  - remove:
+      field: dns.question.domain
+      ignore_missing: true
   ######################
   # Network ECS Fields #
   ######################

--- a/packages/cisco_umbrella/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_umbrella/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -189,6 +189,13 @@ processors:
       field: dns.type
       value: query
       if: ctx?.cisco?.umbrella?.action != null
+  - registered_domain:
+      field: dns.question.name
+      target_field: dns.question.registered_domain
+      target_etld_field: dns.question.top_level_domain
+      target_subdomain_field: dns.question.sudomain
+      ignore_missing: true
+      ignore_failure: true
   ######################
   # Network ECS Fields #
   ######################

--- a/packages/cisco_umbrella/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_umbrella/data_stream/log/fields/ecs.yml
@@ -53,6 +53,12 @@
 - external: ecs
   name: dns.question.name
 - external: ecs
+  name: dns.question.registered_domain
+- external: ecs
+  name: dns.question.subdomain
+- external: ecs
+  name: dns.question.top_level_domain
+- external: ecs
   name: ecs.version
 - external: ecs
   name: error.message

--- a/packages/cisco_umbrella/docs/README.md
+++ b/packages/cisco_umbrella/docs/README.md
@@ -184,6 +184,9 @@ An example event for `log` looks as following:
 | destination.nat.port | Port the source session is translated to by NAT Device. Typically used with load balancers, firewalls, or routers. | long |
 | destination.port | Port of the destination. | long |
 | dns.question.name | The name being queried. If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively. | keyword |
+| dns.question.registered_domain | The highest registered domain, stripped of the subdomain. For example, the registered domain for "foo.example.com" is "example.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
+| dns.question.subdomain | The subdomain is all of the labels under the registered_domain. If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period. | keyword |
+| dns.question.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
 | dns.question.type | The type of record being queried. | keyword |
 | dns.response_code | The DNS response code. | keyword |
 | dns.type | The type of DNS event captured, query or answer. If your source of DNS events only gives you DNS queries, you should only create dns events of type `dns.type:query`. If your source of DNS events gives you answers as well, you should create one event per query (optionally as soon as the query is seen). And a second event containing all query details as well as an array of answers. | keyword |
@@ -203,7 +206,7 @@ An example event for `log` looks as following:
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
+| host.mac | Host mac addresses. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_umbrella
 title: Cisco Umbrella
-version: "1.1.0"
+version: "1.2.0"
 license: basic
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Enriches the `dns` fields from `dns.question.name` to `dns.question.registered_domain`, `dns.question.top_level_domain` and `dns.question.sudomain`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Review that enrichment is happening

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
