### PR TITLE
Fixes to `loadbalancing_metrics` datastream

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -4,6 +4,9 @@
     - description: Add GCP Load Balancing Metricset
       type: enhancement
       link: https://github.com/elastic/integrations/pull/2308
+    - description: Fix credentials_json escaping in loadbalancing_metrics
+      type: bugfix
+      link: foobar
 - version: "2.4.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -10,6 +10,9 @@
     - description: Update loadbalancing_metrics default period to 60s
       type: bugfix
       link: foobar
+    - description: Fix event.dataset for loadbalancing_metrics
+      type: bugfix
+      link: foobar
 - version: "2.4.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -7,6 +7,9 @@
     - description: Fix credentials_json escaping in loadbalancing_metrics
       type: bugfix
       link: foobar
+    - description: Update loadbalancing_metrics default period to 60s
+      type: bugfix
+      link: foobar
 - version: "2.4.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/gcp/data_stream/loadbalancing_metrics/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/loadbalancing_metrics/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ project_id: {{project_id}}
 credentials_file_path: {{credentials_file}}
 {{/if}}
 {{#if credentials_json}}
-credentials_json: {{credentials_json}}
+credentials_json: '{{credentials_json}}'
 {{/if}}
 {{#if region}}
 region: {{region}}

--- a/packages/gcp/data_stream/loadbalancing_metrics/fields/base-fields.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/fields/base-fields.yml
@@ -17,4 +17,4 @@
 - name: event.dataset
   type: constant_keyword
   description: Event dataset
-  value: gcp.loadbalancing
+  value: gcp.loadbalancing_metrics

--- a/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
@@ -20,7 +20,7 @@ streams:
       - name: period
         type: text
         title: Period
-        default: 10s
+        default: 60s
         required: true
       - name: exclude_labels
         type: bool

--- a/packages/gcp/data_stream/loadbalancing_metrics/sample_event.json
+++ b/packages/gcp/data_stream/loadbalancing_metrics/sample_event.json
@@ -9,7 +9,7 @@
         "availability_zone": "us-central1-a"
     },
     "event": {
-        "dataset": "gcp.loadbalancing",
+        "dataset": "gcp.loadbalancing_metrics",
         "duration": 115000,
         "module": "gcp"
     },

--- a/packages/gcp/docs/loadbalancing.md
+++ b/packages/gcp/docs/loadbalancing.md
@@ -18,7 +18,7 @@ An example event for `loadbalancing` looks as following:
         "availability_zone": "us-central1-a"
     },
     "event": {
-        "dataset": "gcp.loadbalancing",
+        "dataset": "gcp.loadbalancing_metrics",
         "duration": 115000,
         "module": "gcp"
     },


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
This PR adds some fixes for issues that slipped through the review of the `loadbalancing_metrics` datastream:

- fix `credentials_json` escaping
- set period default to 60s
- fix event.dataset

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
