### PR TITLE
Osquery_manager: Upgrade osquery fields to match osquery 5.4.0 schema changes

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Update schema for osquery 5.4.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.3.2"
   changes:
     - description: Fix field mapping conflicts

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update schema for osquery 5.4.0
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/3922
 - version: "1.3.2"
   changes:
     - description: Fix field mapping conflicts

--- a/packages/osquery_manager/data_stream/result/fields/osquery.yml
+++ b/packages/osquery_manager/data_stream/result/fields/osquery.yml
@@ -12,23 +12,6 @@
           type: text
           norms: false
           default_field: false
-    - name: abi
-      description: elf_info.abi - Section type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: abi_version
-      description: elf_info.abi_version - Section virtual address in memory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: access
       description: ntfs_acl_permissions.access - Specific permissions that indicate the rights described by the ACE.
       type: keyword
@@ -80,6 +63,15 @@
         - name: number
           type: long
           default_field: false
+    - name: account
+      description: keychain_items.account - Optional item account
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: account_id
       description: ec2_instance_metadata.account_id - AWS account ID which owns this EC2 instance
       type: keyword
@@ -92,7 +84,6 @@
     - name: action
       description: |-
         disk_events.action - Appear or disappear
-        example.action - Action performed in generation
         file_events.action - Change action (UPDATE, REMOVE, etc)
         hardware_events.action - Remove, insert, change properties, etc
         ntfs_journal_events.action - Change action (Write, Delete, etc)
@@ -154,8 +145,8 @@
         - name: number
           type: long
           default_field: false
-    - name: additional_product_id
-      description: smart_drive_info.additional_product_id - An additional drive identifier if any
+    - name: add_reason
+      description: "wifi_networks.add_reason - Shows why this network was added, via menubar or command line or something else "
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -163,8 +154,8 @@
           type: text
           norms: false
           default_field: false
-    - name: addr
-      description: elf_symbols.addr - Symbol address (value)
+    - name: added_at
+      description: wifi_networks.added_at - Time this network was added as a unix_time
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -191,6 +182,15 @@
           default_field: false
     - name: address_width
       description: cpu_info.address_width - The width of the CPU address bus.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: admindir
+      description: deb_packages.admindir - libdpkg admindir. Defaults to /var/lib/dpkg
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -228,16 +228,6 @@
         - name: text
           type: text
           norms: false
-          default_field: false
-    - name: align
-      description: |-
-        elf_sections.align - Segment alignment
-        elf_segments.align - Segment alignment
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
           default_field: false
     - name: allow_maximum
       description: shared_resources.allow_maximum - Number of concurrent users for this resource has been limited. If True, the value in the MaximumAllowed property is ignored.
@@ -434,15 +424,6 @@
           type: text
           norms: false
           default_field: false
-    - name: ata_version
-      description: smart_drive_info.ata_version - ATA version of drive
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: atime
       description: |-
         device_file.atime - Last access time
@@ -522,7 +503,7 @@
       description: |-
         chocolatey_packages.author - Optional package author
         chrome_extensions.author - Optional extension author
-        npm_packages.author - Package author name
+        npm_packages.author - Package-supplied author
         python_packages.author - Optional package author
         safari_extensions.author - Optional extension author
       type: keyword
@@ -567,6 +548,14 @@
         - name: text
           type: text
           norms: false
+          default_field: false
+    - name: auto_join
+      description: wifi_networks.auto_join - 1 if this network set to join automatically, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
           default_field: false
     - name: auto_login
       description: wifi_networks.auto_login - 1 if auto login is enabled, 0 otherwise
@@ -741,15 +730,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: binding
-      description: elf_symbols.binding - Binding type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: bitmap_chunk_size
       description: md_devices.bitmap_chunk_size - Bitmap chunk size
@@ -1231,6 +1211,14 @@
           type: text
           norms: false
           default_field: false
+    - name: captive_login_date
+      description: wifi_networks.captive_login_date - Time this network logged in to a captive portal as unix_time
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
     - name: captive_portal
       description: wifi_networks.captive_portal - 1 if this network has a captive portal, 0 otherwise
       type: keyword
@@ -1380,162 +1368,6 @@
         - name: number
           type: long
           default_field: false
-    - name: chassis_bridge_capability_available
-      description: lldp_neighbors.chassis_bridge_capability_available - Chassis bridge capability availability
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_bridge_capability_enabled
-      description: lldp_neighbors.chassis_bridge_capability_enabled - Is chassis bridge capability enabled.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_docsis_capability_available
-      description: lldp_neighbors.chassis_docsis_capability_available - Chassis DOCSIS capability availability
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_docsis_capability_enabled
-      description: lldp_neighbors.chassis_docsis_capability_enabled - Chassis DOCSIS capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_id
-      description: lldp_neighbors.chassis_id - Neighbor chassis ID value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_id_type
-      description: lldp_neighbors.chassis_id_type - Neighbor chassis ID type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_mgmt_ips
-      description: lldp_neighbors.chassis_mgmt_ips - Comma delimited list of chassis management IPS
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_other_capability_available
-      description: lldp_neighbors.chassis_other_capability_available - Chassis other capability availability
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_other_capability_enabled
-      description: lldp_neighbors.chassis_other_capability_enabled - Chassis other capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_repeater_capability_available
-      description: lldp_neighbors.chassis_repeater_capability_available - Chassis repeater capability availability
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_repeater_capability_enabled
-      description: lldp_neighbors.chassis_repeater_capability_enabled - Chassis repeater capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_router_capability_available
-      description: lldp_neighbors.chassis_router_capability_available - Chassis router capability availability
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_router_capability_enabled
-      description: lldp_neighbors.chassis_router_capability_enabled - Chassis router capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_station_capability_available
-      description: lldp_neighbors.chassis_station_capability_available - Chassis station capability availability
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_station_capability_enabled
-      description: lldp_neighbors.chassis_station_capability_enabled - Chassis station capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_sys_description
-      description: lldp_neighbors.chassis_sys_description - Max number of CPU physical cores
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_sysname
-      description: lldp_neighbors.chassis_sysname - CPU brand string, contains vendor and model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: chassis_tel_capability_available
-      description: lldp_neighbors.chassis_tel_capability_available - Chassis telephone capability availability
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_tel_capability_enabled
-      description: lldp_neighbors.chassis_tel_capability_enabled - Chassis telephone capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: chassis_types
       description: chassis_info.chassis_types - A comma-separated list of chassis types, such as Desktop or Laptop.
       type: keyword
@@ -1544,22 +1376,6 @@
         - name: text
           type: text
           norms: false
-          default_field: false
-    - name: chassis_wlan_capability_available
-      description: lldp_neighbors.chassis_wlan_capability_available - Chassis wlan capability availability
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: chassis_wlan_capability_enabled
-      description: lldp_neighbors.chassis_wlan_capability_enabled - Chassis wlan capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
           default_field: false
     - name: check_array_finish
       description: md_devices.check_array_finish - Estimated duration of the check array activity
@@ -1627,8 +1443,6 @@
       description: |-
         authorizations.class - Label top-level key
         drivers.class - Device/driver class name
-        elf_dynamic.class - Class (32 or 64)
-        elf_info.class - Class type, 32 or 64bit
         iokit_devicetree.class - Best matching device class (most-specific category)
         iokit_registry.class - Best matching device class (most-specific category)
         usb_devices.class - USB Device class
@@ -1636,6 +1450,15 @@
         wmi_event_filters.class - The name of the class.
         wmi_filter_consumer_binding.class - The name of the class.
         wmi_script_event_consumers.class - The name of the class.
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: client_app_id
+      description: windows_update_history.client_app_id - Identifier of the client application that processed an update
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -1844,15 +1667,6 @@
           type: text
           norms: false
           default_field: false
-    - name: command_args
-      description: shortcut_files.command_args - Command args passed to lnk file.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: command_line
       description: windows_crashes.command_line - Command-line string passed to the crashed process
       type: keyword
@@ -1890,15 +1704,6 @@
       description: |-
         certificates.common_name - Certificate CommonName
         curl_certificate.common_name - Common name of company issued to
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: common_path
-      description: shortcut_files.common_path - Common system path to target file.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -2571,6 +2376,7 @@
       description: |-
         drivers.date - Driver date
         platform_info.date - Self-reported platform code update date
+        windows_update_history.date - Date and the time an update was applied
       type: keyword
       ignore_above: 1024
     - name: datetime
@@ -2710,16 +2516,16 @@
         logical_drives.description - The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'.
         lxd_images.description - Image description
         lxd_instances.description - Instance description
-        npm_packages.description - Package supplied description
+        npm_packages.description - Package-supplied description
         osquery_flags.description - Flag description
         patches.description - Fuller description of the patch.
         safari_extensions.description - Optional extension description text
         services.description - Service Description
         shared_resources.description - A textual description of the object
-        shortcut_files.description - Lnk file description.
         smbios_tables.description - Table entry description
         systemd_units.description - Unit description
         users.description - Optional user description
+        windows_update_history.description - Description of an update
         ycloud_instance_metadata.description - Description of the VM
       type: keyword
       ignore_above: 1024
@@ -2735,6 +2541,15 @@
       multi_fields:
         - name: number
           type: long
+          default_field: false
+    - name: dest_filename
+      description: es_process_file_events.dest_filename - Destination filename for the event
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
           default_field: false
     - name: dest_path
       description: process_file_events.dest_path - The canonical path associated with the event
@@ -2857,20 +2672,10 @@
           type: text
           norms: false
           default_field: false
-    - name: device_model
-      description: smart_drive_info.device_model - Device Model
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: device_name
       description: |-
         drivers.device_name - Device name
         md_devices.device_name - md device name
-        smart_drive_info.device_name - Name of block device
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -2888,9 +2693,7 @@
           norms: false
           default_field: false
     - name: device_type
-      description: |-
-        lxd_instance_devices.device_type - Device type
-        shortcut_files.device_type - Device containing the target file.
+      description: lxd_instance_devices.device_type - Device type
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -2947,7 +2750,7 @@
         extended_attributes.directory - Directory of file(s)
         file.directory - Directory of file(s)
         hash.directory - Must provide a path or directory
-        npm_packages.directory - Node module's directory where this package is located
+        npm_packages.directory - Directory where node_modules are located
         python_packages.directory - Directory where Python modules are located
         users.directory - User's home directory
       type: keyword
@@ -3007,14 +2810,6 @@
           default_field: false
     - name: disk_bytes_written
       description: processes.disk_bytes_written - Bytes written to disk
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: disk_id
-      description: smart_drive_info.disk_id - Physical slot number of device, only exists when hardware storage controller exists
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -3210,15 +3005,6 @@
           type: text
           norms: false
           default_field: false
-    - name: driver_type
-      description: smart_drive_info.driver_type - The explicit device type used to retrieve the SMART information
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: driver_version
       description: video_info.driver_version - The version of the installed driver.
       type: keyword
@@ -3305,6 +3091,7 @@
         bpf_socket_events.eid - Event ID
         disk_events.eid - Event ID
         es_process_events.eid - Event ID
+        es_process_file_events.eid - Event ID
         file_events.eid - Event ID
         hardware_events.eid - Event ID
         ntfs_journal_events.eid - Event ID
@@ -3459,7 +3246,6 @@
     - name: entry
       description: |-
         authorization_mechanisms.entry - The whole string entry
-        elf_info.entry - Entry point address
         shimcache.entry - Execution order.
       type: keyword
       ignore_above: 1024
@@ -3620,7 +3406,9 @@
           norms: false
           default_field: false
     - name: event_type
-      description: es_process_events.event_type - Type of EndpointSecurity event
+      description: |-
+        es_process_events.event_type - Type of EndpointSecurity event
+        es_process_file_events.event_type - Type of EndpointSecurity event
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -3801,7 +3589,7 @@
           norms: false
           default_field: false
     - name: external
-      description: app_schemes.external - 1 if this handler does NOT exist on OS X by default, else 0
+      description: app_schemes.external - 1 if this handler does NOT exist on macOS by default, else 0
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -3987,6 +3775,7 @@
     - name: filename
       description: |-
         device_file.filename - Name portion of file path
+        es_process_file_events.filename - The source or target filename for the event
         file.filename - Name portion of file path
         lxd_images.filename - Filename of the image file
         prefetch.filename - Executable filename.
@@ -4088,9 +3877,7 @@
           type: long
           default_field: false
     - name: firmware_version
-      description: |-
-        ibridge_info.firmware_version - The build version of the firmware
-        smart_drive_info.firmware_version - Drive firmware version
+      description: ibridge_info.firmware_version - The build version of the firmware
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -4116,7 +3903,7 @@
           type: long
           default_field: false
     - name: flags
-      description: "device_partitions.flags - \ndns_cache.flags - DNS record flags\nelf_info.flags - ELF header flags\nelf_sections.flags - Section attributes\nelf_segments.flags - Segment attributes\ninterface_details.flags - Flags (netdevice) for the device\nmounts.flags - Mounted device flags\npipes.flags - The flags indicating whether this pipe connection is a server or client end, and if the pipe for sending messages or bytes\nroutes.flags - Flags to describe route"
+      description: "device_partitions.flags - \ndns_cache.flags - DNS record flags\ninterface_details.flags - Flags (netdevice) for the device\nmounts.flags - Mounted device flags\npipes.flags - The flags indicating whether this pipe connection is a server or client end, and if the pipe for sending messages or bytes\nroutes.flags - Flags to describe route"
       type: keyword
       ignore_above: 1024
     - name: flatsize
@@ -4154,9 +3941,7 @@
           type: long
           default_field: false
     - name: form_factor
-      description: |-
-        memory_devices.form_factor - Implementation form factor for this memory device
-        smart_drive_info.form_factor - Form factor if reported
+      description: memory_devices.form_factor - Implementation form factor for this memory device
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -4309,7 +4094,9 @@
           norms: false
           default_field: false
     - name: global_seq_num
-      description: es_process_events.global_seq_num - Global sequence number
+      description: |-
+        es_process_events.global_seq_num - Global sequence number
+        es_process_file_events.global_seq_num - Global sequence number
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -4611,7 +4398,9 @@
           norms: false
           default_field: false
     - name: homepage
-      description: atom_packages.homepage - Package supplied homepage
+      description: |-
+        atom_packages.homepage - Package supplied homepage
+        npm_packages.homepage - Package supplied homepage
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -4669,7 +4458,6 @@
     - name: hostname
       description: |-
         curl_certificate.hostname - Hostname (domain[:port]) to CURL
-        shortcut_files.hostname - Optional hostname of the target file.
         system_info.hostname - Network hostname including domain
         ycloud_instance_metadata.hostname - Hostname of the VM
       type: keyword
@@ -4710,6 +4498,14 @@
           default_field: false
     - name: hours
       description: uptime.hours - Hours of uptime
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
+    - name: hresult
+      description: windows_update_history.hresult - HRESULT value that is returned from the operation on an update
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -4785,15 +4581,6 @@
         - name: number
           type: long
           default_field: false
-    - name: icon_path
-      description: shortcut_files.icon_path - Lnk file icon location.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: id
       description: |-
         disk_info.id - The unique identifier of the drive on the system.
@@ -4814,7 +4601,6 @@
         docker_info.id - Docker system ID
         docker_network_labels.id - Network ID
         docker_networks.id - Network ID
-        example.id - An index of some sort
         iokit_devicetree.id - IOKit internal registry ID
         iokit_registry.id - IOKit internal registry ID
         lxd_images.id - Image ID
@@ -4916,14 +4702,6 @@
           default_field: false
     - name: images
       description: docker_info.images - Number of images
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: in_smartctl_db
-      description: smart_drive_info.in_smartctl_db - Boolean value for if drive is recognized
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -5181,7 +4959,6 @@
         interface_addresses.interface - Interface name
         interface_details.interface - Interface name
         interface_ipv6.interface - Interface name
-        lldp_neighbors.interface - Interface name
         routes.interface - Route local interface
         wifi_status.interface - Name of the interface
         wifi_survey.interface - Name of the interface
@@ -5441,7 +5218,16 @@
           norms: false
           default_field: false
     - name: issuer
-      description: certificates.issuer - Certificate issuer distinguished name
+      description: certificates.issuer - Certificate issuer distinguished name (deprecated, use issuer2)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: issuer2
+      description: certificates.issuer2 - Certificate issuer distinguished name
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -5576,13 +5362,13 @@
         lxd_instance_devices.key - Device info param name
         mdls.key - Name of the metadata key
         plist.key - Preference top-level key
-        power_sensors.key - The SMC key on OS X
+        power_sensors.key - The SMC key on macOS
         preferences.key - Preference top-level key
         process_envs.key - Environment variable name
         registry.key - Name of the key to search for
         selinux_settings.key - Key or class name.
         smc_keys.key - 4-character key
-        temperature_sensors.key - The SMC key on OS X
+        temperature_sensors.key - The SMC key on macOS
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -5729,7 +5515,7 @@
           type: long
           default_field: false
     - name: last_connected
-      description: wifi_networks.last_connected - Last time this netword was connected to as a unix_time
+      description: wifi_networks.last_connected - Last time this network was connected to as a unix_time
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -5896,17 +5682,8 @@
       description: |-
         atom_packages.license - License for package
         chocolatey_packages.license - License under which package is launched
-        npm_packages.license - License for package
+        npm_packages.license - License under which package is launched
         python_packages.license - License under which package is launched
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: link
-      description: elf_sections.link - Link to other section
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -5974,15 +5751,6 @@
           default_field: false
     - name: local_ipv4
       description: ec2_instance_metadata.local_ipv4 - Private IPv4 address of the first interface of this instance
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: local_path
-      description: shortcut_files.local_path - Local system path to target file.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -6167,15 +5935,6 @@
           type: text
           norms: false
           default_field: false
-    - name: lu_wwn_device_id
-      description: smart_drive_info.lu_wwn_device_id - Device Identifier
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: mac
       description: |-
         arp_cache.mac - MAC address of broadcasted address
@@ -6196,14 +5955,6 @@
         - name: text
           type: text
           norms: false
-          default_field: false
-    - name: machine
-      description: elf_info.machine - Machine type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
           default_field: false
     - name: machine_name
       description: windows_crashes.machine_name - Name of the machine where the crash happened
@@ -6468,72 +6219,6 @@
           type: text
           norms: false
           default_field: false
-    - name: med_capability_capabilities
-      description: lldp_neighbors.med_capability_capabilities - Is MED capabilities enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: med_capability_inventory
-      description: lldp_neighbors.med_capability_inventory - Is MED inventory capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: med_capability_location
-      description: lldp_neighbors.med_capability_location - Is MED location capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: med_capability_mdi_pd
-      description: lldp_neighbors.med_capability_mdi_pd - Is MED MDI PD capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: med_capability_mdi_pse
-      description: lldp_neighbors.med_capability_mdi_pse - Is MED MDI PSE capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: med_capability_policy
-      description: lldp_neighbors.med_capability_policy - Is MED policy capability enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: med_device_type
-      description: lldp_neighbors.med_device_type - Chassis MED type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: med_policies
-      description: lldp_neighbors.med_policies - Comma delimited list of MED policies
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: media_name
       description: disk_events.media_name - Disk event media name string
       type: keyword
@@ -6630,6 +6315,14 @@
         - name: text
           type: text
           norms: false
+          default_field: false
+    - name: memory_available
+      description: memory_info.memory_available - The amount of physical RAM, in bytes, available for starting new applications, without swapping
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
           default_field: false
     - name: memory_device_handle
       description: memory_device_mapped_addresses.memory_device_handle - Handle of the memory device structure associated with this structure
@@ -6779,9 +6472,7 @@
           type: double
           default_field: false
     - name: mft_entry
-      description: |-
-        shellbags.mft_entry - Directory master file table entry.
-        shortcut_files.mft_entry - Target mft entry.
+      description: shellbags.mft_entry - Directory master file table entry.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -6789,9 +6480,7 @@
           type: long
           default_field: false
     - name: mft_sequence
-      description: |-
-        shellbags.mft_sequence - Directory master file table sequence.
-        shortcut_files.mft_sequence - Target mft sequence.
+      description: shellbags.mft_sequence - Directory master file table sequence.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -6853,7 +6542,7 @@
           type: long
           default_field: false
     - name: minimum_system_version
-      description: apps.minimum_system_version - Minimum version of OS X required for the app to run
+      description: apps.minimum_system_version - Minimum version of macOS required for the app to run
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -6968,15 +6657,6 @@
           type: text
           norms: false
           default_field: false
-    - name: model_family
-      description: smart_drive_info.model_family - Drive model family
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: model_id
       description: |-
         hardware_events.model_id - Hex encoded Hardware model identifier
@@ -7081,14 +6761,6 @@
         - name: number
           type: long
           default_field: false
-    - name: msize
-      description: elf_segments.msize - Segment offset in memory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: mtime
       description: |-
         device_file.mtime - Last modification time
@@ -7112,7 +6784,7 @@
           type: long
           default_field: false
     - name: name
-      description: "acpi_tables.name - ACPI table name\nad_config.name - The OS X-specific configuration name\napparmor_events.name - Process name\napparmor_profiles.name - Policy name.\napps.name - Name of the Name.app folder\napt_sources.name - Repository name\natom_packages.name - Package display name\nautoexec.name - Name of the program\nazure_instance_metadata.name - Name of the VM\nblock_devices.name - Block device name\nbrowser_plugins.name - Plugin display name\nchocolatey_packages.name - Package display name\nchrome_extensions.name - Extension display name\ncups_destinations.name - Name of the printer\ndeb_packages.name - Package name\ndisk_encryption.name - Disk name\ndisk_events.name - Disk event name\ndisk_info.name - The label of the disk object.\ndns_cache.name - DNS record name\ndocker_container_mounts.name - Optional mount name\ndocker_container_networks.name - Network name\ndocker_container_processes.name - The process path or shorthand argv[0]\ndocker_container_stats.name - Container name\ndocker_containers.name - Container name\ndocker_info.name - Name of the docker host\ndocker_networks.name - Network name\ndocker_volume_labels.name - Volume name\ndocker_volumes.name - Volume name\nelf_sections.name - Section name\nelf_segments.name - Segment type/name\nelf_symbols.name - Symbol name\netc_protocols.name - Protocol name\netc_services.name - Service name\nexample.name - Description for name column\nfan_speed_sensors.name - Fan name\nfbsd_kmods.name - Module name\nfirefox_addons.name - Addon display name\nhomebrew_packages.name - Package name\nie_extensions.name - Extension display name\niokit_devicetree.name - Device node name\niokit_registry.name - Default name of the node\nkernel_extensions.name - Extension label\nkernel_modules.name - Module name\nkernel_panics.name - Process name corresponding to crashed thread\nlaunchd.name - File name of plist (used by launchd)\nlxd_certificates.name - Name of the certificate\nlxd_instance_config.name - Instance name\nlxd_instance_devices.name - Instance name\nlxd_instances.name - Instance name\nlxd_networks.name - Name of the network\nlxd_storage_pools.name - Name of the storage pool\nmanaged_policies.name - Policy key name\nmd_personalities.name - Name of personality supported by kernel\nmemory_map.name - Region name\nnpm_packages.name - Package display name\nntdomains.name - The label by which the object is known.\nnvram.name - Variable name\nos_version.name - Distribution or product name\nosquery_events.name - Event publisher or subscriber name\nosquery_extensions.name - Extension's name\nosquery_flags.name - Flag name\nosquery_packs.name - The given name for this query pack\nosquery_registry.name - Name of the plugin item\nosquery_schedule.name - The given name for this query\npackage_install_history.name - Package display name\nphysical_disk_performance.name - Name of the physical disk\npipes.name - Name of the pipe\npkg_packages.name - Package name\npower_sensors.name - Name of power source\nprocesses.name - The process path or shorthand argv[0]\nprograms.name - Commonly used product name.\npython_packages.name - Package display name\nregistry.name - Name of the registry value entry\nrpm_packages.name - RPM package name\nsafari_extensions.name - Extension display name\nscheduled_tasks.name - Name of the scheduled task\nservices.name - Service name\nshared_folders.name - The shared name of the folder as it appears to other users\nshared_resources.name - Alias given to a path set up as a share on a computer system running Windows.\nstartup_items.name - Name of startup item\nsystem_controls.name - Full sysctl MIB name\ntemperature_sensors.name - Name of temperature source\nwindows_firewall_rules.name - Friendly name of the rule\nwindows_optional_features.name - Name of the feature\nwindows_security_products.name - Name of product\nwmi_bios_info.name - Name of the Bios setting\nwmi_cli_event_consumers.name - Unique name of a consumer.\nwmi_event_filters.name - Unique identifier of an event filter.\nwmi_script_event_consumers.name - Unique identifier for the event consumer. \nxprotect_entries.name - Description of XProtected malware\nxprotect_reports.name - Description of XProtected malware\nycloud_instance_metadata.name - Name of the VM\nyum_sources.name - Repository name"
+      description: "acpi_tables.name - ACPI table name\nad_config.name - The macOS-specific configuration name\napparmor_events.name - Process name\napparmor_profiles.name - Policy name.\napps.name - Name of the Name.app folder\napt_sources.name - Repository name\natom_packages.name - Package display name\nautoexec.name - Name of the program\nazure_instance_metadata.name - Name of the VM\nblock_devices.name - Block device name\nbrowser_plugins.name - Plugin display name\nchocolatey_packages.name - Package display name\nchrome_extensions.name - Extension display name\ncups_destinations.name - Name of the printer\ndeb_packages.name - Package name\ndisk_encryption.name - Disk name\ndisk_events.name - Disk event name\ndisk_info.name - The label of the disk object.\ndns_cache.name - DNS record name\ndocker_container_mounts.name - Optional mount name\ndocker_container_networks.name - Network name\ndocker_container_processes.name - The process path or shorthand argv[0]\ndocker_container_stats.name - Container name\ndocker_containers.name - Container name\ndocker_info.name - Name of the docker host\ndocker_networks.name - Network name\ndocker_volume_labels.name - Volume name\ndocker_volumes.name - Volume name\netc_protocols.name - Protocol name\netc_services.name - Service name\nfan_speed_sensors.name - Fan name\nfbsd_kmods.name - Module name\nfirefox_addons.name - Addon display name\nhomebrew_packages.name - Package name\nie_extensions.name - Extension display name\niokit_devicetree.name - Device node name\niokit_registry.name - Default name of the node\nkernel_extensions.name - Extension label\nkernel_modules.name - Module name\nkernel_panics.name - Process name corresponding to crashed thread\nlaunchd.name - File name of plist (used by launchd)\nlxd_certificates.name - Name of the certificate\nlxd_instance_config.name - Instance name\nlxd_instance_devices.name - Instance name\nlxd_instances.name - Instance name\nlxd_networks.name - Name of the network\nlxd_storage_pools.name - Name of the storage pool\nmanaged_policies.name - Policy key name\nmd_personalities.name - Name of personality supported by kernel\nmemory_map.name - Region name\nnpm_packages.name - Package display name\nntdomains.name - The label by which the object is known.\nnvram.name - Variable name\nos_version.name - Distribution or product name\nosquery_events.name - Event publisher or subscriber name\nosquery_extensions.name - Extension's name\nosquery_flags.name - Flag name\nosquery_packs.name - The given name for this query pack\nosquery_registry.name - Name of the plugin item\nosquery_schedule.name - The given name for this query\npackage_install_history.name - Package display name\nphysical_disk_performance.name - Name of the physical disk\npipes.name - Name of the pipe\npkg_packages.name - Package name\npower_sensors.name - Name of power source\nprocesses.name - The process path or shorthand argv[0]\nprograms.name - Commonly used product name.\npython_packages.name - Package display name\nregistry.name - Name of the registry value entry\nrpm_packages.name - RPM package name\nsafari_extensions.name - Extension display name\nscheduled_tasks.name - Name of the scheduled task\nservices.name - Service name\nshared_folders.name - The shared name of the folder as it appears to other users\nshared_resources.name - Alias given to a path set up as a share on a computer system running Windows.\nstartup_items.name - Name of startup item\nsystem_controls.name - Full sysctl MIB name\ntemperature_sensors.name - Name of temperature source\nwindows_firewall_rules.name - Friendly name of the rule\nwindows_optional_features.name - Name of the feature\nwindows_security_products.name - Name of product\nwmi_bios_info.name - Name of the Bios setting\nwmi_cli_event_consumers.name - Unique name of a consumer.\nwmi_event_filters.name - Unique identifier of an event filter.\nwmi_script_event_consumers.name - Unique identifier for the event consumer. \nxprotect_entries.name - Description of XProtected malware\nxprotect_reports.name - Description of XProtected malware\nycloud_instance_metadata.name - Name of the VM\nyum_sources.name - Repository name"
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7399,7 +7071,7 @@
           norms: false
           default_field: false
     - name: offset
-      description: "device_partitions.offset - \nelf_sections.offset - Offset of section in file\nelf_segments.offset - Segment offset in file\nelf_symbols.offset - Section table index\nprocess_memory_map.offset - Offset into mapped path"
+      description: "device_partitions.offset - \nprocess_memory_map.offset - Offset into mapped path"
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7478,6 +7150,7 @@
       description: |-
         apparmor_events.operation - Permission requested by the process
         process_file_events.operation - Operation type
+        windows_update_history.operation - Operation on an update
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7557,6 +7230,15 @@
           default_field: false
     - name: organization_unit
       description: curl_certificate.organization_unit - Organization unit issued to
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: original_filename
+      description: file.original_filename - (Executable files only) Original filename
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7693,7 +7375,7 @@
           norms: false
           default_field: false
     - name: owned
-      description: tpm_info.owned - TPM is ownned
+      description: tpm_info.owned - TPM is owned
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -7768,15 +7450,6 @@
           type: text
           norms: false
           default_field: false
-    - name: packet_device_type
-      description: smart_drive_info.packet_device_type - Packet device type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: packets
       description: iptables.packets - Number of matching packets for this rule.
       type: keyword
@@ -7826,6 +7499,7 @@
         crashes.parent - Parent PID of the crashed process
         docker_container_processes.parent - Process parent's PID
         es_process_events.parent - Parent process ID
+        es_process_file_events.parent - Parent process ID
         iokit_devicetree.parent - Parent device registry ID
         iokit_registry.parent - Parent registry ID
         process_events.parent - Process parent's PID, or -1 if cannot be determined.
@@ -7975,13 +7649,8 @@
         disk_events.path - Path of the DMG file accessed
         docker_container_fs_changes.path - FIle or directory path relative to rootfs
         docker_containers.path - Container path
-        elf_dynamic.path - Path to ELF file
-        elf_info.path - Path to ELF file
-        elf_sections.path - Path to ELF file
-        elf_segments.path - Path to ELF file
-        elf_symbols.path - Path to ELF file
         es_process_events.path - Path of executed file
-        example.path - Path of example
+        es_process_file_events.path - Path of executed file
         extended_attributes.path - Absolute file path
         file.path - Absolute file path
         firefox_addons.path - Path to plugin bundle
@@ -8002,7 +7671,7 @@
         mdfind.path - Path of the file returned from spotlight
         mdls.path - Path of the file
         mounts.path - Mounted device path
-        npm_packages.path - Module's package.json path
+        npm_packages.path - Path at which this module resides
         ntfs_acl_permissions.path - Path to the file or directory.
         ntfs_journal_events.path - Path
         office_mru.path - File path
@@ -8029,7 +7698,6 @@
         shared_resources.path - Local path of the Windows share.
         shellbags.path - Directory name.
         shimcache.path - This is the path to the executed file.
-        shortcut_files.path - Directory name.
         signature.path - Must provide a path or directory
         socket_events.path - Path of executed file
         startup_items.path - Path of startup item
@@ -8232,6 +7900,14 @@
           type: text
           norms: false
           default_field: false
+    - name: personal_hotspot
+      description: wifi_networks.personal_hotspot - 1 if this network is a personal hotspot, 0 otherwise
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
     - name: pgroup
       description: |-
         docker_container_processes.pgroup - Process group
@@ -8277,6 +7953,7 @@
         docker_container_processes.pid - Process ID
         docker_containers.pid - Identifier of the initial process
         es_process_events.pid - Process (or thread) ID
+        es_process_file_events.pid - Process (or thread) ID
         last.pid - Process (or thread) ID
         listening_ports.pid - Process (or thread) ID
         logged_in_users.pid - Process (or thread) ID
@@ -8343,11 +8020,13 @@
           type: long
           default_field: false
     - name: pids
-      description: |-
-        docker_container_stats.pids - Number of processes
-        lldp_neighbors.pids - Comma delimited list of PIDs
+      description: docker_container_stats.pids - Number of processes
       type: keyword
       ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
+          default_field: false
     - name: placement_group_id
       description: azure_instance_metadata.placement_group_id - Placement group for the VM scale set
       type: keyword
@@ -8446,14 +8125,6 @@
           type: text
           norms: false
           default_field: false
-    - name: points
-      description: example.points - This is a signed SQLite int column
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: policies
       description: curl_certificate.policies - Certificate Policies
       type: keyword
@@ -8481,6 +8152,33 @@
           type: text
           norms: false
           default_field: false
+    - name: policy_content
+      description: password_policy.policy_content - Policy content
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: policy_description
+      description: password_policy.policy_description - Policy description
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: policy_identifier
+      description: password_policy.policy_identifier - Policy Identifier
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: policy_mappings
       description: curl_certificate.policy_mappings - Policy Mappings
       type: keyword
@@ -8501,179 +8199,6 @@
         - name: number
           type: long
           default_field: false
-    - name: port_aggregation_id
-      description: lldp_neighbors.port_aggregation_id - Port aggregation ID
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_autoneg_1000baset_fd_enabled
-      description: lldp_neighbors.port_autoneg_1000baset_fd_enabled - 1000Base-T FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_1000baset_hd_enabled
-      description: lldp_neighbors.port_autoneg_1000baset_hd_enabled - 1000Base-T HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_1000basex_fd_enabled
-      description: lldp_neighbors.port_autoneg_1000basex_fd_enabled - 1000Base-X FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_1000basex_hd_enabled
-      description: lldp_neighbors.port_autoneg_1000basex_hd_enabled - 1000Base-X HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_100baset2_fd_enabled
-      description: lldp_neighbors.port_autoneg_100baset2_fd_enabled - 100Base-T2 FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_100baset2_hd_enabled
-      description: lldp_neighbors.port_autoneg_100baset2_hd_enabled - 100Base-T2 HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_100baset4_fd_enabled
-      description: lldp_neighbors.port_autoneg_100baset4_fd_enabled - 100Base-T4 FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_100baset4_hd_enabled
-      description: lldp_neighbors.port_autoneg_100baset4_hd_enabled - 100Base-T4 HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_100basetx_fd_enabled
-      description: lldp_neighbors.port_autoneg_100basetx_fd_enabled - 100Base-TX FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_100basetx_hd_enabled
-      description: lldp_neighbors.port_autoneg_100basetx_hd_enabled - 100Base-TX HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_10baset_fd_enabled
-      description: lldp_neighbors.port_autoneg_10baset_fd_enabled - 10Base-T FD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_10baset_hd_enabled
-      description: lldp_neighbors.port_autoneg_10baset_hd_enabled - 10Base-T HD auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_enabled
-      description: lldp_neighbors.port_autoneg_enabled - Is auto negotiation enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_autoneg_supported
-      description: lldp_neighbors.port_autoneg_supported - Auto negotiation supported
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_description
-      description: lldp_neighbors.port_description - Port description
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_id
-      description: lldp_neighbors.port_id - Port ID value
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_id_type
-      description: lldp_neighbors.port_id_type - Port ID type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_mau_type
-      description: lldp_neighbors.port_mau_type - MAU type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: port_mfs
-      description: lldp_neighbors.port_mfs - Port max frame size
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: port_ttl
-      description: lldp_neighbors.port_ttl - Age of neighbor port
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: possibly_hidden
       description: wifi_networks.possibly_hidden - 1 if network is possibly a hidden network, 0 otherwise
       type: keyword
@@ -8682,119 +8207,6 @@
         - name: number
           type: long
           default_field: false
-    - name: power_8023at_enabled
-      description: lldp_neighbors.power_8023at_enabled - Is 802.3at enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: power_8023at_power_allocated
-      description: lldp_neighbors.power_8023at_power_allocated - 802.3at power allocated
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_priority
-      description: lldp_neighbors.power_8023at_power_priority - 802.3at power priority
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_requested
-      description: lldp_neighbors.power_8023at_power_requested - 802.3at power requested
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_source
-      description: lldp_neighbors.power_8023at_power_source - 802.3at power source
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_8023at_power_type
-      description: lldp_neighbors.power_8023at_power_type - 802.3at power type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_class
-      description: lldp_neighbors.power_class - Power class
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_device_type
-      description: lldp_neighbors.power_device_type - Dot3 power device type
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_mdi_enabled
-      description: lldp_neighbors.power_mdi_enabled - Is MDI power enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: power_mdi_supported
-      description: lldp_neighbors.power_mdi_supported - MDI power supported
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: power_mode
-      description: smart_drive_info.power_mode - Device power mode
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: power_paircontrol_enabled
-      description: lldp_neighbors.power_paircontrol_enabled - Is power pair control enabled
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: power_pairs
-      description: lldp_neighbors.power_pairs - Dot3 power pairs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: ppid
       description: process_file_events.ppid - Parent process ID
       type: keyword
@@ -8802,24 +8214,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: ppvids_enabled
-      description: lldp_neighbors.ppvids_enabled - Comma delimited list of enabled PPVIDs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ppvids_supported
-      description: lldp_neighbors.ppvids_supported - Comma delimited list of supported PPVIDs
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: pre_cpu_kernelmode_usage
       description: docker_container_stats.pre_cpu_kernelmode_usage - Last read CPU kernel mode usage
@@ -9085,7 +8479,7 @@
           norms: false
           default_field: false
     - name: protected
-      description: app_schemes.protected - 1 if this handler is protected (reserved) by OS X, else 0
+      description: app_schemes.protected - 1 if this handler is protected (reserved) by macOS, else 0
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -9168,14 +8562,6 @@
         - name: number
           type: long
           default_field: false
-    - name: psize
-      description: elf_segments.psize - Size of segment in file
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: public
       description: lxd_images.public - Whether image is public (1) or not (0)
       type: keyword
@@ -9211,15 +8597,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: pvid
-      description: lldp_neighbors.pvid - Primary VLAN id
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: query
       description: |-
@@ -9306,15 +8683,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: read_device_identity_failure
-      description: smart_drive_info.read_device_identity_failure - Error string for device id read, if any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: readonly
       description: nfs_shares.readonly - 1 if the share is exported readonly else 0
@@ -9489,7 +8857,6 @@
           default_field: false
     - name: relative_path
       description: |-
-        shortcut_files.relative_path - Relative path to target file from lnk file.
         wmi_cli_event_consumers.relative_path - Relative path to the class or instance.
         wmi_event_filters.relative_path - Relative path to the class or instance.
         wmi_filter_consumer_binding.relative_path - Relative path to the class or instance.
@@ -9714,6 +9081,15 @@
           type: text
           norms: false
           default_field: false
+    - name: result_code
+      description: windows_update_history.result_code - Result of an operation on an update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: resync_finish
       description: md_devices.resync_finish - Estimated duration of resync activity
       type: keyword
@@ -9763,14 +9139,6 @@
           type: text
           norms: false
           default_field: false
-    - name: rid
-      description: lldp_neighbors.rid - Neighbor chassis index
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: roaming
       description: wifi_networks.roaming - 1 if roaming is supported, 0 otherwise
       type: keyword
@@ -9817,15 +9185,6 @@
           default_field: false
     - name: root_volume_uuid
       description: time_machine_destinations.root_volume_uuid - Root UUID of backup volume
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: rotation_rate
-      description: smart_drive_info.rotation_rate - Drive RPM
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -9900,15 +9259,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: sata_version
-      description: smart_drive_info.sata_version - SATA version, if any
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: scheme
       description: app_schemes.scheme - Name of the scheme/protocol
@@ -10057,15 +9407,6 @@
           type: text
           norms: false
           default_field: false
-    - name: sector_sizes
-      description: smart_drive_info.sector_sizes - Bytes of drive sector sizes
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: secure_boot
       description: secureboot.secure_boot - Whether secure boot is enabled
       type: keyword
@@ -10164,7 +9505,9 @@
           norms: false
           default_field: false
     - name: seq_num
-      description: es_process_events.seq_num - Per event sequence number
+      description: |-
+        es_process_events.seq_num - Per event sequence number
+        es_process_file_events.seq_num - Per event sequence number
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -10191,7 +9534,6 @@
         battery.serial_number - The battery's unique serial number
         curl_certificate.serial_number - Certificate serial number
         memory_devices.serial_number - Serial number of memory device
-        smart_drive_info.serial_number - Device serial number
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -10228,6 +9570,15 @@
           type: text
           norms: false
           default_field: false
+    - name: server_selection
+      description: windows_update_history.server_selection - Value that indicates which server provided an update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: server_version
       description: docker_info.server_version - Server version
       type: keyword
@@ -10256,6 +9607,15 @@
       multi_fields:
         - name: number
           type: long
+          default_field: false
+    - name: service_id
+      description: windows_update_history.service_id - Service identifier of an update service that is not a Windows update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
           default_field: false
     - name: service_key
       description: drivers.service_key - Driver service registry key
@@ -10400,15 +9760,6 @@
           default_field: false
     - name: share
       description: nfs_shares.share - Filesystem path to the share
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: share_name
-      description: shortcut_files.share_name - Share name of the target file.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -10573,9 +9924,6 @@
         device_file.size - Size of file in bytes
         disk_events.size - Size of partition in bytes
         docker_image_history.size - Size of instruction in bytes
-        elf_sections.size - Size of section
-        elf_symbols.size - Size of object
-        example.size - This is a signed SQLite bigint column
         fbsd_kmods.size - Size of module content
         file.size - Size of file in bytes
         file_events.size - Size of file in bytes
@@ -10623,24 +9971,6 @@
         portage_packages.slot - The slot used by package
       type: keyword
       ignore_above: 1024
-    - name: smart_enabled
-      description: smart_drive_info.smart_enabled - SMART enabled status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: smart_supported
-      description: smart_drive_info.smart_supported - SMART support status
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: smbios_tag
       description: chassis_info.smbios_tag - The assigned asset tag number of the chassis.
       type: keyword
@@ -10791,15 +10121,6 @@
           default_field: false
     - name: src_port
       description: iptables.src_port - Protocol source port(s).
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: ssdeep
-      description: hash.ssdeep - ssdeep hash of provided filesystem data
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -11094,7 +10415,16 @@
           norms: false
           default_field: false
     - name: subject
-      description: certificates.subject - Certificate distinguished name
+      description: certificates.subject - Certificate distinguished name (deprecated, use subject2)
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: subject2
+      description: certificates.subject2 - Certificate distinguished name
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -11282,6 +10612,15 @@
           type: text
           norms: false
           default_field: false
+    - name: support_url
+      description: windows_update_history.support_url - Hyperlink to the language-specific support information for an update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
     - name: swap_cached
       description: memory_info.swap_cached - The amount of swap, in bytes, used as cache memory
       type: keyword
@@ -11386,8 +10725,8 @@
         - name: number
           type: long
           default_field: false
-    - name: table
-      description: elf_symbols.table - Table name containing symbol
+    - name: tag
+      description: syslog_events.tag - The syslog tag
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -11395,12 +10734,6 @@
           type: text
           norms: false
           default_field: false
-    - name: tag
-      description: |-
-        elf_dynamic.tag - Tag ID
-        syslog_events.tag - The syslog tag
-      type: keyword
-      ignore_above: 1024
     - name: tags
       description: |-
         docker_image_history.tags - Comma-separated list of tags
@@ -11428,30 +10761,6 @@
         iptables.target - Target that applies for this rule.
       type: keyword
       ignore_above: 1024
-    - name: target_accessed
-      description: shortcut_files.target_accessed - Target Accessed time.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: target_created
-      description: shortcut_files.target_created - Target Created time.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
-    - name: target_modified
-      description: shortcut_files.target_modified - Target Modified time.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: target_name
       description: prometheus_metrics.target_name - Address of prometheus target
       type: keyword
@@ -11464,7 +10773,6 @@
     - name: target_path
       description: |-
         file_events.target_path - The path associated with the event
-        shortcut_files.target_path - Target file path
         yara_events.target_path - The path scanned
       type: keyword
       ignore_above: 1024
@@ -11472,14 +10780,6 @@
         - name: text
           type: text
           norms: false
-          default_field: false
-    - name: target_size
-      description: shortcut_files.target_size - Size of target file.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
           default_field: false
     - name: task
       description: |-
@@ -11575,6 +10875,7 @@
         disk_events.time - Time of appearance/disappearance in UNIX time
         docker_container_processes.time - Cumulative CPU time. [DD-]HH:MM:SS format
         es_process_events.time - Time of execution in UNIX time
+        es_process_file_events.time - Time of execution in UNIX time
         file_events.time - Time of file event
         hardware_events.time - Time of hardware event
         kernel_panics.time - Formatted time of the event
@@ -11654,7 +10955,9 @@
           norms: false
           default_field: false
     - name: title
-      description: cups_jobs.title - Title of the printed job
+      description: |-
+        cups_jobs.title - Title of the printed job
+        windows_update_history.title - Title of an update
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -11698,17 +11001,16 @@
         - name: number
           type: long
           default_field: false
-    - name: transmit_rate
-      description: wifi_status.transmit_rate - The current transmit rate
+    - name: translated
+      description: processes.translated - Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0, error=-1.
       type: keyword
       ignore_above: 1024
       multi_fields:
-        - name: text
-          type: text
-          norms: false
+        - name: number
+          type: long
           default_field: false
-    - name: transport_type
-      description: smart_drive_info.transport_type - Drive transport type
+    - name: transmit_rate
+      description: wifi_status.transmit_rate - The current transmit rate
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -11753,7 +11055,7 @@
           type: long
           default_field: false
     - name: type
-      description: "apparmor_events.type - Event type\nappcompat_shims.type - Type of the SDB database.\nblock_devices.type - Block device type string\nbpf_socket_events.type - The socket type\ncrashes.type - Type of crash log\ndevice_file.type - File status\ndevice_firmware.type - Type of device\ndevice_partitions.type - \ndisk_encryption.type - Description of cipher type and mode if available\ndisk_info.type - The interface type of the disk.\ndns_cache.type - DNS record type\ndns_resolvers.type - Address type: sortlist, nameserver, search\ndocker_container_mounts.type - Type of mount (bind, volume)\ndocker_container_ports.type - Protocol (tcp, udp)\ndocker_volumes.type - Volume type\nelf_info.type - Offset of section in file\nelf_sections.type - Section type\nelf_symbols.type - Symbol type\nfile.type - File status\nfirefox_addons.type - Extension, addon, webapp\nhardware_events.type - Type of hardware and hardware event\ninterface_addresses.type - Type of address. One of dhcp, manual, auto, other, unknown\ninterface_details.type - Interface type (includes virtual)\nkeychain_items.type - Keychain item type (class)\nlast.type - Entry type, according to ut_type types (utmp.h)\nlogged_in_users.type - Login type\nlogical_drives.type - Deprecated (always 'Unknown').\nlxd_certificates.type - Type of the certificate\nlxd_networks.type - Type of network\nmounts.type - Mounted device type\nntfs_acl_permissions.type - Type of access mode for the access control entry.\nnvram.type - Data type (CFData, CFString, etc)\nosquery_events.type - Either publisher or subscriber\nosquery_extensions.type - SDK extension type: extension or module\nosquery_flags.type - Flag type\nprocess_open_pipes.type - Pipe Type: named vs unnamed/anonymous\nregistry.type - Type of the registry value, or 'subkey' if item is a subkey\nroutes.type - Type of route\nselinux_events.type - Event type\nshared_resources.type - Type of resource being shared. Types include: disk drives, print queues, interprocess communications (IPC), and general devices.\nsmbios_tables.type - Table entry type\nsmc_keys.type - SMC-reported type literal type\nstartup_items.type - Startup Item or Login Item\nsystem_controls.type - Data type\nulimit_info.type - System resource to be limited\nuser_events.type - The file description for the process socket\nusers.type - Whether the account is roaming (domain), local, or a system profile\nwindows_crashes.type - Type of crash log\nwindows_security_products.type - Type of security product\nxprotect_meta.type - Either plugin or extension"
+      description: "apparmor_events.type - Event type\nappcompat_shims.type - Type of the SDB database.\nblock_devices.type - Block device type string\nbpf_socket_events.type - The socket type\ncrashes.type - Type of crash log\ndevice_file.type - File status\ndevice_firmware.type - Type of device\ndevice_partitions.type - \ndisk_encryption.type - Description of cipher type and mode if available\ndisk_info.type - The interface type of the disk.\ndns_cache.type - DNS record type\ndns_resolvers.type - Address type: sortlist, nameserver, search\ndocker_container_mounts.type - Type of mount (bind, volume)\ndocker_container_ports.type - Protocol (tcp, udp)\ndocker_volumes.type - Volume type\nfile.type - File status\nfirefox_addons.type - Extension, addon, webapp\nhardware_events.type - Type of hardware and hardware event\ninterface_addresses.type - Type of address. One of dhcp, manual, auto, other, unknown\ninterface_details.type - Interface type (includes virtual)\nkeychain_items.type - Keychain item type (class)\nlast.type - Entry type, according to ut_type types (utmp.h)\nlogged_in_users.type - Login type\nlogical_drives.type - Deprecated (always 'Unknown').\nlxd_certificates.type - Type of the certificate\nlxd_networks.type - Type of network\nmounts.type - Mounted device type\nntfs_acl_permissions.type - Type of access mode for the access control entry.\nnvram.type - Data type (CFData, CFString, etc)\nosquery_events.type - Either publisher or subscriber\nosquery_extensions.type - SDK extension type: extension or module\nosquery_flags.type - Flag type\nprocess_open_pipes.type - Pipe Type: named vs unnamed/anonymous\nregistry.type - Type of the registry value, or 'subkey' if item is a subkey\nroutes.type - Type of route\nselinux_events.type - Event type\nshared_resources.type - Type of resource being shared. Types include: disk drives, print queues, interprocess communications (IPC), and general devices.\nsmbios_tables.type - Table entry type\nsmc_keys.type - SMC-reported type literal type\nstartup_items.type - Startup Item or Login Item\nsystem_controls.type - Data type\nulimit_info.type - System resource to be limited\nuser_events.type - The file description for the process socket\nusers.type - Whether the account is roaming (domain), local, or a system profile\nwindows_crashes.type - Type of crash log\nwindows_security_products.type - Type of security product\nxprotect_meta.type - Either plugin or extension"
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -11762,7 +11064,9 @@
           norms: false
           default_field: false
     - name: type_name
-      description: last.type_name - Entry type name, according to ut_type types (utmp.h)
+      description: |-
+        last.type_name - Entry type name, according to ut_type types (utmp.h)
+        shared_resources.type_name - Human readable value for the 'type' column
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -11792,6 +11096,7 @@
         known_hosts.uid - The local user that owns the known_hosts file
         launchd_overrides.uid - User ID applied to the override, 0 applies to all
         package_bom.uid - Expected user of file or directory
+        password_policy.uid - User ID for the policy if available
         process_events.uid - User ID at process start
         process_file_events.uid - The uid of the process performing the action
         processes.uid - Unsigned user ID
@@ -11872,6 +11177,23 @@
         - name: text
           type: text
           norms: false
+          default_field: false
+    - name: update_id
+      description: windows_update_history.update_id - Revision-independent identifier of an update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+    - name: update_revision
+      description: windows_update_history.update_revision - Revision number of an update
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: number
+          type: long
           default_field: false
     - name: update_source_alias
       description: lxd_images.update_source_alias - Alias of image at update source server
@@ -12066,15 +11388,6 @@
           type: text
           norms: false
           default_field: false
-    - name: user_capacity
-      description: smart_drive_info.user_capacity - Bytes of drive capacity
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
     - name: user_namespace
       description: |-
         docker_containers.user_namespace - User namespace
@@ -12162,16 +11475,6 @@
           type: text
           norms: false
           default_field: false
-    - name: vaddr
-      description: |-
-        elf_sections.vaddr - Section virtual address in memory
-        elf_segments.vaddr - Segment virtual address in memory
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: number
-          type: long
-          default_field: false
     - name: valid_from
       description: curl_certificate.valid_from - Period of validity start date
       type: keyword
@@ -12203,7 +11506,6 @@
         docker_network_labels.value - Optional label value
         docker_volume_labels.value - Optional label value
         ec2_instance_tags.value - Tag value
-        elf_dynamic.value - Tag value
         extended_attributes.value - The parsed information from the attribute
         launchd_overrides.value - Overridden value
         lxd_instance_config.value - Configuration parameter value
@@ -12309,8 +11611,8 @@
         device_firmware.version - Firmware version
         docker_version.version - Docker version
         drivers.version - Driver version
-        elf_info.version - Object file version
         es_process_events.version - Version of EndpointSecurity event
+        es_process_file_events.version - Version of EndpointSecurity event
         firefox_addons.version - Addon-supplied version string
         gatekeeper.version - Version of Gatekeeper's gke.bundle
         homebrew_packages.version - Current 'linked' version
@@ -12319,7 +11621,7 @@
         intel_me_info.version - Intel ME version
         kernel_extensions.version - Extension version
         kernel_info.version - Kernel version
-        npm_packages.version - Package supplied version
+        npm_packages.version - Package-supplied version
         office_mru.version - Office application version number
         os_version.version - Pretty, suitable for presentation, OS version
         osquery_extensions.version - Extension's version
@@ -12373,15 +11675,6 @@
           default_field: false
     - name: visible_alarm
       description: chassis_info.visible_alarm - If TRUE, the frame is equipped with a visual alarm.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-    - name: vlans
-      description: lldp_neighbors.vlans - Comma delimited list of vlan ids
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -12447,7 +11740,6 @@
       description: |-
         file.volume_serial - Volume serial number
         prefetch.volume_serial - Volume serial number.
-        shortcut_files.volume_serial - Volume serial number.
       type: keyword
       ignore_above: 1024
       multi_fields:
@@ -12487,14 +11779,13 @@
         - name: number
           type: long
           default_field: false
-    - name: warnings
-      description: smart_drive_info.warnings - Warning messages from SMART controller
+    - name: was_captive_network
+      description: wifi_networks.was_captive_network - 1 if this network was previously a captive network, 0 otherwise
       type: keyword
       ignore_above: 1024
       multi_fields:
-        - name: text
-          type: text
-          norms: false
+        - name: number
+          type: long
           default_field: false
     - name: watch_paths
       description: launchd.watch_paths - Key that launches daemon or agent if path is modified
@@ -12581,15 +11872,6 @@
       multi_fields:
         - name: number
           type: long
-          default_field: false
-    - name: working_path
-      description: shortcut_files.working_path - Target file directory.
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
           default_field: false
     - name: world
       description: portage_packages.world - If package is in the world file

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.3.2
+version: 1.4.0
 license: basic
 description: Deploy osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
@@ -11,7 +11,7 @@ categories:
   - os_system
   - config_management
 conditions:
-  kibana.version: ^8.3.0
+  kibana.version: ^8.4.0
 icons:
   - src: /img/logo_osquery.svg
     title: logo osquery


### PR DESCRIPTION
## What does this PR do?

Upgrade osquery fields to match osquery 5.4.0 schema changes

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/security-team/issues/4191
