### PR TITLE
synthetics - fix private locations name for icmp and tcp monitors

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.1"
+  changes:
+    - description: Adjusts location name for tcp and icmp monitors
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2744
 - version: "0.10.0"
   changes:
     - description: Segment ILM policies by dataset

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -21,7 +21,7 @@ tags: {{tags}}
 processors:
   - add_observer_metadata:
       geo: 
-        name: Fleet managed
+        name: {{location_name}}
   - add_fields:
       target: ''
       fields:

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -48,7 +48,7 @@ ssl.supported_protocols: {{ssl.supported_protocols}}
 processors:
   - add_observer_metadata:
       geo: 
-        name: Fleet managed
+        name: {{location_name}}
   - add_fields:
       target: ''
       fields:

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.10.0
+version: 0.10.1
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## What does this PR do?

Adds `observer.geo.name` when defined, such as for private location monitors. 