### PR TITLE
[Cisco Meraki] Fix client.geo.location mapping

### DIFF
--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix client.geo.location mapping
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/3941
 - version: "1.0.0"
   changes:
     - description: Make GA

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
-# newer versions go on topA
+# newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Fix client.geo.location mapping
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.0.0"
   changes:
     - description: Make GA

--- a/packages/cisco_meraki/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_meraki/data_stream/log/fields/ecs.yml
@@ -292,10 +292,10 @@
   name: client.geo.country_iso_code
 - external: ecs
   name: client.geo.country_name
-- external: ecs
-  name: client.geo.location.lat
-- external: ecs
-  name: client.geo.location.lon
+- description: Longitude and latitude.
+  level: core
+  name: client.geo.location
+  type: geo_point
 - external: ecs
   name: client.geo.region_iso_code
 - external: ecs

--- a/packages/cisco_meraki/docs/README.md
+++ b/packages/cisco_meraki/docs/README.md
@@ -93,8 +93,7 @@ The `cisco_meraki.log` dataset provides events from the configured syslog server
 | client.geo.continent_name | Name of the continent. | keyword |
 | client.geo.country_iso_code | Country ISO code. | keyword |
 | client.geo.country_name | Country name. | keyword |
-| client.geo.location.lat | Longitude and latitude. | geo_point |
-| client.geo.location.lon | Longitude and latitude. | geo_point |
+| client.geo.location | Longitude and latitude. | geo_point |
 | client.geo.region_iso_code | Region ISO code. | keyword |
 | client.geo.region_name | Region name. | keyword |
 | client.ip | IP address of the client (IPv4 or IPv6). | ip |
@@ -177,7 +176,7 @@ The `cisco_meraki.log` dataset provides events from the configured syslog server
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
-| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
+| host.mac | Host mac addresses. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
 | host.os.codename | OS codename, if any. | keyword |

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_meraki
 title: Cisco Meraki
-version: 1.0.0
+version: 1.0.1
 license: basic
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fix `client.geo.location` mapping from object to geo_point.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3938

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
