### PR TITLE
cisco_asa: relax some grok rules for divergent logs

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.1"
+  changes:
+    - description: Fix handling of some non-canonical log formats.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3943
 - version: "2.7.0"
   changes:
     - description: Add handling of AAA operations.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log
@@ -1,0 +1,19 @@
+Jul 15 13:38:14 216.160.83.56 : %ASA-6-302013: Built inbound TCP connection 3263493120 for DMZ:shule/5802 (shule/5802) to SERVERS:10.10.227.121/80 (10.10.227.121/80)
+Jul 15 13:38:11 216.160.83.56 : %ASA-6-302013: Built outbound TCP connection 3263492189 for MG:exp_srv/10050 (exp_srv/10050) to SERVERS:10.10.227.170/46145 (10.10.224.1/46145)
+Jul 15 13:38:08 81.2.69.142 %ASA-6-302015: Built outbound UDP connection 743108828 for outside:ns10/53 (ns10/53) to MND_sec:192.168.174.100/48347 (89.160.20.128/48347)
+Jul 15 13:38:03 81.2.69.142 %ASA-6-302015: Built outbound UDP connection 743108738 for outside:ns10/53 (ns10/53) to MND_sec:192.168.174.100/55653 (81.2.69.192/55653)
+Jul 15 13:36:59 216.160.83.56 : %ASA-6-106015: Deny TCP (no connection) from 10.12.227.40/389 to exp-angle/54703 flags RST on interface SH_INFRA_MGT
+Jul 15 13:36:39 216.160.83.56 : %ASA-6-106015: Deny TCP (no connection) from 89.160.20.128/56594 to sh-mailgw1/25 flags FIN ACK on interface outside
+Jul 15 13:38:47 216.160.83.56 : %ASA-6-305012: Teardown dynamic UDP translation from SERVERS:exp-wait/62409 to outside:81.2.69.142/62409 duration 0:00:41
+Jul 15 13:37:33 216.160.83.56 : %ASA-6-305012: Teardown dynamic UDP translation from SERVERS:exp-wait/56421 to outside:81.2.69.142/56421 duration 0:00:30
+Jul 15 13:39:04 216.160.83.56 : %ASA-6-305011: Built dynamic TCP translation from SERVERS:exp-srv/50578 to outside:81.2.69.142/50578
+Jul 15 13:37:02 216.160.83.56 : %ASA-6-305011: Built dynamic UDP translation from SERVERS:exp-wait/56570 to outside:81.2.69.142/56570
+Jul 15 13:18:06 216.160.83.56 : %ASA-4-106023: Deny tcp src MG:exp_srv/64593 dst SH_OSS:89.160.20.128/2511 by access-group "MGT_access_in" [0x0, 0x0]
+Jul 15 01:18:01 216.160.83.56 : %ASA-4-106023: Deny tcp src MG:exp_srv/63513 dst SH_OSS:89.160.20.128/2511 by access-group "MGT_access_in" [0x0, 0x0]
+Jul 15 13:30:09 81.2.69.142 %ASA-6-302020: Built inbound ICMP connection for faddr eth0_fw/6553 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0
+Jul 14 01:45:09 81.2.69.142 %ASA-6-302020: Built inbound ICMP connection for faddr eth0_fw/8396 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0
+Jul 15 13:30:09 81.2.69.142 %ASA-6-302021: Teardown ICMP connection for faddr eth0_fw/6553 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0
+Jul 14 01:45:09 81.2.69.142 %ASA-6-302021: Teardown ICMP connection for faddr eth0_fw/8396 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0
+Jul 15 12:18:51 81.2.69.192 %ASA-6-113039: Group <novpn> User <nt\minsk> IP <216.160.83.56> AnyConnect parent session started.
+Jul  1 09:27:13 216.160.83.56 : %ASA-6-113039: Group <Group_VPN> User <support\column> IP <81.2.69.192> AnyConnect parent session started.
+Jun 14 01:22:47 81.2.69.142 %ASA-5-304001: 192.168.14.22 Accessed URL mirror:http://mirror.example.com/path/to/resource

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -1,0 +1,1533 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-07-15T13:38:14.000Z",
+            "cisco": {
+                "asa": {
+                    "connection_id": "3263493120",
+                    "destination_interface": "SERVERS",
+                    "mapped_destination_ip": "10.10.227.121",
+                    "mapped_destination_port": 80,
+                    "mapped_source_host": "shule",
+                    "mapped_source_port": 5802,
+                    "source_interface": "DMZ"
+                }
+            },
+            "destination": {
+                "address": "10.10.227.121",
+                "ip": "10.10.227.121",
+                "port": 80
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302013",
+                "kind": "event",
+                "original": "Jul 15 13:38:14 216.160.83.56 : %ASA-6-302013: Built inbound TCP connection 3263493120 for DMZ:shule/5802 (shule/5802) to SERVERS:10.10.227.121/80 (10.10.227.121/80)",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "direction": "inbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "SERVERS"
+                    }
+                },
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "DMZ"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "shule"
+                ],
+                "ip": [
+                    "10.10.227.121"
+                ]
+            },
+            "source": {
+                "address": "shule",
+                "domain": "shule",
+                "port": 5802
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:38:11.000Z",
+            "cisco": {
+                "asa": {
+                    "connection_id": "3263492189",
+                    "destination_interface": "SERVERS",
+                    "mapped_destination_ip": "10.10.224.1",
+                    "mapped_destination_port": 46145,
+                    "mapped_source_host": "exp_srv",
+                    "mapped_source_port": 10050,
+                    "source_interface": "MG"
+                }
+            },
+            "destination": {
+                "address": "10.10.227.170",
+                "ip": "10.10.227.170",
+                "nat": {
+                    "ip": "10.10.224.1"
+                },
+                "port": 46145
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302013",
+                "kind": "event",
+                "original": "Jul 15 13:38:11 216.160.83.56 : %ASA-6-302013: Built outbound TCP connection 3263492189 for MG:exp_srv/10050 (exp_srv/10050) to SERVERS:10.10.227.170/46145 (10.10.224.1/46145)",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "SERVERS"
+                    }
+                },
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "MG"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "exp_srv"
+                ],
+                "ip": [
+                    "10.10.227.170",
+                    "10.10.224.1"
+                ]
+            },
+            "source": {
+                "address": "exp_srv",
+                "domain": "exp_srv",
+                "port": 10050
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:38:08.000Z",
+            "cisco": {
+                "asa": {
+                    "connection_id": "743108828",
+                    "destination_interface": "MND_sec",
+                    "mapped_destination_ip": "89.160.20.128",
+                    "mapped_destination_port": 48347,
+                    "mapped_source_host": "ns10",
+                    "mapped_source_port": 53,
+                    "source_interface": "outside"
+                }
+            },
+            "destination": {
+                "address": "192.168.174.100",
+                "ip": "192.168.174.100",
+                "nat": {
+                    "ip": "89.160.20.128"
+                },
+                "port": 48347
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302015",
+                "kind": "event",
+                "original": "Jul 15 13:38:08 81.2.69.142 %ASA-6-302015: Built outbound UDP connection 743108828 for outside:ns10/53 (ns10/53) to MND_sec:192.168.174.100/48347 (89.160.20.128/48347)",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.142"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "MND_sec"
+                    }
+                },
+                "hostname": "81.2.69.142",
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.142",
+                    "ns10"
+                ],
+                "ip": [
+                    "192.168.174.100",
+                    "89.160.20.128"
+                ]
+            },
+            "source": {
+                "address": "ns10",
+                "domain": "ns10",
+                "port": 53
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:38:03.000Z",
+            "cisco": {
+                "asa": {
+                    "connection_id": "743108738",
+                    "destination_interface": "MND_sec",
+                    "mapped_destination_ip": "81.2.69.192",
+                    "mapped_destination_port": 55653,
+                    "mapped_source_host": "ns10",
+                    "mapped_source_port": 53,
+                    "source_interface": "outside"
+                }
+            },
+            "destination": {
+                "address": "192.168.174.100",
+                "ip": "192.168.174.100",
+                "nat": {
+                    "ip": "81.2.69.192"
+                },
+                "port": 55653
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "302015",
+                "kind": "event",
+                "original": "Jul 15 13:38:03 81.2.69.142 %ASA-6-302015: Built outbound UDP connection 743108738 for outside:ns10/53 (ns10/53) to MND_sec:192.168.174.100/55653 (81.2.69.192/55653)",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.142"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "direction": "outbound",
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "MND_sec"
+                    }
+                },
+                "hostname": "81.2.69.142",
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.142",
+                    "ns10"
+                ],
+                "ip": [
+                    "192.168.174.100",
+                    "81.2.69.192"
+                ]
+            },
+            "source": {
+                "address": "ns10",
+                "domain": "ns10",
+                "port": 53
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:36:59.000Z",
+            "cisco": {
+                "asa": {
+                    "source_interface": "SH_INFRA_MGT"
+                }
+            },
+            "destination": {
+                "address": "exp-angle",
+                "domain": "exp-angle",
+                "port": 54703
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106015",
+                "kind": "event",
+                "original": "Jul 15 13:36:59 216.160.83.56 : %ASA-6-106015: Deny TCP (no connection) from 10.12.227.40/389 to exp-angle/54703 flags RST on interface SH_INFRA_MGT",
+                "outcome": "success",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "SH_INFRA_MGT"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "exp-angle"
+                ],
+                "ip": [
+                    "10.12.227.40"
+                ]
+            },
+            "source": {
+                "address": "10.12.227.40",
+                "ip": "10.12.227.40",
+                "port": 389
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:36:39.000Z",
+            "cisco": {
+                "asa": {
+                    "source_interface": "outside"
+                }
+            },
+            "destination": {
+                "address": "sh-mailgw1",
+                "domain": "sh-mailgw1",
+                "port": 25
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106015",
+                "kind": "event",
+                "original": "Jul 15 13:36:39 216.160.83.56 : %ASA-6-106015: Deny TCP (no connection) from 89.160.20.128/56594 to sh-mailgw1/25 flags FIN ACK on interface outside",
+                "outcome": "success",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "sh-mailgw1"
+                ],
+                "ip": [
+                    "89.160.20.128"
+                ]
+            },
+            "source": {
+                "address": "89.160.20.128",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 56594
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:38:47.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "outside",
+                    "source_interface": "SERVERS"
+                }
+            },
+            "destination": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142",
+                "port": 62409
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "flow-expiration",
+                "category": [
+                    "network"
+                ],
+                "code": "305012",
+                "duration": 41000000000,
+                "end": "2022-07-15T13:38:47.000Z",
+                "kind": "event",
+                "original": "Jul 15 13:38:47 216.160.83.56 : %ASA-6-305012: Teardown dynamic UDP translation from SERVERS:exp-wait/62409 to outside:81.2.69.142/62409 duration 0:00:41",
+                "severity": 6,
+                "start": "2022-07-15T13:38:06.000Z",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "SERVERS"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "exp-wait"
+                ],
+                "ip": [
+                    "81.2.69.142"
+                ]
+            },
+            "source": {
+                "address": "exp-wait",
+                "domain": "exp-wait",
+                "port": 62409
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:37:33.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "outside",
+                    "source_interface": "SERVERS"
+                }
+            },
+            "destination": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142",
+                "port": 56421
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "flow-expiration",
+                "category": [
+                    "network"
+                ],
+                "code": "305012",
+                "duration": 30000000000,
+                "end": "2022-07-15T13:37:33.000Z",
+                "kind": "event",
+                "original": "Jul 15 13:37:33 216.160.83.56 : %ASA-6-305012: Teardown dynamic UDP translation from SERVERS:exp-wait/56421 to outside:81.2.69.142/56421 duration 0:00:30",
+                "severity": 6,
+                "start": "2022-07-15T13:37:03.000Z",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "SERVERS"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "exp-wait"
+                ],
+                "ip": [
+                    "81.2.69.142"
+                ]
+            },
+            "source": {
+                "address": "exp-wait",
+                "domain": "exp-wait",
+                "port": 56421
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:39:04.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "outside",
+                    "source_interface": "SERVERS"
+                }
+            },
+            "destination": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142",
+                "port": 50578
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "305011",
+                "kind": "event",
+                "original": "Jul 15 13:39:04 216.160.83.56 : %ASA-6-305011: Built dynamic TCP translation from SERVERS:exp-srv/50578 to outside:81.2.69.142/50578",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "SERVERS"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "exp-srv"
+                ],
+                "ip": [
+                    "81.2.69.142"
+                ]
+            },
+            "source": {
+                "address": "exp-srv",
+                "domain": "exp-srv",
+                "port": 50578
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:37:02.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "outside",
+                    "source_interface": "SERVERS"
+                }
+            },
+            "destination": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142",
+                "port": 56570
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "305011",
+                "kind": "event",
+                "original": "Jul 15 13:37:02 216.160.83.56 : %ASA-6-305011: Built dynamic UDP translation from SERVERS:exp-wait/56570 to outside:81.2.69.142/56570",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "SERVERS"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "exp-wait"
+                ],
+                "ip": [
+                    "81.2.69.142"
+                ]
+            },
+            "source": {
+                "address": "exp-wait",
+                "domain": "exp-wait",
+                "port": 56570
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:18:06.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "SH_OSS",
+                    "rule_name": "MGT_access_in",
+                    "source_interface": "MG"
+                }
+            },
+            "destination": {
+                "address": "89.160.20.128",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 2511
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106023",
+                "kind": "event",
+                "original": "Jul 15 13:18:06 216.160.83.56 : %ASA-4-106023: Deny tcp src MG:exp_srv/64593 dst SH_OSS:89.160.20.128/2511 by access-group \"MGT_access_in\" [0x0, 0x0]",
+                "outcome": "success",
+                "severity": 4,
+                "type": [
+                    "connection",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "warning"
+            },
+            "network": {
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "SH_OSS"
+                    }
+                },
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "MG"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "exp_srv"
+                ],
+                "ip": [
+                    "89.160.20.128"
+                ]
+            },
+            "source": {
+                "address": "exp_srv",
+                "domain": "exp_srv",
+                "port": 64593
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T01:18:01.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "SH_OSS",
+                    "rule_name": "MGT_access_in",
+                    "source_interface": "MG"
+                }
+            },
+            "destination": {
+                "address": "89.160.20.128",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 2511
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106023",
+                "kind": "event",
+                "original": "Jul 15 01:18:01 216.160.83.56 : %ASA-4-106023: Deny tcp src MG:exp_srv/63513 dst SH_OSS:89.160.20.128/2511 by access-group \"MGT_access_in\" [0x0, 0x0]",
+                "outcome": "success",
+                "severity": 4,
+                "type": [
+                    "connection",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "warning"
+            },
+            "network": {
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "SH_OSS"
+                    }
+                },
+                "hostname": "216.160.83.56",
+                "ingress": {
+                    "interface": {
+                        "name": "MG"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "exp_srv"
+                ],
+                "ip": [
+                    "89.160.20.128"
+                ]
+            },
+            "source": {
+                "address": "exp_srv",
+                "domain": "exp_srv",
+                "port": 63513
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:30:09.000Z",
+            "cisco": {
+                "asa": {
+                    "icmp_code": 0,
+                    "icmp_type": 8,
+                    "mapped_source_ip": "81.2.69.192"
+                }
+            },
+            "destination": {
+                "domain": "eth0_fw"
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "flow-expiration",
+                "category": [
+                    "network"
+                ],
+                "code": "302020",
+                "kind": "event",
+                "original": "Jul 15 13:30:09 81.2.69.142 %ASA-6-302020: Built inbound ICMP connection for faddr eth0_fw/6553 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.142"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "direction": "inbound",
+                "protocol": "icmp"
+            },
+            "observer": {
+                "hostname": "81.2.69.142",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.142",
+                    "eth0_fw"
+                ],
+                "ip": [
+                    "81.2.69.192"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.192",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.192"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-14T01:45:09.000Z",
+            "cisco": {
+                "asa": {
+                    "icmp_code": 0,
+                    "icmp_type": 8,
+                    "mapped_source_ip": "81.2.69.192"
+                }
+            },
+            "destination": {
+                "domain": "eth0_fw"
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "flow-expiration",
+                "category": [
+                    "network"
+                ],
+                "code": "302020",
+                "kind": "event",
+                "original": "Jul 14 01:45:09 81.2.69.142 %ASA-6-302020: Built inbound ICMP connection for faddr eth0_fw/8396 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.142"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "direction": "inbound",
+                "protocol": "icmp"
+            },
+            "observer": {
+                "hostname": "81.2.69.142",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.142",
+                    "eth0_fw"
+                ],
+                "ip": [
+                    "81.2.69.192"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.192",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.192"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T13:30:09.000Z",
+            "cisco": {
+                "asa": {
+                    "icmp_code": 0,
+                    "icmp_type": 8,
+                    "mapped_source_ip": "81.2.69.192"
+                }
+            },
+            "destination": {
+                "domain": "eth0_fw"
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "flow-expiration",
+                "category": [
+                    "network"
+                ],
+                "code": "302021",
+                "kind": "event",
+                "original": "Jul 15 13:30:09 81.2.69.142 %ASA-6-302021: Teardown ICMP connection for faddr eth0_fw/6553 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.142"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "1",
+                "transport": "icmp"
+            },
+            "observer": {
+                "hostname": "81.2.69.142",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.142",
+                    "eth0_fw"
+                ],
+                "ip": [
+                    "81.2.69.192"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.192",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.192"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-14T01:45:09.000Z",
+            "cisco": {
+                "asa": {
+                    "icmp_code": 0,
+                    "icmp_type": 8,
+                    "mapped_source_ip": "81.2.69.192"
+                }
+            },
+            "destination": {
+                "domain": "eth0_fw"
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "flow-expiration",
+                "category": [
+                    "network"
+                ],
+                "code": "302021",
+                "kind": "event",
+                "original": "Jul 14 01:45:09 81.2.69.142 %ASA-6-302021: Teardown ICMP connection for faddr eth0_fw/8396 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.142"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "1",
+                "transport": "icmp"
+            },
+            "observer": {
+                "hostname": "81.2.69.142",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.142",
+                    "eth0_fw"
+                ],
+                "ip": [
+                    "81.2.69.192"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.192",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.192"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-15T12:18:51.000Z",
+            "cisco": {
+                "asa": {}
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "client-vpn-connected",
+                "category": [
+                    "network",
+                    "session"
+                ],
+                "code": "113039",
+                "kind": "event",
+                "original": "Jul 15 12:18:51 81.2.69.192 %ASA-6-113039: Group \u003cnovpn\u003e User \u003cnt\\minsk\u003e IP \u003c216.160.83.56\u003e AnyConnect parent session started.",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.192"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "observer": {
+                "hostname": "81.2.69.192",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.192",
+                    "nt"
+                ],
+                "ip": [
+                    "216.160.83.56"
+                ],
+                "user": [
+                    "minsk"
+                ]
+            },
+            "source": {
+                "address": "216.160.83.56",
+                "as": {
+                    "number": 209
+                },
+                "geo": {
+                    "city_name": "Milton",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 47.2513,
+                        "lon": -122.3149
+                    },
+                    "region_iso_code": "US-WA",
+                    "region_name": "Washington"
+                },
+                "ip": "216.160.83.56",
+                "user": {
+                    "domain": "nt",
+                    "group": {
+                        "name": "novpn"
+                    },
+                    "name": "minsk"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-01T09:27:13.000Z",
+            "cisco": {
+                "asa": {}
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "client-vpn-connected",
+                "category": [
+                    "network",
+                    "session"
+                ],
+                "code": "113039",
+                "kind": "event",
+                "original": "Jul  1 09:27:13 216.160.83.56 : %ASA-6-113039: Group \u003cGroup_VPN\u003e User \u003csupport\\column\u003e IP \u003c81.2.69.192\u003e AnyConnect parent session started.",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "observer": {
+                "hostname": "216.160.83.56",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56",
+                    "support"
+                ],
+                "ip": [
+                    "81.2.69.192"
+                ],
+                "user": [
+                    "column"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.192",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.192",
+                "user": {
+                    "domain": "support",
+                    "group": {
+                        "name": "Group_VPN"
+                    },
+                    "name": "column"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-06-14T01:22:47.000Z",
+            "cisco": {
+                "asa": {}
+            },
+            "destination": {
+                "address": "mirror",
+                "domain": "mirror"
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "304001",
+                "kind": "event",
+                "original": "Jun 14 01:22:47 81.2.69.142 %ASA-5-304001: 192.168.14.22 Accessed URL mirror:http://mirror.example.com/path/to/resource",
+                "outcome": "success",
+                "severity": 5,
+                "type": [
+                    "connection",
+                    "allowed"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.142"
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "hostname": "81.2.69.142",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.142",
+                    "mirror"
+                ],
+                "ip": [
+                    "192.168.14.22"
+                ]
+            },
+            "source": {
+                "address": "192.168.14.22",
+                "ip": "192.168.14.22"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "mirror.example.com",
+                "original": "http://mirror.example.com/path/to/resource",
+                "path": "/path/to/resource",
+                "scheme": "http"
+            }
+        }
+    ]
+}

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -239,7 +239,7 @@ processors:
       field: "message"
       description: "106015"
       patterns:
-      - "%{NOTSPACE:event.outcome} %{NOTSPACE:network.transport} %{NOTSPACE} %{NOTSPACE} from %{IP:source.address}/%{POSINT:source.port} to %{IP:destination.address}/%{POSINT:destination.port} flags %{DATA} on interface %{NOTSPACE:_temp_.cisco.source_interface}"
+      - "%{NOTSPACE:event.outcome} %{NOTSPACE:network.transport} %{NOTSPACE} %{NOTSPACE} from %{IP:source.address}/%{POSINT:source.port} to %{IPORHOST:destination.address}/%{POSINT:destination.port} flags %{DATA} on interface %{NOTSPACE:_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106016'"
       field: "message"
@@ -277,6 +277,8 @@ processors:
       patterns:
         - ^%{NOTSPACE:event.outcome} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{POSINT:source.port})?\s*(\(%{CISCO_USER:_temp_.cisco.source_username}\) )?dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{POSINT:destination.port})?%{DATA}by access-group "%{NOTSPACE:_temp_.cisco.list_id}"
       pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
@@ -364,15 +366,21 @@ processors:
       field: "message"
       description: "113029, 113030, 113031, 113032, 113033, 113034, 113035, 113036, 113038, 113039"
       patterns:
-      - "Group <%{NOTSPACE:source.user.group.name}> User <%{USER:source.user.name}> IP <%{IP:source.address}>"
-      - "Group %{NOTSPACE:source.user.group.name} User %{USER:source.user.name} IP %{IP:source.address}"
+      - "Group <%{NOTSPACE:source.user.group.name}> User <%{CISCO_USER:source.user.name}> IP <%{IP:source.address}>"
+      - "Group %{NOTSPACE:source.user.group.name} User %{CISCO_USER:source.user.name} IP %{IP:source.address}"
+      pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - grok:
       if: '["302013", "302015"].contains(ctx._temp_.cisco.message_id)'
       field: "message"
       description: "302013, 302015"
       patterns:
-        - Built %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} connection %{NUMBER:_temp_.cisco.connection_id} for %{NOTCOLON:_temp_.cisco.source_interface}:%{IP:source.address}/%{NUMBER:source.port} \(%{IP:_temp_.natsrcip}/%{NUMBER:_temp_.cisco.mapped_source_port}\)(\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{NUMBER:destination.port} \(%{NOTSPACE:_temp_.natdstip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\)(\(%{CISCO_USER:_temp_.cisco.destination_username}\))?( \(%{CISCO_USER:_temp_.cisco.termination_user}\))?%{GREEDYDATA}
+        - Built %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} connection %{NUMBER:_temp_.cisco.connection_id} for %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port} \(%{IPORHOST:_temp_.natsrcip}/%{NUMBER:_temp_.cisco.mapped_source_port}\)(\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{NUMBER:destination.port} \(%{NOTSPACE:_temp_.natdstip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\)(\(%{CISCO_USER:_temp_.cisco.destination_username}\))?( \(%{CISCO_USER:_temp_.cisco.termination_user}\))?%{GREEDYDATA}
       pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
@@ -385,9 +393,11 @@ processors:
       field: "message"
       description: "305012"
       patterns:
-        - Teardown %{DATA} %{NOTSPACE:network.transport} translation from %{NOTCOLON:_temp_.cisco.source_interface}:%{IP:source.address}/%{NUMBER:source.port}(\s*\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port} duration %{DURATION:_temp_.duration_hms}
+        - Teardown %{DATA} %{NOTSPACE:network.transport} translation from %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port}(\s*\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port} duration %{DURATION:_temp_.duration_hms}
       pattern_definitions:
         NOTCOLON: "[^:]*"
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
         DURATION: "%{INT}:%{MINUTE}:%{SECOND}"
   - grok:
@@ -397,6 +407,8 @@ processors:
       patterns:
         - "Built %{NOTSPACE:network.direction} %{NOTSPACE:network.protocol} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER:_temp_.cisco.destination_username}\\) )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER:_temp_.cisco.source_username}\\) )?(type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?"
       pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         ECSSOURCEIPORHOST: "(?:%{IP:source.address}|%{HOSTNAME:source.domain})"
         ECSDESTIPORHOST: "(?:%{IP:destination.address}|%{HOSTNAME:destination.domain})"
@@ -417,7 +429,7 @@ processors:
       field: "message"
       description: "304001"
       patterns:
-        - "(%{NOTSPACE:source.user.name}@)?%{IP:source.address}(\\(%{DATA}\\))? %{DATA} (%{NOTSPACE}@)?%{IP:destination.address}:%{GREEDYDATA:url.original}"
+        - "(%{NOTSPACE:source.user.name}@)?%{IP:source.address}(\\(%{DATA}\\))? %{DATA} (%{NOTSPACE}@)?%{IPORHOST:destination.address}:%{GREEDYDATA:url.original}"
   - set:
       if: "ctx._temp_.cisco.message_id == '304001'"
       field: "event.outcome"
@@ -433,7 +445,7 @@ processors:
       field: "message"
       description: "305011"
       patterns:
-        - Built %{NOTSPACE} %{NOTSPACE:network.transport} translation from %{NOTSPACE:_temp_.cisco.source_interface}:%{IP:source.address}/%{NUMBER:source.port}(\(%{NOTSPACE:source.user.name}\))? to %{NOTSPACE:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port}
+        - Built %{NOTSPACE} %{NOTSPACE:network.transport} translation from %{NOTSPACE:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port}(\(%{NOTSPACE:source.user.name}\))? to %{NOTSPACE:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port}
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313001'"
       field: "message"
@@ -902,6 +914,8 @@ processors:
         - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.source_username}\)? )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?duration (?:%{DURATION:_temp_.duration_hms} bytes %{NUMBER:network.bytes})
         - ^Teardown %{NOTSPACE:network.transport} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\s*(?:\(%{CISCO_USER:_temp_.cisco.source_username}\))?(\s*type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?
       pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         ECSSOURCEIPORHOST: "(?:%{IP:source.address}|%{HOSTNAME:source.domain})"
         ECSDESTIPORHOST: "(?:%{IP:destination.address}|%{HOSTNAME:destination.domain})"

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -277,7 +277,7 @@ processors:
       patterns:
         - ^%{NOTSPACE:event.outcome} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{POSINT:source.port})?\s*(\(%{CISCO_USER:_temp_.cisco.source_username}\) )?dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{POSINT:destination.port})?%{DATA}by access-group "%{NOTSPACE:_temp_.cisco.list_id}"
       pattern_definitions:
-        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
@@ -369,7 +369,7 @@ processors:
       - "Group <%{NOTSPACE:source.user.group.name}> User <%{CISCO_USER:source.user.name}> IP <%{IP:source.address}>"
       - "Group %{NOTSPACE:source.user.group.name} User %{CISCO_USER:source.user.name} IP %{IP:source.address}"
       pattern_definitions:
-        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - grok:
@@ -379,7 +379,7 @@ processors:
       patterns:
         - Built %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} connection %{NUMBER:_temp_.cisco.connection_id} for %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port} \(%{IPORHOST:_temp_.natsrcip}/%{NUMBER:_temp_.cisco.mapped_source_port}\)(\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{NUMBER:destination.port} \(%{NOTSPACE:_temp_.natdstip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\)(\(%{CISCO_USER:_temp_.cisco.destination_username}\))?( \(%{CISCO_USER:_temp_.cisco.termination_user}\))?%{GREEDYDATA}
       pattern_definitions:
-        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
@@ -396,7 +396,7 @@ processors:
         - Teardown %{DATA} %{NOTSPACE:network.transport} translation from %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port}(\s*\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port} duration %{DURATION:_temp_.duration_hms}
       pattern_definitions:
         NOTCOLON: "[^:]*"
-        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
         DURATION: "%{INT}:%{MINUTE}:%{SECOND}"
@@ -407,7 +407,7 @@ processors:
       patterns:
         - "Built %{NOTSPACE:network.direction} %{NOTSPACE:network.protocol} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER:_temp_.cisco.destination_username}\\) )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER:_temp_.cisco.source_username}\\) )?(type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?"
       pattern_definitions:
-        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         ECSSOURCEIPORHOST: "(?:%{IP:source.address}|%{HOSTNAME:source.domain})"
@@ -914,7 +914,7 @@ processors:
         - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.source_username}\)? )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?duration (?:%{DURATION:_temp_.duration_hms} bytes %{NUMBER:network.bytes})
         - ^Teardown %{NOTSPACE:network.transport} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\s*(?:\(%{CISCO_USER:_temp_.cisco.source_username}\))?(\s*type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?
       pattern_definitions:
-        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z_][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         ECSSOURCEIPORHOST: "(?:%{IP:source.address}|%{HOSTNAME:source.domain})"

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.7.0"
+version: "2.7.1"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Fixes grok handling of a variety of non-canonical log formats.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #3942

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
