### PR TITLE
Update Readme - First draft of AWS integration edits

### DIFF
--- a/packages/aws_logs/_dev/build/docs/README.md
+++ b/packages/aws_logs/_dev/build/docs/README.md
@@ -1,28 +1,83 @@
 # Custom AWS Log Integration
 
-The custom AWS input integration offers users two ways to collect logs from AWS: from an [S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html) (with or without SQS notification) and from [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html).
-Custom ingest pipelines may be added by adding the name to the pipeline configuration option, creating custom ingest pipelines can be done either through the API or the [Ingest Node Pipeline UI](/app/management/ingest/ingest_pipelines/).
+The custom AWS logs integration offers users two ways to collect logs from AWS. These are from: 
 
-## Collecting logs from S3 bucket
+* An [S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html) (with or without SQS notification)
+* [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html)
 
-When collecting logs from S3 bucket is enabled, users can retrieve logs from S3
-objects that are pointed to by S3 notification events read from an SQS queue or
-directly polling list of S3 objects in an S3 bucket. 
+You can add custom ingest pipelines by adding the name to the pipeline configuration option. Creating custom ingest pipelines can be done either through the API or the [Ingest Node Pipeline UI](/app/management/ingest/ingest_pipelines/).
 
-The use of SQS notification is preferred: polling list of S3 objects is 
-expensive in terms of performance and costs and should be preferably used only 
-when no SQS notification can be attached to the S3 buckets. This input 
-integration also supports S3 notification from SNS to SQS.
+Use the AWS logs integration to collect logs on the operational health of your AWS resources, applications, and services running on AWS and on-premises. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference the logs when troubleshooting an issue.
 
-SQS notification method is enabled setting `queue_url` configuration value. S3 
-bucket list polling method is enabled setting `bucket_arn` configuration value
-and `number_of_workers` value. Both `queue_url` and `bucket_arn` cannot be set 
-at the same time and at least one of the two value must be set.
+For example, you could use the data from this integration to detect anomalous behavior in your environments. You could also use the data to troubleshoot the underlying issue by looking at additional context in the logs, such as the source of the behavior, and more.
 
-## Collecting logs from CloudWatch
+## Data streams
+
+The custom AWS logs integration collects one type of data stream: logs.
+
+**Logs** help you keep a record of events happening in AWS CloudWatch and your S3 buckets.
+Log data streams collected by the custom AWS logs enable you to:
+
+* Retrieve logs from an S3 bucket
+  * From S3 objects that are pointed to by S3 notification events read from an SQS queue, or
+  * Directly polling a list of S3 objects in an S3 bucket. 
+* Retrieve logs from CloudWatch
+  * You can retrieve logs from all log streams in a specific log group. 
+  * Amazon CloudWatch logs can be used to store log files from Amazon Elastic Compute Cloud(EC2), AWS CloudTrail, Route53, and other sources.
+
+
+
+The log data streams includes the log message, along with contextual information.
+
+See more details in the [Logs reference](#logs-reference).
+
+<!-- etc. -->
+
+<!-- Optional notes -->
+
+## Requirements
+
+You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
+You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
+
+<!-- Other requirements -->
+
+ Before using any AWS integration you will need:
+
+ * **AWS Credentials** to connect with your AWS account.
+ * **AWS Permissions** to make sure the user you're using to connect has permission to share the relevant data.
+
+ For more details about these requirements, see the **AWS** integration documentation.
+
+## Setup
+
+<!-- Any prerequisite instructions -->
+
+For step-by-step instructions on how to set up an integration, see the
+[Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+
+<!-- Additional set up instructions -->
+
+<!-- Repeat for both Logs and Metrics if applicable -->
+
+## Logs reference
+
+### Collecting logs from S3 bucket
+> Note: The `queue_url` and `bucket_arn` cannot be both set at the same time. 
+> At least one of the two values must be set.
+
+#### Using SQS notification
+**We recommend you use SQS notification.** This is because polling list of S3 objects is expensive in terms of performance and costs. This input integration also supports S3 notification from SNS to SQS.
+
+Use the `queue_url` configuration value setting to enable the SQS notification method.
+#### Using polling notification
+We recommend polling should only be used when no SQS notification can be attached to the S3 buckets. 
+
+Use the `bucket_arn` and `number_of_workers` configuration value settings to enable the S3 bucket list polling method.
+
+### Collecting logs from CloudWatch
 
 When collecting logs from CloudWatch is enabled, users can retrieve logs from 
-all log streams in a specific log group. `filterLogEvents` AWS API is used to 
-list log events from the specified log group. Amazon CloudWatch Logs can be used
-to store log files from Amazon Elastic Compute Cloud(EC2), AWS CloudTrail, 
-Route53, and other sources.
+all log streams in a specific log group.
+
+Use the `filterLogEvents` AWS API to list log events from the specified log group. 


### PR DESCRIPTION
Added new content based on the new documentation guidelines
## What does this PR do?

From https://github.com/elastic/integrations/issues/3572:

>In https://github.com/elastic/integrations/pull/3308 we updated docs for two AWS integrations to align with the new documentation guidelines and establish the relationship between the AWS integration/package ("AWS") and integrations for individual AWS services (for example, "AWS CloudFront").
>
>Now we should update the docs for all AWS integrations for individual services to follow the same format as the updated "AWS CloudFront" integration docs.

This PR adds more context the AWS <service> integration including:

- [x] Adds context to the "Overview" including a link to the relevant AWS page and an example
- [x] Lists the types of "Data streams" for the service
- [x] "Requirements" points back to "AWS" for detailed information on credentials and permissions
- [x] "Requirements" includes any other service-specific requirements
- [x] "Setup" establishes a relationship between the AWS integration/package ("AWS") and this integration
- [x] Includes "Reference" sections

## For the reviewer

<!-- anything to highlight for the reviewer -->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Review by docs team 
- [ ] Review by integrations team

## Related issues

- https://github.com/elastic/integrations/issues/3572