### PR TITLE
Remove release experimental, depend just on semver

### DIFF
--- a/packages/elastic_package_registry/changelog.yml
+++ b/packages/elastic_package_registry/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.2"
+  changes:
+    - description: Remove release experimental field
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3854/
 - version: "0.0.1"
   changes:
     - description: Initial version of the Elastic Package Registry package

--- a/packages/elastic_package_registry/data_stream/metrics/manifest.yml
+++ b/packages/elastic_package_registry/data_stream/metrics/manifest.yml
@@ -1,6 +1,5 @@
 title: "Prometheus Metrics"
 type: metrics
-release: experimental
 streams:
   - input: prometheus/metrics
     enabled: true

--- a/packages/elastic_package_registry/manifest.yml
+++ b/packages/elastic_package_registry/manifest.yml
@@ -2,7 +2,6 @@ format_version: 1.0.0
 name: elastic_package_registry
 title: "Elastic Package Registry"
 version: 0.0.1
-release: experimental
 license: basic
 description: "Collect metrics from a Elastic Package Registry instance"
 type: integration

--- a/packages/elastic_package_registry/manifest.yml
+++ b/packages/elastic_package_registry/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: elastic_package_registry
 title: "Elastic Package Registry"
-version: 0.0.1
+version: 0.0.2
 license: basic
 description: "Collect metrics from a Elastic Package Registry instance"
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Remove release experimental field, to just depend on semantic versioning.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/package-registry/issues/797

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

![Elastic Package Registry tile](https://user-images.githubusercontent.com/5330827/181228684-ea045889-face-4d69-b53c-4e691f4be73d.png)

