### PR TITLE
proofpoint_tap: clarify use of {source,destination}.ip

### DIFF
--- a/packages/proofpoint_tap/_dev/build/docs/README.md
+++ b/packages/proofpoint_tap/_dev/build/docs/README.md
@@ -23,6 +23,8 @@ For the more information on generating TAP credentials please follow the steps m
 
 This is the `clicks_blocked` dataset.
 
+NOTE: For the `clicks_blocked` dataset, `source.ip` corresponds to the Proofpoint `senderIP` — the IP of the email sender — and `destination.ip` corresponds to `clickIP` — the IP of the click destination.
+
 {{event "clicks_blocked"}}
 
 {{fields "clicks_blocked"}}
@@ -30,6 +32,8 @@ This is the `clicks_blocked` dataset.
 ### Clicks Permitted
 
 This is the `clicks_permitted` dataset.
+
+NOTE: For the `clicks_permitted` dataset, `source.ip` corresponds to the Proofpoint `senderIP` — the IP of the email sender — and `destination.ip` corresponds to `clickIP` — the IP of the click destination.
 
 {{event "clicks_permitted"}}
 

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Clarify us of `{source,destination}.ip` in click datasets.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3979
 - version: "1.0.0"
   changes:
     - description: Make GA

--- a/packages/proofpoint_tap/docs/README.md
+++ b/packages/proofpoint_tap/docs/README.md
@@ -23,6 +23,8 @@ For the more information on generating TAP credentials please follow the steps m
 
 This is the `clicks_blocked` dataset.
 
+NOTE: For the `clicks_blocked` dataset, `source.ip` corresponds to the Proofpoint `senderIP` — the IP of the email sender — and `destination.ip` corresponds to `clickIP` — the IP of the click destination.
+
 An example event for `clicks_blocked` looks as following:
 
 ```json
@@ -248,6 +250,8 @@ An example event for `clicks_blocked` looks as following:
 ### Clicks Permitted
 
 This is the `clicks_permitted` dataset.
+
+NOTE: For the `clicks_permitted` dataset, `source.ip` corresponds to the Proofpoint `senderIP` — the IP of the email sender — and `destination.ip` corresponds to `clickIP` — the IP of the click destination.
 
 An example event for `clicks_permitted` looks as following:
 

--- a/packages/proofpoint_tap/manifest.yml
+++ b/packages/proofpoint_tap/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: proofpoint_tap
 title: Proofpoint TAP
-version: "1.0.0"
+version: "1.1.0"
 license: basic
 description: Collect logs from Proofpoint TAP with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This adds a note to explain the semantics of `{source,destination}.ip` for the click datasets. The meaning of these fields in this context have caused confusion for some users.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
