### PR TITLE
[GCP] Convert GCP GKE metricset from lightweight

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.1"
+  changes:
+    - description: Move GKE lightweight module config into integration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3797
 - version: "2.11.0"
   changes:
     - description: Move Compute lightweight module config into integration

--- a/packages/gcp/data_stream/gke/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/gke/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["gke"]
+metricsets: ["metrics"]
 period: {{period}}
 project_id: {{project_id}}
 {{#if credentials_file}}
@@ -14,3 +14,47 @@ region: {{region}}
 zone: {{zone}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+metrics:
+  - service: gke
+      service_metric_prefix: kubernetes.io/
+      metric_types:
+      - "container/cpu/core_usage_time"
+      - "container/cpu/limit_cores"
+      - "container/cpu/limit_utilization"
+      - "container/cpu/request_cores"
+      - "container/cpu/request_utilization"
+      - "container/ephemeral_storage/limit_bytes"
+      - "container/ephemeral_storage/request_bytes"
+      - "container/ephemeral_storage/used_bytes"
+      - "container/memory/limit_bytes"
+      - "container/memory/limit_utilization"
+      - "container/memory/page_fault_count"
+      - "container/memory/request_bytes"
+      - "container/memory/request_utilization"
+      - "container/memory/used_bytes"
+      - "container/restart_count"
+      - "container/uptime"
+      - "node/cpu/allocatable_cores"
+      - "node/cpu/allocatable_utilization"
+      - "node/cpu/core_usage_time"
+      - "node/cpu/total_cores"
+      - "node/ephemeral_storage/allocatable_bytes"
+      - "node/ephemeral_storage/inodes_free"
+      - "node/ephemeral_storage/inodes_total"
+      - "node/ephemeral_storage/total_bytes"
+      - "node/ephemeral_storage/used_bytes"
+      - "node/memory/allocatable_bytes"
+      - "node/memory/allocatable_utilization"
+      - "node/memory/total_bytes"
+      - "node/memory/used_bytes"
+      - "node/network/received_bytes_count"
+      - "node/network/sent_bytes_count"
+      - "node/pid_limit"
+      - "node/pid_used"
+      - "node_daemon/cpu/core_usage_time"
+      - "node_daemon/memory/used_bytes"
+      - "pod/network/received_bytes_count"
+      - "pod/network/sent_bytes_count"
+      - "pod/volume/total_bytes"
+      - "pod/volume/used_bytes"
+      - "pod/volume/utilization"

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.11.0"
+version: "2.11.1"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Convert GCP GKE metricset from lightweight

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #490
- Requires #2301
- Requires #3798

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
