### PR TITLE
[apache_spark] Update integration package to remove unnecessary fields

### DIFF
--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -3,8 +3,8 @@
 - version: "0.2.1"
   changes:
     - description: Remove unnecessary fields from fields.yml
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3853
 - version: "0.2.0"
   changes:
     - description: Add dashboards and visualizations

--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+
+- version: "0.2.1"
+  changes:
+    - description: Remove unnecessary fields from fields.yml
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: Add dashboards and visualizations

--- a/packages/apache_spark/data_stream/executor/fields/fields.yml
+++ b/packages/apache_spark/data_stream/executor/fields/fields.yml
@@ -133,12 +133,6 @@
                 - name: write_ops
                   type: long
                   description: Total number of write operations from HDFS.
-        - name: generated_class_size
-          type: long
-          description: Size of the class generated.
-        - name: generated_method_size
-          type: long
-          description: Size of the method generated.
         - name: hive_client_calls
           type: long
           description: Total number of Hive Client calls.
@@ -275,9 +269,6 @@
             - name: write.time
               type: long
               description: Time spent blocking on writes to disk or buffer cache. The value is expressed in nanoseconds.
-        - name: source_code_size
-          type: long
-          description: The total size of the source code.
         - name: succeeded_tasks
           type: long
           description: The number of tasks succeeded.

--- a/packages/apache_spark/docs/README.md
+++ b/packages/apache_spark/docs/README.md
@@ -436,8 +436,6 @@ An example event for `executor` looks as following:
 | apache_spark.executor.gc.major.time | Elapsed total major GC time. The value is expressed in milliseconds. | long |
 | apache_spark.executor.gc.minor.count | Total minor GC count. For example, the garbage collector is one of Copy, PS Scavenge, ParNew, G1 Young Generation and so on. | long |
 | apache_spark.executor.gc.minor.time | Elapsed total minor GC time. The value is expressed in milliseconds. | long |
-| apache_spark.executor.generated_class_size | Size of the class generated. | long |
-| apache_spark.executor.generated_method_size | Size of the method generated. | long |
 | apache_spark.executor.heap_memory.off.execution | Peak off heap execution memory in use, in bytes. | long |
 | apache_spark.executor.heap_memory.off.storage | Peak off heap storage memory in use, in bytes. | long |
 | apache_spark.executor.heap_memory.off.unified | Peak off heap memory (execution and storage). | long |
@@ -481,7 +479,6 @@ An example event for `executor` looks as following:
 | apache_spark.executor.shuffle.server.used.heap_memory | Amount of heap memory used by the shuffle server. | long |
 | apache_spark.executor.shuffle.total.bytes_read | Number of bytes read in shuffle operations (both local and remote) | long |
 | apache_spark.executor.shuffle.write.time | Time spent blocking on writes to disk or buffer cache. The value is expressed in nanoseconds. | long |
-| apache_spark.executor.source_code_size | The total size of the source code. | long |
 | apache_spark.executor.succeeded_tasks | The number of tasks succeeded. | long |
 | apache_spark.executor.threadpool.active_tasks | Number of tasks currently executing. | long |
 | apache_spark.executor.threadpool.complete_tasks | Number of tasks that have completed in this executor. | long |

--- a/packages/apache_spark/manifest.yml
+++ b/packages/apache_spark/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache_spark
 title: Apache Spark
-version: 0.2.0
+version: 0.2.1
 license: basic
 description: Collect metrics from Apache Spark with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug

## What does this PR do?

This PR contains a minor cleanup for Apache Spark integration. It removes the 3 fields which were present in **fields.yml** but not in **stream.yml.hbs**, and hence were not getting collected. The fields were not supposed to be collected as a part of the integration as per the PRD (https://github.com/elastic/integrations/issues/493), as all of them are histogram metrics (Reference: https://spark.apache.org/docs/3.2.0/monitoring.html). The changes which are made do not affect the existing functionality of the integration at all and are just a cleanup to the integration.

> Spark provides the following types of metrics - Gauge, Counter, Histogram, Meter, Timer. The most common types of metrics used in Spark instrumentation are gauges and counters. Hence, we will support only Gauge and Counter metrics from the following providers:

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/apache_spark directory.
- Run the following command to run tests. 
> elastic-package test