### PR TITLE
[Apache] Use new labels for license and subscription

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.4.2"
+- version: "1.5.0"
   changes:
     - description: Use new labels for source license and subscription
       type: enhancement

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.2"
+  changes:
+    - description: Use new labels for source license and subscription
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/3816
 - version: "1.4.1"
   changes:
     - description: Add correct field mapping for event.created

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,8 +1,10 @@
 format_version: 1.0.0
 name: apache
 title: Apache HTTP Server
-version: 1.4.1
+version: 1.4.2
 license: basic
+source:
+  license: Elastic-2.0
 description: Collect logs and metrics from Apache servers with Elastic Agent.
 type: integration
 categories:
@@ -10,6 +12,7 @@ categories:
 release: ga
 conditions:
   kibana.version: "^8.0.0"
+  elastic.subscription: basic
 screenshots:
   - src: /img/apache-metrics-overview.png
     title: Apache metrics overview

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache HTTP Server
-version: 1.4.2
+version: 1.5.0
 license: basic
 source:
   license: Elastic-2.0


### PR DESCRIPTION
## What does this PR do?

`license` field is deprecated as of https://github.com/elastic/package-spec/pull/355, use the new fields in the apache package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related to https://github.com/elastic/package-spec/issues/298