### PR TITLE
[windows] add field to translate_sid processor in powershell operational

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Fix translate_sid processor error in powershell operational data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3989
 - version: "1.14.0"
   changes:
     - description: Use MemberSid to enrich for user name and domain where possible.

--- a/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/winlog.yml.hbs
@@ -20,8 +20,9 @@ include_xml: true
 {{/if}}
 processors:
   - translate_sid:
+      field: winlog.event_data.MemberSid
       account_name_target: winlog.event_data._MemberUserName
-      domain_target:       winlog.event_data._MemberDomain
+      domain_target: winlog.event_data._MemberDomain
       account_type_target: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.14.0
+version: 1.14.1
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Adds `field` to translate_sid processor in powershell operational datastream.  Without the required `field` events can not be processed

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes #3988

