### PR TITLE
[AWS] Move transit gateway lightweight module config into integration

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Move Transit Gateway metrics config from beats to integrations
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3840
 - version: "1.19.0"
   changes:
     - description: Add Kinesis metrics datastream

--- a/packages/aws/data_stream/transitgateway/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/transitgateway/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["transitgateway"]
+metricsets: ["cloudwatch"]
 period: {{period}}
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}
@@ -36,3 +36,13 @@ tags_filter: {{tags_filter}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}
+metrics:
+- namespace: AWS/TransitGateway
+  statistic: ["Sum"]
+  name:
+  - BytesIn
+  - BytesOut
+  - PacketsIn
+  - PacketsOut
+  - PacketDropCountBlackhole
+  - PacketDropCountNoRoute

--- a/packages/aws/data_stream/transitgateway/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/transitgateway/agent/stream/stream.yml.hbs
@@ -46,3 +46,5 @@ metrics:
   - PacketsOut
   - PacketDropCountBlackhole
   - PacketDropCountNoRoute
+  - BytesDropCountNoRoute
+  - BytesDropCountBlackhole

--- a/packages/aws/data_stream/transitgateway/fields/fields.yml
+++ b/packages/aws/data_stream/transitgateway/fields/fields.yml
@@ -34,6 +34,12 @@
             - name: PacketDropCountNoRoute.sum
               type: long
               description: The number of packets dropped because they did not match a route.
+            - name: BytesDropCountNoRoute.sum
+              type: long
+              description: The number of bytes dropped because they did not match a route.
+            - name: BytesDropCountBlackhole.sum
+              type: long
+              description: The number of bytes dropped because they matched a blackhole route.
     - name: cloudwatch
       type: group
       fields:

--- a/packages/aws/data_stream/transitgateway/fields/package-fields.yml
+++ b/packages/aws/data_stream/transitgateway/fields/package-fields.yml
@@ -13,7 +13,3 @@
       type: object
       description: |
         Metric dimensions.
-    - name: '*.metrics.*.*'
-      type: object
-      description: |
-        Metrics that returned from Cloudwatch API query.

--- a/packages/aws/data_stream/transitgateway/sample_event.json
+++ b/packages/aws/data_stream/transitgateway/sample_event.json
@@ -1,63 +1,96 @@
 {
-    "@timestamp": "2020-05-28T20:10:20.953Z",
+    "agent": {
+        "name": "7ea24e234aec",
+        "id": "8cac215c-63ca-4563-82f3-000efe6e7567",
+        "type": "metricbeat",
+        "ephemeral_id": "1d66e840-a76f-4b40-89ef-7cdca685013f",
+        "version": "8.1.0"
+    },
+    "elastic_agent": {
+        "id": "8cac215c-63ca-4563-82f3-000efe6e7567",
+        "version": "8.1.0",
+        "snapshot": false
+    },
     "cloud": {
         "provider": "aws",
-        "region": "us-west-2",
+        "region": "eu-west-1",
         "account": {
-            "name": "elastic-beats",
-            "id": "428152502467"
+            "name": "elastic-observability",
+            "id": "627286350134"
         }
     },
+    "@timestamp": "2022-07-26T21:34:00.000Z",
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "service": {
+        "type": "aws"
+    },
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "aws.transitgateway"
+    },
+    "host": {
+        "hostname": "7ea24e234aec",
+        "os": {
+            "kernel": "5.10.104-linuxkit",
+            "codename": "focal",
+            "name": "Ubuntu",
+            "type": "linux",
+            "family": "debian",
+            "version": "20.04.3 LTS (Focal Fossa)",
+            "platform": "ubuntu"
+        },
+        "containerized": false,
+        "ip": [
+            "172.19.0.6"
+        ],
+        "name": "7ea24e234aec",
+        "mac": [
+            "02:42:ac:13:00:06"
+        ],
+        "architecture": "aarch64"
+    },
+    "metricset": {
+        "period": 60000,
+        "name": "cloudwatch"
+    },
     "aws": {
+        "cloudwatch": {
+            "namespace": "AWS/TransitGateway"
+        },
+        "dimensions": {
+            "TransitGateway": "tgw-04653af6191a63891"
+        },
         "transitgateway": {
             "metrics": {
-                "PacketsIn": {
+                "PacketsOut": {
                     "sum": 0
                 },
-                "BytesIn": {
+                "PacketDropCountNoRoute": {
                     "sum": 0
                 },
                 "BytesOut": {
                     "sum": 0
                 },
-                "PacketsOut": {
+                "BytesIn": {
+                    "sum": 0
+                },
+                "PacketsIn": {
                     "sum": 0
                 },
                 "PacketDropCountBlackhole": {
                     "sum": 0
-                },
-                "PacketDropCountNoRoute": {
-                    "sum": 0
                 }
             }
-        },
-        "cloudwatch": {
-            "namespace": "AWS/TransitGateway"
-        },
-        "dimensions": {
-            "TransitGateway": "tgw-0630672a32f12808a"
         }
     },
-    "ecs": {
-        "version": "1.5.0"
-    },
-    "agent": {
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30",
-        "name": "MacBook-Elastic.local",
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b"
-    },
     "event": {
-        "dataset": "aws.transitgateway",
+        "duration": 1642798501,
+        "agent_id_status": "verified",
+        "ingested": "2022-07-26T21:34:40Z",
         "module": "aws",
-        "duration": 12762825681
-    },
-    "metricset": {
-        "period": 60000,
-        "name": "transitgateway"
-    },
-    "service": {
-        "type": "aws"
+        "dataset": "aws.transitgateway"
     }
 }

--- a/packages/aws/data_stream/transitgateway/sample_event.json
+++ b/packages/aws/data_stream/transitgateway/sample_event.json
@@ -1,13 +1,13 @@
 {
     "agent": {
-        "name": "7ea24e234aec",
-        "id": "8cac215c-63ca-4563-82f3-000efe6e7567",
+        "name": "a20ad158868c",
+        "id": "ac8c5411-b1d9-486a-baf7-a719744b13e5",
+        "ephemeral_id": "d43b281f-9a3e-48be-a7b2-e70c0d0b9acd",
         "type": "metricbeat",
-        "ephemeral_id": "1d66e840-a76f-4b40-89ef-7cdca685013f",
         "version": "8.1.0"
     },
     "elastic_agent": {
-        "id": "8cac215c-63ca-4563-82f3-000efe6e7567",
+        "id": "ac8c5411-b1d9-486a-baf7-a719744b13e5",
         "version": "8.1.0",
         "snapshot": false
     },
@@ -19,20 +19,20 @@
             "id": "627286350134"
         }
     },
-    "@timestamp": "2022-07-26T21:34:00.000Z",
+    "@timestamp": "2022-07-26T21:58:00.000Z",
     "ecs": {
         "version": "8.0.0"
-    },
-    "service": {
-        "type": "aws"
     },
     "data_stream": {
         "namespace": "default",
         "type": "metrics",
         "dataset": "aws.transitgateway"
     },
+    "service": {
+        "type": "aws"
+    },
     "host": {
-        "hostname": "7ea24e234aec",
+        "hostname": "a20ad158868c",
         "os": {
             "kernel": "5.10.104-linuxkit",
             "codename": "focal",
@@ -44,11 +44,11 @@
         },
         "containerized": false,
         "ip": [
-            "172.19.0.6"
+            "172.20.0.7"
         ],
-        "name": "7ea24e234aec",
+        "name": "a20ad158868c",
         "mac": [
-            "02:42:ac:13:00:06"
+            "02:42:ac:14:00:07"
         ],
         "architecture": "aarch64"
     },
@@ -60,12 +60,12 @@
         "cloudwatch": {
             "namespace": "AWS/TransitGateway"
         },
-        "dimensions": {
-            "TransitGateway": "tgw-04653af6191a63891"
-        },
         "transitgateway": {
             "metrics": {
                 "PacketsOut": {
+                    "sum": 0
+                },
+                "BytesDropCountNoRoute": {
                     "sum": 0
                 },
                 "PacketDropCountNoRoute": {
@@ -80,16 +80,22 @@
                 "PacketsIn": {
                     "sum": 0
                 },
+                "BytesDropCountBlackhole": {
+                    "sum": 0
+                },
                 "PacketDropCountBlackhole": {
                     "sum": 0
                 }
             }
+        },
+        "dimensions": {
+            "TransitGateway": "tgw-04653af6191a63891"
         }
     },
     "event": {
-        "duration": 1642798501,
+        "duration": 1614567042,
         "agent_id_status": "verified",
-        "ingested": "2022-07-26T21:34:40Z",
+        "ingested": "2022-07-26T21:59:04Z",
         "module": "aws",
         "dataset": "aws.transitgateway"
     }

--- a/packages/aws/docs/transitgateway.md
+++ b/packages/aws/docs/transitgateway.md
@@ -114,7 +114,6 @@ An example event for `transitgateway` looks as following:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
-| aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.\* | Metric dimensions. | object |
 | aws.dimensions.TransitGateway | Filters the metric data by transit gateway. | keyword |

--- a/packages/aws/docs/transitgateway.md
+++ b/packages/aws/docs/transitgateway.md
@@ -6,66 +6,99 @@ An example event for `transitgateway` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-05-28T20:10:20.953Z",
+    "agent": {
+        "name": "7ea24e234aec",
+        "id": "8cac215c-63ca-4563-82f3-000efe6e7567",
+        "type": "metricbeat",
+        "ephemeral_id": "1d66e840-a76f-4b40-89ef-7cdca685013f",
+        "version": "8.1.0"
+    },
+    "elastic_agent": {
+        "id": "8cac215c-63ca-4563-82f3-000efe6e7567",
+        "version": "8.1.0",
+        "snapshot": false
+    },
     "cloud": {
         "provider": "aws",
-        "region": "us-west-2",
+        "region": "eu-west-1",
         "account": {
-            "name": "elastic-beats",
-            "id": "428152502467"
+            "name": "elastic-observability",
+            "id": "627286350134"
         }
     },
+    "@timestamp": "2022-07-26T21:34:00.000Z",
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "service": {
+        "type": "aws"
+    },
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "aws.transitgateway"
+    },
+    "host": {
+        "hostname": "7ea24e234aec",
+        "os": {
+            "kernel": "5.10.104-linuxkit",
+            "codename": "focal",
+            "name": "Ubuntu",
+            "type": "linux",
+            "family": "debian",
+            "version": "20.04.3 LTS (Focal Fossa)",
+            "platform": "ubuntu"
+        },
+        "containerized": false,
+        "ip": [
+            "172.19.0.6"
+        ],
+        "name": "7ea24e234aec",
+        "mac": [
+            "02:42:ac:13:00:06"
+        ],
+        "architecture": "aarch64"
+    },
+    "metricset": {
+        "period": 60000,
+        "name": "cloudwatch"
+    },
     "aws": {
+        "cloudwatch": {
+            "namespace": "AWS/TransitGateway"
+        },
+        "dimensions": {
+            "TransitGateway": "tgw-04653af6191a63891"
+        },
         "transitgateway": {
             "metrics": {
-                "PacketsIn": {
+                "PacketsOut": {
                     "sum": 0
                 },
-                "BytesIn": {
+                "PacketDropCountNoRoute": {
                     "sum": 0
                 },
                 "BytesOut": {
                     "sum": 0
                 },
-                "PacketsOut": {
+                "BytesIn": {
+                    "sum": 0
+                },
+                "PacketsIn": {
                     "sum": 0
                 },
                 "PacketDropCountBlackhole": {
                     "sum": 0
-                },
-                "PacketDropCountNoRoute": {
-                    "sum": 0
                 }
             }
-        },
-        "cloudwatch": {
-            "namespace": "AWS/TransitGateway"
-        },
-        "dimensions": {
-            "TransitGateway": "tgw-0630672a32f12808a"
         }
     },
-    "ecs": {
-        "version": "1.5.0"
-    },
-    "agent": {
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30",
-        "name": "MacBook-Elastic.local",
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b"
-    },
     "event": {
-        "dataset": "aws.transitgateway",
+        "duration": 1642798501,
+        "agent_id_status": "verified",
+        "ingested": "2022-07-26T21:34:40Z",
         "module": "aws",
-        "duration": 12762825681
-    },
-    "metricset": {
-        "period": 60000,
-        "name": "transitgateway"
-    },
-    "service": {
-        "type": "aws"
+        "dataset": "aws.transitgateway"
     }
 }
 ```
@@ -82,6 +115,8 @@ An example event for `transitgateway` looks as following:
 | aws.dimensions.TransitGatewayAttachment | Filters the metric data by transit gateway attachment. | keyword |
 | aws.s3.bucket.name | Name of a S3 bucket. | keyword |
 | aws.tags.\* | Tag key value pairs from aws resources. | object |
+| aws.transitgateway.metrics.BytesDropCountBlackhole.sum | The number of bytes dropped because they matched a blackhole route. | long |
+| aws.transitgateway.metrics.BytesDropCountNoRoute.sum | The number of bytes dropped because they did not match a route. | long |
 | aws.transitgateway.metrics.BytesIn.sum | The number of bytes received by the transit gateway. | long |
 | aws.transitgateway.metrics.BytesOut.sum | The number of bytes sent from the transit gateway. | long |
 | aws.transitgateway.metrics.PacketDropCountBlackhole.sum | The number of packets dropped because they matched a blackhole route. | long |

--- a/packages/aws/docs/transitgateway.md
+++ b/packages/aws/docs/transitgateway.md
@@ -7,14 +7,14 @@ An example event for `transitgateway` looks as following:
 ```json
 {
     "agent": {
-        "name": "7ea24e234aec",
-        "id": "8cac215c-63ca-4563-82f3-000efe6e7567",
+        "name": "a20ad158868c",
+        "id": "ac8c5411-b1d9-486a-baf7-a719744b13e5",
+        "ephemeral_id": "d43b281f-9a3e-48be-a7b2-e70c0d0b9acd",
         "type": "metricbeat",
-        "ephemeral_id": "1d66e840-a76f-4b40-89ef-7cdca685013f",
         "version": "8.1.0"
     },
     "elastic_agent": {
-        "id": "8cac215c-63ca-4563-82f3-000efe6e7567",
+        "id": "ac8c5411-b1d9-486a-baf7-a719744b13e5",
         "version": "8.1.0",
         "snapshot": false
     },
@@ -26,20 +26,20 @@ An example event for `transitgateway` looks as following:
             "id": "627286350134"
         }
     },
-    "@timestamp": "2022-07-26T21:34:00.000Z",
+    "@timestamp": "2022-07-26T21:58:00.000Z",
     "ecs": {
         "version": "8.0.0"
-    },
-    "service": {
-        "type": "aws"
     },
     "data_stream": {
         "namespace": "default",
         "type": "metrics",
         "dataset": "aws.transitgateway"
     },
+    "service": {
+        "type": "aws"
+    },
     "host": {
-        "hostname": "7ea24e234aec",
+        "hostname": "a20ad158868c",
         "os": {
             "kernel": "5.10.104-linuxkit",
             "codename": "focal",
@@ -51,11 +51,11 @@ An example event for `transitgateway` looks as following:
         },
         "containerized": false,
         "ip": [
-            "172.19.0.6"
+            "172.20.0.7"
         ],
-        "name": "7ea24e234aec",
+        "name": "a20ad158868c",
         "mac": [
-            "02:42:ac:13:00:06"
+            "02:42:ac:14:00:07"
         ],
         "architecture": "aarch64"
     },
@@ -67,12 +67,12 @@ An example event for `transitgateway` looks as following:
         "cloudwatch": {
             "namespace": "AWS/TransitGateway"
         },
-        "dimensions": {
-            "TransitGateway": "tgw-04653af6191a63891"
-        },
         "transitgateway": {
             "metrics": {
                 "PacketsOut": {
+                    "sum": 0
+                },
+                "BytesDropCountNoRoute": {
                     "sum": 0
                 },
                 "PacketDropCountNoRoute": {
@@ -87,16 +87,22 @@ An example event for `transitgateway` looks as following:
                 "PacketsIn": {
                     "sum": 0
                 },
+                "BytesDropCountBlackhole": {
+                    "sum": 0
+                },
                 "PacketDropCountBlackhole": {
                     "sum": 0
                 }
             }
+        },
+        "dimensions": {
+            "TransitGateway": "tgw-04653af6191a63891"
         }
     },
     "event": {
-        "duration": 1642798501,
+        "duration": 1614567042,
         "agent_id_status": "verified",
-        "ingested": "2022-07-26T21:34:40Z",
+        "ingested": "2022-07-26T21:59:04Z",
         "module": "aws",
         "dataset": "aws.transitgateway"
     }

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.19.0
+version: 1.19.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR is to move lightweight module configuration from Metricbeat into integrations for Transit Gateway.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

<!-- ## Author's Checklist

Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved

- [ ]
-->

<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3605

<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
