### PR TITLE
[Cloud Posture] Remove Kibana configuration from README

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.20"
+  changes:
+    - description: Remove Kibana configuration section from README
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3726
 - version: "0.0.19"
   changes:
     - description: Adding EKS rule templates

--- a/packages/cloud_security_posture/docs/README.md
+++ b/packages/cloud_security_posture/docs/README.md
@@ -20,17 +20,6 @@ CIS Kubernetes Benchmark integration is shipped including default dashboards and
 
 ## Deployment
 
-#### Configure Kibana
-
-In order for the integration to be installed, The Cloud Security Posture Kibana plugin must be enabled.
-
-This could be done by adding the following configuration line to `kibana.yml`:
-```
-xpack.cloudSecurityPosture.enabled: true
-```
-For Cloud users, see [Edit Kibana user settings](https://www.elastic.co/guide/en/cloud/current/ec-manage-kibana-settings.html).
-
-
 #### Deploy the Elastic agent
 
 Just like every other integration, the KSPM integration requires an Elastic agent to be deployed.

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "CIS Kubernetes Benchmark"
-version: 0.0.19
+version: 0.0.20
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
 type: integration


### PR DESCRIPTION
## What does this PR do?

Update the cloud security posture package README - remove the Kibana configuration instructions (since the Kibana plugin is enabled by default for 8.4)

