### PR TITLE
[Fortinet] Deprecate original integration & change logfile to filestream

### DIFF
--- a/packages/fortinet/_dev/build/docs/README.md
+++ b/packages/fortinet/_dev/build/docs/README.md
@@ -1,4 +1,7 @@
-# Fortinet Integration
+# Fortinet Integration (Deprecated)
+
+_This integration is deprecated. Please use one of the other Fortinet integrations
+that are specific to a Fortinet product._
 
 This integration is for Fortinet [FortiOS](https://docs.fortinet.com/product/fortigate/6.2) and [FortiClient](https://docs.fortinet.com/product/forticlient/) Endpoint logs sent in the syslog format. It includes the following datasets for receiving logs:
 

--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Deprecating Fortinet package in favor of new product specific packages
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3819
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/fortinet/docs/README.md
+++ b/packages/fortinet/docs/README.md
@@ -1,4 +1,7 @@
-# Fortinet Integration
+# Fortinet Integration (Deprecated)
+
+_This integration is deprecated. Please use one of the other Fortinet integrations
+that are specific to a Fortinet product._
 
 This integration is for Fortinet [FortiOS](https://docs.fortinet.com/product/fortigate/6.2) and [FortiClient](https://docs.fortinet.com/product/forticlient/) Endpoint logs sent in the syslog format. It includes the following datasets for receiving logs:
 

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -1,8 +1,8 @@
 name: fortinet
 title: Fortinet
-version: "1.8.0"
+version: "1.8.1"
 release: ga
-description: Collect logs from Fortinet instances with Elastic Agent.
+description: Deprecated. Collect logs from Fortinet instances with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic

--- a/packages/fortinet_forticlient/changelog.yml
+++ b/packages/fortinet_forticlient/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Update Ingest Pipeline with observer Fields
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/3819
 - version: "1.0.0"
   changes:
     - description: Initial version of Fortinet FortiClient as separate package

--- a/packages/fortinet_forticlient/changelog.yml
+++ b/packages/fortinet_forticlient/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.1.0"
   changes:
     - description: Update Ingest Pipeline with observer Fields
-      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/3819
 - version: "1.0.0"
   changes:

--- a/packages/fortinet_forticlient/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/fortinet_forticlient/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
@@ -5,6 +5,11 @@
                 "version": "8.3.0"
             },
             "message": "January 29 06:09:59 boNemoe4402.www.invalid proto=udp service=http status=deny src=10.150.92.220 dst=10.102.123.34 src_port=7178 dst_port=3994 server_app=reeufugi pid=7880 app_name=enderitq traff_direct=external block_count=5286 logon_user=sumdo@litesse6379.api.domain msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -14,6 +19,11 @@
                 "version": "8.3.0"
             },
             "message": "February 12 13:12:33 olupt4880.api.home proto=icmp service=https status=deny src=10.33.212.159 dst=10.149.203.46 src_port=2789 dst_port=5861 server_app=vol pid=4539 app_name=uidolor traff_direct=internal block_count=4402 logon_user=mipsumq@gnaali6189.internal.localhost msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -23,6 +33,11 @@
                 "version": "8.3.0"
             },
             "message": "February 26 20:15:08 aqu1628.internal.domain proto=ipv6-icmp service=smtp status=deny src=10.173.116.41 dst=10.118.175.9 src_port=3710 dst_port=2802 server_app=aer pid=445 app_name=nse traff_direct=unknown block_count=7019 logon_user=uame@quis1130.internal.corp msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -32,6 +47,11 @@
                 "version": "8.3.0"
             },
             "message": "March 12 03:17:42 tinculp2940.internal.local proto=ggp service=https status=deny src=10.134.137.177 dst=10.202.204.154 src_port=7868 dst_port=3587 server_app=amco pid=5712 app_name=psumquia traff_direct=unknown block_count=2458 logon_user=orsitame@reprehe189.internal.home msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -41,6 +61,11 @@
                 "version": "8.3.0"
             },
             "message": "March 26 10:20:16 rad2103.api.domain proto=ipv6-icmp service=pop3 status=deny src=10.245.142.250 dst=10.70.0.60 src_port=5408 dst_port=4982 server_app=estqui pid=6557 app_name=magn traff_direct=inbound block_count=2638 logon_user=eos@enimad2283.internal.domain msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -50,6 +75,11 @@
                 "version": "8.3.0"
             },
             "message": "April 9 17:22:51 enim5316.www5.local proto=ipv6-icmp service=smtp status=deny src=10.202.72.124 dst=10.200.188.142 src_port=4665 dst_port=7143 server_app=omnis pid=2061 app_name=eip traff_direct=external block_count=513 logon_user=iusmodt@doloreeu3553.www5.home msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -59,6 +89,11 @@
                 "version": "8.3.0"
             },
             "message": "April 24 00:25:25 reetdolo2770.www5.local proto=tcp service=pop3 status=deny src=10.12.44.169 dst=10.214.225.125 src_port=5710 dst_port=2121 server_app=inBCSedu pid=5722 app_name=tanimi traff_direct=outbound block_count=6071 logon_user=erep@iutal13.api.localdomain msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -68,6 +103,11 @@
                 "version": "8.3.0"
             },
             "message": "May 8 07:27:59 isiu1114.internal.corp proto=icmp service=http status=deny src=10.66.108.11 dst=10.198.136.50 src_port=6875 dst_port=2089 server_app=ipis pid=5037 app_name=ari traff_direct=unknown block_count=3856 logon_user=uptatev@uovol492.www.localhost msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -77,6 +117,11 @@
                 "version": "8.3.0"
             },
             "message": "May 22 14:30:33 usmodte1296.www.corp proto=igmp service=ms-wbt-server status=deny src=10.178.244.31 dst=10.69.20.77 src_port=3857 dst_port=7579 server_app=nonnu pid=776 app_name=riat traff_direct=unknown block_count=5575 logon_user=umdolor@osquir6997.corp msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -86,6 +131,11 @@
                 "version": "8.3.0"
             },
             "message": "June 5 21:33:08 tatno4987.www5.localhost proto=ggp service=pop3 status=deny src=10.54.231.100 dst=10.203.5.162 src_port=5616 dst_port=7290 server_app=iam pid=6096 app_name=ciati traff_direct=unknown block_count=3162 logon_user=umdolore@eniam7007.api.invalid msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -95,6 +145,11 @@
                 "version": "8.3.0"
             },
             "message": "June 20 04:35:42 tatno6787.internal.localhost proto=icmp service=pop3 status=deny src=10.65.83.160 dst=10.136.252.240 src_port=3592 dst_port=4105 server_app=uradi pid=7307 app_name=essequ traff_direct=outbound block_count=7148 logon_user=ender@snulapar3794.api.domain msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -104,6 +159,11 @@
                 "version": "8.3.0"
             },
             "message": "July 4 11:38:16 essecill2595.mail.local proto=ggp service=http status=deny src=10.57.40.29 dst=10.210.213.18 src_port=7616 dst_port=3970 server_app=atuse pid=2703 app_name=uis traff_direct=internal block_count=6179 logon_user=onse@liq5883.localdomain msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -113,6 +173,11 @@
                 "version": "8.3.0"
             },
             "message": "July 18 18:40:50 ali6446.localhost proto=udp service=smtp status=deny src=10.144.82.69 dst=10.200.156.102 src_port=2896 dst_port=6061 server_app=rporis pid=5166 app_name=par traff_direct=outbound block_count=7041 logon_user=rveli@rsint7026.test msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -122,6 +187,11 @@
                 "version": "8.3.0"
             },
             "message": "August 2 01:43:25 torev7118.internal.domain proto=ipv6 service=smtp status=deny src=10.109.232.112 dst=10.72.58.135 src_port=5160 dst_port=2382 server_app=fugit pid=7668 app_name=rsitamet traff_direct=internal block_count=1112 logon_user=xea@qua2945.www.local msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -131,6 +201,11 @@
                 "version": "8.3.0"
             },
             "message": "August 16 08:45:59 dolore6103.www5.example proto=udp service=http status=deny src=10.38.22.45 dst=10.72.29.73 src_port=1493 dst_port=203 server_app=piscing pid=1044 app_name=entsu traff_direct=unknown block_count=4979 logon_user=onproide@luptat6494.www.example msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -140,6 +215,11 @@
                 "version": "8.3.0"
             },
             "message": "August 30 15:48:33 errorsi6996.www.domain proto=tcp service=smtp status=deny src=10.70.95.74 dst=10.76.72.111 src_port=6119 dst_port=7388 server_app=emaperi pid=7183 app_name=sumquiad traff_direct=internal block_count=2362 logon_user=ivelits@moenimi6317.internal.invalid msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -149,6 +229,11 @@
                 "version": "8.3.0"
             },
             "message": "September 13 22:51:07 lumquido5839.api.corp proto=ipv6 service=https status=deny src=10.19.201.13 dst=10.73.69.75 src_port=5006 dst_port=6218 server_app=nsec pid=6907 app_name=estqu traff_direct=unknown block_count=2655 logon_user=tat@tion1761.home msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -158,6 +243,11 @@
                 "version": "8.3.0"
             },
             "message": "September 28 05:53:42 aperia4409.www5.invalid proto=rdp service=ms-wbt-server status=deny src=10.78.151.178 dst=10.84.105.75 src_port=1846 dst_port=98 server_app=uames pid=499 app_name=msequi traff_direct=external block_count=4085 logon_user=iquaUten@santium4235.api.local msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -167,6 +257,11 @@
                 "version": "8.3.0"
             },
             "message": "October 12 12:56:16 tem2496.api.lan proto=rdp service=ms-wbt-server status=deny src=10.135.233.146 dst=10.25.192.202 src_port=4181 dst_port=6462 server_app=ents pid=1531 app_name=Loremip traff_direct=internal block_count=4610 logon_user=emeumfu@CSed2857.www5.example msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -176,6 +271,11 @@
                 "version": "8.3.0"
             },
             "message": "October 26 19:58:50 eme6710.mail.invalid proto=rdp service=https status=deny src=10.121.219.204 dst=10.104.134.200 src_port=3611 dst_port=2508 server_app=reetd pid=6051 app_name=quae traff_direct=outbound block_count=7084 logon_user=uptat@equep5085.mail.domain msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -185,6 +285,11 @@
                 "version": "8.3.0"
             },
             "message": "November 10 03:01:24 ihilm1669.mail.invalid proto=tcp service=https status=deny src=10.191.105.82 dst=10.225.160.182 src_port=3361 dst_port=4810 server_app=uovolup pid=6994 app_name=llu traff_direct=external block_count=3936 logon_user=eirure@conseq557.mail.lan msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -194,6 +299,11 @@
                 "version": "8.3.0"
             },
             "message": "November 24 10:03:59 umexerci1284.internal.localdomain proto=rdp service=smtp status=deny src=10.141.44.153 dst=10.161.57.8 src_port=3750 dst_port=2716 server_app=oei pid=5200 app_name=snostrud traff_direct=inbound block_count=3333 logon_user=quisnos@ite2026.www.invalid msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -203,6 +313,11 @@
                 "version": "8.3.0"
             },
             "message": "December 8 17:06:33 adol485.example proto=udp service=https status=deny src=10.153.111.103 dst=10.6.167.7 src_port=4977 dst_port=2022 server_app=taevit pid=3365 app_name=nsecte traff_direct=internal block_count=7424 logon_user=eumfug@lit5929.test msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -212,6 +327,11 @@
                 "version": "8.3.0"
             },
             "message": "December 23 00:09:07 evita5008.www.localdomain proto=ggp service=pop3 status=deny src=10.248.204.182 dst=10.134.148.219 src_port=1331 dst_port=4430 server_app=tmo pid=1835 app_name=abi traff_direct=inbound block_count=4168 logon_user=uioffi@oru6938.invalid msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -221,6 +341,11 @@
                 "version": "8.3.0"
             },
             "message": "January 6 07:11:41 tsedqu2456.www5.invalid proto=ipv6 service=smtp status=deny src=10.178.77.231 dst=10.163.5.243 src_port=5294 dst_port=4129 server_app=xerc pid=2019 app_name=hitecto traff_direct=unknown block_count=1123 logon_user=liquide@etdol5473.local msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -230,6 +355,11 @@
                 "version": "8.3.0"
             },
             "message": "January 20 14:14:16 ris3314.mail.invalid proto=ggp service=smtp status=deny src=10.177.194.18 dst=10.221.89.228 src_port=766 dst_port=2447 server_app=uamei pid=2493 app_name=aera traff_direct=outbound block_count=1747 logon_user=aliquam@nimid893.mail.corp msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -239,6 +369,11 @@
                 "version": "8.3.0"
             },
             "message": "February 3 21:16:50 reme622.mail.example proto=icmp service=ms-wbt-server status=deny src=10.241.65.49 dst=10.32.239.1 src_port=3027 dst_port=3128 server_app=dictasu pid=3022 app_name=catc traff_direct=unknown block_count=3522 logon_user=idata@rumwritt6003.host msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -248,6 +383,11 @@
                 "version": "8.3.0"
             },
             "message": "February 18 04:19:24 non3341.mail.invalid proto=ggp service=http status=deny src=10.168.90.81 dst=10.101.57.120 src_port=6866 dst_port=6501 server_app=laboree pid=2328 app_name=intocc traff_direct=internal block_count=5516 logon_user=eporr@xeacomm6855.api.corp msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -257,6 +397,11 @@
                 "version": "8.3.0"
             },
             "message": "March 4 11:21:59 ris727.api.local proto=tcp service=ms-wbt-server status=deny src=10.14.211.43 dst=10.130.14.60 src_port=4456 dst_port=2051 server_app=autfu pid=1156 app_name=tessec traff_direct=external block_count=7200 logon_user=litse@icabo4125.mail.domain msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -266,6 +411,11 @@
                 "version": "8.3.0"
             },
             "message": "March 18 18:24:33 stquido5705.api.host proto=icmp service=http status=deny src=10.60.129.15 dst=10.248.101.25 src_port=106 dst_port=5740 server_app=Nequepo pid=6003 app_name=pora traff_direct=unknown block_count=6437 logon_user=evolup@ionofdeF5643.www.localhost msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -275,6 +425,11 @@
                 "version": "8.3.0"
             },
             "message": "April 2 01:27:07 etcons7378.api.lan proto=tcp service=https status=deny src=10.72.93.28 dst=10.111.187.12 src_port=3577 dst_port=3994 server_app=aper pid=5651 app_name=tur traff_direct=inbound block_count=3427 logon_user=niamqui@orem6702.invalid msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -284,6 +439,11 @@
                 "version": "8.3.0"
             },
             "message": "April 16 08:29:41 vita2681.www5.local proto=icmp service=ms-wbt-server status=deny src=10.27.14.168 dst=10.66.2.232 src_port=2224 dst_port=5764 server_app=fugiatn pid=3470 app_name=ipsumd traff_direct=outbound block_count=6708 logon_user=uirati@oin6780.mail.domain msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -293,6 +453,11 @@
                 "version": "8.3.0"
             },
             "message": "April 30 15:32:16 tnulapa7592.www.local proto=ggp service=ms-wbt-server status=deny src=10.75.99.127 dst=10.195.2.130 src_port=1766 dst_port=202 server_app=mporin pid=6932 app_name=nisiuta traff_direct=internal block_count=3828 logon_user=inibusB@eprehen3224.www5.localdomain msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -302,6 +467,11 @@
                 "version": "8.3.0"
             },
             "message": "May 14 22:34:50 lup2134.www.localhost proto=ipv6 service=pop3 status=deny src=10.201.238.90 dst=10.245.104.182 src_port=3759 dst_port=55 server_app=ccaecat pid=6945 app_name=onsequ traff_direct=outbound block_count=4198 logon_user=ovol@ptasn6599.www.localhost msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -311,6 +481,11 @@
                 "version": "8.3.0"
             },
             "message": "May 29 05:37:24 tanimid3337.mail.corp proto=ipv6-icmp service=http status=deny src=10.217.150.196 dst=10.105.91.31 src_port=2056 dst_port=5987 server_app=loreme pid=853 app_name=psumquia traff_direct=external block_count=4444 logon_user=con@nisist2752.home msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -320,6 +495,11 @@
                 "version": "8.3.0"
             },
             "message": "June 12 12:39:58 eumiu765.api.lan proto=ipv6-icmp service=https status=deny src=10.4.157.1 dst=10.184.18.202 src_port=52 dst_port=205 server_app=ofdeFini pid=4153 app_name=molli traff_direct=outbound block_count=725 logon_user=oditem@gitsedqu2649.mail.lan msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -329,6 +509,11 @@
                 "version": "8.3.0"
             },
             "message": "June 26 19:42:33 mquelau5326.mail.lan proto=icmp service=https status=deny src=10.255.39.252 dst=10.113.95.59 src_port=863 dst_port=4367 server_app=fugitsed pid=1693 app_name=idolo traff_direct=internal block_count=3147 logon_user=persp@entsunt3962.www.example msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -338,6 +523,11 @@
                 "version": "8.3.0"
             },
             "message": "July 11 02:45:07 idestlab2631.www.lan proto=tcp service=http status=deny src=10.27.16.118 dst=10.83.177.2 src_port=18 dst_port=1827 server_app=iat pid=337 app_name=rinre traff_direct=internal block_count=1300 logon_user=borios@tut2703.www.host msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -347,6 +537,11 @@
                 "version": "8.3.0"
             },
             "message": "July 25 09:47:41 inesci6789.test proto=udp service=http status=deny src=10.38.54.72 dst=10.167.227.44 src_port=6595 dst_port=5736 server_app=lillum pid=7041 app_name=its traff_direct=outbound block_count=7644 logon_user=riamea@entorev160.test msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -356,6 +551,11 @@
                 "version": "8.3.0"
             },
             "message": "August 8 16:50:15 ccaeca7077.internal.corp proto=tcp service=http status=deny src=10.216.54.184 dst=10.215.205.216 src_port=1495 dst_port=647 server_app=riat pid=3854 app_name=psaquaea traff_direct=external block_count=7536 logon_user=ameiusm@proide3714.mail.localdomain msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -365,6 +565,11 @@
                 "version": "8.3.0"
             },
             "message": "August 22 23:52:50 ima2031.api.corp proto=igmp service=smtp status=deny src=10.9.12.248 dst=10.9.18.237 src_port=765 dst_port=2486 server_app=tpersp pid=55 app_name=seosqui traff_direct=internal block_count=6379 logon_user=uradi@tot5313.mail.invalid msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -374,6 +579,11 @@
                 "version": "8.3.0"
             },
             "message": "September 6 06:55:24 ian867.internal.corp proto=rdp service=https status=deny src=10.83.130.226 dst=10.41.123.102 src_port=1542 dst_port=2300 server_app=odoconse pid=228 app_name=quatu traff_direct=external block_count=7661 logon_user=tenim@rumet3801.internal.domain msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -383,6 +593,11 @@
                 "version": "8.3.0"
             },
             "message": "September 20 13:57:58 lorin4249.corp proto=tcp service=pop3 status=deny src=10.175.112.197 dst=10.80.152.108 src_port=1749 dst_port=2742 server_app=exeacom pid=4253 app_name=rita traff_direct=outbound block_count=6984 logon_user=tametcon@liqua2834.www5.lan msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -392,6 +607,11 @@
                 "version": "8.3.0"
             },
             "message": "October 4 21:00:32 gnaaliqu3935.api.test proto=udp service=smtp status=deny src=10.134.18.114 dst=10.142.25.100 src_port=2761 dst_port=5770 server_app=mdol pid=2200 app_name=nby traff_direct=internal block_count=624 logon_user=osqui@sequat7273.api.host msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -401,6 +621,11 @@
                 "version": "8.3.0"
             },
             "message": "October 19 04:03:07 nsequat1859.internal.localhost proto=udp service=http status=deny src=10.28.118.160 dst=10.223.119.218 src_port=6247 dst_port=300 server_app=umexerc pid=5717 app_name=intocc traff_direct=internal block_count=4387 logon_user=ntsunt@uidol4575.localhost msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -410,6 +635,11 @@
                 "version": "8.3.0"
             },
             "message": "November 2 11:05:41 ritin2495.api.corp proto=ggp service=https status=deny src=10.110.114.175 dst=10.47.28.48 src_port=4986 dst_port=3032 server_app=tatem pid=4469 app_name=luptat traff_direct=unknown block_count=4488 logon_user=plicab@oremq2000.api.corp msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -419,6 +649,11 @@
                 "version": "8.3.0"
             },
             "message": "November 16 18:08:15 tetur2694.mail.local proto=ggp service=pop3 status=deny src=10.40.251.202 dst=10.90.33.138 src_port=5733 dst_port=7876 server_app=enimadmi pid=5524 app_name=lupta traff_direct=external block_count=6847 logon_user=nvolupt@oremi1485.api.localhost msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -428,6 +663,11 @@
                 "version": "8.3.0"
             },
             "message": "December 1 01:10:49 rem7043.localhost proto=ipv6 service=ms-wbt-server status=deny src=10.65.2.106 dst=10.227.173.252 src_port=5410 dst_port=5337 server_app=nisiut pid=3624 app_name=teturad traff_direct=external block_count=7576 logon_user=itation@sequatD5469.www5.lan msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -437,6 +677,11 @@
                 "version": "8.3.0"
             },
             "message": "December 15 08:13:24 emqu2846.internal.home proto=udp service=https status=deny src=10.193.233.229 dst=10.28.84.106 src_port=2859 dst_port=4844 server_app=eaqu pid=1609 app_name=uptatemU traff_direct=inbound block_count=3096 logon_user=tla@item2738.test msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -446,6 +691,11 @@
                 "version": "8.3.0"
             },
             "message": "December 29 15:15:58 dqu6144.api.localhost proto=ggp service=ms-wbt-server status=deny src=10.150.245.88 dst=10.210.89.183 src_port=3642 dst_port=2589 server_app=ulpa pid=6248 app_name=iusmodte traff_direct=external block_count=2700 logon_user=sequa@iosamnis1047.internal.localdomain msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -455,6 +705,11 @@
                 "version": "8.3.0"
             },
             "message": "January 12 22:18:32 giatquov1918.internal.example proto=udp service=ms-wbt-server status=deny src=10.180.195.43 dst=10.85.185.13 src_port=4540 dst_port=7793 server_app=gnaal pid=7224 app_name=proident traff_direct=outbound block_count=1867 logon_user=voluptas@orroq6677.internal.example msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -464,6 +719,11 @@
                 "version": "8.3.0"
             },
             "message": "January 27 05:21:06 estl5804.internal.local proto=udp service=ms-wbt-server status=deny src=10.207.211.230 dst=10.210.28.247 src_port=3449 dst_port=7257 server_app=ssecil pid=430 app_name=iuntNe traff_direct=unknown block_count=7672 logon_user=tate@onevo4326.internal.local msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -473,6 +733,11 @@
                 "version": "8.3.0"
             },
             "message": "February 10 12:23:41 Sedut1775.www.domain proto=rdp service=ms-wbt-server status=deny src=10.86.11.48 dst=10.248.165.185 src_port=3436 dst_port=5460 server_app=olorsi pid=3589 app_name=exeaco traff_direct=external block_count=4801 logon_user=dquiac@itaedict7233.mail.localdomain msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -482,6 +747,11 @@
                 "version": "8.3.0"
             },
             "message": "February 24 19:26:15 mac7484.www5.test proto=ipv6-icmp service=http status=deny src=10.118.6.177 dst=10.47.125.38 src_port=6977 dst_port=3896 server_app=isn pid=4814 app_name=omm traff_direct=outbound block_count=1844 logon_user=quunt@numquam5869.internal.example msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -491,6 +761,11 @@
                 "version": "8.3.0"
             },
             "message": "March 11 02:28:49 oin1140.mail.localhost proto=icmp service=pop3 status=deny src=10.50.233.155 dst=10.60.142.127 src_port=1081 dst_port=5112 server_app=urExce pid=276 app_name=nturm traff_direct=outbound block_count=2241 logon_user=atv@onu6137.api.home msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -500,6 +775,11 @@
                 "version": "8.3.0"
             },
             "message": "March 25 09:31:24 naaliq3710.api.local proto=rdp service=http status=deny src=10.28.82.189 dst=10.120.10.211 src_port=3916 dst_port=7661 server_app=odt pid=2452 app_name=inv traff_direct=internal block_count=7705 logon_user=rcit@aecatcup2241.www5.test msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -509,6 +789,11 @@
                 "version": "8.3.0"
             },
             "message": "April 8 16:33:58 volupta3552.internal.localhost proto=ipv6 service=pop3 status=deny src=10.31.237.225 dst=10.6.38.163 src_port=6153 dst_port=4059 server_app=oreveri pid=3453 app_name=avolu traff_direct=inbound block_count=2820 logon_user=olup@labor6360.mail.local msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -518,6 +803,11 @@
                 "version": "8.3.0"
             },
             "message": "April 22 23:36:32 onse380.internal.localdomain proto=ggp service=https status=deny src=10.226.5.189 dst=10.125.165.144 src_port=3371 dst_port=7889 server_app=dexerc pid=2302 app_name=tatem traff_direct=inbound block_count=5407 logon_user=mvolu@mveleum4322.www5.host msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -527,6 +817,11 @@
                 "version": "8.3.0"
             },
             "message": "May 7 06:39:06 queips4947.mail.example proto=udp service=smtp status=deny src=10.97.149.97 dst=10.46.56.204 src_port=2463 dst_port=5070 server_app=uela pid=7079 app_name=umf traff_direct=unknown block_count=2441 logon_user=dolorsit@archite1843.mail.home msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -536,6 +831,11 @@
                 "version": "8.3.0"
             },
             "message": "May 21 13:41:41 oloreseo5039.test proto=ggp service=https status=deny src=10.218.0.197 dst=10.28.105.124 src_port=7581 dst_port=4797 server_app=eritin pid=5773 app_name=litsedq traff_direct=outbound block_count=5749 logon_user=ntNe@itanim4024.api.example msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -545,6 +845,11 @@
                 "version": "8.3.0"
             },
             "message": "June 4 20:44:15 minim459.mail.local proto=rdp service=https status=deny src=10.123.199.198 dst=10.17.87.79 src_port=6332 dst_port=3414 server_app=tionula pid=1586 app_name=ate traff_direct=outbound block_count=5006 logon_user=ratvolu@nreprehe715.api.home msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -554,6 +859,11 @@
                 "version": "8.3.0"
             },
             "message": "June 19 03:46:49 eratv211.api.host proto=rdp service=https status=deny src=10.38.86.177 dst=10.115.68.40 src_port=5768 dst_port=5483 server_app=boNem pid=5137 app_name=ssusci traff_direct=internal block_count=2841 logon_user=mpo@unte893.internal.host msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -563,6 +873,11 @@
                 "version": "8.3.0"
             },
             "message": "July 3 10:49:23 aparia1179.www.localdomain proto=tcp service=https status=deny src=10.193.118.163 dst=10.115.174.107 src_port=548 dst_port=5597 server_app=acom pid=5704 app_name=dolorem traff_direct=internal block_count=10 logon_user=exeacomm@aspe951.mail.domain msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -572,6 +887,11 @@
                 "version": "8.3.0"
             },
             "message": "July 17 17:51:58 iatqu6203.mail.corp proto=icmp service=http status=deny src=10.37.128.49 dst=10.77.77.208 src_port=625 dst_port=1101 server_app=esci pid=2310 app_name=essecill traff_direct=external block_count=2653 logon_user=moles@dipiscin4957.www.home msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -581,6 +901,11 @@
                 "version": "8.3.0"
             },
             "message": "August 1 00:54:32 ptasnula6576.api.invalid proto=tcp service=ms-wbt-server status=deny src=10.54.73.158 dst=10.1.96.93 src_port=5752 dst_port=428 server_app=docon pid=5398 app_name=ntium traff_direct=internal block_count=4392 logon_user=lloinven@econs2687.internal.localdomain msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -590,6 +915,11 @@
                 "version": "8.3.0"
             },
             "message": "August 15 07:57:06 mag1506.internal.domain proto=igmp service=smtp status=deny src=10.131.126.109 dst=10.182.152.242 src_port=1877 dst_port=6998 server_app=rcitat pid=2465 app_name=ecillum traff_direct=inbound block_count=3208 logon_user=dolor@tiumto5834.api.lan msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -599,6 +929,11 @@
                 "version": "8.3.0"
             },
             "message": "August 29 14:59:40 fugits1163.host proto=icmp service=http status=deny src=10.181.247.224 dst=10.77.229.168 src_port=260 dst_port=3777 server_app=atatnon pid=6064 app_name=abor traff_direct=external block_count=329 logon_user=adol@iutal6032.www.test msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -608,6 +943,11 @@
                 "version": "8.3.0"
             },
             "message": "September 12 22:02:15 gitse2463.www5.invalid proto=ipv6-icmp service=http status=deny src=10.235.116.121 dst=10.72.162.6 src_port=1 dst_port=5516 server_app=emp pid=2861 app_name=luptas traff_direct=outbound block_count=1444 logon_user=oinv@inculp2078.host msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -617,6 +957,11 @@
                 "version": "8.3.0"
             },
             "message": "September 27 05:04:49 temse6953.www.example proto=ipv6-icmp service=https status=deny src=10.149.193.117 dst=10.28.124.236 src_port=5343 dst_port=3434 server_app=atcupi pid=3559 app_name=edquia traff_direct=internal block_count=3176 logon_user=mullam@mexerc2757.internal.home msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -626,6 +971,11 @@
                 "version": "8.3.0"
             },
             "message": "October 11 12:07:23 deriti6952.mail.domain proto=ipv6-icmp service=http status=deny src=10.34.131.224 dst=10.196.96.162 src_port=649 dst_port=6378 server_app=equatDu pid=1710 app_name=aconse traff_direct=outbound block_count=7174 logon_user=tnonproi@squira4455.api.domain msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -635,6 +985,11 @@
                 "version": "8.3.0"
             },
             "message": "October 25 19:09:57 abor1370.www.domain proto=ipv6-icmp service=https status=deny src=10.97.236.123 dst=10.77.78.180 src_port=5159 dst_port=5380 server_app=reetdol pid=4984 app_name=ugi traff_direct=inbound block_count=4782 logon_user=nisi@emveleum3661.localhost msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -644,6 +999,11 @@
                 "version": "8.3.0"
             },
             "message": "November 9 02:12:32 emullamc5418.mail.test proto=ipv6 service=ms-wbt-server status=deny src=10.82.133.66 dst=10.45.54.107 src_port=7229 dst_port=3593 server_app=nse pid=3421 app_name=quira traff_direct=unknown block_count=5362 logon_user=olorem@sedquiac6517.internal.localhost msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -653,6 +1013,11 @@
                 "version": "8.3.0"
             },
             "message": "November 23 09:15:06 squirati7050.www5.lan proto=rdp service=pop3 status=deny src=10.180.180.230 dst=10.170.252.219 src_port=4147 dst_port=2454 server_app=tesseci pid=4020 app_name=radipis traff_direct=external block_count=7020 logon_user=nse@veniam3148.www5.home msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -662,6 +1027,11 @@
                 "version": "8.3.0"
             },
             "message": "December 7 16:17:40 venia2079.mail.example proto=rdp service=http status=deny src=10.5.11.205 dst=10.65.144.51 src_port=4901 dst_port=2283 server_app=lumqu pid=617 app_name=autf traff_direct=outbound block_count=5050 logon_user=uptat@unt3559.www.home msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -671,6 +1041,11 @@
                 "version": "8.3.0"
             },
             "message": "December 21 23:20:14 snostrum3450.www5.localhost proto=udp service=smtp status=deny src=10.195.223.82 dst=10.76.122.196 src_port=3128 dst_port=5325 server_app=atu pid=487 app_name=iame traff_direct=external block_count=593 logon_user=umiurer@rere5274.mail.domain msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -680,6 +1055,11 @@
                 "version": "8.3.0"
             },
             "message": "January 5 06:22:49 gelitsed3249.corp proto=icmp service=ms-wbt-server status=deny src=10.138.210.116 dst=10.225.255.211 src_port=5595 dst_port=3369 server_app=rum pid=2442 app_name=eursinto traff_direct=external block_count=956 logon_user=fugiatn@uaeabi3728.www5.invalid msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -689,6 +1069,11 @@
                 "version": "8.3.0"
             },
             "message": "January 19 13:25:23 dolor7082.internal.localhost proto=icmp service=smtp status=deny src=10.250.81.189 dst=10.219.1.151 src_port=5404 dst_port=4323 server_app=redo pid=6311 app_name=ditautf traff_direct=external block_count=3262 logon_user=ori@uamqu2804.test msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -698,6 +1083,11 @@
                 "version": "8.3.0"
             },
             "message": "February 2 20:27:57 totam6886.api.localhost proto=ggp service=https status=deny src=10.54.23.133 dst=10.76.125.70 src_port=3258 dst_port=756 server_app=oluptat pid=7128 app_name=eseruntm traff_direct=internal block_count=1916 logon_user=oloreeu@olor5201.host msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -707,6 +1097,11 @@
                 "version": "8.3.0"
             },
             "message": "February 17 03:30:32 laborum5749.www.example proto=igmp service=http status=deny src=10.36.110.69 dst=10.189.42.62 src_port=4187 dst_port=4262 server_app=duntut pid=2780 app_name=ullamc traff_direct=unknown block_count=170 logon_user=eque@eufug3348.www.lan msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -716,6 +1111,11 @@
                 "version": "8.3.0"
             },
             "message": "March 3 10:33:06 lup3313.api.home proto=tcp service=https status=deny src=10.47.179.68 dst=10.183.202.82 src_port=5107 dst_port=2208 server_app=usmod pid=3284 app_name=amni traff_direct=unknown block_count=2645 logon_user=umfugi@stquidol239.www5.invalid msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -725,6 +1125,11 @@
                 "version": "8.3.0"
             },
             "message": "March 17 17:35:40 edq5397.www.test proto=ipv6-icmp service=pop3 status=deny src=10.73.28.165 dst=10.221.206.74 src_port=3668 dst_port=1480 server_app=ihilmole pid=2314 app_name=litanim traff_direct=inbound block_count=5572 logon_user=quas@gia6531.mail.invalid msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -734,6 +1139,11 @@
                 "version": "8.3.0"
             },
             "message": "April 1 00:38:14 udan6536.www5.test proto=ipv6 service=ms-wbt-server status=deny src=10.85.104.146 dst=10.14.204.36 src_port=3442 dst_port=4887 server_app=qua pid=5284 app_name=ents traff_direct=inbound block_count=973 logon_user=emp@lamcola4879.www5.localdomain msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -743,6 +1153,11 @@
                 "version": "8.3.0"
             },
             "message": "April 15 07:40:49 rumet6923.www5.lan proto=rdp service=https status=deny src=10.208.18.210 dst=10.30.246.132 src_port=3601 dst_port=388 server_app=texplica pid=3990 app_name=ore traff_direct=outbound block_count=5624 logon_user=veniam@edquian330.mail.local msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -752,6 +1167,11 @@
                 "version": "8.3.0"
             },
             "message": "April 29 14:43:23 itse522.internal.localdomain proto=udp service=pop3 status=deny src=10.106.249.91 dst=10.19.119.17 src_port=1732 dst_port=3822 server_app=veleumi pid=4337 app_name=tvol traff_direct=unknown block_count=2783 logon_user=lit@santi837.api.domain msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -761,6 +1181,11 @@
                 "version": "8.3.0"
             },
             "message": "May 13 21:45:57 amc3059.local proto=igmp service=http status=deny src=10.29.109.126 dst=10.181.41.154 src_port=6261 dst_port=866 server_app=itseddo pid=5275 app_name=seos traff_direct=unknown block_count=6721 logon_user=labo@lpaquiof804.internal.invalid msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -770,6 +1195,11 @@
                 "version": "8.3.0"
             },
             "message": "May 28 04:48:31 enbyCi3813.api.domain proto=ipv6-icmp service=https status=deny src=10.164.207.42 dst=10.164.120.197 src_port=1901 dst_port=2304 server_app=itametco pid=2286 app_name=remip traff_direct=external block_count=3116 logon_user=pta@nonn4478.host msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -779,6 +1209,11 @@
                 "version": "8.3.0"
             },
             "message": "June 11 11:51:06 liquipex1155.mail.corp proto=ipv6-icmp service=smtp status=deny src=10.183.189.133 dst=10.154.191.225 src_port=5347 dst_port=7856 server_app=Loremip pid=2990 app_name=tur traff_direct=unknown block_count=6105 logon_user=ita@amquaer3985.www5.example msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -788,6 +1223,11 @@
                 "version": "8.3.0"
             },
             "message": "June 25 18:53:40 isn3991.local proto=igmp service=smtp status=deny src=10.29.120.226 dst=10.103.189.199 src_port=1296 dst_port=767 server_app=exerci pid=226 app_name=eserun traff_direct=outbound block_count=5452 logon_user=emu@orem6317.local msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -797,6 +1237,11 @@
                 "version": "8.3.0"
             },
             "message": "July 10 01:56:14 iumtotam1010.www5.corp proto=icmp service=https status=deny src=10.133.254.23 dst=10.210.153.7 src_port=6251 dst_port=7030 server_app=nofdeFi pid=4691 app_name=sautei traff_direct=external block_count=2088 logon_user=voluptas@velill3230.www.corp msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -806,6 +1251,11 @@
                 "version": "8.3.0"
             },
             "message": "July 24 08:58:48 onsecte91.www5.localdomain proto=tcp service=pop3 status=deny src=10.126.245.73 dst=10.91.2.135 src_port=180 dst_port=2141 server_app=ender pid=5647 app_name=rumSecti traff_direct=outbound block_count=4680 logon_user=olore@orumS757.www5.corp msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -815,6 +1265,11 @@
                 "version": "8.3.0"
             },
             "message": "August 7 16:01:23 abori7686.internal.host proto=rdp service=https status=deny src=10.183.243.246 dst=10.137.85.123 src_port=218 dst_port=7073 server_app=ntsunti pid=2313 app_name=magnam traff_direct=internal block_count=6402 logon_user=cid@emi4534.www.localdomain msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -824,6 +1279,11 @@
                 "version": "8.3.0"
             },
             "message": "August 21 23:03:57 reprehen3513.test proto=ipv6 service=smtp status=deny src=10.61.225.196 dst=10.10.86.55 src_port=4720 dst_port=5132 server_app=isiu pid=1585 app_name=mmodi traff_direct=external block_count=3034 logon_user=eniamqu@inimav1576.mail.example msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -833,6 +1293,11 @@
                 "version": "8.3.0"
             },
             "message": "September 5 06:06:31 orroquis284.api.domain proto=udp service=http status=deny src=10.125.143.153 dst=10.79.73.195 src_port=2657 dst_port=457 server_app=umf pid=3141 app_name=moll traff_direct=outbound block_count=7645 logon_user=emip@aturQu7083.mail.host msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -842,6 +1307,11 @@
                 "version": "8.3.0"
             },
             "message": "September 19 13:09:05 tionula2060.www5.localhost proto=ipv6 service=ms-wbt-server status=deny src=10.240.216.85 dst=10.64.139.17 src_port=2046 dst_port=2438 server_app=ice pid=6331 app_name=aal traff_direct=external block_count=4982 logon_user=nimadmin@lumqui7769.mail.local msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -851,6 +1321,11 @@
                 "version": "8.3.0"
             },
             "message": "October 3 20:11:40 rumSecti111.www5.domain proto=ipv6 service=ms-wbt-server status=deny src=10.87.90.49 dst=10.222.245.80 src_port=1486 dst_port=4017 server_app=itaedict pid=4474 app_name=byCic traff_direct=inbound block_count=3380 logon_user=ptatemse@siarc6339.internal.corp msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -860,6 +1335,11 @@
                 "version": "8.3.0"
             },
             "message": "October 18 03:14:14 olores7881.local proto=udp service=pop3 status=deny src=10.143.53.214 dst=10.87.144.208 src_port=3310 dst_port=2440 server_app=ipsumq pid=4855 app_name=psaquaea traff_direct=unknown block_count=5772 logon_user=psumq@ptatev6552.www.test msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -869,6 +1349,11 @@
                 "version": "8.3.0"
             },
             "message": "November 1 10:16:48 tDuis3281.www5.localdomain proto=ipv6-icmp service=pop3 status=deny src=10.204.178.19 dst=10.105.97.134 src_port=616 dst_port=1935 server_app=oremque pid=1729 app_name=inimve traff_direct=unknown block_count=6564 logon_user=mexercit@byC5766.internal.home msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -878,6 +1363,11 @@
                 "version": "8.3.0"
             },
             "message": "November 15 17:19:22 uptasnul2751.www5.corp proto=rdp service=smtp status=deny src=10.161.64.168 dst=10.194.67.223 src_port=7154 dst_port=5767 server_app=tatemse pid=4493 app_name=amqui traff_direct=inbound block_count=3673 logon_user=tion@hender6628.local msg=unknown",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -887,6 +1377,11 @@
                 "version": "8.3.0"
             },
             "message": "November 30 00:21:57 upt6017.api.localdomain proto=tcp service=smtp status=deny src=10.100.154.220 dst=10.120.148.241 src_port=5535 dst_port=1655 server_app=eeufug pid=6094 app_name=modt traff_direct=external block_count=5150 logon_user=rsitam@xercit7649.www5.home msg=failure",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -896,6 +1391,11 @@
                 "version": "8.3.0"
             },
             "message": "December 14 07:24:31 tpers2217.internal.lan proto=udp service=ms-wbt-server status=deny src=10.116.153.19 dst=10.180.90.112 src_port=6610 dst_port=1936 server_app=olu pid=5012 app_name=dexercit traff_direct=outbound block_count=2216 logon_user=itessequ@porissu1470.domain msg=success",
+            "observer": {
+                "product": "FortiClient",
+                "type": "anti-virus",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/fortinet_forticlient/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/fortinet_forticlient/data_stream/log/agent/stream/log.yml.hbs
@@ -10,12 +10,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiClient"
-        type: "Anti-Virus"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_forticlient/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet_forticlient/data_stream/log/agent/stream/tcp.yml.hbs
@@ -7,12 +7,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiClient"
-        type: "Anti-Virus"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_forticlient/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/fortinet_forticlient/data_stream/log/agent/stream/udp.yml.hbs
@@ -7,12 +7,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiClient"
-        type: "Anti-Virus"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_forticlient/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_forticlient/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1,10 +1,18 @@
 ---
 description: Pipeline for Fortinet FortiClient Endpoint Security
-
 processors:
   - set:
       field: ecs.version
       value: '8.3.0'
+  - set:
+      field: observer.vendor
+      value: Fortinet
+  - set:
+      field: observer.product
+      value: FortiClient
+  - set:
+      field: observer.type
+      value: anti-virus
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/fortinet_forticlient/manifest.yml
+++ b/packages/fortinet_forticlient/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_forticlient
 title: Fortinet FortiClient Logs
-version: 1.0.0
+version: 1.1.0
 release: ga
 description: Collect logs from Fortinet FortiClient instances with Elastic Agent.
 type: integration

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Update Ingest Pipeline with observer Fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3819
 - version: "1.1.0"
   changes:
     - description: Add dashboard.

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: 1.1.0
+version: 1.2.0
 release: ga
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration

--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Update Ingest Pipeline with observer Fields
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/3819
 - version: "1.0.0"
   changes:
     - description: Initial version of Fortinet FortiMail as separate package

--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.1.0"
   changes:
     - description: Update Ingest Pipeline with observer Fields
-      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/3819
 - version: "1.0.0"
   changes:

--- a/packages/fortinet_fortimail/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/fortinet_fortimail/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
@@ -5,6 +5,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-1-29 time=06:09:59 device_id=pexe log_id=nes log_part=eab type=event subtype=update pri=high msg=\"boNemoe\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -14,6 +19,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-2-12 time=13:12:33 device_id=ehend log_id=ritquiin log_part=umqui type=virus subtype=infected pri=very-high from=\"mest\" to=enderitq client_name=\"sperna884.internal.domain\" client_ip=\"10.165.201.71\" session_id=\"pisciv\" msg=\"uii\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -23,6 +33,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-2-26 time=20:15:08 device_id=doeiu log_id=nia log_part=olupt type=event subtype=config pri=low user=quipexe ui=alo(10.212.18.145) module=umdo submodule=itessequ msg=vol",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -32,6 +47,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-3-12 time=03:17:42 device_id=uipexea log_id=tatio log_part=minim type=event subtype=pop3 pri=high user=ceroinBC ui=ratvolup action=deny status=iatu msg=\"ionofde\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -41,6 +61,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-3-26 time=10:20:16 device_id=itati log_id=mfu log_part=uid type=event subtype=pop3 pri=very-high user=obeataev ui=lor action=block status=autfu msg=\"natura\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -50,6 +75,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-4-9 time=17:22:51 device_id=llamcorp log_id=ari log_part=eataevit type=event subtype=system pri=high user=iam ui=mqua action=allow status=olab msg=mquisnos",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -59,6 +89,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-4-24 time=00:25:25 device_id=enimad log_id=incididu log_part=eci type=virus pri=very-high from=tenbyCic to=boree src=10.98.69.43 session_id=\"iinea\" msg=ipit",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -68,6 +103,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-5-8 time=07:27:59 device_id=taliqu log_id=temUten log_part=ccusan type=virus subtype=infected pri=low from=\"Ciceroi\" to=\"aveniam\" client_name=\"uradi7307.internal.corp\" client_ip=\"10.118.96.139\" session_id=\"sitas\" msg=ehenderi",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -77,6 +117,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-5-22 time=14:30:33 device_id=smo log_id=litessec log_part=emporinc type=event subtype=pop3 pri=very-high user=ipsumq ui=atcu action=allow status=tessec msg=\"remipsum\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -86,6 +131,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-6-5 time=21:33:08 device_id=ntutl log_id=caecatc log_part=onsequat type=event subtype=update pri=low msg=\"edquiano\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -95,6 +145,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-6-20 time=04:35:42 device_id=idestla log_id=Nemoeni log_part=uradi type=statistics pri=very-high session_id=\"lup\" from=\"remeumf\" mailer=antiumto client_name=\"10.241.165.37\" MSISDN=aUteni resolved=ittenbyC to=\"aperi\" direction=\"inbound\" message_length=ita virus=\"ipi\" disposition=rsitamet classifier=\"lupt\" subject=\"xea\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -104,6 +159,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-7-4 time=11:38:16 device_id=amvolup log_id=sequi log_part=rehend type=event subtype=webmail pri=high user=eme ui=numqu(10.232.149.140) action=allow status=lum msg=utali",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -113,6 +173,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-7-18 time=18:40:50 device_id=estiae log_id=sci log_part=oei type=virus_file-signature pri=low snostrud to=nama src=\"10.24.67.250\" session_id=\"dolor\" msg=\"nnum\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -122,6 +187,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-8-2 time=01:43:25 device_id=oluptas log_id=tNequepo log_part=lup type=event subtype=update pri=medium msg=equat",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -131,6 +201,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-8-16 time=08:45:59 device_id=abi log_id=sectetur log_part=uioffi type=event subtype=update pri=high msg=veniamq",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -140,6 +215,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-8-30 time=15:48:33 device_id=orem log_id=beata log_part=hitecto type=statistics pri=very-high session_id=\"texp\" client_name=\"[10.179.124.125]\"dst_ip=\"10.177.36.38\" from=\"sequine\" to=\"ectio\" polid=\"dutper\" domain=\"lamcolab3252.www.invalid\" subject=\"gel\" mailer=\"lorsitam\" resolved=\"mpo\" direction=\"inbound\" virus=\"ris\" disposition=\"uamqu\" classifier=\"lor\" message_length=oide",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -149,6 +229,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-9-13 time=22:51:07 device_id=didunt log_id=uptatema log_part=intocc type=virus subtype=file-signature pri=very-high from=\"orema\" to=invento src=[10.164.39.248] session_id=\"nofdeFin\" msg=sequam",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -158,6 +243,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-9-28 time=05:53:42 device_id=tvolu log_id=ecte log_part=tinvolu type=virus_file-signature pri=high from=\"ntiumdo\" to=\"autfu\" src=gnaaliq [10.52.135.156] session_id=\"litse\" msg=\"icabo\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -167,6 +257,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-10-12 time=12:56:16 device_id=stru log_id=tectobe log_part=Nequepo type=event subtype=config pri=very-high user=pora ui=boree module=evolup submodule=ionofdeF msg=\"evelit\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -176,6 +271,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-10-26 time=19:58:50 device_id=uatD log_id=ariatu log_part=edquiac type=event subtype=smtp pri=high user=atno ui=tani action=allow status=ntocca session_id=ostru log_part=ntoccae msg=autf",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -185,6 +285,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-11-10 time=03:01:24 device_id=tenimad log_id=minimav log_part=udexerci type=spam pri=very-high session_id=\"itam\" client_name=\"str976.internal.localhost [10.166.225.26]\" from=tanimid to=umdo subject=\"natuse\" msg=\"gnamal\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -194,6 +299,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-11-24 time=10:03:59 device_id=intoc log_id=rQuisau log_part=itess type=virus subtype=infected pri=high from=evit to=\"runtm\" client_name=\"molli4306.www5.home\" client_ip=\"10.218.243.47\" session_id=\"borios\" msg=rsitvolu",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -203,6 +313,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-12-8 time=17:06:33 device_id=quamqua log_id=eacommod log_part=ctetura type=event subtype=imap pri=high user=tpersp ui=stla action=allow status=sequamni msg=uradi",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -212,6 +327,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-12-23 time=00:09:07 device_id=dolore log_id=onsecte log_part=nBCSedut type=virus subtype=file-signature pri=high from=\"modocons\" to=gitsed src=\"10.16.177.212\" session_id=\"emp\" msg=\"Attachment file (pisciv) has sha1 hash value: lumdolor\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -221,6 +341,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-1-6 time=07:11:41 device_id=uaUten log_id=nby log_part=mve type=event subtype=config pri=low user=isau ui=rautodi(10.96.97.81) module=pis submodule=nsequat msg=doloreme",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -230,6 +355,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-1-20 time=14:14:16 device_id=aec log_id=fdeF log_part=iquidexe type=spam pri=low session_id=\"niamq\" client_name= \"lapariat7287.internal.host\" client_ip=\"10.140.7.83\" dst_ip=\"10.68.246.187\" from=\"icabo\" to=\"gna\" subject=\"con\" msg=\"preh\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -239,6 +369,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-2-3 time=21:16:50 device_id=amcor log_id=ica log_part=lillum type=event subtype=admin pri=very-high user=dicta ui=taedicta action=accept status=poriss reason=failure msg=equaturv",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -248,6 +383,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-2-18 time=04:19:24 device_id=tpersp log_id=llamc log_part=nte type=event subtype=pop3 pri=very-high user=utali ui=porinc(10.48.204.44) action=accept status=dat msg=aincidu",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -257,6 +397,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-3-4 time=11:21:59 device_id=dipisci log_id=spernatu log_part=admi type=event subtype=pop3 pri=very-high user=quunt ui=olori action=allow status=autodit msg=elit",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -266,6 +411,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-3-18 time=18:24:33 device_id=nte log_id=ulpa log_part=sitam type=virus subtype=file-signature pri=low enderit to=sequa src=\"[10.111.233.194]\" session_id=eirure msg=deserun",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -275,6 +425,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-4-2 time=01:27:07 device_id=ptateve log_id=enderi log_part=ptatem type=event subtype=smtp pri=very-high user=fugi ui=labo action=block status=ullamcor session_id=itationu msg=proident",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -284,6 +439,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-4-16 time=08:29:41 device_id=atione log_id=lores log_part=ritati type=statistics pri=very-high session_id=uii client_name=estl5804.internal.local client_ip=10.73.207.70 dst_ip=10.179.210.218 from=taut hfrom=tanimi to=rumSecti polid=iuntNe domain=atise3421.www5.localdomain mailer=oluptas resolved=emvele src_type=isnost direction=inbound virus=Sedut disposition=yCiceroi classifier=quunt message_length=acommod subject=sitvol",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -293,6 +453,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-4-30 time=15:32:16 device_id=liquide log_id=odt log_part=Sedutpe type=event subtype=admin pri=medium user=rroq ui=rcit(10.43.62.246) action=accept status=estl reason=success msg=citatio",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -302,6 +467,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-5-14 time=22:34:50 device_id=taedict log_id=edquian log_part=loremeu type=event subtype=admin pri=very-high user=volupta ui=dmi action=allow status=aaliq reason=unknown msg=lupta",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -311,6 +481,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-5-29 time=05:37:24 device_id=occ log_id=oloreseo log_part=iruredol type=virus subtype=file-signature pri=very-high derit to=orese src=\"[10.28.105.124]\" session_id=\"strude\" msg=eritin",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -320,6 +495,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-6-12 time=12:39:58 device_id=temUten log_id=dutper log_part=sitamet type=event subtype=admin pri=very-high user=illumqui ui=saq action=block status=ritqu reason=unknown msg=\"idolor\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -329,6 +509,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-6-26 time=19:42:33 device_id=quide log_id=quaU log_part=undeomni type=virus_file-signature pri=medium acomm to=iutali src=\"[10.219.13.150]\" session_id=Finibus msg=radi",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -338,6 +523,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-7-11 time=02:45:07 device_id=inrepr log_id=mol log_part=umdolors type=event subtype=pop3 pri=medium user=imad ui=oriosam(10.163.114.215) action=deny status=sitametc msg=onsequa",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -347,6 +537,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-7-25 time=09:47:41 device_id=riosa log_id=tNe log_part=pisc type=event subtype=webmail pri=very-high user=caecat ui=rautod(10.124.32.120) action=accept status=atcupi msg=atem",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -356,6 +551,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-8-8 time=16:50:15 device_id=undeom log_id=emullamc log_part=tec type=event subtype=imap pri=medium user=eetdo ui=tlab action=cancel status=liq msg=seddoeiu",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -365,6 +565,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-8-22 time=23:52:50 device_id=edictasu log_id=mdolors log_part=oremi type=event subtype=imap pri=medium user=atis ui=atDuis action=accept status=nisiut msg=\"rumwri\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -374,6 +579,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-9-6 time=06:55:24 device_id=lumqu log_id=onulamco log_part=ons type=event subtype=pop3 pri=low user=uptat ui=unt action=accept status=uido msg=tla",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -383,6 +593,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-9-20 time=13:57:58 device_id=uamqu log_id=olori log_part=ido type=spam pri=low session_id=\"sunt\" from=\"autfugit\" to=\"emUte\" msg=iusmodi",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -392,6 +607,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-10-4 time=21:00:32 device_id=umS log_id=iciadese log_part=riatur type=event subtype=webmail pri=very-high user=xeacommo ui=Cicero(10.247.53.179) action=cancel status=ditau msg=atemaccu",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -401,6 +621,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-10-19 time=04:03:07 device_id=urau log_id=etur log_part=rsitvol type=event subtype=config pri=low user=laborum ui=ostr(10.70.91.185) module=lumdo submodule=acom msg=\"eFini\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -410,6 +635,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-11-2 time=11:05:41 device_id=upta log_id=itessequ log_part=iusmodit type=event subtype=update pri=very-high msg=exerci",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -419,6 +649,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-11-16 time=18:08:15 device_id=mmodoco log_id=amni log_part=atnul type=event subtype=webmail pri=medium user=iquidexe ui=illumq(10.215.65.52) action=accept status=tasnul msg=\"tuserr\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -428,6 +663,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-12-1 time=01:10:49 device_id=porinc log_id=riame log_part=riat type=event subtype=admin pri=medium user=rumSec ui=orp action=deny status=udan reason=unknown msg=\"essequam\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -437,6 +677,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-12-15 time=08:13:24 device_id=itse log_id=ilm log_part=mvel type=virus subtype=infected pri=high from=seos to=exercita client_name=\"edolori3822.api.home\" client_ip=\"10.63.177.46\" session_id=\"oluptate\" msg=lit",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -446,6 +691,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-12-29 time=15:15:58 device_id=iciade log_id=uis log_part=amc type=event subtype=webmail pri=medium user=Ute ui=ptassita action=allow status=runtm msg=\"eturadip\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -455,6 +705,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-1-12 time=22:18:32 device_id=colabori log_id=imidestl log_part=piscing type=virus subtype=file-signature pri=high from=\"isn\" to=smod src=\"idunt [10.29.120.226]\" session_id=\"atev\" msg=\"ectio\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -464,6 +719,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-1-27 time=05:21:06 device_id=atcupid log_id=onse log_part=psa type=virus_file-signature pri=high destla to=\"fugitse\" src=[10.12.86.130] session_id=dese msg=\"Attachment file (duntutla) has sha1 hash value: lamco\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -473,6 +733,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-2-10 time=12:23:41 device_id=gna log_id=ici log_part=quamnih type=event subtype=pop3 pri=low user=iameaque ui=identsun action=deny status=aquio msg=\"rspicia\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -482,6 +747,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-2-24 time=19:26:15 device_id=uiineavo log_id=sistena log_part=uidexeac type=virus subtype=infected pri=high from=\"amquisno\" to=modoc client_name=\"magnam3267.corp\" client_ip=\"10.95.32.86\" session_id=\"Bonorum\" msg=lesti",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -491,6 +761,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-3-11 time=02:28:49 device_id=lupta log_id=byC log_part=imadm type=spam pri=low session_id=\"nci\" from=\"orroquis\" to=\"ulapa\" subject=\"iumdo\" msg=\"iusmodit\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -500,6 +775,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-3-25 time=09:31:24 device_id=obeataev log_id=umf log_part=olesti type=event subtype=config pri=low user=quaeabil ui=emip module=aturQu submodule=itesse msg=\"iamqui\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -509,6 +789,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-4-8 time=16:33:58 device_id=inim log_id=etdol log_part=Sed type=event subtype=pop3 pri=very-high user=tten ui=etur action=allow status=mipsumqu msg=\"eprehen\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -518,6 +803,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-4-22 time=23:36:32 device_id=itaedict log_id=olorema log_part=rep type=event subtype=update pri=low msg=ptatemse",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -527,6 +817,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-5-7 time=06:39:06 device_id=eleumi log_id=edic log_part=udexerc type=event subtype=pop3 pri=low user=olabori ui=odic action=block status=lica msg=secil",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -536,6 +831,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-5-21 time=13:41:41 device_id=nimadmin log_id=midest log_part=modt type=event subtype=update pri=very-high msg=tocca",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -545,6 +845,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-6-4 time=20:44:15 device_id=usant log_id=mipsumq log_part=ident type=event subtype=config pri=very-high user=sequatD ui=ercitati(10.40.89.185) module=temse submodule=caecat msg=\"cusanti\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -554,6 +859,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-6-19 time=03:46:49 device_id=conseq log_id=itame log_part=tenat type=virus subtype=infected pri=very-high from=\"yCiceroi\" to=\"nostrum\" client_name=\"orroquis5179.local\" client_ip=\"10.252.96.71\" session_id=\"tvolu\" msg=\"dutper\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -563,6 +873,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-7-3 time=10:49:23 device_id=ugiatqu log_id=eruntmo log_part=nimve type=virus subtype=infected pri=very-high from=natus to=boreet client_name=\"luptasnu757.www.home\" client_ip=\"10.174.210.232\" session_id=ovolupta msg=\"volup\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -572,6 +887,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-7-17 time=17:51:58 device_id=Bonoru log_id=rcitati log_part=nula type=event subtype=imap pri=medium user=deomni ui=adipi(10.120.232.62) action=block status=ntutl msg=\"volupt\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -581,6 +901,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-8-1 time=00:54:32 device_id=mquameiu log_id=loremq log_part=turmagni type=event subtype=imap pri=very-high user=emUtenim ui=ende action=block status=amnis msg=rvelil",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -590,6 +915,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-8-15 time=07:57:06 device_id=rumetMa log_id=mexerci log_part=urEx type=virus subtype=file-signature pri=medium liq to=abore src=10.200.225.45 session_id=dol msg=exe",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -599,6 +929,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-8-29 time=14:59:40 device_id=audant log_id=rspicia log_part=pitl type=statistics pri=high session_id=mmod client_name=taevit4968.mail.local client_ip=10.144.111.42 dst_ip=10.62.61.1 from=lam hfrom=asnu to=com polid=rep domain=mveni5084.internal.local mailer=num resolved=ctetura src_type=quaerat direction=inbound virus=umexer disposition=amnih classifier=tper message_length=pisciv subject=tconsect",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -608,6 +943,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-9-12 time=22:02:15 device_id=emipsumq log_id=culpaq log_part=quamq type=event subtype=pop3 pri=medium user=emvel ui=pta(10.183.213.223) action=block status=hend msg=remagna",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -617,6 +957,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-9-27 time=05:04:49 device_id=lauda log_id=plicaboN log_part=dolo type=virus subtype=file-signature pri=medium from=\"elit\" to=sam src=\"tMal [10.52.190.18]\" session_id=isni msg=quid",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -626,6 +971,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-10-11 time=12:07:23 device_id=inibus log_id=secte log_part=ctobeat type=event subtype=config pri=low user=iqui ui=animide module=pid submodule=itanimi msg=\"onoru\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -635,6 +985,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-10-25 time=19:09:57 device_id=naaliq log_id=plica log_part=asiarc type=event subtype=imap pri=low user=seq ui=snula(10.203.110.206) action=deny status=dipi msg=ecatc",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -644,6 +999,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-11-9 time=02:12:32 device_id=dolo log_id=velites log_part=oloremi type=virus_file-signature pri=high apari to=tsunt src=\"caecat [10.108.10.197]\" session_id=enim msg=\"Attachment file (umq) has sha1 hash value: sistena\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -653,6 +1013,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-11-23 time=09:15:06 device_id=imipsam log_id=eumiu log_part=tatevel type=event subtype=smtp pri=high user=quisnostui=sequines(10.115.154.104) action=cancelstatus=lorumsession_id=\"suntexpl\" msg=\"DSN: to \u003c\u003ciqu\u003e; reason:success; sessionid:tatis\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -662,6 +1027,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-12-7 time=16:17:40 device_id=econ log_id=aborio log_part=rve type=event subtype=smtp pri=medium user=nbyCiui=runtmollaction=blockstatus=velillumsession_id=\"ionev\" msg=\"to=\u003c\u003cvitaedi\u003e, delay=rna, xdelay=cons, mailer=ipv6-icmp, pri=lupta, relay=olaboris3175.internal.home[10.250.94.95], dsn=tno, stat=imvenia\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -671,6 +1041,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-12-21 time=23:20:14 device_id=atevelit log_id=ugitsed log_part=dminimve type=virus subtype=file-signature pri=very-high from=\"onse\" to=uiac src=tquii [10.164.49.95] session_id=emeumfu msg=\"inBCSedu\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -680,6 +1055,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-1-5 time=06:22:49 device_id=ddo log_id=emp log_part=inBC type=event subtype=smtp pri=low user=eacommui=aboNem(10.11.45.141) action=allowstatus=remasession_id=\"mcol\"msg=\"STARTTLS=tion, cert-subject=umquia, cert-issuer=lorsita, verifymsg=spici\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -689,6 +1069,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-1-19 time=13:25:23 device_id=odit log_id=vol log_part=epteurs type=statistics pri=very-high session_id=\"cteturad\" client_name=\"modi6930.internal.test[10.60.164.100]\"dst_ip=\"10.161.1.146\" from=\"etconse\" to=\"nproiden\" polid=\"ionem\" domain=\"taevitae6868.www.corp\" subject=\"ehende\" mailer=\"rep\" resolved=\"nostru\" direction=\"internal\" virus=\"ipiscin\" disposition=\"trudexe\" classifier=\"qua\" message_length=modit",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -698,6 +1083,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-2-2 time=20:27:57 device_id=orsit log_id=deFinibu log_part=iaecons type=event subtype=admin pri=very-high user=rautod ui=onorumet(10.157.118.41) action=cancel status=chit reason=unknown msg=\"erspici\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -707,6 +1097,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-2-17 time=03:30:32 device_id=quidol log_id=tinv log_part=Utenima type=statistics pri=high session_id=temqu client_name=uradip7802.mail.example client_ip=10.44.35.57 dst_ip=10.93.239.216 from=vento hfrom=litsed to=ciun polid=rehender domain=tetura7106.www5.corp mailer=eosquir resolved=tqu src_type=emips direction=internal virus=tinvolu disposition=ptat classifier=amquisn message_length=Finibus subject=nsequat",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -716,6 +1111,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-3-3 time=10:33:06 device_id=evelite log_id=remquela log_part=toreve type=event subtype=update pri=high msg=\"dolor\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -725,6 +1125,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-3-17 time=17:35:40 device_id=itse log_id=lapari log_part=Bonor type=event subtype=update pri=medium msg=exeaco",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -734,6 +1139,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-4-1 time=00:38:14 device_id=emvele log_id=tNeq log_part=olorsita type=virus_file-signature pri=medium eleumiu to=etdol src=\"imadmin [10.123.154.140]\" session_id=liqu msg=dolor",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -743,6 +1153,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-4-15 time=07:40:49 device_id=aliq log_id=utem log_part=oreetd type=event subtype=imap pri=very-high user=mremape ui=ude action=deny status=emac msg=rmagnido",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -752,6 +1167,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-4-29 time=14:43:23 device_id=pariatur log_id=cita log_part=tvo type=event subtype=admin pri=high user=rve ui=atemacc(10.141.108.1) action=deny status=ciunt reason=success msg=\"beataevi\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -761,6 +1181,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-5-13 time=21:45:57 device_id=imaven log_id=dmin log_part=sum type=event subtype=system pri=low user=lore ui=nim action=cancel status=edquiac msg=psamvolu",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -770,6 +1195,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-5-28 time=04:48:31 device_id=iade log_id=tae log_part=obe type=event subtype=admin pri=medium user=ulapari ui=rittenby(10.31.31.193) action=deny status=nvol reason=unknown msg=\"luptatem\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -779,6 +1209,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-6-11 time=11:51:06 device_id=conse log_id=ruredolo log_part=ati type=event subtype=system pri=low user=olors ui=roid(10.234.156.8) action=block status=uteiru msg=\"xer\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -788,6 +1223,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-6-25 time=18:53:40 device_id=nvol log_id=uame log_part=quia type=event subtype=update pri=very-high msg=\"labor\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -797,6 +1237,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-7-10 time=01:56:14 device_id=mwritte log_id=modit log_part=quamnih type=event subtype=config pri=medium user=itanimid ui=uiin module=nibusBo submodule=iusm msg=\"nostru\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -806,6 +1251,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-7-24 time=08:58:48 device_id=vel log_id=preh log_part=madmini type=event subtype=update pri=high msg=edutpers",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -815,6 +1265,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-8-7 time=16:01:23 device_id=sBonoru log_id=everi log_part=squ type=virus subtype=file-signature pri=medium from=\"utla\" to=nse src=10.160.236.78 session_id=nostrude msg=\"Attachment file (rinc) has sha1 hash value: tno\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -824,6 +1279,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-8-21 time=23:03:57 device_id=cid log_id=nonproi log_part=dolor type=event subtype=admin pri=medium user=molli ui=oeiusm(10.244.19.62) action=accept status=nnumquam reason=unknown msg=\"tdolore\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -833,6 +1293,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-9-5 time=06:06:31 device_id=icta log_id=epteu log_part=nvent type=event subtype=webmail pri=high user=mquiavol ui=odiconse(10.147.52.164) action=allow status=untutl msg=ugiatnul",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -842,6 +1307,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-9-19 time=13:09:05 device_id=quaturve log_id=elaudant log_part=olup type=spam pri=high session_id=\"iacon\" client_name= \"ncu3839.www.localhost\" client_ip=\"10.201.105.58\" dst_ip=\"10.251.183.113\" from=\"ent\" to=\"ionemu\" subject=\"eseosqu\" msg=\"uptatem\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -851,6 +1321,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-10-3 time=20:11:40 device_id=eprehen log_id=oinB log_part=lor type=statistics pri=low session_id=\"citatio\" client_name=\"[10.209.203.156]\"dst_ip=\"10.132.139.98\" from=\"pariat\" to=\"borisnis\" direction=\"unknown\" virus=\"oremagn\" disposition=\"emagna\" classifier=\"uidolor\" message_length=remag",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -860,6 +1335,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-10-18 time=03:14:14 device_id=tiumtot log_id=ulamcola log_part=epr type=event subtype=admin pri=low user=nculpa ui=enbyCice(10.152.196.145) action=block status=uptas reason=success msg=\"iadeseru\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -869,6 +1349,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-11-1 time=10:16:48 device_id=equ log_id=turadip log_part=ataev type=virus_file-signature pri=medium from=\"oree\" to=\"nimadmi\" src=\"utaliq [10.78.38.143]\" session_id=qui msg=\"Attachment file (epteurs) has sha1 hash value: did\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -878,6 +1363,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-11-15 time=17:19:22 device_id=sunt log_id=orumSe log_part=olupta type=event subtype=update pri=very-high msg=pta",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -887,6 +1377,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-11-30 time=00:21:57 device_id=ntutlabo log_id=leumiure log_part=tasnu type=event subtype=smtp pri=high user=amquaui=tionevol(10.209.124.81) action=allowstatus=tobesession_id=\"ssequa\" log_part=emp msg=\"to=\u003c\u003cemoeni, delay=officiad, xdelay=veniam, mailer=igmp, pri=entoreve, relay=ion3339.www.localdomain\"",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -896,6 +1391,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-12-14 time=07:24:31 device_id=int log_id=oremagn log_part=rnatur type=virus pri=medium from=uptatev to=\"oditem\" src=\"10.176.31.145\" session_id=\"ineavo\" msg=reseo",
+            "observer": {
+                "product": "FortiMail",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/fortinet_fortimail/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/fortinet_fortimail/data_stream/log/agent/stream/log.yml.hbs
@@ -10,12 +10,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiMail"
-        type: "Firewall"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_fortimail/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet_fortimail/data_stream/log/agent/stream/tcp.yml.hbs
@@ -7,12 +7,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiMail"
-        type: "Firewall"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_fortimail/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/fortinet_fortimail/data_stream/log/agent/stream/udp.yml.hbs
@@ -7,12 +7,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiMail"
-        type: "Firewall"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1,10 +1,18 @@
 ---
 description: Pipeline for Fortinet FortiMail
-
 processors:
   - set:
       field: ecs.version
       value: '8.3.0'
+  - set:
+      field: observer.vendor
+      value: Fortinet
+  - set:
+      field: observer.product
+      value: FortiMail
+  - set:
+      field: observer.type
+      value: firewall
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/fortinet_fortimail/manifest.yml
+++ b/packages/fortinet_fortimail/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortimail
 title: Fortinet FortiMail Logs
-version: 1.0.0
+version: 1.1.0
 release: ga
 description: Collect logs from Fortinet FortiMail instances with Elastic Agent.
 type: integration

--- a/packages/fortinet_fortimanager/changelog.yml
+++ b/packages/fortinet_fortimanager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Update Ingest Pipeline with observer Fields
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/3819
 - version: "1.0.0"
   changes:
     - description: Initial version of Fortinet FortiManager as separate package

--- a/packages/fortinet_fortimanager/changelog.yml
+++ b/packages/fortinet_fortimanager/changelog.yml
@@ -2,10 +2,10 @@
 - version: "1.1.0"
   changes:
     - description: Update Ingest Pipeline with observer Fields
-      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/3819
 - version: "1.0.0"
   changes:
     - description: Initial version of Fortinet FortiManager as separate package
-      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/3267

--- a/packages/fortinet_fortimanager/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
+++ b/packages/fortinet_fortimanager/data_stream/log/_dev/test/pipeline/test-generated.log-expected.json
@@ -5,6 +5,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=iusm devname=\"modtempo\" devid=\"olab\" vd=nto date=2016-1-29 time=6:09:59 logid=sse type=exercita subtype=der level=very-high eventtime=odoco logtime=ria srcip=10.20.234.169 srcport=1001 srcintf=eth5722 srcintfrole=vol dstip=10.44.173.44 dstport=6125 dstintf=enp0s3068 dstintfrole=nseq poluuid=itinvol sessionid=psa proto=21 action=allow policyid=ntium policytype=psaq crscore=13.800000 craction=eab crlevel=aliqu appcat=Ute service=lupt srccountry=dolore dstcountry=sequa trandisp=abo tranip=10.189.58.145 tranport=5273 duration=14.119000 sentbyte=7880 rcvdbyte=449 sentpkt=mqui app=nci",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -14,6 +19,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-2-12 time=1:12:33 logver=litesse devid=orev devname=pisciv logid=uii type=umexe subtype=estlabo level=high vd=iatnu srcip=10.182.84.248 srcport=4880 srcintf=enp0s208 dstip=10.162.33.193 dstport=7200 dstintf=enp0s2581 poluuid=nulapari sessionid=mwritten proto=prm action=accept policyid=uidolor trandisp=nibus duration=72.226000 sentbyte=6378 rcvdbyte=3879 devtype=riosam osname=anonnu osversion=1.410 mastersrcmac=ameaqu srcmac=01:00:5e:84:66:6c crscore=145.047000 craction=squame crlevel=ntex eventtype=eius user=luptat service=emape hostname=aer445.host profile=eumiu reqtype=uame url=https://www.example.net/orisn/cca.htm?ofdeF=metcons#roinBCS direction=external msg=com method=eataevi cat=byC catdesc=tinculp device_id=tur log_id=atio pri=high userfrom=atemsequ adminprof=nci timezone=CEST main_type=eFini trigger_policy=amco sub_type=exe severity_level=iatu policy=ionofde src=10.62.4.246 src_port=189 dst=10.171.204.166 dst_port=6668 http_method=mol http_url=taspe http_host=mvolu http_agent=radip http_session_id=tNequ signature_subclass=gelit signature_id=6728 srccountry=tconsec content_switch_name=nsequat server_pool_name=taev false_positive_mitigation=roidents user_name=oluptas monitor_status=llu http_refer=https://api.example.org/tamremap/tur.html?radipis=isetq#estqui http_version=uasiarch dev_id=emaper threat_weight=ssitasp history_threat_weight=eum threat_level=sum ftp_mode=uaerat ftp_cmd=boreet cipher_suite=onev msg_id=tenima",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -23,6 +33,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=seq dtime=2016-02-26 20:15:08.252538723 +0000 UTC devid=olorema devname=ccaecat vd=veleumi date=2016-2-26 time=8:15:08 logid=tia type=enim subtype=dqu level=medium eventtime=uian logtime=tempo srcip=10.200.188.142 srcport=4665 srcintf=eth4496 srcintfrole=eetd dstip=10.94.103.117 dstport=513 dstintf=enp0s3491 dstintfrole=doloreeu poluuid=pori sessionid=occ proto=icmp action=allow policyid=reetdolo policytype=nrepreh crscore=18.839000 craction=uiano crlevel=mrema appcat=autfu service=natura srccountry=aboris dstcountry=ima trandisp=tanimi tranip=10.15.159.80 tranport=6378 duration=121.916000 sentbyte=6517 rcvdbyte=13 sentpkt=ugiatqu app=eacomm",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -32,6 +47,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=liqu devname=\"lorem\" devid=\"emq\" vd=isiu date=2016-3-12 time=3:17:42 logid=nimadmi type=iatisu subtype=iat level=low eventtime=suntinc logtime=elits srcip=10.131.233.27 srcport=5037 srcintf=eth3676 srcintfrole=eataevit dstip=10.50.112.141 dstport=7303 dstintf=eth3391 dstintfrole=olab poluuid=mquisnos sessionid=loremagn proto=1 action=cancel policyid=tsed policytype=orai crscore=61.614000 craction=incididu crlevel=eci appcat=aali service=ametcons srccountry=porainc dstcountry=amquisno trandisp=iinea tranip=10.27.88.95 tranport=776 duration=5.911000 sentbyte=1147 rcvdbyte=3269 sentpkt=tvol app=moll",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -41,6 +61,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-3-26 time=10:20:16 logver=inim devid=ema devname=roinBCSe logid=onse type=tae subtype=tatno level=very-high vd=oluptate srcip=10.52.54.178 srcport=4427 srcintf=lo1567 dstip=10.37.58.155 dstport=2430 dstintf=eth6096 poluuid=ciati sessionid=ercit proto=3 action=allow policyid=eniam trandisp=reetdolo duration=165.411000 sentbyte=7651 rcvdbyte=3982 devtype=rumet osname=oll osversion=1.5670 mastersrcmac=nido srcmac=01:00:5e:c3:0a:41 crscore=71.955000 craction=itlabori crlevel=Ciceroi eventtype=aveniam user=uradi service=nimadmin hostname=olo7148.mail.home profile=snulapar reqtype=aedic url=https://api.example.com/iumto/aboreetd.gif?dun=enim#saute direction=internal msg=eriame method=lorema cat=avol catdesc=labor device_id=atuse log_id=ddoeiu pri=high userfrom=idolore adminprof=onse timezone=PST main_type=tation trigger_policy=ips sub_type=emeumfug severity_level=upta policy=omn src=10.87.212.179 src_port=1758 dst=10.157.213.15 dst_port=3539 http_method=ali http_url=nsect http_host=ntutl http_agent=caecatc http_session_id=onsequat signature_subclass=siuta signature_id=2896 srccountry=loru content_switch_name=ema server_pool_name=par false_positive_mitigation=itaut user_name=rveli monitor_status=rsint http_refer=https://example.com/idestla/Nemoeni.htm?taed=lup#remeumf http_version=antiumto dev_id=strude threat_weight=ctetura history_threat_weight=usmod threat_level=edqui ftp_mode=mquidol ftp_cmd=ita cipher_suite=ipi msg_id=rsitamet",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -50,6 +75,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-4-9 time=5:22:51 logver=eseru devid=remeum devname=orain logid=quip type=oin subtype=uisquam level=high vd=tinvol srcip=10.19.68.92 srcport=1409 srcintf=enp0s33 dstip=10.38.22.45 dstport=7036 dstintf=lo1120 poluuid=ditautfu sessionid=piscing proto=icmp action=accept policyid=ostr trandisp=rudexerc duration=135.013000 sentbyte=3369 rcvdbyte=927 devtype=itaut osname=imaven osversion=1.152 mastersrcmac=umdolo srcmac=01:00:5e:f7:4a:fd crscore=169.252000 craction=tfug crlevel=icab eventtype=mwr user=fugi service=inculpaq hostname=agna7678.internal.host profile=equa reqtype=mexercit url=https://www.example.net/tasuntex/sunt.txt?ume=incidi#picia direction=unknown msg=olupt method=dit cat=sumquiad catdesc=dexeaco device_id=ivelits log_id=moenimi pri=medium userfrom=etdolo adminprof=inv timezone=CEST main_type=ommod trigger_policy=sequatur sub_type=uidolo severity_level=lumquido policy=nihi src=10.114.150.67 src_port=1407 dst=10.76.73.140 dst_port=3075 http_method=uines http_url=nsec http_host=onse http_agent=emips http_session_id=imadmi signature_subclass=ostrume signature_id=6051 srccountry=eataev content_switch_name=liquide server_pool_name=uasia false_positive_mitigation=emp user_name=aperia monitor_status=ofdeFini http_refer=https://example.org/vol/riat.htm?atvol=umiur#imad http_version=msequi dev_id=isnostru threat_weight=iquaUten history_threat_weight=santium threat_level=iciatisu ftp_mode=rehender ftp_cmd=eporroqu cipher_suite=uat msg_id=tem",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -59,6 +89,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=suntinc date=2016-4-24 time=12:25:25 log_id=xeac devid=nidolo devname=tatn logid=eli type=nnu subtype=dolo level=low vd=nse srcip=10.202.204.239 srcport=7783 srcintf=lo2857 dstip=10.147.28.176 dstport=7432 dstintf=enp0s1462 poluuid=mporain sessionid=icons proto=0 action=accept policyid=sequi trandisp=rehend duration=3.138000 sentbyte=6354 rcvdbyte=3605 devtype=numqu osname=qui osversion=1.4059 mastersrcmac=equi srcmac=01:00:5e:68:86:a1 crscore=72.701000 craction=tat crlevel=ipitla eventtype=quae user=maccusa service=uptat hostname=equep5085.mail.domain profile=aqu reqtype=rpo url=https://www.example.org/inesci/serror.html?mqu=apariat#tlabore direction=internal msg=ihilm method=atDu cat=eav catdesc=ionevo device_id=remagn log_id=run pri=very-high userfrom=iamquis adminprof=quirat timezone=CET main_type=ittenbyC trigger_policy=isc sub_type=aturve severity_level=emulla policy=mpori src=10.195.36.51 src_port=3905 dst=10.95.64.124 dst_port=7042 http_method=iadese http_url=nsectet http_host=utla http_agent=utei http_session_id=laborum signature_subclass=tionof signature_id=7613 srccountry=oin content_switch_name=lapari server_pool_name=data false_positive_mitigation=dolor user_name=nnum monitor_status=eritqu http_refer=https://internal.example.net/wri/bor.jpg?hitect=dol#leumiu http_version=namali dev_id=taevit threat_weight=rinrepre history_threat_weight=etconse threat_level=tincu ftp_mode=ari ftp_cmd=exercit cipher_suite=sci msg_id=quamnih",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -68,6 +103,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=occae dtime=2016-05-08 07:27:59.552538723 +0000 UTC devid=ctetura devname=labore vd=texp date=2016-5-8 time=7:27:59 logid=tMalor type=acc subtype=amc level=very-high eventtime=amest logtime=corp srcip=10.176.216.90 srcport=2428 srcintf=eth2591 srcintfrole=dantiumt dstip=10.186.85.3 dstport=5366 dstintf=lo821 dstintfrole=ento poluuid=pic sessionid=evita proto=prm action=allow policyid=duntut policytype=magni crscore=102.339000 craction=uptat crlevel=uam appcat=boris service=nti srccountry=abi dstcountry=sectetur trandisp=uioffi tranip=10.114.16.155 tranport=1608 duration=62.941000 sentbyte=5110 rcvdbyte=3818 sentpkt=ipi app=reseos",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -77,6 +117,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=mcolab date=2016-5-22 time=2:30:33 log_id=neav devid=oquisqu devname=sperna logid=eabilloi type=estia subtype=tper level=very-high vd=volupt srcip=10.188.169.107 srcport=2138 srcintf=eth6448 dstip=10.214.7.83 dstport=1696 dstintf=lo1616 poluuid=tenatu sessionid=uun proto=HOPOPT action=cancel policyid=ectio trandisp=dutper duration=4.781000 sentbyte=3423 rcvdbyte=3252 devtype=radi osname=gel osversion=1.3917 mastersrcmac=iduntu srcmac=01:00:5e:21:f5:0a crscore=57.435000 craction=uamqu crlevel=lor eventtype=oide user=dolore service=amvolu hostname=eturadi6608.mail.host profile=aera reqtype=ate url=https://api.example.com/nimid/itatione.htm?umwr=oluptate#issus direction=inbound msg=uaUteni method=udantium cat=pre catdesc=xeacom device_id=stlabo log_id=dictasu pri=low userfrom=catc adminprof=nsect timezone=GMT-07:00 main_type=asia trigger_policy=econs sub_type=uir severity_level=dol policy=essecil src=10.23.62.94 src_port=4368 dst=10.61.163.4 dst_port=1232 http_method=luptatem http_url=atem http_host=gnido http_agent=ratvolu http_session_id=olup signature_subclass=numqua signature_id=1411 srccountry=inculpa content_switch_name=abo server_pool_name=veniamqu false_positive_mitigation=nse user_name=non monitor_status=paquioff http_refer=https://www5.example.org/maven/hende.jpg?labor=didunt#uptatema http_version=intocc dev_id=liqu threat_weight=eporr history_threat_weight=xeacomm threat_level=mveleu ftp_mode=nofdeFin ftp_cmd=sequam cipher_suite=temvel msg_id=ris",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -86,6 +131,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-6-5 time=9:33:08 logver=nisiuta devid=tvolu devname=ecte logid=tinvolu type=iurer subtype=iciadese level=medium vd=gnaaliq srcip=10.52.135.156 srcport=2660 srcintf=eth4502 dstip=10.133.89.11 dstport=1098 dstintf=lo4901 poluuid=sintoc sessionid=volupt proto=1 action=deny policyid=uiinea trandisp=Utenima duration=111.502000 sentbyte=1871 rcvdbyte=5074 devtype=ptatem osname=Nequepor osversion=1.2580 mastersrcmac=ugiatnu srcmac=01:00:5e:4a:7f:b8 crscore=103.738000 craction=mnisi crlevel=scivelit eventtype=tDuisaut user=oinBC service=quameius hostname=ipsumdol4488.api.localdomain profile=ommodico reqtype=ptas url=https://example.com/tetu/stru.htm?tlabore=Exc#pora direction=unknown msg=uteirure method=nevo cat=ide catdesc=aali device_id=adip log_id=tium pri=very-high userfrom=iusmodi adminprof=uamest timezone=PST main_type=uiac trigger_policy=epte sub_type=idolo severity_level=quinesc policy=madmi src=10.28.76.42 src_port=3427 dst=10.106.31.86 dst_port=4198 http_method=sno http_url=atno http_host=tani http_agent=volu http_session_id=nonn signature_subclass=inventor signature_id=6088 srccountry=autf content_switch_name=quamni server_pool_name=iatisu false_positive_mitigation=sec user_name=cons monitor_status=sBon http_refer=https://www.example.com/tae/ccaec.htm?aperiame=isc#ullamcor http_version=tobea dev_id=tor threat_weight=qui history_threat_weight=ntmollit threat_level=tenatus ftp_mode=cipitlab ftp_cmd=ipsumd cipher_suite=antiu msg_id=uirati",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -95,6 +145,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=ersp dtime=2016-06-20 04:35:42.332538723 +0000 UTC devid=tquov devname=diconseq vd=inven date=2016-6-20 time=4:35:42 logid=osquira type=tes subtype=mquame level=medium eventtime=tnulapa logtime=orain srcip=10.238.164.74 srcport=2201 srcintf=lo4249 srcintfrole=madmi dstip=10.106.162.153 dstport=341 dstintf=lo7114 dstintfrole=amvo poluuid=qui sessionid=tasn proto=1 action=accept policyid=squirati policytype=Sedutp crscore=92.058000 craction=nbyCic crlevel=utlabor appcat=itessequ service=porro srccountry=ine dstcountry=lup trandisp=tatemUt tranip=10.58.214.16 tranport=508 duration=166.566000 sentbyte=2715 rcvdbyte=7130 sentpkt=pici app=abor",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -104,6 +159,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=tquiin dtime=2016-07-04 11:38:16.592538723 +0000 UTC devid=tse devname=tenimad vd=minimav date=2016-7-4 time=11:38:16 logid=udexerci type=naal subtype=lore level=high eventtime=idolore logtime=pid srcip=10.225.141.20 srcport=2282 srcintf=enp0s4046 srcintfrole=natuse dstip=10.217.150.196 dstport=4639 dstintf=lo2438 dstintfrole=archite poluuid=loreme sessionid=untu proto=6 action=cancel policyid=datatno policytype=siutali crscore=49.988000 craction=usmodte crlevel=msequi appcat=tau service=exercita srccountry=ris dstcountry=eumiu trandisp=orumSe tranip=10.110.31.190 tranport=945 duration=12.946000 sentbyte=248 rcvdbyte=5300 sentpkt=eeufugia app=evit",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -113,6 +173,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-7-18 time=6:40:50 devname=molli device_id=velitse log_id=oditem type=generic subtype=gitsedqu pri=very-high devid=oremi devname=mestq logid=temUt type=olor subtype=ineavo level=very-high vd=mquelau srcip=10.168.236.85 srcport=6846 srcintf=eth651 dstip=10.140.113.244 dstport=4374 dstintf=lo4367 poluuid=fugitsed sessionid=quam proto=tcp action=deny policyid=fugiat trandisp=atisun duration=101.653000 sentbyte=3962 rcvdbyte=7741 devtype=dmin osname=fugi osversion=1.3319 mastersrcmac=inci srcmac=01:00:5e:e6:ad:ae crscore=39.291000 craction=avol crlevel=icero eventtype=xer user=emipsumd service=isisten hostname=cusant4946.www.domain profile=itecto reqtype=reetdol url=https://api.example.com/isnostr/umqu.htm?emquia=inesci#isnisi direction=unknown msg=aquioffi method=tamet cat=quatur catdesc=uisa device_id=eFi log_id=mexe pri=high userfrom=rpori adminprof=ice timezone=GMT+02:00 main_type=entorev trigger_policy=commodo sub_type=conseq severity_level=ame policy=tatn src=10.137.56.173 src_port=3932 dst=10.69.103.176 dst_port=1229 http_method=umdolo http_url=uptate http_host=amc http_agent=cusant http_session_id=orumSe signature_subclass=ratv signature_id=5227 srccountry=dutp content_switch_name=psaquaea server_pool_name=taevita false_positive_mitigation=ameiusm user_name=proide monitor_status=ano http_refer=https://www5.example.org/tvol/velitess.htm?edqui=nre#veli http_version=volupta dev_id=rnatu threat_weight=elitse history_threat_weight=ima threat_level=quasia ftp_mode=adi ftp_cmd=umwrit cipher_suite=uptate msg_id=mac",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -122,6 +187,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=dolore devname=\"onsecte\" devid=\"nBCSedut\" vd=ugiat date=2016-8-2 time=1:43:25 logid=onulam type=ate subtype=odoconse level=high eventtime=quatu logtime=veli srcip=10.30.47.165 srcport=631 srcintf=eth267 srcintfrole=sectet dstip=10.5.235.217 dstport=3689 dstintf=lo5047 dstintfrole=pitl poluuid=por sessionid=quidexea proto=tcp action=deny policyid=runtmol policytype=texpli crscore=57.772000 craction=ptass crlevel=rita appcat=esseci service=tametcon srccountry=liqua dstcountry=mvele trandisp=isis tranip=10.25.212.118 tranport=1190 duration=179.686000 sentbyte=238 rcvdbyte=7122 sentpkt=dantium app=lor",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -131,6 +201,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-8-16 time=8:45:59 logver=onemulla devid=dolorem devname=tvolu logid=nreprehe type=tetu subtype=mdol level=high vd=nby srcip=10.20.26.210 srcport=2791 srcintf=eth5968 dstip=10.85.96.153 dstport=5286 dstintf=eth4392 poluuid=nsequat sessionid=doloreme proto=0 action=deny policyid=reprehe trandisp=tincu duration=93.111000 sentbyte=2826 rcvdbyte=6247 devtype=lor osname=oraincid osversion=1.225 mastersrcmac=emeumfug srcmac=01:00:5e:1d:39:39 crscore=114.626000 craction=liqua crlevel=olo eventtype=psumqu user=untincul service=iduntu hostname=ccaeca5504.internal.example profile=reseo reqtype=oreetd url=https://example.org/tiaec/rumwrit.txt?oconsequ=edquiac#urerepr direction=external msg=ercit method=etMal cat=qua catdesc=rsita device_id=ate log_id=ipsamvo pri=low userfrom=adeseru adminprof=tdol timezone=CET main_type=rem trigger_policy=asper sub_type=idunt severity_level=luptat policy=eveli src=10.149.13.76 src_port=7809 dst=10.40.152.253 dst_port=1478 http_method=ritt http_url=iaeco http_host=equaturv http_agent=siu http_session_id=snost signature_subclass=tpersp signature_id=2624 srccountry=quaea content_switch_name=ametcons server_pool_name=utali false_positive_mitigation=porinc user_name=tetur monitor_status=xce http_refer=https://example.com/aincidu/nimadmin.jpg?itinv=eumfugi#etdolor http_version=lupta dev_id=xeaco threat_weight=nvolupt history_threat_weight=oremi threat_level=elites ftp_mode=nbyCi ftp_cmd=tevel cipher_suite=usc msg_id=rem",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -140,6 +215,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=cab dtime=2016-08-30 15:48:33.632538723 +0000 UTC devid=atisund devname=xea vd=ites date=2016-8-30 time=3:48:33 logid=isetq type=iutali subtype=velite level=high eventtime=avolupt logtime=ariatur srcip=10.98.194.212 srcport=5469 srcintf=lo1208 srcintfrole=atisetqu dstip=10.51.213.42 dstport=988 dstintf=enp0s3449 dstintfrole=ilmol poluuid=eri sessionid=quunt proto=HOPOPT action=deny policyid=mquae policytype=eriti crscore=96.729000 craction=cidunt crlevel=plica appcat=ore service=quidolor srccountry=inven dstcountry=eufugi trandisp=accusant tranip=10.233.120.207 tranport=136 duration=171.844000 sentbyte=2859 rcvdbyte=4844 sentpkt=eaqu app=nvol",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -149,6 +229,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=leumiu devname=\"tla\" devid=\"item\" vd=nimid date=2016-9-13 time=10:51:07 logid=dat type=periam subtype=dqu level=high eventtime=dminima logtime=dutpers srcip=10.245.187.229 srcport=4953 srcintf=lo3642 srcintfrole=prehen dstip=10.67.132.242 dstport=2340 dstintf=enp0s2700 dstintfrole=sequa poluuid=iosamnis sessionid=volupt proto=6 action=allow policyid=idid policytype=tesse crscore=64.509000 craction=boru crlevel=ptateve appcat=enderi service=ptatem srccountry=ptatevel dstcountry=tenatuse trandisp=psaqua tranip=10.241.132.176 tranport=7224 duration=167.705000 sentbyte=6595 rcvdbyte=7301 sentpkt=tame app=atione",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -158,6 +243,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-9-28 time=5:53:42 logver=vitaedic devid=orin devname=uii logid=estl type=sitam subtype=orem level=very-high vd=uuntur srcip=10.210.28.247 srcport=3449 srcintf=eth4185 dstip=10.237.180.17 dstport=3023 dstintf=lo7672 poluuid=tate sessionid=onevo proto=6 action=allow policyid=aeconseq trandisp=lor duration=96.560000 sentbyte=2760 rcvdbyte=1775 devtype=emqu osname=riss osversion=1.1847 mastersrcmac=sitvol srcmac=01:00:5e:a5:5a:54 crscore=129.120000 craction=olorsi crlevel=aliq eventtype=mes user=mven service=olorsit hostname=tore7088.www.invalid profile=ruredo reqtype=mac url=https://mail.example.org/ptassita/its.gif?risnis=uov#itlab direction=outbound msg=sBono method=loremqu cat=tetur catdesc=amvo device_id=siuta log_id=urmagn pri=low userfrom=uptat adminprof=idex timezone=GMT+02:00 main_type=tatione trigger_policy=nimveni sub_type=idi severity_level=ore policy=quid src=10.212.214.4 src_port=6040 dst=10.199.47.220 dst_port=4084 http_method=oin http_url=hil http_host=cingel http_agent=modocon http_session_id=ipsu signature_subclass=ntNeq signature_id=1081 srccountry=aUt content_switch_name=boNem server_pool_name=nturm false_positive_mitigation=emips user_name=atv monitor_status=onu http_refer=https://www5.example.net/alorum/obeataev.gif?atDu=nsec#quidolor http_version=oqu dev_id=naaliq threat_weight=remeu history_threat_weight=osquir threat_level=mod ftp_mode=col ftp_cmd=mve cipher_suite=liquide msg_id=odt",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -167,6 +257,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-10-12 time=12:56:16 logver=inv devid=rroq devname=rcit logid=aecatcup type=olabor subtype=estl level=very-high vd=citatio srcip=10.168.40.197 srcport=7699 srcintf=enp0s3071 dstip=10.206.69.135 dstport=6396 dstintf=eth3862 poluuid=utfug sessionid=aturQu proto=udp action=deny policyid=mipsamvo trandisp=eiusmod duration=91.147000 sentbyte=6153 rcvdbyte=4059 devtype=oreveri osname=ehende osversion=1.760 mastersrcmac=Except srcmac=01:00:5e:bf:07:ee crscore=45.760000 craction=dol crlevel=sciun eventtype=metcons user=itasper service=uae hostname=mve1890.internal.home profile=tatemU reqtype=mad url=https://www.example.org/redol/gnaa.htm?aliquamq=dtempori#toditaut direction=unknown msg=dexerc method=strumex cat=eprehend catdesc=asnu device_id=hitec log_id=henderit pri=medium userfrom=perspici adminprof=ationul timezone=PST main_type=itsedq trigger_policy=uto sub_type=emUte severity_level=molestia policy=quir src=10.46.56.204 src_port=2463 dst=10.234.165.130 dst_port=7079 http_method=umf http_url=quames http_host=dolorsit http_agent=archite http_session_id=remq signature_subclass=veniamq signature_id=1236 srccountry=uta content_switch_name=emo server_pool_name=itq false_positive_mitigation=derit user_name=orese monitor_status=dolor http_refer=https://mail.example.com/ntexpl/dunt.jpg?yCic=nder#mdolore http_version=Cic dev_id=olorema threat_weight=mollita history_threat_weight=tatem threat_level=iae ftp_mode=quido ftp_cmd=emip cipher_suite=inBC msg_id=mol",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -176,6 +271,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=turadipi date=2016-10-26 time=7:58:50 log_id=usmodi devid=ree devname=saquaea logid=ation type=luptas subtype=minim level=very-high vd=lorsi srcip=10.61.123.159 srcport=754 srcintf=eth7713 dstip=10.141.158.225 dstport=4690 dstintf=lo1586 poluuid=ate sessionid=idolor proto=1 action=block policyid=nreprehe trandisp=onse duration=71.505000 sentbyte=4010 rcvdbyte=4527 devtype=duntutla osname=ntium osversion=1.4450 mastersrcmac=asuntexp srcmac=01:00:5e:26:56:73 crscore=5.843000 craction=nse crlevel=modoc eventtype=boNem user=iumt service=tsed hostname=eturad6143.www.home profile=uamnihil reqtype=llam url=https://example.net/aparia/tatnon.jpg?rever=ore#offici direction=outbound msg=metco method=acom cat=ceroinB catdesc=nim device_id=utaliqu log_id=rsi pri=high userfrom=imadmi adminprof=isnis timezone=CEST main_type=olupta trigger_policy=tsuntinc sub_type=inrepreh severity_level=quovo policy=urExcep src=10.128.46.70 src_port=5269 dst=10.95.117.134 dst_port=1723 http_method=acommodi http_url=essecill http_host=billoi http_agent=moles http_session_id=dipiscin signature_subclass=olup signature_id=5976 srccountry=undeomni content_switch_name=accusa server_pool_name=natu false_positive_mitigation=liquid user_name=enim monitor_status=Finibus http_refer=https://www.example.org/xeacom/des.gif?umdolo=ntiu#radipisc http_version=Cice dev_id=taedi threat_weight=tquido history_threat_weight=ptasnula threat_level=oru ftp_mode=ill ftp_cmd=mporinc cipher_suite=onsectet msg_id=idolo",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -185,6 +285,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2016-11-10 time=3:01:24 logver=edolo devid=ugiatquo devname=ntium logid=uptate type=lloinven subtype=econs level=medium vd=tetura srcip=10.135.106.42 srcport=6602 srcintf=lo154 dstip=10.224.30.160 dstport=5302 dstintf=eth1247 poluuid=etconsec sessionid=caboNem proto=21 action=cancel policyid=rumetMal trandisp=oconse duration=2.970000 sentbyte=7685 rcvdbyte=1506 devtype=sequam osname=oditempo osversion=1.7544 mastersrcmac=taliqui srcmac=01:00:5e:98:79:a3 crscore=78.248000 craction=rcitat crlevel=dolorema eventtype=emagn user=radipis service=ctetu hostname=orinrep5386.www.corp profile=stenatus reqtype=equep url=https://www.example.com/tali/BCS.txt?iqu=niamqu#equamnih direction=inbound msg=autemv method=emq cat=plicaboN catdesc=amc device_id=vol log_id=admi pri=medium userfrom=culpaq adminprof=saute timezone=GMT+02:00 main_type=ende trigger_policy=abor sub_type=magnid severity_level=adol policy=iutal src=10.208.21.135 src_port=2721 dst=10.253.228.140 dst_port=6748 http_method=ugitse http_url=quiineav http_host=billoinv http_agent=sci http_session_id=col signature_subclass=obea signature_id=5700 srccountry=tatev content_switch_name=luptas server_pool_name=uptatem false_positive_mitigation=oinv user_name=inculp monitor_status=onofd http_refer=https://internal.example.org/nisiu/imad.html?ptatem=itasp#dexe http_version=tat dev_id=onproide threat_weight=ntmo history_threat_weight=loreeu threat_level=temse ftp_mode=aspernat ftp_cmd=ume cipher_suite=caecat msg_id=rautod",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -194,6 +299,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=ercitat date=2016-11-24 time=10:03:59 log_id=lapar devid=ritati devname=edquia logid=itesse type=mullam subtype=mexerc level=medium vd=amvolu srcip=10.120.231.161 srcport=1129 srcintf=lo653 dstip=10.210.62.203 dstport=4381 dstintf=lo3057 poluuid=ataevita sessionid=oremqu proto=6 action=cancel policyid=velitsed trandisp=magnaali duration=92.900000 sentbyte=3984 rcvdbyte=4009 devtype=ulla osname=equatDu osversion=1.1710 mastersrcmac=aconse srcmac=01:00:5e:92:c2:23 crscore=20.350000 craction=squira crlevel=aliqui eventtype=ess user=uide service=scivel hostname=henderi724.www5.home profile=tquas reqtype=aquio url=https://www.example.com/iame/orroquis.htm?tiumd=ntmoll#mexer direction=internal msg=isnostru method=nofdeFi cat=aquioff catdesc=saqu device_id=remips log_id=illoi pri=medium userfrom=abori adminprof=uisnostr timezone=GMT+02:00 main_type=ilmole trigger_policy=ugi sub_type=niamquis severity_level=nisi policy=emveleum src=10.243.226.122 src_port=3512 dst=10.3.23.172 dst_port=7332 http_method=emullamc http_url=tec http_host=Nemo http_agent=tutlabo http_session_id=mveleum signature_subclass=liq signature_id=7229 srccountry=sBonorum content_switch_name=atems server_pool_name=quira false_positive_mitigation=tassita user_name=olorem monitor_status=sedquiac http_refer=https://www.example.com/atDuis/asnulapa.html?rumwri=velill#ore http_version=tation dev_id=loinve threat_weight=tatevel history_threat_weight=iumdolo threat_level=untu ftp_mode=ict ftp_cmd=squirati cipher_suite=tem msg_id=mestq",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -203,6 +313,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=luptate date=2016-12-8 time=5:06:33 log_id=llamc devid=eleumiu devname=uei logid=Nequepo type=radipis subtype=cive level=low vd=orumSec srcip=10.56.74.7 srcport=6149 srcintf=eth2940 dstip=10.73.10.215 dstport=2079 dstintf=lo3472 poluuid=oeni sessionid=untutlab proto=0 action=cancel policyid=consecte trandisp=pteurs duration=26.872000 sentbyte=617 rcvdbyte=1651 devtype=ons osname=tiaecon osversion=1.5380 mastersrcmac=unt srcmac=01:00:5e:99:7b:4a crscore=124.392000 craction=queporro crlevel=uid eventtype=snostrum user=psa service=nculpaq hostname=reseosqu1629.mail.lan profile=utemvel reqtype=epteur url=https://www.example.net/iame/laudanti.htm?stquido=rsitvolu#mnisi direction=external msg=uameiusm method=adm cat=gelitsed catdesc=tiumto device_id=cor log_id=odoco pri=high userfrom=labore adminprof=ianonnu timezone=PST main_type=rum trigger_policy=erc sub_type=ehende severity_level=tutla policy=licaboNe src=10.94.242.80 src_port=2724 dst=10.106.85.174 dst_port=307 http_method=atiset http_url=serror http_host=onse http_agent=umquam http_session_id=emagn signature_subclass=emulla signature_id=1963 srccountry=iquaUt content_switch_name=mnihilm server_pool_name=redo false_positive_mitigation=etMaloru user_name=lmo monitor_status=iquidex http_refer=https://www.example.org/remipsu/tan.html?mcorpor=doconse#etdol http_version=dolorsi dev_id=nturmag threat_weight=tura history_threat_weight=osquirat threat_level=equat ftp_mode=aliquid ftp_cmd=usantiu cipher_suite=idunt msg_id=atqu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -212,6 +327,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=liquam dtime=2016-12-23 00:09:07.712538723 +0000 UTC devid=min devname=oluptat vd=odt date=2016-12-23 time=12:09:07 logid=rspici type=snisi subtype=magnaal level=low eventtime=etquasia logtime=nula srcip=10.117.63.181 srcport=5299 srcintf=lo7416 srcintfrole=Cicero dstip=10.247.53.179 dstport=6493 dstintf=lo3706 dstintfrole=atemaccu poluuid=veritat sessionid=aliquipe proto=3 action=block policyid=aer policytype=osquira crscore=171.144000 craction=minim crlevel=scipi appcat=tur service=acon srccountry=Nemoenim dstcountry=usm trandisp=labori tranip=10.168.20.20 tranport=68 duration=167.038000 sentbyte=7188 rcvdbyte=5749 sentpkt=xeac app=umdolors",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -221,6 +341,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=uiadolo date=2017-1-6 time=7:11:41 log_id=empor devid=umexerci devname=duntut logid=uovol type=prehend subtype=eufug level=low vd=eufug srcip=10.100.53.8 srcport=4318 srcintf=eth5767 dstip=10.163.17.172 dstport=854 dstintf=enp0s3903 poluuid=upta sessionid=atc proto=3 action=block policyid=upta trandisp=itessequ duration=165.935000 sentbyte=4211 rcvdbyte=405 devtype=exerci osname=idata osversion=1.2208 mastersrcmac=usmod srcmac=01:00:5e:c0:47:f3 crscore=135.374000 craction=isiutali crlevel=iquidexe eventtype=illumq user=luptatem service=ite hostname=tasnul4179.internal.host profile=amvo reqtype=tnul url=https://www.example.org/ess/quiad.jpg?ten=litanim#rQuisaut direction=inbound msg=modico method=metco cat=cillu catdesc=iuntNeq device_id=eddoei log_id=rsin pri=very-high userfrom=eriam adminprof=pernat timezone=CEST main_type=imve trigger_policy=essequam sub_type=ueporro severity_level=aliqu policy=upt src=10.141.156.217 src_port=2700 dst=10.53.168.187 dst_port=73 http_method=emacc http_url=emp http_host=lamcola http_agent=veli http_session_id=venia signature_subclass=risni signature_id=1535 srccountry=uat content_switch_name=onemulla server_pool_name=riaturEx false_positive_mitigation=deri user_name=amqu monitor_status=lorsitam http_refer=https://api.example.org/onpr/litseddo.gif?oremqu=idex#radip http_version=upta dev_id=tetura threat_weight=rumet history_threat_weight=uptasnul threat_level=antiumdo ftp_mode=ecill ftp_cmd=iduntu cipher_suite=pisci msg_id=sunt",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -230,6 +355,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-1-20 time=2:14:16 devname=oco device_id=aboree log_id=ainci type=generic subtype=osqu pri=very-high devid=sus devname=imavenia logid=expli type=ugiat subtype=rnat level=low vd=orem srcip=10.37.174.58 srcport=3193 srcintf=lo2990 dstip=10.249.60.66 dstport=4859 dstintf=enp0s1732 poluuid=eve sessionid=tco proto=3 action=accept policyid=oluptate trandisp=lit duration=70.988000 sentbyte=6327 rcvdbyte=837 devtype=oquisqu osname=turadip osversion=1.3402 mastersrcmac=amc srcmac=01:00:5e:dd:dc:44 crscore=160.379000 craction=apar crlevel=runtm eventtype=eturadip user=olorsi service=itseddo hostname=bore5546.www.local profile=labo reqtype=lpaquiof url=https://example.com/xeac/llitanim.txt?oreverit=scip#Finibus direction=inbound msg=eufugia method=ncididun cat=hen catdesc=periamea device_id=itametco log_id=vel pri=high userfrom=rere adminprof=pta timezone=CEST main_type=equeporr trigger_policy=met sub_type=volup severity_level=ptate policy=entsu src=10.44.198.184 src_port=5695 dst=10.189.82.19 dst_port=4267 http_method=odoc http_url=atura http_host=tur http_agent=tur http_session_id=atnonpr signature_subclass=ita signature_id=7570 srccountry=colabori content_switch_name=imidestl server_pool_name=piscing false_positive_mitigation=ceroi user_name=iconsequ monitor_status=iat http_refer=https://www.example.net/siuta/atev.htm?CSe=exerci#inesciu http_version=quid dev_id=atcupid threat_weight=onse history_threat_weight=psa threat_level=ate ftp_mode=con ftp_cmd=tqu cipher_suite=eirur msg_id=dese",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -239,6 +369,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=mquisnos date=2017-2-3 time=9:16:50 log_id=lore devid=isci devname=Dui logid=reetdo type=ever subtype=civelits level=high vd=quiav srcip=10.154.34.15 srcport=5986 srcintf=enp0s4064 dstip=10.153.172.249 dstport=7030 dstintf=enp0s3067 poluuid=henderit sessionid=remq proto=21 action=cancel policyid=tla trandisp=arch duration=52.795000 sentbyte=5453 rcvdbyte=3097 devtype=ror osname=onsecte osversion=1.91 mastersrcmac=aecatcup srcmac=01:00:5e:58:7e:f5 crscore=133.560000 craction=quas crlevel=occaeca eventtype=eturadip user=ent service=rumSecti hostname=Utenima260.mail.invalid profile=cept reqtype=aedictas url=https://api.example.org/orio/gna.gif?aaliquaU=olu#iameaque direction=external msg=essequa method=aquio cat=rspicia catdesc=deom device_id=oluptat log_id=roinBCSe pri=medium userfrom=onproide adminprof=uamnih timezone=GMT+02:00 main_type=tatisetq trigger_policy=uidolo sub_type=umdolore severity_level=dmi policy=tam src=10.151.170.207 src_port=1400 dst=10.181.183.104 dst_port=5554 http_method=amni http_url=tatio http_host=amquisno http_agent=modoc http_session_id=magnam signature_subclass=uinesc signature_id=4248 srccountry=idatat content_switch_name=onev server_pool_name=orsi false_positive_mitigation=ntsunt user_name=iosamni monitor_status=idu http_refer=https://example.net/idolo/reet.txt?its=umdolor#isiu http_version=assi dev_id=eserun threat_weight=rvelill history_threat_weight=lupta threat_level=byC ftp_mode=imadm ftp_cmd=uta cipher_suite=tisu msg_id=remagnam",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -248,6 +383,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=iumdo date=2017-2-18 time=4:19:24 log_id=iusmodit devid=aturv devname=ectetura logid=obeataev type=umf subtype=olesti level=low vd=quaeabil srcip=10.19.99.129 srcport=956 srcintf=eth62 dstip=10.205.132.218 dstport=1643 dstintf=enp0s5908 poluuid=inim sessionid=etdol proto=17 action=deny policyid=oremeumf trandisp=lesti duration=49.961000 sentbyte=3376 rcvdbyte=6209 devtype=enima osname=tnulapar osversion=1.7278 mastersrcmac=sequ srcmac=01:00:5e:4a:1d:f8 crscore=84.522000 craction=tionula crlevel=accus eventtype=uatu user=mquis service=lab hostname=uido2046.mail.lan profile=tena reqtype=aal url=https://mail.example.org/nimadmin/lumqui.txt?iquip=tinculpa#umtota direction=external msg=rumSecti method=riamea cat=eca catdesc=oluptate device_id=Duisa log_id=consequa pri=low userfrom=iaecon adminprof=aevitaed timezone=PT main_type=rep trigger_policy=remap sub_type=deri severity_level=quaeratv policy=involu src=10.70.7.23 src_port=2758 dst=10.130.240.11 dst_port=6515 http_method=odic http_url=iuta http_host=liquaUte http_agent=scivelit http_session_id=Nequ signature_subclass=quid signature_id=1044 srccountry=lloinve content_switch_name=borisnis server_pool_name=onorumet false_positive_mitigation=ptatema user_name=eavolup monitor_status=ipsumq http_refer=https://www.example.org/tno/iss.gif?ptatev=atu#teturad http_version=eturad dev_id=tDuis threat_weight=mwritten history_threat_weight=tat threat_level=equ ftp_mode=sumdolo ftp_cmd=idolorem cipher_suite=temvele msg_id=oremque",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -257,6 +397,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=inimve devname=\"uio\" devid=\"mexercit\" vd=byC date=2017-3-4 time=11:21:59 logid=uae type=oremip subtype=its level=very-high eventtime=iavol logtime=natuserr srcip=10.37.161.101 srcport=1552 srcintf=enp0s6659 srcintfrole=evit dstip=10.111.182.212 dstport=4493 dstintf=lo6533 dstintfrole=lamco poluuid=tion sessionid=hender proto=icmp action=deny policyid=seq policytype=rumSe crscore=88.660000 craction=madmi crlevel=tlabore appcat=idunt service=expl srccountry=olore dstcountry=uian trandisp=atuserro tranip=10.17.209.252 tranport=2119 duration=135.770000 sentbyte=313 rcvdbyte=6509 sentpkt=oinBCS app=itsedd",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -266,6 +411,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=ipis devname=\"itautfu\" devid=\"nesci\" vd=tam date=2017-3-18 time=6:24:33 logid=sin type=idexeac subtype=nimadmin level=medium eventtime=edutper logtime=tevelite srcip=10.158.175.98 srcport=1491 srcintf=enp0s7649 srcintfrole=oinBCSed dstip=10.170.196.181 dstport=6994 dstintf=enp0s5873 dstintfrole=obeatae poluuid=iquid sessionid=evo proto=udp action=allow policyid=mqu policytype=pteursi crscore=98.596000 craction=expl crlevel=essecill appcat=totamre service=rpo srccountry=velites dstcountry=nonpro trandisp=nula tranip=10.153.166.133 tranport=4638 duration=39.506000 sentbyte=6610 rcvdbyte=1936 sentpkt=olu app=imide",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -275,6 +425,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-4-2 time=1:27:07 logver=amn devid=itessequ devname=porissu logid=umd type=sumd subtype=sectetur level=low vd=aUtenima srcip=10.62.10.137 srcport=5596 srcintf=lo6539 dstip=10.138.249.251 dstport=630 dstintf=eth1576 poluuid=deritinv sessionid=evelite proto=6 action=accept policyid=stiaecon trandisp=usBono duration=155.835000 sentbyte=3942 rcvdbyte=5360 devtype=ttenb osname=olor osversion=1.5978 mastersrcmac=lapa srcmac=01:00:5e:b0:3e:44 crscore=105.845000 craction=lors crlevel=oluptat eventtype=enimad user=tis service=qua hostname=con6049.internal.lan profile=quelaud reqtype=luptat url=https://internal.example.com/temse/caecat.jpg?emeu=tatemac#quisn direction=inbound msg=teursint method=etMa cat=llita catdesc=ntsunt device_id=nturmag log_id=uredol pri=high userfrom=temsequi adminprof=mquia timezone=ET main_type=enbyCic trigger_policy=iveli sub_type=conseq severity_level=itame policy=tenat src=10.63.171.91 src_port=4396 dst=10.48.25.200 dst_port=5179 http_method=nse http_url=mveniam http_host=tuser http_agent=mmo http_session_id=eve signature_subclass=nbyCicer signature_id=6129 srccountry=ciad content_switch_name=ugiatqu server_pool_name=eruntmo false_positive_mitigation=nimve user_name=usanti monitor_status=ion http_refer=https://mail.example.org/gelits/iavo.txt?udexerc=ovolupta#volup http_version=macc dev_id=ria threat_weight=beat history_threat_weight=rro threat_level=tuser ftp_mode=ctasu ftp_cmd=irat cipher_suite=sitame msg_id=oinven",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -284,6 +439,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=ute dtime=2017-04-16 08:29:41.792538723 +0000 UTC devid=mexer devname=iam vd=Bonoru date=2017-4-16 time=8:29:41 logid=rcitati type=nula subtype=ameaquei level=low eventtime=adipi logtime=mquis srcip=10.174.17.46 srcport=2743 srcintf=eth6814 srcintfrole=ine dstip=10.77.105.81 dstport=4455 dstintf=enp0s7799 dstintfrole=orem poluuid=giatqu sessionid=rsint proto=udp action=allow policyid=paq policytype=uianon crscore=60.762000 craction=uisautem crlevel=mquameiu appcat=loremq service=turmagni srccountry=ores dstcountry=ddoe trandisp=uid tranip=10.38.168.190 tranport=7260 duration=129.140000 sentbyte=368 rcvdbyte=7791 sentpkt=incidi app=aedictas",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -293,6 +453,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=temaccus devname=\"ons\" devid=\"unt\" vd=liq date=2017-4-30 time=3:32:16 logid=abore type=iumdo subtype=oreeu level=high eventtime=exe logtime=tis srcip=10.36.99.207 srcport=4829 srcintf=lo497 srcintfrole=tvol dstip=10.225.37.73 dstport=5630 dstintf=eth1882 dstintfrole=eniamqu poluuid=iumt sessionid=porissus proto=udp action=cancel policyid=tsunt policytype=rnat crscore=88.508000 craction=ured crlevel=ctetu appcat=oreeu service=uasiarch srccountry=Malor dstcountry=boriosa trandisp=cillumdo tranip=10.166.142.198 tranport=4151 duration=1.040000 sentbyte=465 rcvdbyte=7663 sentpkt=oreetd app=lor",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -302,6 +467,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=etc devname=\"eturadip\" devid=\"nost\" vd=atus date=2017-5-14 time=10:34:50 logid=tassitas type=obea subtype=velite level=medium eventtime=litse logtime=san srcip=10.66.90.225 srcport=4846 srcintf=lo4891 srcintfrole=moenimi dstip=10.214.156.161 dstport=3854 dstintf=eth1188 dstintfrole=ati poluuid=rauto sessionid=doloreeu proto=6 action=block policyid=eumfu policytype=docons crscore=3.408000 craction=eumf crlevel=roquisq appcat=uasi service=maveniam srccountry=uis dstcountry=lill trandisp=remeum tranip=10.145.194.12 tranport=1001 duration=25.398000 sentbyte=6452 rcvdbyte=6820 sentpkt=aturE app=umto",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -311,6 +481,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=pariat devname=\"iutal\" devid=\"teturad\" vd=ese date=2017-5-29 time=5:37:24 logid=eddoei type=lorumw subtype=eca level=medium eventtime=nimve logtime=duntut srcip=10.6.242.108 srcport=3373 srcintf=lo3230 srcintfrole=qua dstip=10.156.208.5 dstport=7612 dstintf=lo1800 dstintfrole=quisn poluuid=pteu sessionid=uatD proto=0 action=cancel policyid=antiu policytype=velillum crscore=166.389000 craction=iatquovo crlevel=lapari appcat=Mal service=itinvo srccountry=snulap dstcountry=cidu trandisp=hilmol tranip=10.163.36.101 tranport=253 duration=72.488000 sentbyte=1880 rcvdbyte=4638 sentpkt=ident app=scip",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -320,6 +495,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-6-12 time=12:39:58 devname=uamqu device_id=iusmodi log_id=esciun type=generic subtype=tasnul pri=medium devid=ccusant devname=epteurs logid=rmag type=quisquam subtype=eporroqu level=very-high vd=dit srcip=10.25.134.171 srcport=7867 srcintf=eth4543 dstip=10.43.235.230 dstport=2198 dstintf=lo4581 poluuid=BCSe sessionid=rem proto=0 action=allow policyid=eeufug trandisp=ntin duration=6.686000 sentbyte=5763 rcvdbyte=1048 devtype=cinge osname=tatem osversion=1.4713 mastersrcmac=eritqu srcmac=01:00:5e:ed:6b:57 crscore=10.603000 craction=nimip crlevel=iutaliq eventtype=olore user=onemul service=trudexe hostname=remeum2641.www5.corp profile=Quisa reqtype=quiav url=https://www5.example.com/elit/sam.htm?nevolu=unt#isni direction=outbound msg=ecillum method=olor cat=amei catdesc=doconseq device_id=conseq log_id=emve pri=very-high userfrom=tiu adminprof=wri timezone=GMT-07:00 main_type=asper trigger_policy=dictasun sub_type=psa severity_level=lorese policy=olupta src=10.220.148.127 src_port=6681 dst=10.68.233.163 dst_port=3126 http_method=itanimi http_url=onoru http_host=data http_agent=ugits http_session_id=ittenb signature_subclass=tobeatae signature_id=5617 srccountry=quis content_switch_name=exe server_pool_name=naa false_positive_mitigation=equat user_name=estiaec monitor_status=pitlabo http_refer=https://example.net/rcitat/ree.htm?ionofdeF=rsp#imipsa http_version=nostrum dev_id=autodita threat_weight=ntut history_threat_weight=temveleu threat_level=itametco ftp_mode=etcons ftp_cmd=etco cipher_suite=iuntN msg_id=utfugi",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -329,6 +509,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=isnostru date=2017-6-26 time=7:42:33 log_id=nul devid=ntocca devname=trudex logid=tvol type=lup subtype=mipsamv level=medium vd=qua srcip=10.249.194.7 srcport=4987 srcintf=enp0s2282 dstip=10.57.116.17 dstport=90 dstintf=enp0s7442 poluuid=xcep sessionid=gnidol proto=0 action=allow policyid=uaeab trandisp=ptat duration=136.310000 sentbyte=1078 rcvdbyte=6196 devtype=eturadip osname=amquaera osversion=1.4481 mastersrcmac=equ srcmac=01:00:5e:00:fd:79 crscore=18.750000 craction=olesti crlevel=edquia eventtype=ihi user=undeomn service=ape hostname=itaspe3216.localdomain profile=onsecte reqtype=prehende url=https://example.org/porro/issu.htm?inculpa=ruredol#iadeseru direction=unknown msg=numq method=quae cat=periam catdesc=ain device_id=umiurer log_id=mquido pri=very-high userfrom=onorume adminprof=abill timezone=GMT+02:00 main_type=uov trigger_policy=mini sub_type=mve severity_level=tionev policy=uasiarch src=10.116.82.108 src_port=7276 dst=10.94.177.125 dst_port=6683 http_method=nimides http_url=olorsit http_host=naaliq http_agent=plica http_session_id=asiarc signature_subclass=lor signature_id=5152 srccountry=snula content_switch_name=pici server_pool_name=bori false_positive_mitigation=dipi user_name=ecatc monitor_status=quovolu http_refer=https://example.net/itse/sse.gif?lupt=quatur#dminim http_version=ptatevel dev_id=aperiame threat_weight=stenat history_threat_weight=uianonnu threat_level=tatiset ftp_mode=quira ftp_cmd=ciatisun cipher_suite=duntutl msg_id=nven",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -338,6 +523,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-7-11 time=2:45:07 devname=saq device_id=asiarch log_id=ssuscipi type=generic subtype=utla pri=medium devid=tquovo devname=fugi logid=nse type=nesciu subtype=todit level=very-high vd=inrepreh srcip=10.14.192.162 srcport=2536 srcintf=enp0s4429 dstip=10.179.128.6 dstport=3375 dstintf=enp0s4580 poluuid=ptate sessionid=volupta proto=3 action=cancel policyid=utla trandisp=emi duration=171.651000 sentbyte=3313 rcvdbyte=7131 devtype=velites osname=oloremi osversion=1.4442 mastersrcmac=apari srcmac=01:00:5e:0c:fb:2b crscore=140.065000 craction=uel crlevel=fficiad eventtype=teirured user=nostru service=rcit hostname=mea6298.api.example profile=eumiu reqtype=tatevel url=https://mail.example.org/uamquaer/texplica.gif?sequa=lorum#suntexpl direction=inbound msg=Sedut method=tatis cat=audant catdesc=obeata device_id=uredol log_id=uptat pri=low userfrom=entorev adminprof=quuntur timezone=GMT+02:00 main_type=exercit trigger_policy=dexer sub_type=idolor severity_level=onpr policy=uira src=10.115.121.243 src_port=550 dst=10.113.152.241 dst_port=2330 http_method=ali http_url=udexerci http_host=uae http_agent=imveni http_session_id=econ signature_subclass=aborio signature_id=1122 srccountry=setquas content_switch_name=nbyCi server_pool_name=runtmoll false_positive_mitigation=busBon user_name=norumetM monitor_status=isno http_refer=https://internal.example.com/ameaq/Quis.html?lestiae=iav#umiure http_version=isiut dev_id=tin threat_weight=rporiss history_threat_weight=billoinv threat_level=etconse ftp_mode=nesciu ftp_cmd=mali cipher_suite=roinBCSe msg_id=eetdolor",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -347,6 +537,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-7-25 time=9:47:41 logver=upt devid=equamni devname=atcupi logid=enima type=uptateve subtype=fugitsed level=medium vd=lorem srcip=10.68.159.207 srcport=3320 srcintf=enp0s7206 dstip=10.139.195.188 dstport=893 dstintf=enp0s6960 poluuid=lits sessionid=tvolu proto=17 action=accept policyid=ollitan trandisp=temseq duration=0.684000 sentbyte=3045 rcvdbyte=6863 devtype=edictasu osname=eturadi osversion=1.3804 mastersrcmac=edquiano srcmac=01:00:5e:09:79:f2 crscore=11.231000 craction=taevitae crlevel=tevel eventtype=tatemse user=gitsed service=agn hostname=iqu7510.internal.corp profile=equeporr reqtype=amremap url=https://www5.example.org/aqu/utemvele.gif?serrorsi=tsedquia#rsit direction=unknown msg=ntutlabo method=idex cat=nihilmo catdesc=reetdo device_id=xeaco log_id=taliqu pri=medium userfrom=hite adminprof=umfugi timezone=CT main_type=dminimve trigger_policy=remips sub_type=laboreet severity_level=uptate policy=tot src=10.49.82.45 src_port=435 dst=10.179.153.97 dst_port=1908 http_method=ade http_url=nihilmol http_host=nder http_agent=ano http_session_id=rumexer signature_subclass=eab signature_id=2387 srccountry=saquaeab content_switch_name=eli server_pool_name=rissusci false_positive_mitigation=ectetur user_name=dictasun monitor_status=inimv http_refer=https://api.example.org/volup/untNeq.htm?mremaper=uteirur#ntium http_version=ide dev_id=quunturm threat_weight=quovo history_threat_weight=quaturve threat_level=ntiumdol ftp_mode=conse ftp_cmd=aturve cipher_suite=edqui msg_id=tvolu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -356,6 +551,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=ore devname=\"lors\" devid=\"saute\" vd=ecillumd date=2017-8-8 time=4:50:15 logid=iumto type=sequatu subtype=tiumtot level=medium eventtime=mdoloree logtime=que srcip=10.98.52.184 srcport=7402 srcintf=eth3784 srcintfrole=ita dstip=10.99.55.115 dstport=1537 dstintf=eth855 dstintfrole=isnostru poluuid=iad sessionid=ngelits proto=tcp action=accept policyid=billoi policytype=reseo crscore=158.047000 craction=uov crlevel=pariat appcat=icaboNe service=boreetd srccountry=uir dstcountry=rumex trandisp=ectobea tranip=10.205.83.138 tranport=6239 duration=170.113000 sentbyte=3290 rcvdbyte=722 sentpkt=ibus app=lumdol",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -365,6 +565,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=onnu devname=\"reprehe\" devid=\"metMa\" vd=emoen date=2017-8-22 time=11:52:50 logid=ptate type=mipsumqu subtype=turad level=high eventtime=billo logtime=doloremi srcip=10.197.128.162 srcport=2052 srcintf=lo6750 srcintfrole=ionof dstip=10.90.189.248 dstport=1293 dstintf=lo2402 dstintfrole=roi poluuid=reh sessionid=volup proto=prm action=allow policyid=iconsequ policytype=ueporr crscore=127.832000 craction=archite crlevel=tur appcat=ddo service=emp srccountry=inBC dstcountry=did trandisp=atcupi tranip=10.228.11.50 tranport=984 duration=3.401000 sentbyte=6907 rcvdbyte=422 sentpkt=mcol app=tion",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -374,6 +579,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-9-6 time=6:55:24 devname=moll device_id=roinBCS log_id=odit type=event subtype=vol pri=low desc=aloru user=cteturad userfrom=modi msg=cip action=deny adom=ntoccae2859.www.test session_id=incididu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -383,6 +593,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-9-20 time=1:57:58 devname=uinesci device_id=otamr log_id=tsed type=generic subtype=rExc pri=medium devid=saute devname=umdol logid=rerepr type=ipiscin subtype=trudexe level=high vd=ineavol srcip=10.29.34.211 srcport=5638 srcintf=eth1805 dstip=10.161.15.82 dstport=6598 dstintf=enp0s5799 poluuid=aco sessionid=eFini proto=17 action=cancel policyid=mipsa trandisp=uas duration=118.122000 sentbyte=1737 rcvdbyte=6283 devtype=umexe osname=xce osversion=1.7318 mastersrcmac=suntex srcmac=01:00:5e:5b:68:89 crscore=29.865000 craction=rcitati crlevel=siutali eventtype=uiratio user=ficia service=orsit hostname=deFinibu3940.internal.lan profile=rautod reqtype=onorumet url=https://www5.example.com/etcon/chit.txt?erspici=itinvolu#adeserun direction=unknown msg=tinv method=Utenima cat=nse catdesc=umq device_id=enim log_id=oreve pri=low userfrom=snisiu adminprof=atem timezone=ET main_type=vento trigger_policy=litsed sub_type=ciun severity_level=rehender policy=tetura src=10.124.71.88 src_port=7540 dst=10.22.248.52 dst_port=6566 http_method=cons http_url=tinvolu http_host=ptat http_agent=amquisn http_session_id=Finibus signature_subclass=nsequat signature_id=3661 srccountry=scipi content_switch_name=rem server_pool_name=reh false_positive_mitigation=rsitame user_name=tcons monitor_status=squamest http_refer=https://mail.example.com/emveleum/siuta.html?ate=epteur#onproi http_version=usmodit dev_id=orese threat_weight=umdolore history_threat_weight=umqui threat_level=adipisci ftp_mode=eir ftp_cmd=ull cipher_suite=tlabor msg_id=itecto",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -392,6 +607,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-10-4 time=9:00:32 logver=ametcons devid=velite devname=ipexeac logid=explicab type=samvolu subtype=teiru level=low vd=orinrep srcip=10.228.213.136 srcport=7247 srcintf=lo1719 dstip=10.185.107.27 dstport=2257 dstintf=enp0s4999 poluuid=iduntutl sessionid=mipsumd proto=udp action=block policyid=quelauda trandisp=rcit duration=166.303000 sentbyte=7229 rcvdbyte=6230 devtype=orese osname=evelite osversion=1.4895 mastersrcmac=oremipsu srcmac=01:00:5e:cd:f6:0e crscore=37.237000 craction=equunt crlevel=mto eventtype=iae user=dent service=Uten hostname=tatiset4191.localdomain profile=aconseq reqtype=mquamei url=https://api.example.org/fug/liquid.txt?ptate=lloi#nseq direction=external msg=isetqua method=ianonn cat=oluptas catdesc=doe device_id=quipex log_id=rchitect pri=very-high userfrom=Bonor adminprof=ipex timezone=PT main_type=upta trigger_policy=ivel sub_type=tmollita severity_level=tionofd policy=iatnula src=10.185.37.176 src_port=1859 dst=10.26.58.20 dst_port=2809 http_method=essequam http_url=undeo http_host=ficiade http_agent=uiinea http_session_id=uianonn signature_subclass=eavolupt signature_id=784 srccountry=elitsedq content_switch_name=liquam server_pool_name=sinto false_positive_mitigation=edi user_name=eumiure monitor_status=ore http_refer=https://internal.example.com/mSe/sis.gif?rchite=rcit#orumwri http_version=tiae dev_id=giat threat_weight=nculpa history_threat_weight=olupt threat_level=tvol ftp_mode=ostru ftp_cmd=mea cipher_suite=tuserror msg_id=agnama",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -401,6 +621,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=deritq dtime=2017-10-19 04:03:07.172538723 +0000 UTC devid=boreetdo devname=teni vd=iin date=2017-10-19 time=4:03:07 logid=nostr type=luptatem subtype=tNequepo level=low eventtime=eumfug logtime=sper srcip=10.200.12.126 srcport=2347 srcintf=enp0s7374 srcintfrole=liqu dstip=10.14.145.107 dstport=4362 dstintf=enp0s7861 dstintfrole=aliq poluuid=utem sessionid=oreetd proto=HOPOPT action=block policyid=Nequepo policytype=edictas crscore=55.933000 craction=tur crlevel=borisnis appcat=elitsedd service=hitecto srccountry=loremi dstcountry=nven trandisp=isci tranip=10.250.231.196 tranport=5863 duration=4.105000 sentbyte=2763 rcvdbyte=5047 sentpkt=aquioff app=cip",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -410,6 +635,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=onsequat dtime=2017-11-02 11:05:41.432538723 +0000 UTC devid=tiumd devname=atuse vd=imad date=2017-11-2 time=11:05:41 logid=tura type=equuntur subtype=rve level=high eventtime=mqua logtime=xer srcip=10.225.34.176 srcport=5569 srcintf=lo2867 srcintfrole=amquisn dstip=10.21.203.112 dstport=5930 dstintf=enp0s1294 dstintfrole=sum poluuid=lloinve sessionid=eni proto=HOPOPT action=cancel policyid=edquiac policytype=psamvolu crscore=80.314000 craction=unturma crlevel=iavol appcat=psumdol service=urautodi srccountry=equamni dstcountry=fugia trandisp=uptate tranip=10.103.36.192 tranport=1974 duration=129.001000 sentbyte=2801 rcvdbyte=2565 sentpkt=imidest app=citation",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -419,6 +649,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=nof devname=\"usantiu\" devid=\"periam\" vd=remip date=2017-11-16 time=6:08:15 logid=dexea type=aturExc subtype=antiumto level=low eventtime=obe logtime=niamqu srcip=10.140.59.161 srcport=3599 srcintf=eth575 srcintfrole=tev dstip=10.5.67.140 dstport=5687 dstintf=enp0s6143 dstintfrole=intoc poluuid=obeataev sessionid=rrorsit proto=udp action=accept policyid=umquid policytype=olabo crscore=79.046000 craction=dolor crlevel=rsp appcat=quir service=giatqu srccountry=olors dstcountry=roid trandisp=lorum tranip=10.118.111.183 tranport=5410 duration=96.462000 sentbyte=6821 rcvdbyte=6222 sentpkt=mipsu app=nvol",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -428,6 +663,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-12-1 time=1:10:49 logver=llu devid=quaUt devname=labor logid=oris type=tatemse subtype=uta level=very-high vd=tse srcip=10.170.104.148 srcport=5722 srcintf=lo259 dstip=10.60.92.40 dstport=5836 dstintf=enp0s4446 poluuid=dicons sessionid=BCSedutp proto=udp action=accept policyid=ritatise trandisp=nihilm duration=104.607000 sentbyte=6659 rcvdbyte=5351 devtype=isauteir osname=eritquii osversion=1.4493 mastersrcmac=uisno srcmac=01:00:5e:e9:ec:d5 crscore=34.736000 craction=itaed crlevel=invol eventtype=Loremips user=cidun service=tassitas hostname=nimadmi4084.api.home profile=eufugia reqtype=nor url=https://example.net/aturQui/tquii.html?uiac=squ#litess direction=unknown msg=involupt method=itempo cat=upt catdesc=rve device_id=amq log_id=abillo pri=high userfrom=ationem adminprof=Nem timezone=OMST main_type=ollita trigger_policy=dipisci sub_type=amnisiu severity_level=ptat policy=epr src=10.7.70.169 src_port=2514 dst=10.28.212.191 dst_port=1997 http_method=nostru http_url=Loremip http_host=veleumiu http_agent=rcita http_session_id=turad signature_subclass=sequamni signature_id=4799 srccountry=ollita content_switch_name=ectetu server_pool_name=radi false_positive_mitigation=ula user_name=itsed monitor_status=rad http_refer=https://internal.example.com/ididu/autodit.gif?seru=oriss#imadmin http_version=suntexpl dev_id=urve threat_weight=sBonoru history_threat_weight=everi threat_level=squ ftp_mode=emagnaal ftp_cmd=nih cipher_suite=ncididu msg_id=itati",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -437,6 +677,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2017-12-15 time=8:13:24 logver=estla devid=ione devname=ecillum logid=maccu type=ame subtype=pitlabo level=very-high vd=urExc srcip=10.37.124.214 srcport=6919 srcintf=lo7727 dstip=10.37.111.228 dstport=7082 dstintf=enp0s20 poluuid=dmini sessionid=tquid proto=17 action=block policyid=iatisun trandisp=cto duration=144.899000 sentbyte=2372 rcvdbyte=7417 devtype=imadmini osname=iatisund osversion=1.6506 mastersrcmac=aUtenim srcmac=01:00:5e:28:0c:11 crscore=172.422000 craction=etdol crlevel=sed eventtype=uep user=ametco service=nde hostname=reprehe3525.www5.example profile=mquisno reqtype=eaco url=https://mail.example.org/mvele/teveli.htm?Nequepor=luptate#aturvel direction=internal msg=dexea method=sedquia cat=litesse catdesc=ntmo device_id=aliqu log_id=iqu pri=very-high userfrom=ationula adminprof=doconse timezone=CEST main_type=oreeufug trigger_policy=ptatems sub_type=tenima severity_level=emagnam policy=iaco src=10.148.197.60 src_port=5711 dst=10.143.144.52 dst_port=974 http_method=nvo http_url=lab http_host=sedqui http_agent=iuntNe http_session_id=tdolor signature_subclass=Ute signature_id=2191 srccountry=uepor content_switch_name=umSecti server_pool_name=eabil false_positive_mitigation=ibusB user_name=rporis monitor_status=etco http_refer=https://example.org/ereprehe/olu.html?liqu=ipsu#siarch http_version=itautfu dev_id=rrorsi threat_weight=ole history_threat_weight=odi threat_level=tper ftp_mode=olor ftp_cmd=corpo cipher_suite=commod msg_id=iumd",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -446,6 +691,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=aborisn dtime=2017-12-29 15:15:58.472538723 +0000 UTC devid=onproid devname=sitv vd=equam date=2017-12-29 time=3:15:58 logid=bor type=ameaquei subtype=aeca level=very-high eventtime=aperiam logtime=ngelit srcip=10.217.145.137 srcport=5242 srcintf=enp0s6940 srcintfrole=orema dstip=10.22.149.132 dstport=7725 dstintf=lo7156 dstintfrole=neavolup poluuid=lits sessionid=Nemoen proto=0 action=block policyid=rur policytype=quaturve crscore=166.007000 craction=oeiusmod crlevel=uidolore appcat=iacon service=ncu srccountry=quaturve dstcountry=ciad trandisp=diconseq tranip=10.251.183.113 tranport=2604 duration=161.433000 sentbyte=5697 rcvdbyte=7299 sentpkt=eseosqu app=uptatem",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -455,6 +705,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=uamnihil devname=\"nisi\" devid=\"imadm\" vd=siutali date=2018-1-12 time=10:18:32 logid=mfugi type=ceroinBC subtype=lorumw level=low eventtime=squir logtime=commod srcip=10.183.16.252 srcport=3150 srcintf=lo6718 srcintfrole=eabillo dstip=10.203.66.175 dstport=3904 dstintf=enp0s3868 dstintfrole=dipisciv poluuid=nsequun sessionid=hen proto=icmp action=accept policyid=velillum policytype=itamet crscore=123.013000 craction=hil crlevel=itl appcat=idolo service=ncidid srccountry=oid dstcountry=iarchit trandisp=volupt tranip=10.51.60.203 tranport=5315 duration=165.955000 sentbyte=7551 rcvdbyte=1519 sentpkt=ten app=Utenim",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -464,6 +719,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-1-27 time=5:21:06 logver=uasiarch devid=iamquisn devname=magnama logid=reprehe type=citatio subtype=dolo level=medium vd=esciunt srcip=10.133.245.26 srcport=1727 srcintf=enp0s2674 dstip=10.76.87.30 dstport=2858 dstintf=enp0s2918 poluuid=remag sessionid=roinBCSe proto=HOPOPT action=accept policyid=labori trandisp=ditau duration=39.920000 sentbyte=5413 rcvdbyte=6650 devtype=tam osname=olu osversion=1.409 mastersrcmac=iut srcmac=01:00:5e:5c:c2:50 crscore=69.137000 craction=boris crlevel=ris eventtype=nisiuta user=utper service=uipexe hostname=ursint411.www.lan profile=gnamali reqtype=iumdo url=https://example.org/tem/iadeseru.jpg?olorsita=odoco#etc direction=internal msg=lamco method=natuser cat=Excepteu catdesc=omnis device_id=tati log_id=orinc pri=very-high userfrom=eturadi adminprof=cinge timezone=PT main_type=ira trigger_policy=niamq sub_type=quatD severity_level=nevol policy=lumquid src=10.157.14.165 src_port=7170 dst=10.61.200.105 dst_port=2813 http_method=tquov http_url=natu http_host=doei http_agent=acomm http_session_id=veleumi signature_subclass=volupt signature_id=6822 srccountry=itatise content_switch_name=ure server_pool_name=userro false_positive_mitigation=oree user_name=nimadmi monitor_status=utaliq http_refer=https://example.com/tinvolu/uredol.txt?did=lamcol#idolor http_version=tutlabor dev_id=nse threat_weight=rauto history_threat_weight=rese threat_level=nonproi ftp_mode=doconse ftp_cmd=henderi cipher_suite=tisunde msg_id=ende",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -473,6 +733,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-2-10 time=12:23:41 logver=commod devid=oris devname=rcita logid=ataev type=oris subtype=incidi level=high vd=tutlabo srcip=10.32.66.161 srcport=881 srcintf=lo4523 dstip=10.134.238.8 dstport=2976 dstintf=enp0s1238 poluuid=edquiac sessionid=sit proto=HOPOPT action=allow policyid=olo trandisp=laboris duration=163.866000 sentbyte=7328 rcvdbyte=5375 devtype=tutl osname=nevolu osversion=1.5475 mastersrcmac=ostru srcmac=01:00:5e:e9:5f:84 crscore=157.516000 craction=aven crlevel=idolore eventtype=psaqu user=psa service=pta hostname=ididunt7607.mail.localhost profile=ntutlabo reqtype=leumiure url=https://mail.example.net/epteurs/usmodtem.gif?itvo=asi#tobe direction=internal msg=Lore method=oin cat=eritquii catdesc=taliqui device_id=ecatcu log_id=entoreve pri=high userfrom=umquam adminprof=onev timezone=CET main_type=tionev trigger_policy=ali sub_type=ionu severity_level=perna policy=moll src=10.242.178.15 src_port=3948 dst=10.217.111.77 dst_port=7309 http_method=datatno http_url=equepor http_host=antium http_agent=ugiatn http_session_id=utpe signature_subclass=hend signature_id=1170 srccountry=agnamali content_switch_name=ptateve server_pool_name=aliqua false_positive_mitigation=officiad user_name=nimadmin monitor_status=iavol http_refer=https://example.net/iumtota/qui.jpg?quel=ugitsed#ritatis http_version=olor dev_id=emoenim threat_weight=turadipi history_threat_weight=umSec threat_level=onsecte ftp_mode=inibusBo ftp_cmd=tqui cipher_suite=sequun msg_id=nimadm",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -482,6 +747,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-2-24 time=7:26:15 logver=vitaedic devid=remip devname=rsita logid=rehe type=aper subtype=gnaa level=low vd=uta srcip=10.161.128.235 srcport=6280 srcintf=eth2121 dstip=10.84.29.117 dstport=1245 dstintf=eth7500 poluuid=errorsi sessionid=umwr proto=HOPOPT action=cancel policyid=cupida trandisp=rinc duration=5.709000 sentbyte=289 rcvdbyte=6059 devtype=dquia osname=ommod osversion=1.142 mastersrcmac=dico srcmac=01:00:5e:06:53:8a crscore=35.836000 craction=imipsa crlevel=iscinge eventtype=ora user=meumfug service=inimve hostname=mco2906.domain profile=sitvolu reqtype=eratv url=https://www.example.com/iadolo/cidu.txt?aliquide=redolori#eav direction=inbound msg=nse method=turQuis cat=tat catdesc=pta device_id=henderi log_id=onsec pri=high userfrom=itaspern adminprof=tau timezone=GMT+02:00 main_type=rsintoc trigger_policy=boreetd sub_type=rehende severity_level=sitamet policy=xerc src=10.199.119.251 src_port=7286 dst=10.86.152.227 dst_port=850 http_method=ant http_url=tiu http_host=ommodoco http_agent=rehe http_session_id=eseosqu signature_subclass=oeius signature_id=641 srccountry=eaqueip content_switch_name=laud server_pool_name=uido false_positive_mitigation=uis user_name=msequin monitor_status=autem http_refer=https://internal.example.org/ipi/qua.htm?itat=adipisc#omnisist http_version=orroqui dev_id=sci threat_weight=psamvolu history_threat_weight=itsedqui threat_level=oreve ftp_mode=omn ftp_cmd=onevol cipher_suite=ese msg_id=reprehen",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -491,6 +761,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-3-11 time=2:28:49 logver=eumfugia devid=nimvenia devname=dol logid=rissusc type=lit subtype=quin level=low vd=eddoei srcip=10.35.73.208 srcport=7081 srcintf=eth6552 dstip=10.216.120.61 dstport=6389 dstintf=eth2068 poluuid=dolor sessionid=emUteni proto=tcp action=deny policyid=illoin trandisp=rinre duration=166.295000 sentbyte=5988 rcvdbyte=3374 devtype=olorem osname=mquae osversion=1.1789 mastersrcmac=rQuis srcmac=01:00:5e:b5:9a:3e crscore=5.250000 craction=enimadmi crlevel=elit eventtype=uia user=tem service=unt hostname=ntex5135.corp profile=mqua reqtype=equa url=https://internal.example.com/isc/umdol.jpg?atn=sectet#boreetd direction=outbound msg=olorin method=oluptat cat=olors catdesc=mSecti device_id=ius log_id=quian pri=low userfrom=urExce adminprof=upt timezone=PST main_type=pteurs trigger_policy=intocc sub_type=abo severity_level=orisnis policy=reseo src=10.239.194.105 src_port=3629 dst=10.234.171.117 dst_port=4488 http_method=tenatus http_url=odic http_host=ono http_agent=umtota http_session_id=consequ signature_subclass=ine signature_id=3409 srccountry=dex content_switch_name=ipis server_pool_name=nsecte false_positive_mitigation=miurere user_name=tat monitor_status=pitlabor http_refer=https://example.com/olupta/ape.jpg?mnisiut=eabil#olu http_version=uaUte dev_id=empor threat_weight=ate history_threat_weight=eca threat_level=inre ftp_mode=aliqu ftp_cmd=orem cipher_suite=dquian msg_id=isaute",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -500,6 +775,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=emagnaal dtime=2018-03-25 09:31:24.032538723 +0000 UTC devid=uunturm devname=nonnumq vd=tqu date=2018-3-25 time=9:31:24 logid=ntocca type=emquelau subtype=adolorsi level=medium eventtime=maliquam logtime=ovol srcip=10.34.41.75 srcport=4436 srcintf=enp0s7638 srcintfrole=eseosqu dstip=10.249.16.201 dstport=4293 dstintf=lo5084 dstintfrole=mvele poluuid=qui sessionid=etMa proto=3 action=accept policyid=aspe policytype=uradipi crscore=22.220000 craction=atu crlevel=amremape appcat=illoinve service=uis srccountry=itanimi dstcountry=rinc trandisp=isistena tranip=10.107.168.208 tranport=1864 duration=45.477000 sentbyte=1067 rcvdbyte=2855 sentpkt=ctionofd app=uianonnu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -509,6 +789,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=nisiste date=2018-4-8 time=4:33:58 log_id=sedqu devid=itautfu devname=aaliq logid=tDui type=ernatur subtype=itsed level=low vd=xeacomm srcip=10.112.57.220 srcport=5803 srcintf=enp0s1897 dstip=10.19.151.236 dstport=884 dstintf=enp0s4144 poluuid=estiaeco sessionid=vele proto=HOPOPT action=allow policyid=yCiceroi trandisp=loremeu duration=156.263000 sentbyte=3719 rcvdbyte=7292 devtype=colab osname=itte osversion=1.6905 mastersrcmac=orumS srcmac=01:00:5e:c1:b8:93 crscore=60.950000 craction=uptat crlevel=incidun eventtype=agnaaliq user=aturQuis service=cepteurs hostname=tat1845.internal.invalid profile=rumetMal reqtype=tiumtot url=https://www.example.com/imadm/ugiat.txt?Nequepor=nisiu#ptat direction=inbound msg=eddoe method=seq cat=uae catdesc=tobeata device_id=ctas log_id=vol pri=high userfrom=gna adminprof=itautf timezone=ET main_type=eprehe trigger_policy=ariatu sub_type=aqueip severity_level=aqueip policy=rautod src=10.96.168.24 src_port=6206 dst=10.109.106.194 dst_port=5356 http_method=Sedut http_url=stiaec http_host=rveli http_agent=serr http_session_id=umdolo signature_subclass=iduntut signature_id=4281 srccountry=rorsitv content_switch_name=caboNemo server_pool_name=cididun false_positive_mitigation=iamqu user_name=ommodoc monitor_status=mwrit http_refer=https://www5.example.com/madminim/onse.txt?reeuf=orinrepr#tinvo http_version=oru dev_id=ainc threat_weight=aeab history_threat_weight=iat threat_level=acom ftp_mode=olo ftp_cmd=eipsaq cipher_suite=enatu msg_id=mfu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -518,6 +803,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=aliqui date=2018-4-22 time=11:36:32 log_id=uipexea devid=sauteiru devname=nibusB logid=eetdolo type=issuscip subtype=iduntu level=high vd=rinc srcip=10.109.224.208 srcport=1769 srcintf=enp0s3638 dstip=10.31.34.96 dstport=4651 dstintf=enp0s390 poluuid=atis sessionid=edol proto=icmp action=deny policyid=adip trandisp=ugiatq duration=128.795000 sentbyte=4249 rcvdbyte=6693 devtype=atemUte osname=emag osversion=1.1353 mastersrcmac=ecatcup srcmac=01:00:5e:63:85:d2 crscore=62.286000 craction=oin crlevel=isautem eventtype=eiusm user=assit service=ulpaq hostname=ulamc767.internal.lan profile=iades reqtype=mremape url=https://mail.example.net/ionemu/nul.jpg?volupt=ori#sed direction=inbound msg=maveniam method=ctobeat cat=emoenim catdesc=oqui device_id=olab log_id=remagnam pri=high userfrom=mSecti adminprof=volupt timezone=OMST main_type=ela trigger_policy=fugits sub_type=litseddo severity_level=idestl policy=ptasn src=10.112.155.228 src_port=5011 dst=10.47.191.95 dst_port=6242 http_method=velillu http_url=radipi http_host=iatn http_agent=aturE http_session_id=beat signature_subclass=pern signature_id=7568 srccountry=itvolupt content_switch_name=uradip server_pool_name=perspi false_positive_mitigation=uaer user_name=aed monitor_status=tectobe http_refer=https://example.org/scingeli/uatDuis.gif?apari=itesseci#utali http_version=ofdeFin dev_id=siutaliq threat_weight=urvel history_threat_weight=turE threat_level=ntium ftp_mode=imadmi ftp_cmd=dquiac cipher_suite=liquide msg_id=uatD",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -527,6 +817,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=gnidolor dtime=2018-05-07 06:39:06.812538723 +0000 UTC devid=BCSedut devname=metco vd=vel date=2018-5-7 time=6:39:06 logid=tmol type=acommodi subtype=ccaecat level=low eventtime=mqu logtime=mips srcip=10.103.169.94 srcport=2174 srcintf=lo5821 srcintfrole=osqu dstip=10.140.137.17 dstport=446 dstintf=enp0s4444 dstintfrole=iono poluuid=atcupi sessionid=dexe proto=0 action=allow policyid=exerci policytype=ems crscore=15.728000 craction=nulapa crlevel=tess appcat=eroi service=enby srccountry=riatur dstcountry=amrema trandisp=illum tranip=10.62.241.218 tranport=7444 duration=5.969000 sentbyte=4832 rcvdbyte=6033 sentpkt=urere app=involu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -536,6 +831,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=tem devname=\"litsedq\" devid=\"amre\" vd=orpori date=2018-5-21 time=1:41:41 logid=sistena type=iam subtype=saquae level=low eventtime=itanimid logtime=ianonnum srcip=10.90.229.92 srcport=6796 srcintf=lo1752 srcintfrole=inculp dstip=10.251.212.166 dstport=3925 dstintf=eth1592 dstintfrole=aboNemo poluuid=tsedquia sessionid=ididun proto=21 action=cancel policyid=enim policytype=gnido crscore=85.453000 craction=erepr crlevel=tsedqu appcat=uisa service=uptat srccountry=siutal dstcountry=umetMalo trandisp=onevolu tranip=10.77.105.160 tranport=5541 duration=155.903000 sentbyte=5294 rcvdbyte=2687 sentpkt=ira app=umfu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -545,6 +845,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-6-4 time=8:44:15 logver=uamq devid=mnisist devname=dutp logid=ecillu type=ipsaqu subtype=asun level=very-high vd=llumd srcip=10.100.223.157 srcport=1307 srcintf=eth5742 dstip=10.232.243.87 dstport=4546 dstintf=lo299 poluuid=atisetq sessionid=mSectio proto=0 action=cancel policyid=nonnumqu trandisp=atis duration=63.050000 sentbyte=3508 rcvdbyte=205 devtype=uam osname=tisunde osversion=1.4261 mastersrcmac=rured srcmac=01:00:5e:8a:c1:2a crscore=19.243000 craction=meumfug crlevel=iam eventtype=animi user=porainc service=nsectetu hostname=spici5547.internal.test profile=tate reqtype=sintocca url=https://mail.example.org/asuntex/uovolup.html?amali=uiav#henderi direction=internal msg=tnul method=ons cat=radip catdesc=amremap device_id=dolorsit log_id=atisund pri=very-high userfrom=uredo adminprof=uamni timezone=CT main_type=quisqua trigger_policy=sedquian sub_type=lamcorpo severity_level=rem policy=apariat src=10.216.49.112 src_port=4521 dst=10.112.242.68 dst_port=3105 http_method=aut http_url=eriti http_host=ipsum http_agent=com http_session_id=uptate signature_subclass=tevelite signature_id=5880 srccountry=nimadmi content_switch_name=mquiado server_pool_name=agn false_positive_mitigation=dip user_name=urmag monitor_status=nim http_refer=https://www5.example.net/tutlabo/incid.gif?ptate=tconsect#usm http_version=uunturma dev_id=namaliqu threat_weight=tatemacc history_threat_weight=licab threat_level=roidents ftp_mode=volupta ftp_cmd=stiaeco cipher_suite=tanim msg_id=osam",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -554,6 +859,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-6-19 time=3:46:49 logver=tla devid=nimve devname=edutpe logid=tenb type=billoinv subtype=asia level=medium vd=paquioff srcip=10.252.175.174 srcport=1995 srcintf=enp0s1531 dstip=10.196.226.219 dstport=545 dstintf=lo2390 poluuid=uaera sessionid=nsequa proto=tcp action=accept policyid=orporis trandisp=oluptate duration=28.731000 sentbyte=2397 rcvdbyte=1768 devtype=itvolu osname=citation osversion=1.491 mastersrcmac=aincid srcmac=01:00:5e:7e:ea:3f crscore=149.960000 craction=tNeque crlevel=uidolore eventtype=uatDuisa user=usB service=magnaali hostname=istenatu3686.invalid profile=remagna reqtype=eritqu url=https://example.org/mnisiut/porinci.htm?norum=emUten#dminimve direction=internal msg=oremagna method=nulamc cat=tempori catdesc=rsintocc device_id=nderit log_id=etco pri=very-high userfrom=lore adminprof=ameiusmo timezone=PT main_type=veniamqu trigger_policy=equat sub_type=reeu severity_level=atemacc policy=rsitvolu src=10.182.58.108 src_port=4811 dst=10.96.100.84 dst_port=2253 http_method=utlabore http_url=texplica http_host=boru http_agent=ntut http_session_id=elaud signature_subclass=acomm signature_id=5667 srccountry=emUten content_switch_name=uamni server_pool_name=laboris false_positive_mitigation=pers user_name=lpaquiof monitor_status=isisten http_refer=https://api.example.net/seddoei/rnatur.jpg?olores=idolorem#umdolors http_version=uid dev_id=numqua threat_weight=citatio history_threat_weight=sed threat_level=mUten ftp_mode=eursint ftp_cmd=velillum cipher_suite=oin msg_id=teurs",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -563,6 +873,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=untutl devname=\"cons\" devid=\"vel\" vd=illumdo date=2018-7-3 time=10:49:23 logid=rios type=deF subtype=dutpe level=very-high eventtime=itan logtime=uisnos srcip=10.228.61.5 srcport=1179 srcintf=eth4741 srcintfrole=lites dstip=10.246.41.77 dstport=1217 dstintf=lo7502 dstintfrole=olu poluuid=ectet sessionid=tquovo proto=17 action=block policyid=lapa policytype=xeacom crscore=22.822000 craction=qui crlevel=henderi appcat=rainc service=dminim srccountry=sse dstcountry=tatem trandisp=umexe tranip=10.157.22.21 tranport=5252 duration=135.630000 sentbyte=2167 rcvdbyte=2952 sentpkt=quamei app=nvento",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -572,6 +887,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=qua devname=\"llumdo\" devid=\"tot\" vd=itquii date=2018-7-17 time=5:51:58 logid=psu type=iat subtype=ept level=high eventtime=ectob logtime=aUtenim srcip=10.242.119.111 srcport=645 srcintf=lo1640 srcintfrole=tDuisa dstip=10.239.231.168 dstport=88 dstintf=lo3385 dstintfrole=nimi poluuid=niamqu sessionid=uioffi proto=1 action=allow policyid=consequa policytype=tionu crscore=60.452000 craction=quines crlevel=entsu appcat=ineavol service=abor srccountry=giatq dstcountry=nonpro trandisp=elitsedd tranip=10.188.131.18 tranport=981 duration=46.954000 sentbyte=2770 rcvdbyte=4226 sentpkt=tam app=uovo",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -581,6 +901,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=orinrepr date=2018-8-1 time=12:54:32 log_id=untut devid=siu devname=lorem logid=icons type=hende subtype=umdol level=medium vd=psaq srcip=10.24.154.250 srcport=2108 srcintf=eth2707 dstip=10.124.187.230 dstport=6119 dstintf=lo105 poluuid=mqu sessionid=tse proto=udp action=accept policyid=ueip trandisp=amvo duration=20.956000 sentbyte=2068 rcvdbyte=306 devtype=reetdolo osname=tten osversion=1.979 mastersrcmac=usa srcmac=01:00:5e:6a:a6:c9 crscore=45.307000 craction=oremagna crlevel=siuta eventtype=amnihil user=nderit service=ficia hostname=tru3812.mail.lan profile=olo reqtype=xer url=https://api.example.net/nsec/smo.gif?etq=trumexe#rai direction=outbound msg=tNequepo method=byCicer cat=imvenia catdesc=ipit device_id=tdolorem log_id=nderitin pri=low userfrom=enderitq adminprof=amvolu timezone=GMT-07:00 main_type=temvele trigger_policy=ofd sub_type=quam severity_level=umdol policy=porincid src=10.106.101.87 src_port=7569 dst=10.247.124.74 dst_port=2491 http_method=inea http_url=ipsu http_host=iden http_agent=oreseo http_session_id=edictasu signature_subclass=aerat signature_id=4358 srccountry=lites content_switch_name=col server_pool_name=litsedd false_positive_mitigation=mnis user_name=ainci monitor_status=aturve http_refer=https://api.example.com/mporain/secte.txt?amqui=rume#uptate http_version=tisundeo dev_id=uid threat_weight=eFini history_threat_weight=mnis threat_level=tametco ftp_mode=snisiut ftp_cmd=lit cipher_suite=laborio msg_id=aaliqu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -590,6 +915,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-8-15 time=7:57:06 devname=mid device_id=henderi log_id=consec type=event subtype=dquia pri=high desc=isiutali user=rehe userfrom=volupta msg=etcons action=deny adom=etdol408.internal.home session_id=agnamali",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -599,6 +929,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-8-29 time=2:59:40 logver=cae devid=Utenimad devname=onsequ logid=Bon type=amquisno subtype=mullam level=very-high vd=admi srcip=10.111.106.60 srcport=5449 srcintf=lo5820 dstip=10.142.181.192 dstport=4386 dstintf=lo6200 poluuid=lmolest sessionid=miurerep proto=17 action=allow policyid=Sed trandisp=isau duration=66.574000 sentbyte=75 rcvdbyte=806 devtype=idest osname=ostru osversion=1.4342 mastersrcmac=enimip srcmac=01:00:5e:11:d6:5d crscore=66.141000 craction=umquiado crlevel=taspe eventtype=empori user=mipsum service=tium hostname=riaturE1644.www5.example profile=ender reqtype=uine url=https://internal.example.com/dolo/exeacom.txt?tlab=eufugiat#upta direction=internal msg=reetdo method=mad cat=mdolor catdesc=amcorpor device_id=oremquel log_id=san pri=high userfrom=amqui adminprof=itatise timezone=GMT-07:00 main_type=cia trigger_policy=lup sub_type=cipitla severity_level=niam policy=mullamc src=10.215.144.167 src_port=6675 dst=10.162.114.52 dst_port=2925 http_method=quepor http_url=Lor http_host=ten http_agent=exeacomm http_session_id=cusan signature_subclass=oquisq signature_id=4993 srccountry=ihilmol content_switch_name=seosqui server_pool_name=tiset false_positive_mitigation=ciade user_name=erspici monitor_status=xercitat http_refer=https://internal.example.net/utlab/entoreve.html?umdol=nseq#autodita http_version=loreme dev_id=eratv threat_weight=tametcon history_threat_weight=orsi threat_level=ull ftp_mode=mcor ftp_cmd=iamquis cipher_suite=aeabi msg_id=ore",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -608,6 +943,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-9-12 time=10:02:15 logver=catcup devid=ectetur devname=cons logid=spiciati type=upidata subtype=utlabo level=high vd=ersp srcip=10.101.207.156 srcport=2086 srcintf=enp0s4931 dstip=10.12.8.82 dstport=4369 dstintf=enp0s7520 poluuid=nemull sessionid=trumex proto=6 action=accept policyid=doloremq trandisp=iade duration=26.420000 sentbyte=5013 rcvdbyte=7641 devtype=uidolo osname=ita osversion=1.6452 mastersrcmac=rchite srcmac=01:00:5e:41:90:bf crscore=107.693000 craction=tionem crlevel=volupta eventtype=adol user=econsequ service=orever hostname=mdolo7008.api.corp profile=reetdolo reqtype=psam url=https://www5.example.org/orumet/aliqu.txt?tion=sun#utod direction=outbound msg=rinci method=uamestqu cat=riatu catdesc=ulaparia device_id=remagna log_id=fugi pri=very-high userfrom=xerc adminprof=caecat timezone=OMST main_type=cor trigger_policy=nonnumqu sub_type=uidexea severity_level=emu policy=asia src=10.162.128.87 src_port=6214 dst=10.78.75.82 dst_port=7799 http_method=uptat http_url=con http_host=tem http_agent=orpori http_session_id=lor signature_subclass=quiinea signature_id=7098 srccountry=rroquis content_switch_name=dolorema server_pool_name=prehe false_positive_mitigation=bori user_name=Sedutp monitor_status=ritinvo http_refer=https://internal.example.net/ica/nat.jpg?ddoe=nsequ#lloinve http_version=tdolo dev_id=billoi threat_weight=sequu history_threat_weight=ffic threat_level=imadmini ftp_mode=isnostru ftp_cmd=ostr cipher_suite=tinvo msg_id=lorumwr",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -617,6 +957,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=ctetura devname=\"reseosqu\" devid=\"ittenbyC\" vd=tlabor date=2018-9-27 time=5:04:49 logid=auteir type=uredolo subtype=uido level=medium eventtime=quiratio logtime=aincidu srcip=10.75.198.93 srcport=1982 srcintf=eth725 srcintfrole=umqu dstip=10.137.36.151 dstport=196 dstintf=lo1813 dstintfrole=rspici poluuid=duntutla sessionid=emeu proto=1 action=block policyid=atemUten policytype=turadipi crscore=16.226000 craction=estqu crlevel=orinre appcat=prehen service=equa srccountry=ciatisun dstcountry=mdolorem trandisp=nnumq tranip=10.51.106.43 tranport=6486 duration=78.551000 sentbyte=3531 rcvdbyte=5464 sentpkt=oremeumf app=volupt",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -626,6 +971,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=tnulapa devname=\"caecatcu\" devid=\"xcepte\" vd=deserun date=2018-10-11 time=12:07:23 logid=mvol type=erep subtype=teurs level=low eventtime=tiumdol logtime=byCicer srcip=10.154.151.111 srcport=5860 srcintf=eth1273 srcintfrole=uisnos dstip=10.7.230.206 dstport=5757 dstintf=lo1291 dstintfrole=pisc poluuid=eumfu sessionid=tseddoe proto=HOPOPT action=allow policyid=emulla policytype=bill crscore=147.522000 craction=oditaut crlevel=oloremqu appcat=untNeque service=reetdol srccountry=perspi dstcountry=tlab trandisp=udexerci tranip=10.249.93.150 tranport=799 duration=113.020000 sentbyte=2808 rcvdbyte=5744 sentpkt=ovolup app=squ",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -635,6 +985,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-10-25 time=7:09:57 logver=dolor devid=lit devname=ptatem logid=oeiusmod type=ugi subtype=utaliq level=very-high vd=toc srcip=10.76.177.154 srcport=1428 srcintf=eth4425 dstip=10.207.160.170 dstport=7037 dstintf=lo1570 poluuid=reseo sessionid=iration proto=tcp action=deny policyid=magn trandisp=iaecon duration=54.100000 sentbyte=622 rcvdbyte=6280 devtype=ill osname=oris osversion=1.5718 mastersrcmac=ulamcol srcmac=01:00:5e:19:ce:4b crscore=142.771000 craction=oNe crlevel=utfu eventtype=santiumd user=cididunt service=ctasu hostname=itse5466.api.example profile=ica reqtype=mnisis url=https://internal.example.com/nonnumqu/isciveli.gif?wri=aute#iscin direction=outbound msg=uat method=itasper cat=nibusBo catdesc=volupta device_id=olorinr log_id=iameaq pri=high userfrom=docons adminprof=uun timezone=OMST main_type=mremap trigger_policy=ate sub_type=agnaal severity_level=ibusB policy=mexe src=10.217.209.221 src_port=3639 dst=10.26.4.3 dst_port=5291 http_method=rsitame http_url=eca http_host=quirat http_agent=urmagn http_session_id=essec signature_subclass=prehende signature_id=1261 srccountry=setquas content_switch_name=nti server_pool_name=osamnis false_positive_mitigation=atisetqu user_name=ciduntut monitor_status=atisu http_refer=https://internal.example.com/architec/incul.txt?aborios=mco#amnisiu http_version=suntincu dev_id=lore threat_weight=equatu history_threat_weight=enbyCi threat_level=dolo ftp_mode=adipi ftp_cmd=beata cipher_suite=evelites msg_id=ipiscive",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -644,6 +999,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=umtot date=2018-11-9 time=2:12:32 log_id=eumiurer devid=inv devname=eac logid=rainc type=tinculp subtype=uianon level=high vd=corpori srcip=10.232.131.132 srcport=581 srcintf=enp0s6255 dstip=10.232.246.98 dstport=1854 dstintf=enp0s1526 poluuid=ivelit sessionid=itlabori proto=icmp action=accept policyid=oide trandisp=magni duration=72.993000 sentbyte=5817 rcvdbyte=6960 devtype=rrorsit osname=emipsu osversion=1.6603 mastersrcmac=temUte srcmac=01:00:5e:fe:be:28 crscore=134.746000 craction=hitec crlevel=sci eventtype=luptatev user=ruredo service=iamquis hostname=dquiac6194.api.lan profile=nidolo reqtype=runtmoll url=https://www5.example.org/utlabo/scip.html?voluptas=inv#upta direction=external msg=ors method=olupta cat=raincidu catdesc=nisi device_id=uipexea log_id=taedic pri=high userfrom=ugi adminprof=urExcep timezone=CET main_type=usant trigger_policy=uidolore sub_type=litse severity_level=ugitse policy=utfugi src=10.241.140.241 src_port=1813 dst=10.180.162.174 dst_port=7186 http_method=ido http_url=atnu http_host=ssuscipi http_agent=evita http_session_id=tconsect signature_subclass=lpaquiof signature_id=532 srccountry=lors content_switch_name=Finibus server_pool_name=totam false_positive_mitigation=idat user_name=nulapar monitor_status=git http_refer=https://www5.example.com/odtem/tati.jpg?ueips=umqu#ntexpli http_version=siuta dev_id=porincid threat_weight=itame history_threat_weight=inv threat_level=remaper ftp_mode=quaUteni ftp_cmd=evelit cipher_suite=oluptat msg_id=ditem",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -653,6 +1013,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2018-11-23 time=9:15:06 devname=oditautf device_id=asiarc log_id=eddoei type=generic subtype=iatqu pri=very-high devid=itessec devname=dat logid=tdol type=emul subtype=ariatu level=high vd=reseo srcip=10.53.70.207 srcport=1793 srcintf=lo2279 dstip=10.73.140.61 dstport=2114 dstintf=lo368 poluuid=stlabo sessionid=atema proto=1 action=deny policyid=orporiss trandisp=iamq duration=128.426000 sentbyte=1800 rcvdbyte=5783 devtype=pis osname=riosam osversion=1.2052 mastersrcmac=iosam srcmac=01:00:5e:21:d3:0a crscore=65.426000 craction=archi crlevel=nes eventtype=atvolupt user=umwritt service=uae hostname=amco1592.mail.host profile=aaliq reqtype=olupta url=https://internal.example.com/ssusci/snostrud.txt?dolo=siutaliq#obeata direction=outbound msg=tame method=olo cat=vel catdesc=equamn device_id=tempora log_id=enimip pri=very-high userfrom=saqua adminprof=aperia timezone=OMST main_type=tNeque trigger_policy=metcon sub_type=enimadmi severity_level=orem policy=corpor src=10.110.99.222 src_port=5685 dst=10.62.140.108 dst_port=1225 http_method=ssitasp http_url=ptat http_host=asp http_agent=uatDui http_session_id=nofdeFin signature_subclass=unde signature_id=3979 srccountry=seruntm content_switch_name=aera server_pool_name=scive false_positive_mitigation=ngelit user_name=moenimi monitor_status=mqu http_refer=https://mail.example.org/ueipsaq/upid.gif?utla=emUte#tisund http_version=tutla dev_id=isund threat_weight=atemU history_threat_weight=uidex threat_level=uptate ftp_mode=eac ftp_cmd=peria cipher_suite=amaliq msg_id=ium",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -662,6 +1027,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=ptate date=2018-12-7 time=4:17:40 log_id=tenatu devid=emo devname=ratio logid=maperia type=Maloru subtype=sumquia level=low vd=imadmini srcip=10.237.5.219 srcport=3828 srcintf=eth4604 dstip=10.197.99.150 dstport=3877 dstintf=enp0s7388 poluuid=odo sessionid=itseddoe proto=prm action=accept policyid=itinvo trandisp=uiavol duration=96.864000 sentbyte=2685 rcvdbyte=7612 devtype=urmagn osname=ficiade osversion=1.2691 mastersrcmac=equ srcmac=01:00:5e:f5:2a:24 crscore=163.671000 craction=mipsum crlevel=dolor eventtype=cupidata user=niamquis service=lapariat hostname=dicta7226.mail.example profile=eddoei reqtype=cingel url=https://api.example.com/temporai/umw.jpg?mveniamq=litsed#ptasn direction=unknown msg=loinv method=umd cat=madmi catdesc=xercit device_id=avolup log_id=etdo pri=medium userfrom=veleum adminprof=emUten timezone=CT main_type=proiden trigger_policy=cita sub_type=iac severity_level=ntincul policy=mnisiste src=10.4.244.115 src_port=4588 dst=10.53.50.77 dst_port=5330 http_method=lorem http_url=lore http_host=orroqu http_agent=tlabo http_session_id=iameaque signature_subclass=sautemve signature_id=6466 srccountry=emoe content_switch_name=ameiusmo server_pool_name=ntiumtot false_positive_mitigation=aeab user_name=idolo monitor_status=temac http_refer=https://api.example.net/ollita/idolore.html?illu=iut#asiarc http_version=imidest dev_id=mwri threat_weight=orsi history_threat_weight=ritinvol threat_level=rporiss ftp_mode=atu ftp_cmd=ddo cipher_suite=veli msg_id=ata",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -671,6 +1041,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=lor dtime=2018-12-21 23:20:14.972538723 +0000 UTC devid=ori devname=eleumiu vd=amre date=2018-12-21 time=11:20:14 logid=atur type=untex subtype=Except level=very-high eventtime=econse logtime=iac srcip=10.221.100.157 srcport=865 srcintf=lo4518 srcintfrole=mqu dstip=10.236.211.111 dstport=1801 dstintf=enp0s454 dstintfrole=rauto poluuid=pteursi sessionid=iquamqua proto=tcp action=allow policyid=psumqui policytype=equeporr crscore=32.741000 craction=cusanti crlevel=doloreme appcat=nsecte service=reprehen srccountry=taspe dstcountry=litess trandisp=enimadm tranip=10.120.212.78 tranport=119 duration=17.257000 sentbyte=4752 rcvdbyte=3484 sentpkt=ntsuntin app=ectetur",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -680,6 +1055,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-1-5 time=6:22:49 logver=intocca devid=vel devname=xeacom logid=orum type=voluptat subtype=nsequ level=medium vd=tenimad srcip=10.140.215.210 srcport=7229 srcintf=lo568 dstip=10.71.213.217 dstport=7475 dstintf=eth5820 poluuid=lup sessionid=reetdolo proto=HOPOPT action=accept policyid=dolor trandisp=emagnam duration=154.150000 sentbyte=2336 rcvdbyte=5326 devtype=emull osname=enatuser osversion=1.3052 mastersrcmac=ectob srcmac=01:00:5e:4a:5d:af crscore=9.013000 craction=niamqu crlevel=nrep eventtype=lauda user=ionevo service=busB hostname=pidatatn2627.www.localdomain profile=eritinvo reqtype=quiav url=https://mail.example.org/ngelit/dipiscin.gif?serro=ctet#umiurere direction=inbound msg=ciun method=ssitaspe cat=deomnis catdesc=ulamcol device_id=onn log_id=redol pri=medium userfrom=utlabore adminprof=nci timezone=OMST main_type=liqu trigger_policy=ectetura sub_type=aUte severity_level=untNeque policy=roi src=10.210.82.202 src_port=2749 dst=10.208.231.15 dst_port=412 http_method=rios http_url=diconseq http_host=tenima http_agent=iusm http_session_id=mveleumi signature_subclass=equinesc signature_id=5076 srccountry=mfugiatq content_switch_name=dmini server_pool_name=emveleu false_positive_mitigation=loree user_name=riatur monitor_status=tempor http_refer=https://internal.example.com/spiciati/tise.gif?ctas=rvelillu#qua http_version=ciat dev_id=iamq threat_weight=porin history_threat_weight=yCi threat_level=arc ftp_mode=santium ftp_cmd=numquame cipher_suite=umfugi msg_id=amestqui",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -689,6 +1069,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=tesseq devname=\"nimides\" devid=\"iusmodte\" vd=involup date=2019-1-19 time=1:25:23 logid=edd type=dolorsi subtype=mcolabo level=low eventtime=exe logtime=nve srcip=10.226.255.3 srcport=5449 srcintf=lo7680 srcintfrole=iaconseq dstip=10.123.59.69 dstport=5399 dstintf=lo5835 dstintfrole=ntsunti poluuid=bor sessionid=uisnos proto=6 action=accept policyid=tation policytype=seddoe crscore=21.625000 craction=eur crlevel=ntmolli appcat=pitl service=nulap srccountry=ipexe dstcountry=aqueipsa trandisp=psum tranip=10.53.251.202 tranport=7501 duration=131.751000 sentbyte=6876 rcvdbyte=220 sentpkt=ugi app=ptate",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -698,6 +1083,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=rur devname=\"edut\" devid=\"sitametc\" vd=iarchite date=2019-2-2 time=8:27:57 logid=uide type=iono subtype=aboris level=very-high eventtime=imidest logtime=ulamc srcip=10.3.85.176 srcport=318 srcintf=eth2546 srcintfrole=uptateve dstip=10.212.56.26 dstport=3032 dstintf=enp0s2353 dstintfrole=loin poluuid=cinge sessionid=tutl proto=udp action=block policyid=nesciu policytype=ueip crscore=162.484000 craction=orumSe crlevel=mSe appcat=itame service=quaturv srccountry=lumdolor dstcountry=persp trandisp=leumi tranip=10.29.141.252 tranport=2077 duration=106.468000 sentbyte=3472 rcvdbyte=7868 sentpkt=orum app=reseos",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -707,6 +1097,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-2-17 time=3:30:32 devname=orem device_id=seq log_id=cus type=generic subtype=tnulap pri=very-high devid=psamvolu devname=inculp logid=eni type=tcupid subtype=ercita level=very-high vd=olorinr srcip=10.110.166.81 srcport=7354 srcintf=lo3023 dstip=10.181.48.82 dstport=1225 dstintf=eth7640 poluuid=conseq sessionid=Nemoen proto=6 action=cancel policyid=umquamei trandisp=nih duration=55.527000 sentbyte=3449 rcvdbyte=4658 devtype=quia osname=eabill osversion=1.95 mastersrcmac=oeiusmo srcmac=01:00:5e:82:ca:1b crscore=67.321000 craction=rumwrit crlevel=tionofd eventtype=ill user=orroquis service=laparia hostname=emveleu4029.api.local profile=tconse reqtype=ntsun url=https://internal.example.net/inc/riaturEx.htm?mnihilm=itinvo#lestia direction=external msg=metcons method=lumd cat=liquaUt catdesc=snos device_id=maccusan log_id=oeni pri=medium userfrom=tiaecon adminprof=tincu timezone=GMT-07:00 main_type=untmoll trigger_policy=par sub_type=idatatno severity_level=tfugit policy=tla src=10.126.11.186 src_port=589 dst=10.236.175.163 dst_port=6562 http_method=atemqui http_url=icaboN http_host=Utenimad http_agent=res http_session_id=officiad signature_subclass=nsectet signature_id=3977 srccountry=temU content_switch_name=ciduntut server_pool_name=ionofd false_positive_mitigation=etqua user_name=udantiu monitor_status=tium http_refer=https://internal.example.net/leumiu/iuta.html?tfugit=rorsitv#tiaecons http_version=uamestq dev_id=aliquaUt threat_weight=boreet history_threat_weight=mquam threat_level=volu ftp_mode=nof ftp_cmd=boNe cipher_suite=ovolu msg_id=cid",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -716,6 +1111,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=equamn devname=\"mes\" devid=\"itatio\" vd=ssecillu date=2019-3-3 time=10:33:06 logid=oeius type=itin subtype=nostrud level=medium eventtime=byCic logtime=mnisiuta srcip=10.171.60.173 srcport=209 srcintf=lo1917 srcintfrole=usmodite dstip=10.11.150.136 dstport=3615 dstintf=lo5438 dstintfrole=olup poluuid=urQuis sessionid=iquip proto=1 action=cancel policyid=untutl policytype=elite crscore=176.898000 craction=ipsaq crlevel=spici appcat=nvolupt service=antiu srccountry=llumquid dstcountry=paq trandisp=olup tranip=10.83.98.220 tranport=1300 duration=73.115000 sentbyte=5812 rcvdbyte=3339 sentpkt=amquis app=umtotam",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -725,6 +1125,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=pitlabo dtime=2019-03-17 17:35:40.532538723 +0000 UTC devid=lorsita devname=datatno vd=emac date=2019-3-17 time=5:35:40 logid=uiavo type=tdo subtype=ratvolup level=high eventtime=dolo logtime=quioffic srcip=10.238.49.73 srcport=1554 srcintf=enp0s11 srcintfrole=riatu dstip=10.74.88.209 dstport=740 dstintf=lo5287 dstintfrole=quep poluuid=tfugitse sessionid=oenimips proto=udp action=deny policyid=mdo policytype=map crscore=148.871000 craction=osqui crlevel=consequ appcat=catcupid service=velitess srccountry=sit dstcountry=ipisc trandisp=onsectet tranip=10.92.3.166 tranport=5777 duration=156.314000 sentbyte=715 rcvdbyte=3946 sentpkt=itvol app=dolo",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -734,6 +1139,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=amquisno dtime=2019-04-01 00:38:14.792538723 +0000 UTC devid=uptasnul devname=ptate vd=deri date=2019-4-1 time=12:38:14 logid=periamea type=equatD subtype=quaturQu level=high eventtime=rpo logtime=inr srcip=10.119.248.36 srcport=2450 srcintf=enp0s1885 srcintfrole=ten dstip=10.187.107.47 dstport=288 dstintf=lo2445 dstintfrole=fugia poluuid=psa sessionid=iset proto=prm action=allow policyid=ecte policytype=ionemull crscore=84.399000 craction=sBo crlevel=nimides appcat=iurere service=edolorin srccountry=labor dstcountry=quelaud trandisp=ira tranip=10.84.200.121 tranport=3226 duration=128.212000 sentbyte=2150 rcvdbyte=4329 sentpkt=nos app=icta",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -743,6 +1153,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=itseddo devname=\"tasu\" devid=\"mquae\" vd=CSedu date=2019-4-15 time=7:40:49 logid=atae type=aeconseq subtype=boNemo level=very-high eventtime=nemulla logtime=tmollit srcip=10.167.128.229 srcport=4052 srcintf=eth1833 srcintfrole=ciatisu dstip=10.135.213.17 dstport=6427 dstintf=eth6468 dstintfrole=ritat poluuid=dipi sessionid=asnulapa proto=prm action=block policyid=onsequa policytype=seddoe crscore=23.021000 craction=Bonorume crlevel=emeumfu appcat=tla service=uidexea srccountry=odtem dstcountry=nvolupt trandisp=stia tranip=10.30.239.222 tranport=1546 duration=10.721000 sentbyte=6561 rcvdbyte=1057 sentpkt=itectobe app=rroq",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -752,6 +1167,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-4-29 time=2:43:23 devname=uunt device_id=pic log_id=unt type=generic subtype=emUt pri=medium devid=pernatur devname=orem logid=enbyCice type=velil subtype=nsequat level=low vd=duntutl srcip=10.238.172.76 srcport=156 srcintf=lo1215 dstip=10.201.119.253 dstport=2230 dstintf=enp0s7218 poluuid=nimad sessionid=tionu proto=udp action=block policyid=emagna trandisp=quin duration=68.078000 sentbyte=2527 rcvdbyte=1150 devtype=consequ osname=min osversion=1.1028 mastersrcmac=edicta srcmac=01:00:5e:cd:6c:ed crscore=163.905000 craction=itinvolu crlevel=urerepre eventtype=iumdol user=serror service=uptass hostname=rspic5637.api.local profile=itatise reqtype=iut url=https://api.example.net/ita/esse.txt?amquis=iatquovo#rExce direction=inbound msg=uraut method=reetdol cat=umtotam catdesc=itaedi device_id=ant log_id=tiumt pri=very-high userfrom=ratvolup adminprof=iamqu timezone=CT main_type=quaturve trigger_policy=tsunti sub_type=ero severity_level=iusmodi policy=acomm src=10.169.133.219 src_port=92 dst=10.115.166.48 dst_port=7491 http_method=eleumiur http_url=ididun http_host=edi http_agent=gia http_session_id=uaturQui signature_subclass=emi signature_id=5446 srccountry=etM content_switch_name=eve server_pool_name=iru false_positive_mitigation=ipit user_name=emq monitor_status=elitsedq http_refer=https://www.example.net/onsequat/emagnaa.gif?itse=tco#nnumqua http_version=erit dev_id=lorsitam threat_weight=emagnama history_threat_weight=ute threat_level=Excep ftp_mode=utpersp ftp_cmd=rehe cipher_suite=tiumt msg_id=ulamc",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -761,6 +1181,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=runt date=2019-5-13 time=9:45:57 log_id=emipsu devid=icaboNem devname=Except logid=fugits type=maliquam subtype=mav level=very-high vd=ecill srcip=10.36.122.89 srcport=5040 srcintf=lo3887 dstip=10.206.76.186 dstport=741 dstintf=eth2435 poluuid=atisund sessionid=enbyCic proto=1 action=block policyid=nrepre trandisp=uisautem duration=145.667000 sentbyte=4247 rcvdbyte=4374 devtype=tio osname=aconseq osversion=1.4195 mastersrcmac=enatuser srcmac=01:00:5e:1a:9c:4f crscore=124.786000 craction=rcitatio crlevel=olore eventtype=ntexp user=atio service=roquisqu hostname=rror3870.www5.local profile=volu reqtype=occ url=https://www5.example.net/culpa/isun.txt?cola=tura#rat direction=internal msg=sect method=ing cat=nis catdesc=aboreet device_id=ulapari log_id=isetqu pri=high userfrom=ons adminprof=Sedu timezone=CEST main_type=icaboNem trigger_policy=enderi sub_type=edqu severity_level=cita policy=uidolore src=10.146.255.40 src_port=3003 dst=10.226.39.82 dst_port=3950 http_method=oluptate http_url=orumwrit http_host=aconse http_agent=ites http_session_id=abori signature_subclass=dolor signature_id=3543 srccountry=amqu content_switch_name=uamest server_pool_name=ntoccaec false_positive_mitigation=ites user_name=caecatcu monitor_status=iof http_refer=https://api.example.com/uae/mdolo.txt?aute=itatise#utpers http_version=equunt dev_id=Nemo threat_weight=itse history_threat_weight=lillumq threat_level=idid ftp_mode=uis ftp_cmd=velits cipher_suite=mmodo msg_id=rporissu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -770,6 +1195,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=utemvel dtime=2019-05-28 04:48:31.832538723 +0000 UTC devid=exercita devname=emaperi vd=aspernat date=2019-5-28 time=4:48:31 logid=ddoei type=nihi subtype=umfu level=low eventtime=ehen logtime=olupt srcip=10.53.82.96 srcport=7088 srcintf=eth297 srcintfrole=nostru dstip=10.224.212.88 dstport=5404 dstintf=lo4266 dstintfrole=natuserr poluuid=ipi sessionid=eniamqui proto=icmp action=deny policyid=urvelill policytype=iadese crscore=174.116000 craction=isundeo crlevel=emq appcat=rehender service=uat srccountry=apa dstcountry=tani trandisp=per tranip=10.35.240.70 tranport=2587 duration=62.993000 sentbyte=7102 rcvdbyte=2380 sentpkt=ataevit app=chi",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -779,6 +1209,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=lorsita devname=\"oeius\" devid=\"trud\" vd=aco date=2019-6-11 time=11:51:06 logid=uei type=tsedqu subtype=agni level=very-high eventtime=rsint logtime=catc srcip=10.186.253.240 srcport=6982 srcintf=enp0s5429 srcintfrole=end dstip=10.233.128.7 dstport=2455 dstintf=eth5315 dstintfrole=onnumq poluuid=lupt sessionid=ugiatq proto=prm action=cancel policyid=utla policytype=iosamn crscore=164.209000 craction=tor crlevel=toreve appcat=ita service=orain srccountry=tnulap dstcountry=aevitae trandisp=aqu tranip=10.66.149.234 tranport=6236 duration=128.130000 sentbyte=6344 rcvdbyte=475 sentpkt=loremeu app=tate",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -788,6 +1223,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=elaud dtime=2019-06-25 18:53:40.352538723 +0000 UTC devid=iad devname=irat vd=upi date=2019-6-25 time=6:53:40 logid=rsintocc type=itanim subtype=sinto level=medium eventtime=lore logtime=eabi srcip=10.227.133.134 srcport=3351 srcintf=enp0s4820 srcintfrole=erspici dstip=10.46.11.114 dstport=4009 dstintf=enp0s7159 dstintfrole=oremq poluuid=rspiciat sessionid=ptas proto=tcp action=cancel policyid=ore policytype=dut crscore=128.554000 craction=remape crlevel=itectob appcat=sedquia service=mquisnos srccountry=mwritt dstcountry=avolupt trandisp=lumdolo tranip=10.173.140.201 tranport=6422 duration=133.394000 sentbyte=7249 rcvdbyte=1387 sentpkt=str app=sit",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -797,6 +1237,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=elillum dtime=2019-07-10 01:56:14.612538723 +0000 UTC devid=isnos devname=emp vd=eos date=2019-7-10 time=1:56:14 logid=sciveli type=Bonoru subtype=rai level=low eventtime=omm logtime=cepteu srcip=10.205.18.11 srcport=6737 srcintf=eth4759 srcintfrole=ueipsa dstip=10.69.130.207 dstport=1191 dstintf=eth614 dstintfrole=architec poluuid=era sessionid=ptatem proto=udp action=cancel policyid=isi policytype=ssecill crscore=44.181000 craction=exerci crlevel=ptatemUt appcat=temqu service=ofd srccountry=nimvenia dstcountry=ari trandisp=eir tranip=10.170.236.123 tranport=4346 duration=150.036000 sentbyte=6877 rcvdbyte=1751 sentpkt=orum app=tation",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -806,6 +1251,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=repre date=2019-7-24 time=8:58:48 log_id=ore devid=ionemu devname=rehend logid=uiad type=tasu subtype=sciun level=high vd=taev srcip=10.196.124.206 srcport=7569 srcintf=enp0s2181 dstip=10.186.88.110 dstport=4203 dstintf=enp0s5497 poluuid=asnulapa sessionid=hende proto=0 action=deny policyid=ntmolli trandisp=uto duration=178.755000 sentbyte=6361 rcvdbyte=1742 devtype=ipsu osname=taedi osversion=1.2682 mastersrcmac=acom srcmac=01:00:5e:99:e3:a5 crscore=175.099000 craction=Cic crlevel=aturveli eventtype=lica user=Exc service=amvolup hostname=velill3821.mail.invalid profile=asnulap reqtype=usmodte url=https://example.com/loremag/mqu.gif?bore=lapari#aborios direction=external msg=lorem method=mnisiuta cat=quiadolo catdesc=abo device_id=msequine log_id=mrem pri=medium userfrom=atuserr adminprof=nsequatu timezone=ET main_type=uptasnu trigger_policy=atemUt sub_type=iurere severity_level=oident policy=volup src=10.97.254.192 src_port=302 dst=10.124.34.251 dst_port=3899 http_method=imide http_url=sequa http_host=ine http_agent=ollitan http_session_id=eacomm signature_subclass=onseq signature_id=6250 srccountry=reetd content_switch_name=equamnih server_pool_name=tevelite false_positive_mitigation=sitvolup user_name=epor monitor_status=atatnonp http_refer=https://example.org/elauda/ria.htm?uptatemU=iono#quun http_version=itationu dev_id=eniamqui threat_weight=adolo history_threat_weight=oreetdol threat_level=uinesciu ftp_mode=sciun ftp_cmd=tametc cipher_suite=rExcep msg_id=avolup",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -815,6 +1265,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=olores devname=\"ineavol\" devid=\"bori\" vd=taev date=2019-8-7 time=4:01:23 logid=ngelit type=uidexea subtype=stiaec level=very-high eventtime=quipex logtime=rsintoc srcip=10.9.41.221 srcport=4010 srcintf=eth434 srcintfrole=estlabor dstip=10.81.58.91 dstport=2247 dstintf=lo6072 dstintfrole=udexerci poluuid=onemul sessionid=elaud proto=tcp action=cancel policyid=trudexe policytype=tiumtota crscore=53.861000 craction=ariaturE crlevel=fug appcat=umqu service=umqu srccountry=roide dstcountry=tio trandisp=autem tranip=10.204.98.238 tranport=3885 duration=108.380000 sentbyte=2498 rcvdbyte=3936 sentpkt=aquioffi app=aliqui",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -824,6 +1279,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-8-21 time=11:03:57 devname=unti device_id=tena log_id=velits type=event subtype=oditautf pri=high desc=rmagni user=tiono userfrom=utemvele msg=taevi action=cancel adom=xplicabo4308.www.example session_id=tquo",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -833,6 +1293,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=nrepr devname=\"uipex\" devid=\"alorumw\" vd=nibus date=2019-9-5 time=6:06:31 logid=eiusmo type=rci subtype=seosquir level=medium eventtime=ume logtime=ercitati srcip=10.35.84.125 srcport=341 srcintf=enp0s2388 srcintfrole=pernatu dstip=10.37.120.29 dstport=4170 dstintf=enp0s1127 dstintfrole=tasuntex poluuid=etura sessionid=taedi proto=udp action=accept policyid=quiacon policytype=udexerc crscore=66.169000 craction=undeomni crlevel=ritquiin appcat=taspern service=iadeser srccountry=nos dstcountry=mollita trandisp=eserun tranip=10.212.208.70 tranport=3237 duration=36.569000 sentbyte=5330 rcvdbyte=11 sentpkt=otamr app=eveli",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -842,6 +1307,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=temsequi devname=\"aturvel\" devid=\"elaudan\" vd=alorum date=2019-9-19 time=1:09:05 logid=olor type=inesc subtype=tlaborio level=high eventtime=equeporr logtime=seq srcip=10.143.65.84 srcport=2670 srcintf=enp0s5828 srcintfrole=ddoeiu dstip=10.199.201.26 dstport=3770 dstintf=eth4236 dstintfrole=ore poluuid=onse sessionid=abo proto=1 action=accept policyid=magnaa policytype=tateveli crscore=94.258000 craction=xplica crlevel=dex appcat=rsintocc service=iusmo srccountry=oquisqu dstcountry=ullamcor trandisp=remagn tranip=10.207.207.106 tranport=2048 duration=94.877000 sentbyte=6896 rcvdbyte=7419 sentpkt=tvolup app=ites",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -851,6 +1321,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=rExce dtime=2019-10-03 20:11:40.172538723 +0000 UTC devid=rittenby devname=gni vd=ritq date=2019-10-3 time=8:11:40 logid=lestiaec type=rissusci subtype=fdeFi level=high eventtime=ehende logtime=riatu srcip=10.204.27.48 srcport=5998 srcintf=lo7358 srcintfrole=emaperia dstip=10.163.236.253 dstport=7768 dstintf=enp0s2100 dstintfrole=sequatu poluuid=ugi sessionid=oditau proto=1 action=block policyid=mvele policytype=atae crscore=123.668000 craction=imips crlevel=admi appcat=ocons service=tiumdol srccountry=sunt dstcountry=rrorsi trandisp=remagna tranip=10.41.61.88 tranport=426 duration=82.943000 sentbyte=525 rcvdbyte=3702 sentpkt=dolor app=ips",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -860,6 +1335,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=ipitlab dtime=2019-10-18 03:14:14.432538723 +0000 UTC devid=ipsa devname=dents vd=erepreh date=2019-10-18 time=3:14:14 logid=amest type=dolore subtype=xer level=medium eventtime=onemul logtime=off srcip=10.246.81.164 srcport=3453 srcintf=lo3071 srcintfrole=ende dstip=10.185.44.26 dstport=3193 dstintf=lo7861 dstintfrole=tationul poluuid=tam sessionid=byCic proto=0 action=cancel policyid=cons policytype=serro crscore=5.473000 craction=uiac crlevel=aecatcu appcat=sed service=uisnostr srccountry=aquei dstcountry=ation trandisp=sumqu tranip=10.53.110.111 tranport=2549 duration=141.141000 sentbyte=5569 rcvdbyte=5239 sentpkt=entore app=uaturQ",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -869,6 +1349,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=xpli date=2019-11-1 time=10:16:48 log_id=quae devid=totamre devname=lam logid=quamestq type=porai subtype=oinve level=medium vd=hender srcip=10.84.154.230 srcport=1335 srcintf=enp0s1127 dstip=10.212.63.179 dstport=6790 dstintf=eth1762 poluuid=eufugia sessionid=temqu proto=3 action=allow policyid=tvolup trandisp=lori duration=130.339000 sentbyte=4763 rcvdbyte=4334 devtype=rnatur osname=etdolo osversion=1.802 mastersrcmac=adipisci srcmac=01:00:5e:7b:68:0e crscore=36.122000 craction=culpaq crlevel=quis eventtype=lupt user=upt service=aboN hostname=cupida6106.www5.local profile=tdo reqtype=asperna url=https://api.example.com/aco/empo.jpg?iumdol=iusm#ido direction=unknown msg=peri method=aspernat cat=seq catdesc=olup device_id=uamqu log_id=veli pri=high userfrom=etco adminprof=nulap timezone=CT main_type=radip trigger_policy=tali sub_type=ntin severity_level=loreseos policy=ites src=10.109.172.90 src_port=2785 dst=10.146.77.206 dst_port=1554 http_method=amnihilm http_url=ipsamv http_host=proid http_agent=xcep http_session_id=udantium signature_subclass=sum signature_id=1723 srccountry=iaecon content_switch_name=euf server_pool_name=norume false_positive_mitigation=hilmo user_name=aquaeab monitor_status=eporr http_refer=https://www.example.com/metMalo/santiu.jpg?icon=enderit#roquisqu http_version=lapa dev_id=imadm threat_weight=giatquo history_threat_weight=oeiusm threat_level=oreeuf ftp_mode=iusmodt ftp_cmd=umwrit cipher_suite=atatn msg_id=uatD",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -878,6 +1363,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-11-15 time=5:19:22 devname=ptate device_id=Nemoe log_id=cupidat type=generic subtype=onsequ pri=high devid=nostr devname=umtotam logid=mqua type=emU subtype=gnido level=very-high vd=plicab srcip=10.8.161.226 srcport=3191 srcintf=eth5256 dstip=10.13.234.237 dstport=3760 dstintf=enp0s1149 poluuid=oeiusmo sessionid=nisi proto=6 action=allow policyid=lupt trandisp=tlaborio duration=18.804000 sentbyte=1061 rcvdbyte=6464 devtype=itan osname=iquidexe osversion=1.2314 mastersrcmac=fugia srcmac=01:00:5e:09:8f:0e crscore=5.320000 craction=onof crlevel=quam eventtype=rure user=ipis service=liqu hostname=unt2122.internal.local profile=orsitame reqtype=tassitas url=https://example.org/uidolor/turve.htm?temporai=uasiarch#ect direction=unknown msg=occae method=lpaqu cat=minimav catdesc=col device_id=riamea log_id=ern pri=low userfrom=odtempo adminprof=con timezone=CEST main_type=offici trigger_policy=uipexe sub_type=ium severity_level=quamqua policy=nsequatu src=10.38.18.72 src_port=3177 dst=10.202.250.141 dst_port=1824 http_method=volu http_url=quatDui http_host=stenat http_agent=liquip http_session_id=eiusmodt signature_subclass=dmi signature_id=4174 srccountry=ameaque content_switch_name=pitlabor server_pool_name=essequa false_positive_mitigation=ini user_name=maperia monitor_status=ovolup http_refer=https://mail.example.com/veniamq/uisno.htm?luptas=omm#eaquei http_version=iveli dev_id=lill threat_weight=voluptat history_threat_weight=aturveli threat_level=incidunt ftp_mode=tatnonp ftp_cmd=abi cipher_suite=nimave msg_id=atu",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -887,6 +1377,11 @@
                 "version": "8.3.0"
             },
             "message": "logver=siu date=2019-11-30 time=12:21:57 log_id=inrepr devid=cero devname=ita logid=xercitat type=meumfug subtype=umt level=very-high vd=laparia srcip=10.195.87.127 srcport=760 srcintf=lo3094 dstip=10.52.118.202 dstport=6556 dstintf=enp0s5751 poluuid=ectobe sessionid=rehender proto=udp action=block policyid=orinc trandisp=tcons duration=52.473000 sentbyte=7043 rcvdbyte=4714 devtype=suscipi osname=imipsam osversion=1.4674 mastersrcmac=hilm srcmac=01:00:5e:73:ca:c1 crscore=54.412000 craction=etd crlevel=erspici eventtype=tfug user=atatno service=sed hostname=luptat2613.internal.localhost profile=olupt reqtype=mipsum url=https://www.example.net/Maloru/lapariat.htm?tlabori=rehender#odtempo direction=inbound msg=alorum method=tmollit cat=bori catdesc=antium device_id=reetdo log_id=rchitec pri=medium userfrom=cipitlab adminprof=venia timezone=CT main_type=quid trigger_policy=mwrit sub_type=cid severity_level=lupt policy=adipisc src=10.182.124.88 src_port=116 dst=10.139.144.75 dst_port=5037 http_method=utodi http_url=isiutali http_host=oremeu http_agent=mquaerat http_session_id=conse signature_subclass=mestq signature_id=5535 srccountry=turQuisa content_switch_name=itasper server_pool_name=cidu false_positive_mitigation=ips user_name=modo monitor_status=ela http_refer=https://example.org/unti/niamqu.html?ris=veli#giatnu http_version=tanimide dev_id=ectetur threat_weight=umexer history_threat_weight=nim threat_level=nisiuta ftp_mode=cipitla ftp_cmd=ditautf cipher_suite=oluptasn msg_id=madmin",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]
@@ -896,6 +1391,11 @@
                 "version": "8.3.0"
             },
             "message": "date=2019-12-14 time=7:24:31 logver=imadm devid=stla devname=cab logid=orr type=olu subtype=quatDu level=low vd=siste srcip=10.151.47.249 srcport=6697 srcintf=lo5632 dstip=10.155.194.6 dstport=3005 dstintf=enp0s6106 poluuid=quatDu sessionid=deFinib proto=HOPOPT action=block policyid=taedic trandisp=ffi duration=130.219000 sentbyte=2693 rcvdbyte=568 devtype=consequ osname=rumw osversion=1.1386 mastersrcmac=temveleu srcmac=01:00:5e:df:96:27 crscore=104.315000 craction=item crlevel=remipsum eventtype=olupt user=usc service=ernat hostname=neavo4796.internal.domain profile=tatemac reqtype=exer url=https://www5.example.com/xea/ssecill.html?quianonn=quun#one direction=internal msg=riame method=uaUte cat=quae catdesc=utlabor device_id=ameius log_id=tate pri=very-high userfrom=lupta adminprof=atemseq timezone=CEST main_type=amcolab trigger_policy=ectobea sub_type=itsedq severity_level=pta policy=remipsu src=10.35.10.19 src_port=3941 dst=10.188.124.185 dst_port=5837 http_method=tali http_url=tasper http_host=amquisn http_agent=esciu http_session_id=iamea signature_subclass=perspi signature_id=7117 srccountry=emaccus content_switch_name=expl server_pool_name=giat false_positive_mitigation=uscipi user_name=dolo monitor_status=tionevol http_refer=https://internal.example.com/uptatema/dutpers.htm?tion=iumdol#ept http_version=Mal dev_id=tquasia threat_weight=ficiad history_threat_weight=roinBC threat_level=eufu ftp_mode=tio ftp_cmd=equatDu cipher_suite=exea msg_id=tasnulap",
+            "observer": {
+                "product": "FortiManager",
+                "type": "configuration",
+                "vendor": "Fortinet"
+            },
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/fortinet_fortimanager/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/fortinet_fortimanager/data_stream/log/agent/stream/log.yml.hbs
@@ -10,12 +10,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiManager"
-        type: "Configuration"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_fortimanager/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet_fortimanager/data_stream/log/agent/stream/tcp.yml.hbs
@@ -7,12 +7,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiManager"
-        type: "Configuration"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_fortimanager/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/fortinet_fortimanager/data_stream/log/agent/stream/udp.yml.hbs
@@ -7,12 +7,6 @@ tags:
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}
-fields_under_root: true
-fields:
-    observer:
-        vendor: "Fortinet"
-        product: "FortiManager"
-        type: "Configuration"
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}

--- a/packages/fortinet_fortimanager/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1,10 +1,18 @@
 ---
 description: Pipeline for Fortinet Manager/Analyzer
-
 processors:
   - set:
       field: ecs.version
       value: '8.3.0'
+  - set:
+      field: observer.vendor
+      value: Fortinet
+  - set:
+      field: observer.product
+      value: FortiManager
+  - set:
+      field: observer.type
+      value: configuration
   # User agent
   - user_agent:
       field: user_agent.original

--- a/packages/fortinet_fortimanager/manifest.yml
+++ b/packages/fortinet_fortimanager/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortimanager
 title: Fortinet FortiManager Logs
-version: 1.0.0
+version: 1.1.0
 release: ga
 description: Collect logs from Fortinet FortiManager instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

- Deprecate original Fortinet integration
- Swap the logfile legacy input for the filestream input

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
