### PR TITLE
[AWS Fargate] Clarify how to run the agent as sidecar container

### DIFF
--- a/packages/awsfargate/_dev/build/docs/README.md
+++ b/packages/awsfargate/_dev/build/docs/README.md
@@ -2,7 +2,7 @@
 
 The AWS Fargate integration helps to retrieve metadata, network metrics, and Docker stats about your containers and the tasks that are a part of an [Amazon Elastic Container Service (Amazon ECS)](https://aws.amazon.com/ecs/?pg=ln&sec=hiw) cluster.
 
-## How it works?
+## How to set it up
 
 To start collecting AWS Fargate metrics, you must run the Elastic Agent as a [sidecar](https://www.oreilly.com/library/view/designing-distributed-systems/9781491983638/ch02.html) container alongside your application container in the same task definition.
 

--- a/packages/awsfargate/_dev/build/docs/README.md
+++ b/packages/awsfargate/_dev/build/docs/README.md
@@ -4,9 +4,32 @@ The AWS Fargate integration helps to retrieve metadata, network metrics, and Doc
 
 ## How it works?
 
-The Elastic Agent runs in a container (as a sidecar) defined in the same task definition inside your ECS cluster and collects metrics using the [Amazon ECS task metadata endpoint](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-fargate.html).
+To start collecting AWS Fargate metrics, you must run the Elastic Agent as a [sidecar](https://www.oreilly.com/library/view/designing-distributed-systems/9781491983638/ch02.html) container alongside your application container in the same task definition.
 
-The ECS task metadata endpoint is an HTTP endpoint available to each container and enabled by default on [AWS Fargate platform version 1.4.0](https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/) and later. The Elastic Agent uses [Task metadata endpoint version 4](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v4-fargate.html).
+Each task definition must run an Agent because task metadata information is only available to containers running in the task.
+
+Here's an example of an Elastic Agent running as a sidecar with an application container:
+
+```yaml
+TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref TaskName
+      Cpu: 256
+      Memory: 512
+      NetworkMode: awsvpc
+      ExecutionRoleArn: !Ref ExecutionRole
+      ContainerDefinitions:
+        - Name: <application-container>              << ===== Application container
+          Image: <application-container-image>
+          <application-container-settings>
+        - Name: elastic-agent-container              << ===== Elastic Agent container
+          Image: docker.elastic.co/beats/elastic-agent:8.1.0
+```
+
+The Elastic Agent collects metrics using the [Amazon ECS task metadata endpoint](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-fargate.html).
+
+The Amazon ECS task metadata endpoint is an HTTP endpoint available to each container and enabled by default on [AWS Fargate platform version 1.4.0](https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/) and later. The Elastic Agent uses [Task metadata endpoint version 4](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v4-fargate.html).
 
 ## Credentials
 

--- a/packages/awsfargate/changelog.yml
+++ b/packages/awsfargate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.1.3
+  changes:
+    - description: Clarify how to run the `awsfargate` integration as a sidecar container.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999999999 # FIXME: link to the PR
 - version: 0.1.2
   changes:
     - description: Add DesiredStatus and KnownStatus for Fargate Tasks among the collected fields

--- a/packages/awsfargate/docs/README.md
+++ b/packages/awsfargate/docs/README.md
@@ -2,7 +2,7 @@
 
 The AWS Fargate integration helps to retrieve metadata, network metrics, and Docker stats about your containers and the tasks that are a part of an [Amazon Elastic Container Service (Amazon ECS)](https://aws.amazon.com/ecs/?pg=ln&sec=hiw) cluster.
 
-## How it works?
+## How to set it up
 
 To start collecting AWS Fargate metrics, you must run the Elastic Agent as a [sidecar](https://www.oreilly.com/library/view/designing-distributed-systems/9781491983638/ch02.html) container alongside your application container in the same task definition.
 

--- a/packages/awsfargate/docs/README.md
+++ b/packages/awsfargate/docs/README.md
@@ -4,9 +4,32 @@ The AWS Fargate integration helps to retrieve metadata, network metrics, and Doc
 
 ## How it works?
 
-The Elastic Agent runs in a container (as a sidecar) defined in the same task definition inside your ECS cluster and collects metrics using the [Amazon ECS task metadata endpoint](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-fargate.html).
+To start collecting AWS Fargate metrics, you must run the Elastic Agent as a [sidecar](https://www.oreilly.com/library/view/designing-distributed-systems/9781491983638/ch02.html) container alongside your application container in the same task definition.
 
-The ECS task metadata endpoint is an HTTP endpoint available to each container and enabled by default on [AWS Fargate platform version 1.4.0](https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/) and later. The Elastic Agent uses [Task metadata endpoint version 4](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v4-fargate.html).
+Each task definition must run an Agent because task metadata information is only available to containers running in the task.
+
+Here's an example of an Elastic Agent running as a sidecar with an application container:
+
+```yaml
+TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref TaskName
+      Cpu: 256
+      Memory: 512
+      NetworkMode: awsvpc
+      ExecutionRoleArn: !Ref ExecutionRole
+      ContainerDefinitions:
+        - Name: <application-container>              << ===== Application container
+          Image: <application-container-image>
+          <application-container-settings>
+        - Name: elastic-agent-container              << ===== Elastic Agent container
+          Image: docker.elastic.co/beats/elastic-agent:8.1.0
+```
+
+The Elastic Agent collects metrics using the [Amazon ECS task metadata endpoint](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-fargate.html).
+
+The Amazon ECS task metadata endpoint is an HTTP endpoint available to each container and enabled by default on [AWS Fargate platform version 1.4.0](https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/) and later. The Elastic Agent uses [Task metadata endpoint version 4](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v4-fargate.html).
 
 ## Credentials
 

--- a/packages/awsfargate/manifest.yml
+++ b/packages/awsfargate/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: awsfargate
 title: AWS Fargate
-version: 0.1.2
+version: 0.1.3
 license: basic
 description: Collects metrics from containers and tasks running on Amazon ECS clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This change adds more details about running the agent as a sidecar container to deploy the integration in an ECS cluster.

Feedback from the support team proved that the current version of the docs is inadequate to explain how and why to deploy the Elastic Agent as a sidecar container in the task definition.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~~I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

<!-- Recommended

## Author's Checklist

Add a checklist of things that are required to be reviewed in order to have the PR approved

- [ ]

## How to test this PR locally
-->

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Recommended
## Related issues
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

![CleanShot 2022-08-03 at 16 33 48@2x](https://user-images.githubusercontent.com/25941/182635320-c589166d-131a-49a8-8251-97edbaa64b7f.png)

