### PR TITLE
[activemq] Update integration package to remove unnecessary fields

### DIFF
--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -4,7 +4,7 @@
   changes:
     - description: Remove unnecessary fields from fields.yml
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/3882
 - version: "0.4.1"
   changes:
     - description: fixed line break in readme

--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+
+- version: "0.4.2"
+  changes:
+    - description: Remove unnecessary fields from fields.yml
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.4.1"
   changes:
     - description: fixed line break in readme

--- a/packages/activemq/data_stream/log/fields/fields.yml
+++ b/packages/activemq/data_stream/log/fields/fields.yml
@@ -4,12 +4,6 @@
     - name: caller
       type: keyword
       description: Name of the caller issuing the logging request (class or resource).
-    - name: log_stack_trace
-      type: text
-      description: The stack trace of this log in plain text.
-    - name: message
-      type: text
-      description: Description of action taken by user.
     - name: thread
       type: keyword
       description: Thread that generated the logging event.

--- a/packages/activemq/docs/README.md
+++ b/packages/activemq/docs/README.md
@@ -78,8 +78,6 @@ An example event for `log` looks as following:
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | activemq.log.caller | Name of the caller issuing the logging request (class or resource). | keyword |
-| activemq.log.log_stack_trace | The stack trace of this log in plain text. | text |
-| activemq.log.message | Description of action taken by user. | text |
 | activemq.log.thread | Thread that generated the logging event. | keyword |
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,7 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: 0.4.1
-release: beta
+version: 0.4.2
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
- Bug
## What does this PR do?

This PR contains a minor cleanup for ActiveMQ integration. It removes the 2 fields which were present in **fields.yml** . These two fields are `activemq.log.log_stack_trace` and `activemq.log.message` which are regrouped in `error.stack_trace` and `message` fields. Since these fields are replaced they are no longer required in fields.yml. 
As we know that release tag got deprecated but recently got added by [ellis-elastic](https://github.com/ellis-elastic) in this [PR](https://github.com/elastic/integrations/pull/3535/files) , so removed that tag as a part of this bugfix PR
  The changes which are made do not affect the existing functionality of the integration at all and are just a cleanup to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/activemq directory.
- Run the following command to run tests. 
> elastic-package test