### PR TITLE
Fix: increase CI job timeout due to publishing

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
     PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH = "gs://elastic-bekitzur-package-storage-internal/queue-publishing/${env.REPO_BUILD_TAG}"
   }
   options {
-    timeout(time: 2, unit: 'HOURS')
+    timeout(time: 4, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -9,7 +9,7 @@ pipeline {
     INTEGRATION_JOB = 'Ingest-manager/integrations/main'
   }
   options {
-    timeout(time: 4, unit: 'HOURS')
+    timeout(time: 6, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
This PR increases timeout for CI jobs to manage to finish package publishing to Package Storage v2.

Related: https://github.com/elastic/integrations/pull/3658