### PR TITLE
[docs] Add contributor agreement prereq to dev docs

### DIFF
--- a/docs/developer_workflow_design_build_test_integration.md
+++ b/docs/developer_workflow_design_build_test_integration.md
@@ -119,7 +119,7 @@ using the tool's [documentation](https://github.com/elastic/elastic-package/tree
 
 ### Open a PR
 
-Prior to opening a PR, you must sign the [elastic contributor agreement](https://www.elastic.co/contributor-agreement) if you haven't already. CI builds will fail if this agreement isn't on file for your GitHub username.
+Prior to opening a PR, you must sign the [elastic contributor agreement](https://www.elastic.co/contributor-agreement) if you haven't already.
 
 If you think that you've finished work on your integration, you've verified that it collects data, and you've written some tests,
 you can [open a PR](https://github.com/elastic/integrations/compare) to include your integration in the [Integrations](https://github.com/elastic/integrations) repository.

--- a/docs/developer_workflow_design_build_test_integration.md
+++ b/docs/developer_workflow_design_build_test_integration.md
@@ -119,7 +119,9 @@ using the tool's [documentation](https://github.com/elastic/elastic-package/tree
 
 ### Open a PR
 
-If you think that you've finished works on your integration, you've verified that it collects data, wrote some tests,
+Prior to opening a PR, you must sign the [elastic contributor agreement](https://www.elastic.co/contributor-agreement) if you haven't already. CI builds will fail if this agreement isn't on file for your GitHub username.
+
+If you think that you've finished work on your integration, you've verified that it collects data, and you've written some tests,
 you can [open a PR](https://github.com/elastic/integrations/compare) to include your integration in the [Integrations](https://github.com/elastic/integrations) repository.
 The CI will verify if your integration is correct (`elastic-package check`) - a green status is a must.
 


### PR DESCRIPTION
## What does this PR do?

CI builds fail if the [elastic contributor agreement](https://www.elastic.co/contributor-agreement) isn't on file for a github user. However, I didn't see that info anywhere prior to trying to submit my first integration so my initial CI build failed due to it. 

This PR adds that language to the dev docs about building a new integration, specifically in the **Open a PR** section.

## Related issues

- See #3839 for a PR that failed due to no contributor agreement on file at time PR was submitted.