### PR TITLE
[Couchbase] Update manifest file for bucket data stream

### DIFF
--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update "bucket" data stream with manifest changes.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link
+      link: https://github.com/elastic/integrations/pull/3900
 - version: "0.1.0"
   changes:
     - description: Couchbase integration package with "bucket" data stream.

--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Update "bucket" data stream with manifest changes.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link
 - version: "0.1.0"
   changes:
     - description: Couchbase integration package with "bucket" data stream.

--- a/packages/couchbase/data_stream/bucket/_dev/test/system/test-default-config.yml
+++ b/packages/couchbase/data_stream/bucket/_dev/test/system/test-default-config.yml
@@ -1,4 +1,6 @@
+input: http/metrics
+vars:
+  hosts:
+    - http://Administrator:password@{{Hostname}}:{{Ports}}
 data_stream:
-  vars:
-    hosts:
-      - http://Administrator:password@{{Hostname}}:{{Ports}}
+  vars: ~

--- a/packages/couchbase/data_stream/bucket/manifest.yml
+++ b/packages/couchbase/data_stream/bucket/manifest.yml
@@ -6,49 +6,6 @@ streams:
     title: Couchbase bucket metrics
     description: Collect Couchbase bucket metrics.
     vars:
-      - name: hosts
-        type: text
-        title: Hosts
-        multi: true
-        required: true
-        show_user: true
-        description: "Host for Couchbase metrics. (example: http://username:password@localhost:8091)."
-        default:
-          - http://username:password@localhost:8091
-      - name: ssl
-        type: yaml
-        title: SSL Configuration
-        default: |
-          # ssl.certificate_authorities:
-          # - |
-          #   -----BEGIN CERTIFICATE-----
-          #   MIID+jCCAuKgAwIBAgIGAJJMzlxLMA0GCSqGSIb3DQEBCwUAMHoxCzAJBgNVBAYT
-          #   AlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHROb2RlMDExFjAUBgNV
-          #   BAsTDURlZmF1bHRDZWxsMDExGTAXBgNVBAsTEFJvb3QgQ2VydGlmaWNhdGUxEjAQ
-          #   BgNVBAMTCWxvY2FsaG9zdDAeFw0yMTEyMTQyMjA3MTZaFw0yMjEyMTQyMjA3MTZa
-          #   MF8xCzAJBgNVBAYTAlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHRO
-          #   b2RlMDExFjAUBgNVBAsTDURlZmF1bHRDZWxsMDExEjAQBgNVBAMTCWxvY2FsaG9z
-          #   dDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMv5HCsJZIpI5zCy+jXV
-          #   z6lmzNc9UcVSEEHn86h6zT6pxuY90TYeAhlZ9hZ+SCKn4OQ4GoDRZhLPTkYDt+wW
-          #   CV3NTIy9uCGUSJ6xjCKoxClJmgSQdg5m4HzwfY4ofoEZ5iZQ0Zmt62jGRWc0zuxj
-          #   hegnM+eO2reBJYu6Ypa9RPJdYJsmn1RNnC74IDY8Y95qn+WZj//UALCpYfX41hko
-          #   i7TWD9GKQO8SBmAxhjCDifOxVBokoxYrNdzESl0LXvnzEadeZTd9BfUtTaBHhx6t
-          #   njqqCPrbTY+3jAbZFd4RiERPnhLVKMytw5ot506BhPrUtpr2lusbN5svNXjuLeea
-          #   MMUCAwEAAaOBoDCBnTATBgNVHSMEDDAKgAhOatpLwvJFqjAdBgNVHSUEFjAUBggr
-          #   BgEFBQcDAQYIKwYBBQUHAwIwVAYDVR0RBE0wS4E+UHJvZmlsZVVVSUQ6QXBwU3J2
-          #   MDEtQkFTRS05MDkzMzJjMC1iNmFiLTQ2OTMtYWI5NC01Mjc1ZDI1MmFmNDiCCWxv
-          #   Y2FsaG9zdDARBgNVHQ4ECgQITzqhA5sO8O4wDQYJKoZIhvcNAQELBQADggEBAKR0
-          #   gY/BM69S6BDyWp5dxcpmZ9FS783FBbdUXjVtTkQno+oYURDrhCdsfTLYtqUlP4J4
-          #   CHoskP+MwJjRIoKhPVQMv14Q4VC2J9coYXnePhFjE+6MaZbTjq9WaekGrpKkMaQA
-          #   iQt5b67jo7y63CZKIo9yBvs7sxODQzDn3wZwyux2vPegXSaTHR/rop/s/mPk3YTS
-          #   hQprs/IVtPoWU4/TsDN3gIlrAYGbcs29CAt5q9MfzkMmKsuDkTZD0ry42VjxjAmk
-          #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
-          #   7RhLQyWn2u00L7/9Omw=
-          #   -----END CERTIFICATE-----
-        description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
-        multi: false
-        required: false
-        show_user: false
       - name: period
         type: text
         title: Period

--- a/packages/couchbase/manifest.yml
+++ b/packages/couchbase/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: couchbase
 title: Couchbase
-version: 0.1.0
+version: 0.1.1
 license: basic
 description: Collect metrics from Couchbase databases with Elastic Agent.
 type: integration
@@ -23,5 +23,49 @@ policy_templates:
       - type: http/metrics
         title: Collect Couchbase metrics using http module
         description: Collect Couchbase metrics using http module.
+        vars:
+          - name: hosts
+            type: text
+            title: Hosts
+            multi: true
+            required: true
+            show_user: true
+            description: "Hosts for Couchbase metrics (example: http://username:password@localhost:8091)."
+            default:
+              - http://username:password@localhost:8091
+          - name: ssl
+            type: yaml
+            title: SSL Configuration
+            default: |
+              # ssl.certificate_authorities:
+              # - |
+              #   -----BEGIN CERTIFICATE-----
+              #   MIID+jCCAuKgAwIBAgIGAJJMzlxLMA0GCSqGSIb3DQEBCwUAMHoxCzAJBgNVBAYT
+              #   AlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHROb2RlMDExFjAUBgNV
+              #   BAsTDURlZmF1bHRDZWxsMDExGTAXBgNVBAsTEFJvb3QgQ2VydGlmaWNhdGUxEjAQ
+              #   BgNVBAMTCWxvY2FsaG9zdDAeFw0yMTEyMTQyMjA3MTZaFw0yMjEyMTQyMjA3MTZa
+              #   MF8xCzAJBgNVBAYTAlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHRO
+              #   b2RlMDExFjAUBgNVBAsTDURlZmF1bHRDZWxsMDExEjAQBgNVBAMTCWxvY2FsaG9z
+              #   dDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMv5HCsJZIpI5zCy+jXV
+              #   z6lmzNc9UcVSEEHn86h6zT6pxuY90TYeAhlZ9hZ+SCKn4OQ4GoDRZhLPTkYDt+wW
+              #   CV3NTIy9uCGUSJ6xjCKoxClJmgSQdg5m4HzwfY4ofoEZ5iZQ0Zmt62jGRWc0zuxj
+              #   hegnM+eO2reBJYu6Ypa9RPJdYJsmn1RNnC74IDY8Y95qn+WZj//UALCpYfX41hko
+              #   i7TWD9GKQO8SBmAxhjCDifOxVBokoxYrNdzESl0LXvnzEadeZTd9BfUtTaBHhx6t
+              #   njqqCPrbTY+3jAbZFd4RiERPnhLVKMytw5ot506BhPrUtpr2lusbN5svNXjuLeea
+              #   MMUCAwEAAaOBoDCBnTATBgNVHSMEDDAKgAhOatpLwvJFqjAdBgNVHSUEFjAUBggr
+              #   BgEFBQcDAQYIKwYBBQUHAwIwVAYDVR0RBE0wS4E+UHJvZmlsZVVVSUQ6QXBwU3J2
+              #   MDEtQkFTRS05MDkzMzJjMC1iNmFiLTQ2OTMtYWI5NC01Mjc1ZDI1MmFmNDiCCWxv
+              #   Y2FsaG9zdDARBgNVHQ4ECgQITzqhA5sO8O4wDQYJKoZIhvcNAQELBQADggEBAKR0
+              #   gY/BM69S6BDyWp5dxcpmZ9FS783FBbdUXjVtTkQno+oYURDrhCdsfTLYtqUlP4J4
+              #   CHoskP+MwJjRIoKhPVQMv14Q4VC2J9coYXnePhFjE+6MaZbTjq9WaekGrpKkMaQA
+              #   iQt5b67jo7y63CZKIo9yBvs7sxODQzDn3wZwyux2vPegXSaTHR/rop/s/mPk3YTS
+              #   hQprs/IVtPoWU4/TsDN3gIlrAYGbcs29CAt5q9MfzkMmKsuDkTZD0ry42VjxjAmk
+              #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
+              #   7RhLQyWn2u00L7/9Omw=
+              #   -----END CERTIFICATE-----
+            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            multi: false
+            required: false
+            show_user: false
 owner:
   github: elastic/obs-service-integrations


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Change `host` parameter from data stream specific manifest  to integration specific manifest.

## Why is this PR important?

For Couchbase, there can be multiple data streams for which we currently have a `host` inside the manifest (data stream specific), but it seems easier in terms of user experience to have the `host` field inside the main manifest (integration specific). Hence, the end-user won't have to enter the same host multiple times for multiple data streams.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's changelog.yml file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's manifest.yml file to point to the latest Elastic stack release (e.g. ^7.13.0).

<!-- ## Author's Checklist

Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved

- [ ]
-->
## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/couchbase directory.
- Run the following command to run tests. 
> elastic-package test 

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
![ss1](https://user-images.githubusercontent.com/108920532/177944349-6eab5000-c6f0-4ce8-bd1d-2f87e35abc25.png)
![ss2](https://user-images.githubusercontent.com/108920532/177944366-2737f206-90de-41b8-8509-15fbeb4a80d8.png)

