### PR TITLE
Update Route 53 -  First draft of AWS integration edits

### DIFF
--- a/packages/aws/_dev/build/docs/route53.md
+++ b/packages/aws/_dev/build/docs/route53.md
@@ -1,9 +1,53 @@
 # Route 53
 
-This integration is used to fetch logs from [Route 53](https://aws.amazon.com/route53/).
-## Logs
+The Route 53 integration allows you to monitor [Amazon Route 53](https://aws.amazon.com/route53/). Amazon Route 53 is Domain Name System (DNS) web service It connects user requests to the relevant IP addresses for the internet applications that are running on Amazon Web Services or on-premises.
 
-### Public Hosted Zone Logs
+Use the Route 53 integration to collect and parse logs related to DNS activity across your AWS infrastructure. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs when troubleshooting an issue.
+
+For example, you could use the data from this integration to spot unusual activity in your network traffic routing, in a given time period. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs, such as the forwarding rules and DNS endpoints for relevant custom names. 
+
+## Data streams
+
+The Route 53 integration collects one type of data stream: logs.
+
+**Logs** help you keep a record of events happening in Amazon Route 53.
+It collects Public Hosted Zone logs and Resolver logs. Log data streams collected by the Route 53 integration include the names being queried, the highest registered domain, the DNS response code, the edge location that served the request, and more. See more details in the [Logs reference](#logs-reference).
+
+<!-- etc. -->
+
+<!-- Optional notes -->
+
+## Requirements
+
+You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
+You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
+
+<!-- Other requirements -->
+
+ Before using any AWS integration you will need:
+
+ * **AWS Credentials** to connect with your AWS account.
+ * **AWS Permissions** to make sure the user you're using to connect has permission to share the relevant data.
+
+ For more details about these requirements, see the **AWS** integration documentation.
+
+## Setup
+
+<!-- Any prerequisite instructions -->
+
+For step-by-step instructions on how to set up an integration, see the
+[Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+
+<!-- Additional set up instructions -->
+
+ Use this integration if you only need to collect data from the Route 53 service.
+
+ If you want to collect data from two or more AWS services, consider using the **AWS** integration.
+ When you configure the AWS integration, you can collect data from as many AWS services as you'd like.
+
+## Logs reference
+
+### Public Hosted Zone logs
 
 The `route53_public_logs` dataset collects information about public DNS queries that Route 53 receives.
 
@@ -17,7 +61,7 @@ See [Route 53 Documentation](https://docs.aws.amazon.com/Route53/latest/Develope
 
 {{fields "route53_public_logs"}}
 
-### Resolver Logs
+### Resolver logs
 
 The `route53_resolver_logs` dataset collects all DNS queries & responses for:
 * Queries that originate in Amazon Virtual Private Cloud VPCs that you specify, as well as the responses to those DNS queries.

--- a/packages/aws/_dev/build/docs/route53.md
+++ b/packages/aws/_dev/build/docs/route53.md
@@ -1,6 +1,6 @@
 # Route 53
 
-The Route 53 integration allows you to monitor [Amazon Route 53](https://aws.amazon.com/route53/). Amazon Route 53 is Domain Name System (DNS) web service It connects user requests to the relevant IP addresses for the internet applications that are running on Amazon Web Services or on-premises.
+The Route 53 integration allows you to monitor [Amazon Route 53](https://aws.amazon.com/route53/). Amazon Route 53 is Domain Name System (DNS) web service. It connects user requests to the relevant IP addresses for the internet applications that are running on Amazon Web Services or on-premises.
 
 Use the Route 53 integration to collect and parse logs related to DNS activity across your AWS infrastructure. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference logs when troubleshooting an issue.
 


### PR DESCRIPTION
## What does this PR do?

From https://github.com/elastic/integrations/issues/3572:

>In https://github.com/elastic/integrations/pull/3308 we updated docs for two AWS integrations to align with the new documentation guidelines and establish the relationship between the AWS integration/package ("AWS") and integrations for individual AWS services (for example, "AWS CloudFront").
>
>Now we should update the docs for all AWS integrations for individual services to follow the same format as the updated "AWS CloudFront" integration docs.

This PR adds more context the AWS <service> integration including:

- [x] Adds context to the "Overview" including a link to the relevant AWS page and an example
- [x] Lists the types of "Data streams" for the service
- [x] "Requirements" points back to "AWS" for detailed information on credentials and permissions
- [x] "Requirements" includes any other service-specific requirements
- [x] "Setup" establishes a relationship between the AWS integration/package ("AWS") and this integration
- [x] Includes "Reference" sections

## For the reviewer

<!-- anything to highlight for the reviewer -->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Review by docs team 
- [ ] Review by integrations team

## Related issues

- https://github.com/elastic/integrations/issues/3572