### PR TITLE
synthetics - adjust configuration to account for project monitor ids

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.2"
+  changes:
+    - description: Adjusts ids for project monitors and add playwright_options
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2744
 - version: "0.10.1"
   changes:
     - description: Adjusts location name for tcp and icmp monitors

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adjusts ids for project monitors and add playwright_options
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/2744
+      link: https://github.com/elastic/integrations/pull/3998
 - version: "0.10.1"
   changes:
     - description: Adjusts location name for tcp and icmp monitors

--- a/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
+++ b/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
@@ -1,8 +1,8 @@
 __ui: {{__ui}}
 type: {{type}}
 name: {{name}}
-{{#if config_id}}
-id: {{config_id}}
+{{#if id}}
+id: {{id}}
 {{/if}}
 {{#if origin}}
 origin: {{origin}}
@@ -37,6 +37,9 @@ source.project.content: {{source.project.content}}
 {{/if}}
 {{#if params}}
 params: {{params}}
+{{/if}}
+{{#if playwright_options}}
+playwright_options: {{playwright_options}}
 {{/if}}
 {{#if screenshots}}
 screenshots: {{screenshots}}

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -113,6 +113,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: playwright_options
+        type: yaml
+        title: Synthetics playwright options
+        multi: false
+        required: false
+        show_user: true
       - name: screenshots
         type: text
         title: Synthetics screenshot options
@@ -198,6 +204,12 @@ streams:
         required: false
         show_user: true
         default: "Fleet managed"
+      - name: id
+        type: text
+        title: id
+        multi: false
+        required: false
+        show_user: false
       - name: config_id
         type: text
         title: Config Id

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -1,8 +1,8 @@
 __ui: {{__ui}}
 type: {{type}}
 name: {{name}}
-{{#if config_id}}
-id: {{config_id}}
+{{#if id}}
+id: {{id}}
 {{/if}}
 {{#if origin}}
 origin: {{origin}}

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -199,6 +199,12 @@ streams:
         required: false
         show_user: true
         default: "Fleet managed"
+      - name: id
+        type: text
+        title: id
+        multi: false
+        required: false
+        show_user: false
       - name: config_id
         type: text
         title: Config Id

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -1,8 +1,8 @@
 __ui: {{__ui}}
 type: {{type}}
 name: {{name}}
-{{#if config_id}}
-id: {{config_id}}
+{{#if id}}
+id: {{id}}
 {{/if}}
 {{#if origin}}
 origin: {{origin}}

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -92,6 +92,12 @@ streams:
         required: false
         show_user: true
         default: "Fleet managed"
+      - name: id
+        type: text
+        title: id
+        multi: false
+        required: false
+        show_user: false
       - name: config_id
         type: text
         title: Config Id

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -1,8 +1,8 @@
 __ui: {{__ui}}
 type: {{type}}
 name: {{name}}
-{{#if config_id}}
-id: {{config_id}}
+{{#if id}}
+id: {{id}}
 {{/if}}
 {{#if origin}}
 origin: {{origin}}

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -146,6 +146,12 @@ streams:
         required: false
         show_user: true
         default: "Fleet managed"
+      - name: id
+        type: text
+        title: id
+        multi: false
+        required: false
+        show_user: false
       - name: config_id
         type: text
         title: Config Id

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.10.1
+version: 0.10.2
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
- Bug

## What does this PR do?

This PR adjusts the monitor ids to account for custom ids from project monitors.

This PR also ads `playwright_options`. Playwright options were added to monitor management to account for project monitors, but since it's not available as an option in the UI, it was never added to the synthetics integration config. This caused playwright_options config to be missing for project monitors with private locations.
