### PR TITLE
[infoblox_nios] Update ECS to 8.4.0

### DIFF
--- a/packages/infoblox_nios/_dev/build/build.yml
+++ b/packages/infoblox_nios/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.3.0
+    reference: git@v8.4.0-rc1

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Update package to ECS 8.4.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3893
+    - description: Switch to ECS allowed values in dns.header_flags, original values now in infoblox_nios.log.dns.header_flags
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3893
 - version: "0.2.0"
   changes:
     - description: Update package to ECS 8.3.0.

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2022-03-18T13:24:41.705Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "logout",
@@ -57,7 +57,7 @@
         {
             "@timestamp": "2022-04-13T16:44:36.850Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "login_denied",
@@ -112,7 +112,7 @@
         {
             "@timestamp": "2022-03-21T08:53:51.087Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "login_allowed",
@@ -171,7 +171,7 @@
         {
             "@timestamp": "2011-10-19T19:48:37.299Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "login_allowed",
@@ -224,7 +224,7 @@
         {
             "@timestamp": "2011-10-19T14:02:32.750Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "login_denied",
@@ -273,7 +273,7 @@
         {
             "@timestamp": "2011-10-19T12:43:47.375Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "first_login",
@@ -321,7 +321,7 @@
         {
             "@timestamp": "2011-10-19T13:07:33.343Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "password_reset_error",
@@ -366,7 +366,7 @@
         {
             "@timestamp": "2022-03-21T17:19:02.204Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "modified",
@@ -413,7 +413,7 @@
         {
             "@timestamp": "2022-03-24T09:37:29.261Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "created",
@@ -460,7 +460,7 @@
         {
             "@timestamp": "2022-03-18T11:46:38.877Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "modified",
@@ -507,7 +507,7 @@
         {
             "@timestamp": "2022-03-29T19:29:20.468Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "called",
@@ -553,7 +553,7 @@
         {
             "@timestamp": "2022-03-29T18:30:58.656Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "created",
@@ -600,7 +600,7 @@
         {
             "@timestamp": "2022-03-24T09:28:24.476Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "called",
@@ -646,7 +646,7 @@
         {
             "@timestamp": "2022-03-21T15:08:08.238Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "created",
@@ -693,7 +693,7 @@
         {
             "@timestamp": "2022-03-21T15:08:08.239Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "created",
@@ -740,7 +740,7 @@
         {
             "@timestamp": "2022-03-21T15:08:48.455Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "deleted",
@@ -787,7 +787,7 @@
         {
             "@timestamp": "2022-03-22T13:26:54.596Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "deleted",
@@ -834,7 +834,7 @@
         {
             "@timestamp": "2022-03-22T13:26:54.596Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "created",
@@ -881,7 +881,7 @@
         {
             "@timestamp": "2022-03-22T13:26:54.596Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "modified",
@@ -928,7 +928,7 @@
         {
             "@timestamp": "2022-03-18T12:40:05.241Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "modified",
@@ -974,7 +974,7 @@
         },
         {
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-18T13:40:05.000Z",
@@ -1006,7 +1006,7 @@
         {
             "@timestamp": "2022-03-29T19:29:20.468Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "called",
@@ -1049,7 +1049,7 @@
         {
             "@timestamp": "2022-03-21T17:19:02.204Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "modified",
@@ -1092,7 +1092,7 @@
         {
             "@timestamp": "2022-03-29T18:30:58.656Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "created",

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
@@ -7,7 +7,7 @@
                 "mac": "00-50-56-81-14-6C"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -52,7 +52,7 @@
                 "mac": "00-50-56-81-14-6C"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -99,7 +99,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpdiscover",
@@ -148,7 +148,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpdiscover",
@@ -199,7 +199,7 @@
                 "mac": "00-50-56-83-D0-F6"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpdiscover",
@@ -249,7 +249,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpdiscover",
@@ -295,7 +295,7 @@
                 "mac": "00-00-00-00-00-00"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpdiscover",
@@ -347,7 +347,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpoffer",
@@ -408,7 +408,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpoffer",
@@ -468,7 +468,7 @@
                 "mac": "26-9A-76-87-8A-06"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpoffer",
@@ -525,7 +525,7 @@
                 "mac": "00-00-00-00-00-00"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpoffer",
@@ -584,7 +584,7 @@
                 "mac": "CC-BB-CC-DD-EE-FF"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpoffer",
@@ -642,7 +642,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -702,7 +702,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -759,7 +759,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -815,7 +815,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -866,7 +866,7 @@
                 "mac": "00-50-56-83-D3-83"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -923,7 +923,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -979,7 +979,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -1033,7 +1033,7 @@
                 "mac": "00-50-56-83-96-03"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -1086,7 +1086,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -1136,7 +1136,7 @@
                 "mac": "9A-DF-6E-F6-1F-23"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -1189,7 +1189,7 @@
                 "mac": "00-00-00-00-00-00"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprequest",
@@ -1247,7 +1247,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpack",
@@ -1308,7 +1308,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpack",
@@ -1368,7 +1368,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpack",
@@ -1427,7 +1427,7 @@
                 "mac": "9A-DF-6E-F6-1F-23"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpack",
@@ -1485,7 +1485,7 @@
                 "mac": "00-00-00-00-00-00"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpack",
@@ -1546,7 +1546,7 @@
                 "mac": "CC-BB-CC-DD-EE-FF"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpack",
@@ -1604,7 +1604,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprelease",
@@ -1660,7 +1660,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcprelease",
@@ -1713,7 +1713,7 @@
                 "mac": "00-50-56-83-6C-A0"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpexpire",
@@ -1756,7 +1756,7 @@
                 "ip": "192.168.0.4"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpinform",
@@ -1804,7 +1804,7 @@
                 "ip": "192.168.0.4"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpinform",
@@ -1851,7 +1851,7 @@
                 "ip": "192.168.0.4"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpinform",
@@ -1905,7 +1905,7 @@
                 "mac": "34-29-8F-71-B8-99"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpdecline",
@@ -1957,7 +1957,7 @@
                 "mac": "00-C0-DD-07-18-E2"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpdecline",
@@ -2010,7 +2010,7 @@
                 "mac": "F4-30-B9-17-AB-0E"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpnak",
@@ -2059,7 +2059,7 @@
                 "ip": "192.168.0.4"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "action": "dhcpleasequery",
@@ -2104,7 +2104,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2143,7 +2143,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2182,7 +2182,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2221,7 +2221,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2260,7 +2260,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2299,7 +2299,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2338,7 +2338,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2377,7 +2377,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2416,7 +2416,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2455,7 +2455,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",
@@ -2494,7 +2494,7 @@
         {
             "@timestamp": "2022-03-27T08:32:59.000Z",
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-27T08:32:59.000Z",

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -41,7 +41,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -101,7 +101,7 @@
                 "response_code": "REFUSED"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -181,7 +181,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -244,7 +244,7 @@
                 "response_code": "NXDOMAIN"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -328,7 +328,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -379,7 +379,7 @@
                 "port": 59735
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-09T23:59:59.000Z",
@@ -436,7 +436,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-09T23:59:59.000Z",
@@ -481,7 +481,7 @@
         },
         {
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -528,7 +528,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -580,7 +580,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -634,7 +634,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -691,7 +691,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -737,7 +737,7 @@
                 "port": 46982
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -789,7 +789,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -841,7 +841,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -894,7 +894,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -947,7 +947,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -989,7 +989,7 @@
         },
         {
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -1033,7 +1033,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -1078,7 +1078,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -1123,7 +1123,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-03-11T23:51:31.000Z",
@@ -1175,7 +1175,7 @@
                 "response_code": "REFUSED"
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-04-14T16:17:20.000Z",
@@ -1236,7 +1236,7 @@
                 }
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-04-14T16:16:05.000Z",
@@ -1288,7 +1288,7 @@
                 "port": 64727
             },
             "ecs": {
-                "version": "8.3.0"
+                "version": "8.4.0"
             },
             "event": {
                 "created": "2022-04-14T16:16:05.000Z",

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -29,7 +29,10 @@
                         "A"
                     ]
                 },
-                "header_flags": "+ED",
+                "header_flags": [
+                    "DO",
+                    "RA"
+                ],
                 "question": {
                     "class": "IN",
                     "name": "a1.foo.com",
@@ -49,6 +52,9 @@
             },
             "infoblox_nios": {
                 "log": {
+                    "dns": {
+                        "header_flags": "+ED"
+                    },
                     "service_name": "named",
                     "type": "DNS"
                 }
@@ -87,7 +93,6 @@
                 "port": 50565
             },
             "dns": {
-                "header_flags": "-",
                 "question": {
                     "class": "IN",
                     "name": "test.com",
@@ -107,6 +112,9 @@
             },
             "infoblox_nios": {
                 "log": {
+                    "dns": {
+                        "header_flags": "-"
+                    },
                     "service_name": "named",
                     "type": "DNS"
                 }
@@ -160,7 +168,11 @@
                         "A"
                     ]
                 },
-                "header_flags": "+AED",
+                "header_flags": [
+                    "AA",
+                    "DO",
+                    "RA"
+                ],
                 "question": {
                     "class": "IN",
                     "name": "a2.foo.com",
@@ -180,6 +192,9 @@
             },
             "infoblox_nios": {
                 "log": {
+                    "dns": {
+                        "header_flags": "+AED"
+                    },
                     "service_name": "named",
                     "type": "DNS"
                 }
@@ -217,7 +232,10 @@
                 "port": 57398
             },
             "dns": {
-                "header_flags": "+ED",
+                "header_flags": [
+                    "DO",
+                    "RA"
+                ],
                 "question": {
                     "class": "IN",
                     "name": "non-exist.foo.com",
@@ -237,6 +255,9 @@
             },
             "infoblox_nios": {
                 "log": {
+                    "dns": {
+                        "header_flags": "+ED"
+                    },
                     "service_name": "named",
                     "type": "DNS"
                 }
@@ -295,7 +316,10 @@
                         "A"
                     ]
                 },
-                "header_flags": "+ED",
+                "header_flags": [
+                    "DO",
+                    "RA"
+                ],
                 "question": {
                     "class": "IN",
                     "name": "a1.foo.com",
@@ -315,6 +339,9 @@
             },
             "infoblox_nios": {
                 "log": {
+                    "dns": {
+                        "header_flags": "+ED"
+                    },
                     "service_name": "named",
                     "type": "DNS"
                 }
@@ -399,7 +426,9 @@
                 "port": 59735
             },
             "dns": {
-                "header_flags": "+",
+                "header_flags": [
+                    "RD"
+                ],
                 "question": {
                     "class": "IN",
                     "name": "config.nos-avg.cz",
@@ -418,6 +447,9 @@
             },
             "infoblox_nios": {
                 "log": {
+                    "dns": {
+                        "header_flags": "+"
+                    },
                     "service_name": "named",
                     "type": "DNS"
                 }
@@ -1135,7 +1167,6 @@
                 "port": 57738
             },
             "dns": {
-                "header_flags": "-",
                 "question": {
                     "class": "IN",
                     "name": "settings-win.data.microsoft.com",
@@ -1156,7 +1187,8 @@
             "infoblox_nios": {
                 "log": {
                     "dns": {
-                        "category": "infoblox-responses"
+                        "category": "infoblox-responses",
+                        "header_flags": "-"
                     },
                     "service_name": "named",
                     "type": "DNS"
@@ -1194,7 +1226,9 @@
                 "port": 64727
             },
             "dns": {
-                "header_flags": "+",
+                "header_flags": [
+                    "RD"
+                ],
                 "question": {
                     "class": "IN",
                     "name": "ocsp.digicert.com",
@@ -1214,7 +1248,8 @@
             "infoblox_nios": {
                 "log": {
                     "dns": {
-                        "category": "queries"
+                        "category": "queries",
+                        "header_flags": "+"
                     },
                     "service_name": "named",
                     "type": "DNS"

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
       ignore_missing: true
   - set:
       field: ecs.version
-      value: '8.3.0'
+      value: '8.4.0'
   - grok:
       field: event.original
       patterns:

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -10,12 +10,12 @@ processors:
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{DATA} %{IP:client.ip}#%{NUMBER:client.port:long}:? updating zone '%{DATA:dns.question.name}/%{DATA:dns.question.class}': %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{DATA} %{IP:client.ip}#%{NUMBER:client.port:long}:? \\(%{DATA:client.domain}\\): query failed %{GREEDYDATA:infoblox_nios.log.dns.message}$"       
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{DATA} %{IP:client.ip}#%{NUMBER:client.port:long}:? \\(%{DATA:infoblox_nios.log.dns.before_query}\\): rewriting query name %{DATA} to '%{DATA:infoblox_nios.log.dns.after_query}', type %{DATA:dns.question.type}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{DATA} %{IP:client.ip}#%{NUMBER:client.port:long}:? \\(%{DATA:client.domain}\\): query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} %{DATA:dns.header_flags} \\(%{IP:server.ip}\\)$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{IP:client.ip}#%{NUMBER:client.port:long}:? %{DATA:network.transport}: query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:dns.header_flags}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{DATA} %{IP:client.ip}#%{NUMBER:client.port:long}:? \\(%{DATA:client.domain}\\): query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} %{DATA:infoblox_nios.log.dns.header_flags} \\(%{IP:server.ip}\\)$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{IP:client.ip}#%{NUMBER:client.port:long}:? %{DATA:network.transport}: query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{DATA} %{IP:client.ip}#%{NUMBER:client.port:long}:? \\(%{DATA:client.domain}\\): transfer of '%{DATA:dns.question.name}/%{DATA:dns.question.class}': %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*CEF:0\\|Infoblox\\|NIOS\\|%{GREEDYDATA:infoblox_nios.log.dns.version}\\|RPZ-%{DATA:dns.answers.type}\\|%{DATA:infoblox_nios.log.dns.answers_policy}\\|\\d+\\|app=DNS dst=%{IP:server.ip} src=%{IP:client.ip} spt=%{NUMBER:client.port:long} view=%{DATA:infoblox_nios.log.dns.view_name} qtype=%{WORD:dns.question.type} msg=%{GREEDYDATA:infoblox_nios.log.dns.message}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:timestamp} client %{IP:client.ip}#%{NUMBER:client.port:long}:? %{DATA:network.transport}: query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:dns.header_flags} %{GREEDYDATA:repeat_message}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:timestamp} client %{IP:client.ip}#%{NUMBER:client.port:long}:? %{DATA:network.transport}: query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:dns.header_flags}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:timestamp} client %{IP:client.ip}#%{NUMBER:client.port:long}:? %{DATA:network.transport}: query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags} %{GREEDYDATA:repeat_message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:timestamp} client %{IP:client.ip}#%{NUMBER:client.port:long}:? %{DATA:network.transport}: query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*client %{DATA} %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.dns.message}$"
   - date:
@@ -107,6 +107,39 @@ processors:
       if: ctx.dns?.question?.name != null
       allow_duplicates: false
       ignore_failure: true
+  - script:
+      lang: painless
+      if: ctx.infoblox_nios?.log?.dns?.header_flags != null && ctx.infoblox_nios.log.dns.header_flags != ""
+      params:
+        'A': 'AA'
+        't': 'TC'
+        'C': 'CD'
+        'D': 'DO'
+      source: |
+        ArrayList hf = new ArrayList();
+        for (entry in params.entrySet()) {
+          if (ctx.infoblox_nios.log.dns.header_flags.contains(entry.getKey())) {
+            hf.add(entry.getValue());
+          }
+        }
+        if (ctx.dns?.response_code != null && ctx.dns.response_code != "") {
+          if (ctx.infoblox_nios.log.dns.header_flags.contains("+")) {
+            hf.add("RA")
+          }
+        } else {
+          if (ctx.infoblox_nios.log.dns.header_flags.contains("+")) {
+            hf.add("RD")
+          }
+        }
+        if (hf.length == 0) {
+          return;
+        }
+        if (ctx.dns == null) {
+          HashMap hm = new HashMap();
+          ctx.put("dns", hm);
+        }
+        ctx.dns.put("header_flags", hf);
+
   - remove:
       field:
         - timestamp

--- a/packages/infoblox_nios/data_stream/log/fields/fields.yml
+++ b/packages/infoblox_nios/data_stream/log/fields/fields.yml
@@ -120,6 +120,8 @@
           type: text
         - name: version
           type: text
+        - name: header_flags
+          type: keyword
     - name: service_name
       type: keyword
     - name: type

--- a/packages/infoblox_nios/docs/README.md
+++ b/packages/infoblox_nios/docs/README.md
@@ -245,7 +245,7 @@ An example event for `log` looks as following:
 | dns.answers.name | The domain name to which this resource record pertains. If a chain of CNAME is being resolved, each answer's `name` should be the one that corresponds with the answer's `data`. It should not simply be the original `question.name` repeated. | keyword |
 | dns.answers.ttl | The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached. | long |
 | dns.answers.type | The type of data contained in this resource record. | keyword |
-| dns.header_flags | Array of 2 letter DNS header flags. Expected values are: AA, TC, RD, RA, AD, CD, DO. | keyword |
+| dns.header_flags | Array of 2 letter DNS header flags. | keyword |
 | dns.question.class | The class of records being queried. | keyword |
 | dns.question.name | The name being queried. If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively. | keyword |
 | dns.question.type | The type of record being queried. | keyword |
@@ -307,6 +307,7 @@ An example event for `log` looks as following:
 | infoblox_nios.log.dns.before_query |  | text |
 | infoblox_nios.log.dns.category |  | text |
 | infoblox_nios.log.dns.failed_message |  | text |
+| infoblox_nios.log.dns.header_flags |  | keyword |
 | infoblox_nios.log.dns.message |  | text |
 | infoblox_nios.log.dns.version |  | text |
 | infoblox_nios.log.dns.view_name |  | text |

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: infoblox_nios
 title: Infoblox NIOS
-version: "0.2.0"
+version: "0.3.0"
 license: basic
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration


### PR DESCRIPTION
- update infoblox_nios to ECS 8.4.0
- switch to ECS allowed values in `dns.header_flags`, original values are now in `infoblox_nios.log.dns.header_flags`

Closes #3884 