### PR TITLE
[PFsense] Fix Redundant Grok pattern

### DIFF
--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Fix redundant Grok pattern
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.0"
   changes:
     - description: Add DHCPv6 support

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix redundant Grok pattern
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/3969
 - version: "1.3.0"
   changes:
     - description: Add DHCPv6 support

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/dhcp.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/dhcp.yml
@@ -7,7 +7,7 @@ processors:
         - '%{DATA:_tmp.action}/%{INTERFACE:observer.ingress.interface.name}/%{MAC_ADDRESS:server.mac}/%{NOTSPACE:pfsense.dhcp.subnet}'
         - '%{DATA:_tmp.action} %{IPV6:client.address}(/%{NUMBER})? on %{INTERFACE:observer.ingress.interface.name}'
         - '%{DATA:_tmp.action} (from|to) %{IPV6:client.address} port %{POSINT:client.port:long}(, transaction ID %{NOTSPACE:pfsense.dhcp.transaction_id})?'
-        - '%{DATA:_tmp.action} for: %{IPV6:client.address}(, age %{POSINT:pfsense.dhcp.age:long} secs %{DATA})?%{GREEDYDATA}?'
+        - '%{DATA:_tmp.action} for: %{IPV6:client.address}(, age %{POSINT:pfsense.dhcp.age:long} secs)?%{GREEDYDATA}'
         - '%{DATA:_tmp.action}: address %{IPV6:client.address} to client with duid %{DUID:pfsense.dhcp.duid} iaid = -%{NOTSPACE:pfsense.dhcp.iaid} valid for %{POSINT:pfsense.dhcp.lease_time:long} seconds'
         - '%{WORD:event.action} %{MIDDLE} via %{INTERFACE:observer.ingress.interface.name}'
         - '%{DATA:_tmp.action} %{IPV6:client.address}'

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,6 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.3.0"
+version: "1.3.1"
 release: ga
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fix redundant Grok Pattern that causes "warning" messages in Elasticsearch logs.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3955

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
