### PR TITLE
[github] Add support for ingesting Advanced Security alerts for an entire organization

### DIFF
--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Add org endpoints for Code Scanning, Secret Scanning, and Dependabot
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXX
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: 1.3.0
+version: 1.4.0
 release: ga
 description: Collect logs from GitHub with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Currently Github Code Scanning, Secret Scanning, and Dependabot alerts only support repo level endpoints. This PR adds support for organisation endpoints giving choice to user to choose.
 
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).