### PR TITLE
[Prometheus] Add dynamic mapping to fix prometheus histogram type

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.11.0"
   changes:
-    - description: Fix histogram type in collector pipeline
+    - description: Fix histogram type in collector data_stream
       type: bugfix
       link: https://github.com/elastic/integrations/pull/3891
 - version: "0.10.0"

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Fix histogram type in collector pipeline
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3662
 - version: "0.10.0"
   changes:
     - description: Hide some configuration for remote_write data_stream; Add leader election for collector and query data_streams

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix histogram type in collector pipeline
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/3662
+      link: https://github.com/elastic/integrations/pull/3891
 - version: "0.10.0"
   changes:
     - description: Hide some configuration for remote_write data_stream; Add leader election for collector and query data_streams

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -122,3 +122,12 @@ streams:
     title: Prometheus collector metrics
     enabled: true
     description: Collect Prometheus collector metrics
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: true
+      dynamic_templates:
+        - histogram:
+            path_match: "prometheus.*.histogram"
+            mapping:
+              type: histogram

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus Metrics
-version: 0.10.0
+version: 0.11.0
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?
This PR fixes a problem that the Prometheus package has to ingest histogram data type

<img width="1321" alt="image" src="https://user-images.githubusercontent.com/2767137/181577621-9a907d10-bf29-4b18-86c5-41293e8e622f.png">

I've tried different approaches but this one seems to be the only one that works. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

* Install Prometheus or use a docker container
a. I've used a docker image following this [doc](https://prometheus.io/docs/prometheus/latest/installation/) and [this](https://github.com/prometheus/prometheus/blob/main/documentation/examples/prometheus.yml) example for the `prometheus.yml` config file
b. Make sure that http://localhost:9090/metrics has data
* Install the Prometheus integration
a. If using docker, run ` docker run -it --rm alpine nslookup host.docker.internal  ` to retrieve the host
b. **DISABLE** the Leader Election option (it seems that we have a bug here too)
c. Clear all authentication fields 

## Related issues
Closes [#2257](https://github.com/elastic/observability-dev/issues/2257)

## Screenshots

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/2767137/181580895-0eeadefb-2b33-4fea-8fe3-000964c65245.png">

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/2767137/181581019-1fede34d-d325-424c-a76d-03be49d20cb1.png">
