### PR TITLE
Update Lambda - first draft of AWS integration edits

### DIFF
--- a/packages/aws/_dev/build/docs/lambda.md
+++ b/packages/aws/_dev/build/docs/lambda.md
@@ -1,8 +1,8 @@
 # AWS Lambda
 
-The AWS Lambda integration allows you to monitor [AWS Lambda](https://aws.amazon.com/lambda/). AWS Lambda is a service for  running code in a way that doesn't require you to provision a server or manage that server. 
+The AWS Lambda integration allows you to monitor [AWS Lambda](https://aws.amazon.com/lambda/). AWS Lambda is a service for running code in a way that doesn't require you to provision a server or manage that server. 
 
-Use the AWS Lambda integration to collect metrics related to your [Lamda functions](https://aws.amazon.com/lambda/faqs/#AWS_Lambda_functions). Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference metrics when troubleshooting an issue.
+Use the AWS Lambda integration to collect metrics related to your [Lambda functions](https://aws.amazon.com/lambda/faqs/#AWS_Lambda_functions). Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference metrics when troubleshooting an issue.
 
 For example, you could use this data to view the events that trigger an AWS Lambda function to run. Then you can alert the relevant project manager about those events by email.
 
@@ -11,7 +11,7 @@ For example, you could use this data to view the events that trigger an AWS Lamb
 The AWS Lambda integration collects one type of data stream: metrics.
 
 **Metrics** give you insight into the state of AWS Lambda.
-Metric data streams collected by the AWS Lambda integration include the  number of times your function code is executed, the amount of time that your function code spends processing an event, the number of invocations that result in a function error and more. See more details in the [Metrics reference](#metrics-reference).
+Metric data streams collected by the AWS Lambda integration include the number of times your function code is executed, the amount of time that your function code spends processing an event, the number of invocations that result in a function error and more. See more details in the [Metrics reference](#metrics-reference).
 
 <!-- etc. -->
 

--- a/packages/aws/_dev/build/docs/lambda.md
+++ b/packages/aws/_dev/build/docs/lambda.md
@@ -1,6 +1,47 @@
-# lambda
+# AWS Lambda
 
-## Metrics
+The AWS Lambda integration allows you to monitor [AWS Lambda](https://aws.amazon.com/lambda/). AWS Lambda is a service for  running code in a way that doesn't require you to provision a server or manage that server. 
+
+Use the AWS Lambda integration to collect metrics related to your [Lamda functions](https://aws.amazon.com/lambda/faqs/#AWS_Lambda_functions). Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference metrics when troubleshooting an issue.
+
+For example, you could use this data to view the events that trigger an AWS Lambda function to run. Then you can alert the relevant project manager about those events by email.
+
+## Data streams
+
+The AWS Lambda integration collects one type of data stream: metrics.
+
+**Metrics** give you insight into the state of AWS Lambda.
+Metric data streams collected by the AWS Lambda integration include the  number of times your function code is executed, the amount of time that your function code spends processing an event, the number of invocations that result in a function error and more. See more details in the [Metrics reference](#metrics-reference).
+
+<!-- etc. -->
+
+<!-- Optional notes -->
+
+## Requirements
+
+You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
+You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
+
+ Before using any AWS integration you will need:
+
+ * **AWS Credentials** to connect with your AWS account.
+ * **AWS Permissions** to make sure the user you're using to connect has permission to share the relevant data.
+
+ For more details about these requirements, see the **AWS** integration documentation.
+
+## Setup
+
+<!-- Any prerequisite instructions -->
+
+For step-by-step instructions on how to set up an integration, see the
+[Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+
+ Use this integration if you only need to collect data from the AWS Lambda service.
+
+ If you want to collect data from two or more AWS services, consider using the **AWS** integration.
+ When you configure the AWS integration, you can collect data from as many AWS services as you'd like.
+
+## Metrics reference 
 
 {{event "lambda"}}
 


### PR DESCRIPTION
## What does this PR do?

From https://github.com/elastic/integrations/issues/3572:

>In https://github.com/elastic/integrations/pull/3308 we updated docs for two AWS integrations to align with the new documentation guidelines and establish the relationship between the AWS integration/package ("AWS") and integrations for individual AWS services (for example, "AWS CloudFront").
>
>Now we should update the docs for all AWS integrations for individual services to follow the same format as the updated "AWS CloudFront" integration docs.

This PR adds more context the AWS <service> integration including:

- [x] Adds context to the "Overview" including a link to the relevant AWS page and an example
- [x] Lists the types of "Data streams" for the service
- [x] "Requirements" points back to "AWS" for detailed information on credentials and permissions
- [x] "Requirements" includes any other service-specific requirements
- [x] "Setup" establishes a relationship between the AWS integration/package ("AWS") and this integration
- [x] Includes "Reference" sections

## For the reviewer

<!-- anything to highlight for the reviewer -->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Review by docs team 
- [ ] Review by integrations team

## Related issues

- https://github.com/elastic/integrations/issues/3572