### PR TITLE
[panw] Preserve original event for syslog messages

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.0.2"
+  changes:
+    - description: Preserve original event for syslog messages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9999 #FIXME: Change PR number
 - version: "3.0.1"
   changes:
     - description: Improve TCP, SSL config description and example.

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Preserve original event for syslog messages.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9999 #FIXME: Change PR number
+      link: https://github.com/elastic/integrations/pull/3811
 - version: "3.0.1"
   changes:
     - description: Improve TCP, SSL config description and example.

--- a/packages/panw/data_stream/panos/_dev/test/system/test-logfile-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-logfile-config.yml
@@ -1,5 +1,8 @@
 service: panw-logfile
 input: logfile
+data_stream:
+  vars:
+    preserve_original_event: true
 vars:
   paths:
     - "{{SERVICE_LOGS_DIR}}/*panos*.log"

--- a/packages/panw/data_stream/panos/_dev/test/system/test-tcp-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-tcp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     syslog_host: 0.0.0.0
     syslog_port: 9514
+    preserve_original_event: true

--- a/packages/panw/data_stream/panos/_dev/test/system/test-tls-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-tls-config.yml
@@ -5,6 +5,7 @@ data_stream:
   vars:
     syslog_host: 0.0.0.0
     syslog_port: 9515
+    preserve_original_event: true
     ssl: |
       key: |
         -----BEGIN PRIVATE KEY-----

--- a/packages/panw/data_stream/panos/_dev/test/system/test-udp-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-udp-config.yml
@@ -5,3 +5,4 @@ data_stream:
   vars:
     syslog_host: 0.0.0.0
     syslog_port: 9514
+    preserve_original_event: true

--- a/packages/panw/data_stream/panos/agent/stream/tcp.yml.hbs
+++ b/packages/panw/data_stream/panos/agent/stream/tcp.yml.hbs
@@ -17,6 +17,12 @@ ssl: {{ssl}}
 {{/if}}
 processors:
   - add_locale: ~
+  {{#if preserve_original_event}}
+  - copy_fields:
+       fields:
+         - from: message
+           to: event.original
+  {{/if}}
   - syslog:
       field: message
       format: auto

--- a/packages/panw/data_stream/panos/agent/stream/udp.yml.hbs
+++ b/packages/panw/data_stream/panos/agent/stream/udp.yml.hbs
@@ -14,6 +14,12 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
   - add_locale: ~
+  {{#if preserve_original_event}}
+  - copy_fields:
+       fields:
+         - from: message
+           to: event.original
+  {{/if}}
   - syslog:
       field: message
       format: auto

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -20,12 +20,15 @@ processors:
       if: ctx._conf?.tz_offset != null && ctx._conf?.tz_offset != 'local'
 
 # Collects the first few parts of the message to be used for conditional parsing later
+  - set:
+      field: event.original
+      copy_from: message
+      if: ctx.event?.original == null
   - rename:
       field: message
-      target_field: event.original
-      ignore_missing: true
+      target_field: _temp_.message
   - grok:
-      field: event.original
+      field: _temp_.message
       patterns:
         - "^%{DATA},%{TIMESTAMP:event.created},%{FIELD:observer.serial_number},%{FIELD:panw.panos.type},(?:%{FIELD:panw.panos.sub_type})?,%{FIELD:_temp_.config_version},%{TIMESTAMP:_temp_.generated_time},%{GREEDYDATA:message}$"
       pattern_definitions:

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: 3.0.1
+version: 3.0.2
 release: ga
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

- Add processor to preserve original event message when using tcp/udp
with syslog in agent config

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/panw && elastic-package test
```

## Related issues

- Closes #3774 
