### PR TITLE
docs: update instructions for synthetic source

### DIFF
--- a/docs/how_to_test_new_indexing_features.md
+++ b/docs/how_to_test_new_indexing_features.md
@@ -22,7 +22,7 @@ PUT /_component_template/metrics-nginx.substatus@custom
     "settings": {},
     "mappings": {
       "_source": {
-        "synthetic": true
+        "mode": "synthetic"
       }
     }
   },


### PR DESCRIPTION
## What does this PR do?

Update the docs about enabling synthetic source due to a recent change in Elasticsearch.
See https://github.com/elastic/elasticsearch/pull/88211