### PR TITLE
[docs] Update Jamf docs to align with docs guidelines

### DIFF
--- a/packages/jamf_compliance_reporter/_dev/build/docs/README.md
+++ b/packages/jamf_compliance_reporter/_dev/build/docs/README.md
@@ -19,7 +19,7 @@ The log data stream collected by the Jamf Compliance Reporter integration includ
 You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
 You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
 
-Note: This package has been tested for Compliance Reporter against Jamf pro version 10.39.0 and Jamf Compliance Reporter version 1.0.4.
+Note: This package has been tested for Compliance Reporter against Jamf Pro version 10.39.0 and Jamf Compliance Reporter version 1.0.4.
 
 ## Setup
 
@@ -41,12 +41,12 @@ For more information on using configuration profiles in Jamf Pro, see [Creating 
 Then, follow _one_ of the below methods to collect logs from Jamf Compliance Reporter:
 
 **REST Endpoint Remote logging**:
-1. Reference link for configuring [REST Endpoint Remote logging](https://docs.jamf.com/compliance-reporter/documentation/REST_Endpoint_Remote_Logging.html) for Compliance Reporter.
-2. In Jamf Configuration Profile, form the full URL with port in the form `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
+1. Read [Jamf's REST Endpoint Remote logging documentation](https://docs.jamf.com/compliance-reporter/documentation/REST_Endpoint_Remote_Logging.html).
+2. In your Jamf Configuration Profile, form the full URL with port using this format: `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
 
 **TLS Remote Logging**:
-1. Reference link for generating [TLS Remote Logging](https://docs.jamf.com/compliance-reporter/documentation/TLS_Remote_Logging.html) for Compliance Reporter.
-2. In Jamf Configuration Profile, form the full URL with port in the form `tls://{AGENT_ADDRESS}:{AGENT_PORT}`.
+1. Read [Jamf's TLS Remote Logging documentation](https://docs.jamf.com/compliance-reporter/documentation/TLS_Remote_Logging.html).
+2. In your Jamf Configuration Profile, form the full URL with port using this format: `tls://{AGENT_ADDRESS}:{AGENT_PORT}`.
 
 **Configure the Jamf Compliance Reporter integration with REST Endpoint Remote logging for Rest Endpoint Input**:
 1. Enter values for "Listen Address", "Listen Port" and "URL" to form the endpoint URL. Make note of the **Endpoint URL** `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.

--- a/packages/jamf_compliance_reporter/_dev/build/docs/README.md
+++ b/packages/jamf_compliance_reporter/_dev/build/docs/README.md
@@ -5,7 +5,7 @@ The Jamf Compliance Reporter integration collects and parses data received from 
 Use the Jamf Compliance Reporter integration to collect logs from your machines.
 Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference data when troubleshooting an issue.
 
-For example, if you wanted to be notified when (something happens) you could (collect data). Then you can (visualize|alert|troubleshoot) by (doing something in Kibana).
+For example, if you wanted to monitor shell script commands performed by the root user, you could [configure Jamf to monitor those events](https://docs.jamf.com/compliance-reporter/documentation/Audit_Log_Levels_in_Compliance_Reporter.html) and then send them to Elastic for further investigation.
 
 ## Data streams
 

--- a/packages/jamf_compliance_reporter/_dev/build/docs/README.md
+++ b/packages/jamf_compliance_reporter/_dev/build/docs/README.md
@@ -1,46 +1,60 @@
 # Jamf Compliance Reporter
 
-The [Jamf Compliance Reporter](https://docs.jamf.com/compliance-reporter/documentation/Compliance_Reporter_Overview.html) Integration collects and parses data received from Jamf Compliance Reporter using a TLS or HTTP endpoint.
+The Jamf Compliance Reporter integration collects and parses data received from [Jamf Compliance Reporter](https://docs.jamf.com/compliance-reporter/documentation/Compliance_Reporter_Overview.html) using a TLS or HTTP endpoint.
+
+Use the Jamf Compliance Reporter integration to collect logs from your machines.
+Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference data when troubleshooting an issue.
+
+For example, if you wanted to be notified when (something happens) you could (collect data). Then you can (visualize|alert|troubleshoot) by (doing something in Kibana).
+
+## Data streams
+
+The Jamf Compliance Reporter integration collects one type of data stream: logs.
+
+**Logs** help you keep a record of events happening on computers using Jamf.
+The log data stream collected by the Jamf Compliance Reporter integration includes events that are related to security compliance requirements. See more details in the [Logs](#logs-reference).
 
 ## Requirements
-- Enable the Integration with the TLS or HTTP Endpoint input.
-- Configure Jamf Compliance Reporter to send logs to the Elastic Agent.
 
-### Enabling the integration in Elastic
+You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
+You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
 
-1. In Kibana go to **Management > Integrations**.
-2. In "Search for integrations" search bar type **Jamf Compliance Reporter**.
-3. Click on "Jamf Compliance Reporter" integration from the search results.
-4. Click on **Add Jamf Compliance Reporter** button to add Jamf Compliance Reporter integration.
+Note: This package has been tested for Compliance Reporter against Jamf pro version 10.39.0 and Jamf Compliance Reporter version 1.0.4.
 
-## Setup Steps
+## Setup
 
-- After validating settings, you can use a configuration profile in Jamf Pro to deploy certificates to endpoints in production.
+To use this integration, you will also need to:
+- Enable the integration in Elastic
+- Configure Jamf Compliance Reporter to send logs to the Elastic Agent
 
-- Reference link for [Creating a Configuration Profile](https://docs.jamf.com/compliance-reporter/documentation/Configuring_Compliance_Reporter_Properties_Using_Jamf_Pro.html) using Jamf Pro.
+### Enable the integration in Elastic
 
-## Follow one of the below methods to collect logs from Jamf Compliance Reporter
+For step-by-step instructions on how to set up an new integration in Elastic, see the
+[Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+When setting up the integration, you will choose to collect logs either via TLS or HTTP Endpoint.
 
-### REST Endpoint Remote logging
+### Configure Jamf Compliance Reporter
+
+After validating settings, you can use a configuration profile in Jamf Pro to deploy certificates to endpoints in production.
+For more information on using configuration profiles in Jamf Pro, see [Creating a Configuration Profile](https://docs.jamf.com/compliance-reporter/documentation/Configuring_Compliance_Reporter_Properties_Using_Jamf_Pro.html).
+
+Then, follow _one_ of the below methods to collect logs from Jamf Compliance Reporter:
+
+**REST Endpoint Remote logging**:
 1. Reference link for configuring [REST Endpoint Remote logging](https://docs.jamf.com/compliance-reporter/documentation/REST_Endpoint_Remote_Logging.html) for Compliance Reporter.
 2. In Jamf Configuration Profile, form the full URL with port in the form `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
 
-### TLS Remote Logging
+**TLS Remote Logging**:
 1. Reference link for generating [TLS Remote Logging](https://docs.jamf.com/compliance-reporter/documentation/TLS_Remote_Logging.html) for Compliance Reporter.
 2. In Jamf Configuration Profile, form the full URL with port in the form `tls://{AGENT_ADDRESS}:{AGENT_PORT}`.
 
-### Configure the Jamf Compliance Reporter integration with REST Endpoint Remote logging for Rest Endpoint Input
+**Configure the Jamf Compliance Reporter integration with REST Endpoint Remote logging for Rest Endpoint Input**:
+1. Enter values for "Listen Address", "Listen Port" and "URL" to form the endpoint URL. Make note of the **Endpoint URL** `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
 
-- Enter values for "Listen Address", "Listen Port" and "URL" to form the endpoint URL. Make note of the **Endpoint URL** `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
+**Configure the Jamf Compliance Reporter integration with TLS Remote Logging for TCP Input**:
+1. Enter values for "Listen Address" and "Listen Port" to form the TLS.
 
-### Configure the Jamf Compliance Reporter integration with TLS Remote Logging for TCP Input
-
-- Enter values for "Listen Address" and "Listen Port" to form the TLS.
-
-## Compatibility
-This package has been tested for Compliance Reporter against Jamf pro version 10.39.0 and Jamf Compliance Reporter version 1.0.4.
-
-## Logs
+## Logs reference
 
 ### log
 

--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update docs to align with new docs guidelines.
       type: enhancement
-      link: TBD
+      link: https://github.com/elastic/integrations/pull/3862
 - version: "0.1.1"
   changes:
     - description: Improve SSL config description and example.

--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Update docs to align with new docs guidelines.
+      type: enhancement
+      link: TBD
 - version: "0.1.1"
   changes:
     - description: Improve SSL config description and example.

--- a/packages/jamf_compliance_reporter/docs/README.md
+++ b/packages/jamf_compliance_reporter/docs/README.md
@@ -19,7 +19,7 @@ The log data stream collected by the Jamf Compliance Reporter integration includ
 You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
 You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
 
-Note: This package has been tested for Compliance Reporter against Jamf pro version 10.39.0 and Jamf Compliance Reporter version 1.0.4.
+Note: This package has been tested for Compliance Reporter against Jamf Pro version 10.39.0 and Jamf Compliance Reporter version 1.0.4.
 
 ## Setup
 
@@ -41,12 +41,12 @@ For more information on using configuration profiles in Jamf Pro, see [Creating 
 Then, follow _one_ of the below methods to collect logs from Jamf Compliance Reporter:
 
 **REST Endpoint Remote logging**:
-1. Reference link for configuring [REST Endpoint Remote logging](https://docs.jamf.com/compliance-reporter/documentation/REST_Endpoint_Remote_Logging.html) for Compliance Reporter.
-2. In Jamf Configuration Profile, form the full URL with port in the form `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
+1. Read [Jamf's REST Endpoint Remote logging documentation](https://docs.jamf.com/compliance-reporter/documentation/REST_Endpoint_Remote_Logging.html).
+2. In your Jamf Configuration Profile, form the full URL with port using this format: `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
 
 **TLS Remote Logging**:
-1. Reference link for generating [TLS Remote Logging](https://docs.jamf.com/compliance-reporter/documentation/TLS_Remote_Logging.html) for Compliance Reporter.
-2. In Jamf Configuration Profile, form the full URL with port in the form `tls://{AGENT_ADDRESS}:{AGENT_PORT}`.
+1. Read [Jamf's TLS Remote Logging documentation](https://docs.jamf.com/compliance-reporter/documentation/TLS_Remote_Logging.html).
+2. In your Jamf Configuration Profile, form the full URL with port using this format: `tls://{AGENT_ADDRESS}:{AGENT_PORT}`.
 
 **Configure the Jamf Compliance Reporter integration with REST Endpoint Remote logging for Rest Endpoint Input**:
 1. Enter values for "Listen Address", "Listen Port" and "URL" to form the endpoint URL. Make note of the **Endpoint URL** `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.

--- a/packages/jamf_compliance_reporter/docs/README.md
+++ b/packages/jamf_compliance_reporter/docs/README.md
@@ -5,7 +5,7 @@ The Jamf Compliance Reporter integration collects and parses data received from 
 Use the Jamf Compliance Reporter integration to collect logs from your machines.
 Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference data when troubleshooting an issue.
 
-For example, if you wanted to be notified when (something happens) you could (collect data). Then you can (visualize|alert|troubleshoot) by (doing something in Kibana).
+For example, if you wanted to monitor shell script commands performed by the root user, you could [configure Jamf to monitor those events](https://docs.jamf.com/compliance-reporter/documentation/Audit_Log_Levels_in_Compliance_Reporter.html) and then send them to Elastic for further investigation.
 
 ## Data streams
 

--- a/packages/jamf_compliance_reporter/docs/README.md
+++ b/packages/jamf_compliance_reporter/docs/README.md
@@ -1,46 +1,60 @@
 # Jamf Compliance Reporter
 
-The [Jamf Compliance Reporter](https://docs.jamf.com/compliance-reporter/documentation/Compliance_Reporter_Overview.html) Integration collects and parses data received from Jamf Compliance Reporter using a TLS or HTTP endpoint.
+The Jamf Compliance Reporter integration collects and parses data received from [Jamf Compliance Reporter](https://docs.jamf.com/compliance-reporter/documentation/Compliance_Reporter_Overview.html) using a TLS or HTTP endpoint.
+
+Use the Jamf Compliance Reporter integration to collect logs from your machines.
+Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference data when troubleshooting an issue.
+
+For example, if you wanted to be notified when (something happens) you could (collect data). Then you can (visualize|alert|troubleshoot) by (doing something in Kibana).
+
+## Data streams
+
+The Jamf Compliance Reporter integration collects one type of data stream: logs.
+
+**Logs** help you keep a record of events happening on computers using Jamf.
+The log data stream collected by the Jamf Compliance Reporter integration includes events that are related to security compliance requirements. See more details in the [Logs](#logs-reference).
 
 ## Requirements
-- Enable the Integration with the TLS or HTTP Endpoint input.
-- Configure Jamf Compliance Reporter to send logs to the Elastic Agent.
 
-### Enabling the integration in Elastic
+You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
+You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
 
-1. In Kibana go to **Management > Integrations**.
-2. In "Search for integrations" search bar type **Jamf Compliance Reporter**.
-3. Click on "Jamf Compliance Reporter" integration from the search results.
-4. Click on **Add Jamf Compliance Reporter** button to add Jamf Compliance Reporter integration.
+Note: This package has been tested for Compliance Reporter against Jamf pro version 10.39.0 and Jamf Compliance Reporter version 1.0.4.
 
-## Setup Steps
+## Setup
 
-- After validating settings, you can use a configuration profile in Jamf Pro to deploy certificates to endpoints in production.
+To use this integration, you will also need to:
+- Enable the integration in Elastic
+- Configure Jamf Compliance Reporter to send logs to the Elastic Agent
 
-- Reference link for [Creating a Configuration Profile](https://docs.jamf.com/compliance-reporter/documentation/Configuring_Compliance_Reporter_Properties_Using_Jamf_Pro.html) using Jamf Pro.
+### Enable the integration in Elastic
 
-## Follow one of the below methods to collect logs from Jamf Compliance Reporter
+For step-by-step instructions on how to set up an new integration in Elastic, see the
+[Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+When setting up the integration, you will choose to collect logs either via TLS or HTTP Endpoint.
 
-### REST Endpoint Remote logging
+### Configure Jamf Compliance Reporter
+
+After validating settings, you can use a configuration profile in Jamf Pro to deploy certificates to endpoints in production.
+For more information on using configuration profiles in Jamf Pro, see [Creating a Configuration Profile](https://docs.jamf.com/compliance-reporter/documentation/Configuring_Compliance_Reporter_Properties_Using_Jamf_Pro.html).
+
+Then, follow _one_ of the below methods to collect logs from Jamf Compliance Reporter:
+
+**REST Endpoint Remote logging**:
 1. Reference link for configuring [REST Endpoint Remote logging](https://docs.jamf.com/compliance-reporter/documentation/REST_Endpoint_Remote_Logging.html) for Compliance Reporter.
 2. In Jamf Configuration Profile, form the full URL with port in the form `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
 
-### TLS Remote Logging
+**TLS Remote Logging**:
 1. Reference link for generating [TLS Remote Logging](https://docs.jamf.com/compliance-reporter/documentation/TLS_Remote_Logging.html) for Compliance Reporter.
 2. In Jamf Configuration Profile, form the full URL with port in the form `tls://{AGENT_ADDRESS}:{AGENT_PORT}`.
 
-### Configure the Jamf Compliance Reporter integration with REST Endpoint Remote logging for Rest Endpoint Input
+**Configure the Jamf Compliance Reporter integration with REST Endpoint Remote logging for Rest Endpoint Input**:
+1. Enter values for "Listen Address", "Listen Port" and "URL" to form the endpoint URL. Make note of the **Endpoint URL** `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
 
-- Enter values for "Listen Address", "Listen Port" and "URL" to form the endpoint URL. Make note of the **Endpoint URL** `http[s]://{AGENT_ADDRESS}:{AGENT_PORT}/{URL}`.
+**Configure the Jamf Compliance Reporter integration with TLS Remote Logging for TCP Input**:
+1. Enter values for "Listen Address" and "Listen Port" to form the TLS.
 
-### Configure the Jamf Compliance Reporter integration with TLS Remote Logging for TCP Input
-
-- Enter values for "Listen Address" and "Listen Port" to form the TLS.
-
-## Compatibility
-This package has been tested for Compliance Reporter against Jamf pro version 10.39.0 and Jamf Compliance Reporter version 1.0.4.
-
-## Logs
+## Logs reference
 
 ### log
 

--- a/packages/jamf_compliance_reporter/manifest.yml
+++ b/packages/jamf_compliance_reporter/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: jamf_compliance_reporter
 title: Jamf Compliance Reporter
-version: 0.1.1
+version: 0.1.2
 license: basic
 description: Collect logs from Jamf Compliance Reporter with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Updates the Jamf Compliance Reporter integration docs to align with the documentation guidelines established in https://github.com/elastic/integrations/pull/3433.  

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] review by @jamiehynds 
- [ ] add PR link to changelog
- [ ] fill in example
- [x] run `docs-lint`

## Related issues

- https://github.com/elastic/integrations/pull/3433.

