### PR TITLE
system/security: fix handling of events 4674, 4738 and 4742

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Fix handling of security events 4674, 4738 and 3742.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3930
 - version: "1.19.0"
   changes:
     - description: Add ignore_older to remaining logs

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-4674.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-4674.json
@@ -67,6 +67,59 @@
             "host": {
                 "name": "DC01.contoso.local"
             }
+        },
+        {
+            "@timestamp": "2021-11-11T17:14:53.001Z",
+            "event": {
+                "action": "Sensitive Privilege Use",
+                "code": "4674",
+                "kind": "event",
+                "outcome": "success",
+                "provider": "Microsoft-Windows-Security-Auditing"
+            },
+            "host": {
+                "name": "DC_TEST2k12.TEST.SAAS"
+            },
+            "log": {
+                "level": "information"
+            },
+            "message": "An operation was attempted on a privileged object.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-21-1717121054-434620538-60925301-2794\n\tAccount Name:\t\tat_adm\n\tAccount Domain:\t\tTEST\n\tLogon ID:\t\t0x5E2887\n\nObject:\n\tObject Server:\tSecurity\n\tObject Type:\tFile\n\tObject Name:\tC:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\PLA\\Server Manager Performance Monitor\n\tObject Handle:\t0x1684\n\nProcess Information:\n\tProcess ID:\t0x3e4\n\tProcess Name:\tC:\\Windows\\System32\\svchost.exe\n\nRequested Operation:\n\tDesired Access:\tREAD_CONTROL\n\t\t\t\tACCESS_SYS_SEC\n\n\tPrivileges:\t\tSeSecurityPrivilege",
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "DC_TEST2k12.TEST.SAAS",
+                "event_data": {
+                    "AccessMask": "%%1538\n\t\t\t\t%%1542\n\t\t\t\t",
+                    "HandleId": "0x1684",
+                    "ObjectName": "C:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\PLA\\Server Manager Performance Monitor",
+                    "ObjectServer": "Security",
+                    "ObjectType": "File",
+                    "PrivilegeList": "SeSecurityPrivilege",
+                    "ProcessId": "0x3e4",
+                    "ProcessName": "C:\\Windows\\System32\\svchost.exe",
+                    "SubjectDomainName": "TEST",
+                    "SubjectLogonId": "0x5e2887",
+                    "SubjectUserName": "at_adm",
+                    "SubjectUserSid": "S-1-5-21-1717121054-434620538-60925301-2794"
+                },
+                "event_id": "4674",
+                "keywords": [
+                    "Audit Success"
+                ],
+                "level": "information",
+                "opcode": "Info",
+                "outcome": "success",
+                "process": {
+                    "pid": 604,
+                    "thread": {
+                        "id": 612
+                    }
+                },
+                "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": 18232147,
+                "task": "Sensitive Privilege Use",
+                "time_created": "2022-08-01T08:53:50.3336583Z"
+            }
         }
     ]
 }

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-4674.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-4674.json-expected.json
@@ -95,6 +95,90 @@
                 "record_id": "1099680",
                 "time_created": "2015-10-09T00:22:36.237Z"
             }
+        },
+        {
+            "@timestamp": "2022-08-01T08:53:50.333Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "privileged-operation",
+                "category": [
+                    "iam"
+                ],
+                "code": "4674",
+                "kind": "event",
+                "outcome": "success",
+                "provider": "Microsoft-Windows-Security-Auditing",
+                "type": [
+                    "admin"
+                ]
+            },
+            "host": {
+                "name": "DC_TEST2k12.TEST.SAAS"
+            },
+            "log": {
+                "level": "information"
+            },
+            "message": "An operation was attempted on a privileged object.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-21-1717121054-434620538-60925301-2794\n\tAccount Name:\t\tat_adm\n\tAccount Domain:\t\tTEST\n\tLogon ID:\t\t0x5E2887\n\nObject:\n\tObject Server:\tSecurity\n\tObject Type:\tFile\n\tObject Name:\tC:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\PLA\\Server Manager Performance Monitor\n\tObject Handle:\t0x1684\n\nProcess Information:\n\tProcess ID:\t0x3e4\n\tProcess Name:\tC:\\Windows\\System32\\svchost.exe\n\nRequested Operation:\n\tDesired Access:\tREAD_CONTROL\n\t\t\t\tACCESS_SYS_SEC\n\n\tPrivileges:\t\tSeSecurityPrivilege",
+            "process": {
+                "executable": "C:\\Windows\\System32\\svchost.exe",
+                "name": "svchost.exe",
+                "pid": 996
+            },
+            "related": {
+                "user": [
+                    "at_adm"
+                ]
+            },
+            "user": {
+                "domain": "TEST",
+                "id": "S-1-5-21-1717121054-434620538-60925301-2794",
+                "name": "at_adm"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "DC_TEST2k12.TEST.SAAS",
+                "event_data": {
+                    "AccessMask": "%%1538\n\t\t\t\t%%1542\n\t\t\t\t",
+                    "AccessMaskDescription": [
+                        "Delete Child",
+                        "List Contents"
+                    ],
+                    "HandleId": "0x1684",
+                    "ObjectName": "C:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\PLA\\Server Manager Performance Monitor",
+                    "ObjectServer": "Security",
+                    "ObjectType": "File",
+                    "PrivilegeList": [
+                        "SeSecurityPrivilege"
+                    ],
+                    "SubjectDomainName": "TEST",
+                    "SubjectLogonId": "0x5e2887",
+                    "SubjectUserName": "at_adm",
+                    "SubjectUserSid": "S-1-5-21-1717121054-434620538-60925301-2794"
+                },
+                "event_id": "4674",
+                "keywords": [
+                    "Audit Success"
+                ],
+                "level": "information",
+                "logon": {
+                    "id": "0x5e2887"
+                },
+                "opcode": "Info",
+                "outcome": "success",
+                "process": {
+                    "pid": 604,
+                    "thread": {
+                        "id": 612
+                    }
+                },
+                "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "18232147",
+                "task": "Sensitive Privilege Use",
+                "time_created": "2022-08-01T08:53:50.3336583Z"
+            }
         }
     ]
 }

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2016-4738-account-changed.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2016-4738-account-changed.json-expected.json
@@ -83,9 +83,7 @@
                     "TargetDomainName": "WIN-41OB2LO92CR",
                     "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1005",
                     "TargetUserName": "elastictest1",
-                    "UserAccountControl": [
-                        "-"
-                    ],
+                    "UserAccountControl": "-",
                     "UserParameters": "%%1793",
                     "UserPrincipalName": "-",
                     "UserWorkstations": "%%1793"

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -819,7 +819,10 @@ processors:
         "0x01000000": TRUSTED_TO_AUTH_FOR_DELEGATION
         "0x04000000": PARTIAL_SECRETS_ACCOUNT
       source: |-
-        if (ctx?.winlog?.event_data?.NewUacValue == null) {
+        if (ctx.winlog?.event_data == null) {
+          return;
+        }
+        if (ctx.winlog.event_data.NewUacValue == null || ctx.winlog.event_data.NewUacValue == "-") {
           return;
         }
         Long newUacValue = Long.decode(ctx.winlog.event_data.NewUacValue);
@@ -834,7 +837,7 @@ processors:
           return;
         }
         ctx.winlog.event_data.put("NewUACList", uacResult);
-        if (ctx?.winlog?.event_data?.UserAccountControl == null) {
+        if (ctx.winlog.event_data.UserAccountControl == null || ctx.winlog.event_data.UserAccountControl == "-") {
           return;
         }
         ArrayList uac_array = new ArrayList();
@@ -2094,6 +2097,21 @@ processors:
           "0x40000000": ADS_RIGHT_GENERIC_WRITE
           "0x80000000": ADS_RIGHT_GENERIC_READ
       source: |-
+        def split(String s) {
+          def f = new ArrayList();
+          int last = 0;
+          for (; last < s.length() && Character.isWhitespace(s.charAt(last)); last++) {}
+          for (def i = last; i < s.length(); i++) {
+            if (!Character.isWhitespace(s.charAt(i))) {
+              continue;
+            }
+            f.add(s.substring(last, i));
+            for (; i < s.length() && Character.isWhitespace(s.charAt(i)); i++) {}
+            last = i;
+          }
+          f.add(s.substring(last));
+          return f;
+        }
         if (ctx?.winlog?.event_data?.FailureReason != null) {
           def code = ctx.winlog.event_data.FailureReason.replace("%%","");
           if (params.descriptions.containsKey(code)) {
@@ -2134,17 +2152,36 @@ processors:
         }
         if (ctx?.winlog?.event_data?.AccessMask != null) {
           ArrayList results = new ArrayList();
-          Long accessMask = Long.decode(ctx.winlog.event_data.AccessMask);
-          for (entry in params.AccessMaskDescriptions.entrySet()) {
-            Long accessFlag = Long.decode(entry.getKey());
-            if ((accessMask.longValue() & accessFlag.longValue()) == accessFlag.longValue()) {
-              results.add(entry.getValue());
+          for (elem in split(ctx.winlog.event_data.AccessMask)) {
+            def mask = elem.replace("%%","").trim();
+            if (mask == "") {
+              continue;
+            }
+            Long accessMask = Long.decode(mask);
+            for (entry in params.AccessMaskDescriptions.entrySet()) {
+              Long accessFlag = Long.decode(entry.getKey());
+              if ((accessMask.longValue() & accessFlag.longValue()) == accessFlag.longValue()) {
+                results.add(entry.getValue());
+              }
             }
           }
           if (results.length > 0) {
-            ctx.winlog.event_data.put("AccessMaskDescription", results);
+            ctx.winlog.event_data.put("_AccessMaskDescription", results);
           }
         }
+  - foreach:
+      field: winlog.event_data._AccessMaskDescription
+      processor:
+        append:
+          field: winlog.event_data.AccessMaskDescription
+          value: '{{{_ingest._value}}}'
+          allow_duplicates: false
+          ignore_failure: true
+      ignore_failure: true
+      if: ctx.winlog?.event_data?._AccessMaskDescription != null && ctx.winlog.event_data._AccessMaskDescription instanceof List
+  - remove:
+      field: winlog.event_data._AccessMaskDescription
+      ignore_failure: true
   - script:
       lang: painless
       ignore_failure: false

--- a/packages/system/data_stream/security/fields/winlog.yml
+++ b/packages/system/data_stream/security/fields/winlog.yml
@@ -111,6 +111,8 @@
           type: keyword
         - name: Company
           type: keyword
+        - name: ComputerAccountChange
+          type: keyword
         - name: CorruptionActionState
           type: keyword
         - name: CrashOnAuditFailValue
@@ -132,6 +134,8 @@
         - name: DeviceVersionMinor
           type: keyword
         - name: DisplayName
+          type: keyword
+        - name: DnsHostName
           type: keyword
         - name: DomainBehaviorVersion
           type: keyword
@@ -358,6 +362,8 @@
         - name: ServiceFileName
           type: keyword
         - name: ServiceName
+          type: keyword
+        - name: ServicePrincipalNames
           type: keyword
         - name: ServiceSid
           type: keyword

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -686,6 +686,7 @@ An example event for `security` looks as following:
 | winlog.event_data.ClientName |  | keyword |
 | winlog.event_data.CommandLine |  | keyword |
 | winlog.event_data.Company |  | keyword |
+| winlog.event_data.ComputerAccountChange |  | keyword |
 | winlog.event_data.CorruptionActionState |  | keyword |
 | winlog.event_data.CrashOnAuditFailValue |  | keyword |
 | winlog.event_data.CreationUtcTime |  | keyword |
@@ -697,6 +698,7 @@ An example event for `security` looks as following:
 | winlog.event_data.DeviceVersionMajor |  | keyword |
 | winlog.event_data.DeviceVersionMinor |  | keyword |
 | winlog.event_data.DisplayName |  | keyword |
+| winlog.event_data.DnsHostName |  | keyword |
 | winlog.event_data.DomainBehaviorVersion |  | keyword |
 | winlog.event_data.DomainName |  | keyword |
 | winlog.event_data.DomainPolicyChanged |  | keyword |
@@ -809,6 +811,7 @@ An example event for `security` looks as following:
 | winlog.event_data.ServiceAccount |  | keyword |
 | winlog.event_data.ServiceFileName |  | keyword |
 | winlog.event_data.ServiceName |  | keyword |
+| winlog.event_data.ServicePrincipalNames |  | keyword |
 | winlog.event_data.ServiceSid |  | keyword |
 | winlog.event_data.ServiceStartType |  | keyword |
 | winlog.event_data.ServiceType |  | keyword |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.19.0
+version: 1.19.1
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes cases where NewUacValue and UserAccountControl are set to the
blank value ("-") in 4738 and 4742, and cases in 4674 where there is
more than one access mask value.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Equivalent changes will need to be made in the windows package.
- [ ] Original event obtained from partial processing of XML events posted in https://github.com/elastic/integrations/issues/3898.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #3898

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
