### PR TITLE
[network_traffic] Add option to use TCP for the SIP protocol.

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add option to use TCP for the SIP protocol.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3772
 - version: "1.4.1"
   changes:
     - description: Add mappings for `process.*`.

--- a/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
+++ b/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
@@ -1,4 +1,7 @@
 type: sip
+{{#if use_tcp}}
+transport_protocol: "tcp"
+{{/if}}
 {{#if port}}
 ports:
 {{#each port as |p|}}

--- a/packages/network_traffic/data_stream/sip/manifest.yml
+++ b/packages/network_traffic/data_stream/sip/manifest.yml
@@ -14,6 +14,13 @@ streams:
         required: true
         show_user: true
         default: [5060]
+      - name: use_tcp
+        type: bool
+        title: Use TCP
+        description: Enables the use of TCP. By default UDP is used.
+        required: true
+        show_user: true
+        default: false
       - name: monitor_processes
         type: bool
         title: Monitor Processes

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.4.1"
+version: "1.5.0"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
@@ -9,7 +9,7 @@ categories:
   - web
 release: ga
 conditions:
-  kibana.version: ^7.17.0 || ^8.0.0
+  kibana.version: ^8.4.0
 policy_templates:
   - name: network
     title: Network Packet Capture


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Exposes the newly added TCP transport option to the sip protocol.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
