### PR TITLE
[AWS] Move usage lightweight module config into integration

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.3"
+  changes:
+    - description: Move usage metrics config from beats to integrations
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3764
 - version: "1.17.2"
   changes:
     - description: Improve support for event.original field from upstream forwarders.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -4,6 +4,9 @@
     - description: Move usage metrics config from beats to integrations
       type: enhancement
       link: https://github.com/elastic/integrations/pull/3764
+    - description: Move dynamodb metrics config from beats to integrations
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3764
 - version: "1.17.2"
   changes:
     - description: Improve support for event.original field from upstream forwarders.

--- a/packages/aws/data_stream/dynamodb/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/dynamodb/agent/stream/stream.yml.hbs
@@ -33,3 +33,43 @@ tags_filter: {{tags_filter}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}
+metrics:
+- namespace: AWS/DynamoDB
+  resource_type: dynamodb
+  statistic: ["Average"]
+  name:
+  - SuccessfulRequestLatency
+  - OnlineIndexPercentageProgress
+  - ProvisionedWriteCapacityUnits
+  - ProvisionedReadCapacityUnits
+  - ConsumedReadCapacityUnits
+  - ConsumedWriteCapacityUnits
+  - ReplicationLatency
+  - TransactionConflict
+  - AccountProvisionedReadCapacityUtilization
+  - AccountProvisionedWriteCapacityUtilization
+- namespace: AWS/DynamoDB
+  resource_type: dynamodb
+  statistic: ["Sum"]
+  name:
+  - SystemErrors
+  - ConsumedReadCapacityUnits
+  - ConsumedWriteCapacityUnits
+  - ConditionalCheckFailedRequests
+  - PendingReplicationCount
+  - TransactionConflict
+  - ReadThrottleEvents
+  - ThrottledRequests
+  - WriteThrottleEvents
+- namespace: AWS/DynamoDB
+  resource_type: dynamodb
+  statistic: ["Maximum"]
+  name:
+  - SuccessfulRequestLatency
+  - ReplicationLatency
+  - AccountMaxReads
+  - AccountMaxTableLevelReads
+  - AccountMaxTableLevelWrites
+  - AccountMaxWrites
+  - MaxProvisionedTableReadCapacityUtilization
+  - MaxProvisionedTableWriteCapacityUtilization

--- a/packages/aws/data_stream/dynamodb/fields/package-fields.yml
+++ b/packages/aws/data_stream/dynamodb/fields/package-fields.yml
@@ -13,7 +13,3 @@
       type: object
       description: |
         Metric dimensions.
-    - name: '*.metrics.*.*'
-      type: object
-      description: |
-        Metrics that returned from Cloudwatch API query.

--- a/packages/aws/data_stream/dynamodb/sample_event.json
+++ b/packages/aws/data_stream/dynamodb/sample_event.json
@@ -1,59 +1,78 @@
 {
-    "@timestamp": "2020-05-28T17:17:08.666Z",
+    "@timestamp": "2022-07-25T21:53:00.000Z",
     "agent": {
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b",
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30",
-        "name": "MacBook-Elastic.local",
+        "name": "docker-fleet-agent",
+        "id": "2d4b09d0-cdb6-445e-ac3f-6415f87b9864",
         "type": "metricbeat",
-        "version": "8.0.0"
+        "ephemeral_id": "64a12b83-a4f1-487c-8d2c-9581fda6ca2a",
+        "version": "8.3.2"
     },
-    "event": {
-        "dataset": "aws.dynamodb",
-        "module": "aws",
-        "duration": 10266182336
+    "elastic_agent": {
+        "id": "2d4b09d0-cdb6-445e-ac3f-6415f87b9864",
+        "version": "8.3.2",
+        "snapshot": false
+    },
+    "cloud": {
+        "provider": "aws",
+        "region": "eu-central-1",
+        "account": {
+            "name": "elastic-beats",
+            "id": "428152502467"
+        }
+    },
+    "ecs": {
+        "version": "8.0.0"
     },
     "service": {
         "type": "aws"
     },
-    "ecs": {
-        "version": "1.5.0"
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "aws.dynamodb"
     },
-    "cloud": {
-        "account": {
-            "name": "elastic-beats",
-            "id": "428152502467"
-        },
-        "provider": "aws",
-        "region": "eu-central-1"
+    "metricset": {
+        "period": 300000,
+        "name": "dynamodb"
+    },
+    "event": {
+        "duration": 10586366300,
+        "agent_id_status": "verified",
+        "ingested": "2022-07-25T21:57:51Z",
+        "module": "aws",
+        "dataset": "aws.dynamodb"
     },
     "aws": {
-        "dimensions": {
-            "TableName": "TryDaxTable3"
+        "cloudwatch": {
+            "namespace": "AWS/DynamoDB"
         },
         "dynamodb": {
             "metrics": {
-                "ProvisionedWriteCapacityUnits": {
-                    "avg": 1
+                "AccountProvisionedWriteCapacityUtilization": {
+                    "avg": 0.01
                 },
-                "ProvisionedReadCapacityUnits": {
-                    "avg": 1
+                "MaxProvisionedTableWriteCapacityUtilization": {
+                    "max": 0.01
                 },
-                "ConsumedWriteCapacityUnits": {
-                    "avg": 0,
-                    "sum": 0
+                "MaxProvisionedTableReadCapacityUtilization": {
+                    "max": 0.01
                 },
-                "ConsumedReadCapacityUnits": {
-                    "avg": 0,
-                    "sum": 0
+                "AccountMaxTableLevelReads": {
+                    "max": 40000
+                },
+                "AccountMaxReads": {
+                    "max": 80000
+                },
+                "AccountProvisionedReadCapacityUtilization": {
+                    "avg": 0.01
+                },
+                "AccountMaxWrites": {
+                    "max": 80000
+                },
+                "AccountMaxTableLevelWrites": {
+                    "max": 40000
                 }
             }
-        },
-        "cloudwatch": {
-            "namespace": "AWS/DynamoDB"
         }
-    },
-    "metricset": {
-        "name": "dynamodb",
-        "period": 300000
     }
 }

--- a/packages/aws/data_stream/usage/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/usage/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["usage"]
+metricsets: ["cloudwatch"]
 period: {{period}}
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}
@@ -33,3 +33,6 @@ tags_filter: {{tags_filter}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}
+metrics:
+- namespace: AWS/Usage
+  statistic: ["Sum"]

--- a/packages/aws/data_stream/usage/fields/package-fields.yml
+++ b/packages/aws/data_stream/usage/fields/package-fields.yml
@@ -13,7 +13,3 @@
       type: object
       description: |
         Metric dimensions.
-    - name: '*.metrics.*.*'
-      type: object
-      description: |
-        Metrics that returned from Cloudwatch API query.

--- a/packages/aws/data_stream/usage/sample_event.json
+++ b/packages/aws/data_stream/usage/sample_event.json
@@ -1,5 +1,40 @@
 {
-    "@timestamp": "2020-05-28T17:58:30.929Z",
+    "@timestamp": "2022-07-25T20:50:00.000Z",
+    "agent": {
+        "name": "docker-fleet-agent",
+        "id": "2d4b09d0-cdb6-445e-ac3f-6415f87b9864",
+        "type": "metricbeat",
+        "ephemeral_id": "6bab70d4-84d9-411d-887c-f144d4244e78",
+        "version": "8.3.2"
+    },
+    "elastic_agent": {
+        "id": "2d4b09d0-cdb6-445e-ac3f-6415f87b9864",
+        "version": "8.3.2",
+        "snapshot": false
+    },
+    "cloud": {
+        "provider": "aws",
+        "region": "eu-north-1",
+        "account": {
+            "name": "elastic-beats",
+            "id": "428152502467"
+        }
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "service": {
+        "type": "aws"
+    },
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "aws.usage"
+    },
+    "metricset": {
+        "period": 60000,
+        "name": "cloudwatch"
+    },
     "aws": {
         "usage": {
             "metrics": {
@@ -13,39 +48,16 @@
         },
         "dimensions": {
             "Type": "API",
-            "Resource": "GetMetricData",
+            "Resource": "ListMetrics",
             "Service": "CloudWatch",
             "Class": "None"
         }
     },
     "event": {
-        "duration": 1191329839,
-        "dataset": "aws.usage",
-        "module": "aws"
-    },
-    "service": {
-        "type": "aws"
-    },
-    "ecs": {
-        "version": "1.5.0"
-    },
-    "cloud": {
-        "provider": "aws",
-        "region": "eu-north-1",
-        "account": {
-            "name": "elastic-beats",
-            "id": "428152502467"
-        }
-    },
-    "metricset": {
-        "name": "usage",
-        "period": 60000
-    },
-    "agent": {
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b",
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30",
-        "name": "MacBook-Elastic.local",
-        "type": "metricbeat",
-        "version": "8.0.0"
+        "duration": 1432082500,
+        "agent_id_status": "verified",
+        "ingested": "2022-07-25T20:51:19Z",
+        "module": "aws",
+        "dataset": "aws.usage"
     }
 }

--- a/packages/aws/docs/dynamodb.md
+++ b/packages/aws/docs/dynamodb.md
@@ -6,62 +6,81 @@ An example event for `dynamodb` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-05-28T17:17:08.666Z",
+    "@timestamp": "2022-07-25T21:53:00.000Z",
     "agent": {
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b",
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30",
-        "name": "MacBook-Elastic.local",
+        "name": "docker-fleet-agent",
+        "id": "2d4b09d0-cdb6-445e-ac3f-6415f87b9864",
         "type": "metricbeat",
-        "version": "8.0.0"
+        "ephemeral_id": "64a12b83-a4f1-487c-8d2c-9581fda6ca2a",
+        "version": "8.3.2"
     },
-    "event": {
-        "dataset": "aws.dynamodb",
-        "module": "aws",
-        "duration": 10266182336
+    "elastic_agent": {
+        "id": "2d4b09d0-cdb6-445e-ac3f-6415f87b9864",
+        "version": "8.3.2",
+        "snapshot": false
+    },
+    "cloud": {
+        "provider": "aws",
+        "region": "eu-central-1",
+        "account": {
+            "name": "elastic-beats",
+            "id": "428152502467"
+        }
+    },
+    "ecs": {
+        "version": "8.0.0"
     },
     "service": {
         "type": "aws"
     },
-    "ecs": {
-        "version": "1.5.0"
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "aws.dynamodb"
     },
-    "cloud": {
-        "account": {
-            "name": "elastic-beats",
-            "id": "428152502467"
-        },
-        "provider": "aws",
-        "region": "eu-central-1"
+    "metricset": {
+        "period": 300000,
+        "name": "dynamodb"
+    },
+    "event": {
+        "duration": 10586366300,
+        "agent_id_status": "verified",
+        "ingested": "2022-07-25T21:57:51Z",
+        "module": "aws",
+        "dataset": "aws.dynamodb"
     },
     "aws": {
-        "dimensions": {
-            "TableName": "TryDaxTable3"
+        "cloudwatch": {
+            "namespace": "AWS/DynamoDB"
         },
         "dynamodb": {
             "metrics": {
-                "ProvisionedWriteCapacityUnits": {
-                    "avg": 1
+                "AccountProvisionedWriteCapacityUtilization": {
+                    "avg": 0.01
                 },
-                "ProvisionedReadCapacityUnits": {
-                    "avg": 1
+                "MaxProvisionedTableWriteCapacityUtilization": {
+                    "max": 0.01
                 },
-                "ConsumedWriteCapacityUnits": {
-                    "avg": 0,
-                    "sum": 0
+                "MaxProvisionedTableReadCapacityUtilization": {
+                    "max": 0.01
                 },
-                "ConsumedReadCapacityUnits": {
-                    "avg": 0,
-                    "sum": 0
+                "AccountMaxTableLevelReads": {
+                    "max": 40000
+                },
+                "AccountMaxReads": {
+                    "max": 80000
+                },
+                "AccountProvisionedReadCapacityUtilization": {
+                    "avg": 0.01
+                },
+                "AccountMaxWrites": {
+                    "max": 80000
+                },
+                "AccountMaxTableLevelWrites": {
+                    "max": 40000
                 }
             }
-        },
-        "cloudwatch": {
-            "namespace": "AWS/DynamoDB"
         }
-    },
-    "metricset": {
-        "name": "dynamodb",
-        "period": 300000
     }
 }
 ```
@@ -71,7 +90,6 @@ An example event for `dynamodb` looks as following:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
-| aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.\* | Metric dimensions. | object |
 | aws.dimensions.DelegatedOperation | This dimension limits the data to operations DynamoDB performs on your behalf. | keyword |
@@ -121,7 +139,7 @@ An example event for `dynamodb` looks as following:
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host, resource, or service is located. | keyword |
+| cloud.region | Region in which this host is running. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |

--- a/packages/aws/docs/usage.md
+++ b/packages/aws/docs/usage.md
@@ -6,7 +6,42 @@ An example event for `usage` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-05-28T17:58:30.929Z",
+    "@timestamp": "2022-07-25T20:50:00.000Z",
+    "agent": {
+        "name": "docker-fleet-agent",
+        "id": "2d4b09d0-cdb6-445e-ac3f-6415f87b9864",
+        "type": "metricbeat",
+        "ephemeral_id": "6bab70d4-84d9-411d-887c-f144d4244e78",
+        "version": "8.3.2"
+    },
+    "elastic_agent": {
+        "id": "2d4b09d0-cdb6-445e-ac3f-6415f87b9864",
+        "version": "8.3.2",
+        "snapshot": false
+    },
+    "cloud": {
+        "provider": "aws",
+        "region": "eu-north-1",
+        "account": {
+            "name": "elastic-beats",
+            "id": "428152502467"
+        }
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "service": {
+        "type": "aws"
+    },
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "aws.usage"
+    },
+    "metricset": {
+        "period": 60000,
+        "name": "cloudwatch"
+    },
     "aws": {
         "usage": {
             "metrics": {
@@ -20,40 +55,17 @@ An example event for `usage` looks as following:
         },
         "dimensions": {
             "Type": "API",
-            "Resource": "GetMetricData",
+            "Resource": "ListMetrics",
             "Service": "CloudWatch",
             "Class": "None"
         }
     },
     "event": {
-        "duration": 1191329839,
-        "dataset": "aws.usage",
-        "module": "aws"
-    },
-    "service": {
-        "type": "aws"
-    },
-    "ecs": {
-        "version": "1.5.0"
-    },
-    "cloud": {
-        "provider": "aws",
-        "region": "eu-north-1",
-        "account": {
-            "name": "elastic-beats",
-            "id": "428152502467"
-        }
-    },
-    "metricset": {
-        "name": "usage",
-        "period": 60000
-    },
-    "agent": {
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b",
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30",
-        "name": "MacBook-Elastic.local",
-        "type": "metricbeat",
-        "version": "8.0.0"
+        "duration": 1432082500,
+        "agent_id_status": "verified",
+        "ingested": "2022-07-25T20:51:19Z",
+        "module": "aws",
+        "dataset": "aws.usage"
     }
 }
 ```
@@ -63,7 +75,6 @@ An example event for `usage` looks as following:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
-| aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.\* | Metric dimensions. | object |
 | aws.dimensions.Class | The class of resource being tracked. | keyword |
@@ -77,14 +88,14 @@ An example event for `usage` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host, resource, or service is located. | keyword |
+| cloud.region | Region in which this host is running. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.17.2
+version: 1.17.3
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to move lightweight module configuration from metricbeat into integrations for usage.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

closes https://github.com/elastic/integrations/issues/3606 
closes https://github.com/elastic/integrations/issues/3597