### PR TITLE
Fix a typo and a bug in `gcp` integration package

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.1"
+  changes:
+    - description: Fix Billing policy template title and default period for gcp.compute
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3821
 - version: "2.2.0"
   changes:
     - description: Remove fields duplicated in ECS fields

--- a/packages/gcp/data_stream/compute/manifest.yml
+++ b/packages/gcp/data_stream/compute/manifest.yml
@@ -20,7 +20,7 @@ streams:
       - name: period
         type: text
         title: Period
-        default: 10s
+        default: 60s
         required: true
       - name: exclude_labels
         type: bool

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.2.0"
+version: "2.2.1"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -94,7 +94,7 @@ policy_templates:
         description: "Collecting vpcflow logs from Google Cloud Platform (GCP) instances (input: gcp-pubsub)"
         input_group: logs
   - name: billing
-    title: Google Cloud Platform (GCP) Billine metrics
+    title: Google Cloud Platform (GCP) Billing metrics
     description: Collect billing metrics from Google Cloud Platform (GCP) with Elastic Agent
     data_streams:
       - billing


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
While testing the `gcp` integration I noticed there have been a regression in the GCP Billing policy templated (incorrectly named `Billine`), and found a bug in the GCP Compute default `period` value (which was `10s` when the minimum acceptable in Metricbeat is `60s`; this produces an error if trying to run the default configuration).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
