### PR TITLE
[AWS] Move natgateway lightweight module config into integration

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.2"
+  changes:
+    - description: Move NATGateway metrics config from beats to integrations
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3873
 - version: "1.19.1"
   changes:
     - description: Move Transit Gateway metrics config from beats to integrations

--- a/packages/aws/data_stream/natgateway/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/natgateway/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["natgateway"]
+metricsets: ["cloudwatch"]
 period: {{period}}
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}
@@ -36,3 +36,24 @@ tags_filter: {{tags_filter}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}
+metrics:
+  - namespace: AWS/NATGateway
+    statistic: ["Sum"]
+    name:
+      - BytesInFromDestination
+      - BytesInFromSource
+      - BytesOutToDestination
+      - BytesOutToSource
+      - ConnectionAttemptCount
+      - ConnectionEstablishedCount
+      - ErrorPortAllocation
+      - IdleTimeoutCount
+      - PacketsDropCount
+      - PacketsInFromDestination
+      - PacketsInFromSource
+      - PacketsOutToDestination
+      - PacketsOutToSource
+  - namespace: AWS/NATGateway
+    statistic: ["Maximum"]
+    name:
+      - ActiveConnectionCount

--- a/packages/aws/data_stream/natgateway/sample_event.json
+++ b/packages/aws/data_stream/natgateway/sample_event.json
@@ -1,84 +1,116 @@
 {
-    "@timestamp": "2020-05-28T17:58:27.154Z",
+    "agent": {
+        "name": "a3fc2d7bc1c5",
+        "id": "8940152e-2f20-4ad1-bc96-4db45cb7fc89",
+        "ephemeral_id": "b7f3d3f4-137a-443f-90a7-ad2a5d81f81b",
+        "type": "metricbeat",
+        "version": "8.1.0"
+    },
+    "elastic_agent": {
+        "id": "8940152e-2f20-4ad1-bc96-4db45cb7fc89",
+        "version": "8.1.0",
+        "snapshot": false
+    },
+    "cloud": {
+        "provider": "aws",
+        "region": "eu-west-1"
+    },
+    "@timestamp": "2022-07-27T22:02:00.000Z",
+    "ecs": {
+        "version": "8.0.0"
+    },
     "service": {
         "type": "aws"
     },
-    "ecs": {
-        "version": "1.5.0"
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "aws.natgateway"
+    },
+    "host": {
+        "hostname": "a3fc2d7bc1c5",
+        "os": {
+            "kernel": "5.10.104-linuxkit",
+            "codename": "focal",
+            "name": "Ubuntu",
+            "type": "linux",
+            "family": "debian",
+            "version": "20.04.3 LTS (Focal Fossa)",
+            "platform": "ubuntu"
+        },
+        "containerized": false,
+        "ip": [
+            "172.20.0.7"
+        ],
+        "name": "a3fc2d7bc1c5",
+        "mac": [
+            "02:42:ac:14:00:07"
+        ],
+        "architecture": "aarch64"
+    },
+    "metricset": {
+        "period": 180000,
+        "name": "cloudwatch"
     },
     "aws": {
         "cloudwatch": {
             "namespace": "AWS/NATGateway"
         },
-        "dimensions": {
-            "NatGatewayId": "nat-0a5cb7b9807908cc0"
-        },
         "natgateway": {
             "metrics": {
-                "ActiveConnectionCount": {
-                    "max": 0
-                },
-                "BytesInFromDestination": {
-                    "sum": 0
-                },
-                "BytesInFromSource": {
-                    "sum": 0
-                },
-                "BytesOutToDestination": {
-                    "sum": 0
-                },
-                "BytesOutToSource": {
-                    "sum": 0
-                },
-                "ConnectionAttemptCount": {
-                    "sum": 0
-                },
-                "ConnectionEstablishedCount": {
-                    "sum": 0
+                "PacketsInFromSource": {
+                    "sum": 421
                 },
                 "ErrorPortAllocation": {
                     "sum": 0
                 },
+                "PacketsOutToDestination": {
+                    "sum": 421
+                },
+                "PacketsOutToSource": {
+                    "sum": 472
+                },
+                "BytesOutToDestination": {
+                    "sum": 42505
+                },
+                "ConnectionEstablishedCount": {
+                    "sum": 23
+                },
+                "ConnectionAttemptCount": {
+                    "sum": 23
+                },
+                "PacketsInFromDestination": {
+                    "sum": 472
+                },
+                "BytesInFromDestination": {
+                    "sum": 164752
+                },
                 "PacketsDropCount": {
                     "sum": 0
                 },
-                "PacketsInFromDestination": {
+                "BytesInFromSource": {
+                    "sum": 42505
+                },
+                "BytesOutToSource": {
+                    "sum": 164752
+                },
+                "IdleTimeoutCount": {
                     "sum": 0
                 },
-                "PacketsInFromSource": {
-                    "sum": 0
-                },
-                "PacketsOutToDestination": {
-                    "sum": 0
-                },
-                "PacketsOutToSource": {
-                    "sum": 0
+                "ActiveConnectionCount": {
+                    "max": 0
                 }
             }
+        },
+        "dimensions": {
+            "NatGatewayId": "nat-038389b5fc0734aa0"
         }
     },
     "event": {
-        "dataset": "aws.natgateway",
+        "duration": 612193833,
+        "agent_id_status": "verified",
+        "ingested": "2022-07-27T22:05:27Z",
         "module": "aws",
-        "duration": 10418157072
-    },
-    "metricset": {
-        "period": 60000,
-        "name": "natgateway"
-    },
-    "cloud": {
-        "region": "us-west-2",
-        "account": {
-            "name": "elastic-beats",
-            "id": "428152502467"
-        },
-        "provider": "aws"
-    },
-    "agent": {
-        "version": "8.0.0",
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b",
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30",
-        "name": "MacBook-Elastic.local",
-        "type": "metricbeat"
+        "dataset": "aws.natgateway"
     }
 }

--- a/packages/aws/docs/natgateway.md
+++ b/packages/aws/docs/natgateway.md
@@ -6,87 +6,119 @@ An example event for `natgateway` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-05-28T17:58:27.154Z",
+    "agent": {
+        "name": "a3fc2d7bc1c5",
+        "id": "8940152e-2f20-4ad1-bc96-4db45cb7fc89",
+        "ephemeral_id": "b7f3d3f4-137a-443f-90a7-ad2a5d81f81b",
+        "type": "metricbeat",
+        "version": "8.1.0"
+    },
+    "elastic_agent": {
+        "id": "8940152e-2f20-4ad1-bc96-4db45cb7fc89",
+        "version": "8.1.0",
+        "snapshot": false
+    },
+    "cloud": {
+        "provider": "aws",
+        "region": "eu-west-1"
+    },
+    "@timestamp": "2022-07-27T22:02:00.000Z",
+    "ecs": {
+        "version": "8.0.0"
+    },
     "service": {
         "type": "aws"
     },
-    "ecs": {
-        "version": "1.5.0"
+    "data_stream": {
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "aws.natgateway"
+    },
+    "host": {
+        "hostname": "a3fc2d7bc1c5",
+        "os": {
+            "kernel": "5.10.104-linuxkit",
+            "codename": "focal",
+            "name": "Ubuntu",
+            "type": "linux",
+            "family": "debian",
+            "version": "20.04.3 LTS (Focal Fossa)",
+            "platform": "ubuntu"
+        },
+        "containerized": false,
+        "ip": [
+            "172.20.0.7"
+        ],
+        "name": "a3fc2d7bc1c5",
+        "mac": [
+            "02:42:ac:14:00:07"
+        ],
+        "architecture": "aarch64"
+    },
+    "metricset": {
+        "period": 180000,
+        "name": "cloudwatch"
     },
     "aws": {
         "cloudwatch": {
             "namespace": "AWS/NATGateway"
         },
-        "dimensions": {
-            "NatGatewayId": "nat-0a5cb7b9807908cc0"
-        },
         "natgateway": {
             "metrics": {
-                "ActiveConnectionCount": {
-                    "max": 0
-                },
-                "BytesInFromDestination": {
-                    "sum": 0
-                },
-                "BytesInFromSource": {
-                    "sum": 0
-                },
-                "BytesOutToDestination": {
-                    "sum": 0
-                },
-                "BytesOutToSource": {
-                    "sum": 0
-                },
-                "ConnectionAttemptCount": {
-                    "sum": 0
-                },
-                "ConnectionEstablishedCount": {
-                    "sum": 0
+                "PacketsInFromSource": {
+                    "sum": 421
                 },
                 "ErrorPortAllocation": {
                     "sum": 0
                 },
+                "PacketsOutToDestination": {
+                    "sum": 421
+                },
+                "PacketsOutToSource": {
+                    "sum": 472
+                },
+                "BytesOutToDestination": {
+                    "sum": 42505
+                },
+                "ConnectionEstablishedCount": {
+                    "sum": 23
+                },
+                "ConnectionAttemptCount": {
+                    "sum": 23
+                },
+                "PacketsInFromDestination": {
+                    "sum": 472
+                },
+                "BytesInFromDestination": {
+                    "sum": 164752
+                },
                 "PacketsDropCount": {
                     "sum": 0
                 },
-                "PacketsInFromDestination": {
+                "BytesInFromSource": {
+                    "sum": 42505
+                },
+                "BytesOutToSource": {
+                    "sum": 164752
+                },
+                "IdleTimeoutCount": {
                     "sum": 0
                 },
-                "PacketsInFromSource": {
-                    "sum": 0
-                },
-                "PacketsOutToDestination": {
-                    "sum": 0
-                },
-                "PacketsOutToSource": {
-                    "sum": 0
+                "ActiveConnectionCount": {
+                    "max": 0
                 }
             }
+        },
+        "dimensions": {
+            "NatGatewayId": "nat-038389b5fc0734aa0"
         }
     },
     "event": {
-        "dataset": "aws.natgateway",
+        "duration": 612193833,
+        "agent_id_status": "verified",
+        "ingested": "2022-07-27T22:05:27Z",
         "module": "aws",
-        "duration": 10418157072
-    },
-    "metricset": {
-        "period": 60000,
-        "name": "natgateway"
-    },
-    "cloud": {
-        "region": "us-west-2",
-        "account": {
-            "name": "elastic-beats",
-            "id": "428152502467"
-        },
-        "provider": "aws"
-    },
-    "agent": {
-        "version": "8.0.0",
-        "ephemeral_id": "17803f33-b617-4ce9-a9ac-e218c02aeb4b",
-        "id": "12f376ef-5186-4e8b-a175-70f1140a8f30",
-        "name": "MacBook-Elastic.local",
-        "type": "metricbeat"
+        "dataset": "aws.natgateway"
     }
 }
 ```

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.19.1
+version: 1.19.2
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR is to move lightweight module configuration from Metricbeat into integrations for NATGateway.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Remove AWS resources used for testing

<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3600

<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
