### PR TITLE
Fixes the ML jobs query for the LotL Attack Detection Package

### DIFF
--- a/packages/problemchild/changelog.yml
+++ b/packages/problemchild/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.0.4"
+  changes:
+    - description: Fix the ML jobs query.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3777
 - version: "0.0.3"
   changes:
     - description: Add a `LotL` tag to all rules, fix a script in the inference pipeline, update ML job configs.

--- a/packages/problemchild/changelog.yml
+++ b/packages/problemchild/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix the ML jobs query.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/3777
+      link: https://github.com/elastic/integrations/pull/3999
 - version: "0.0.3"
   changes:
     - description: Add a `LotL` tag to all rules, fix a script in the inference pipeline, update ML job configs.

--- a/packages/problemchild/kibana/ml_module/problemchild-ml.json
+++ b/packages/problemchild/kibana/ml_module/problemchild-ml.json
@@ -12,13 +12,13 @@
                 "minimum_should_match": 1,
                 "should": [
                     {
-                        "match": {
-                            "problemchild.prediction": 1
+                        "exists": {
+                            "field": "problemchild.prediction"
                         }
                     },
                     {
-                        "match": {
-                            "blocklist_label": 1
+                        "exists": {
+                            "field": "blocklist_label"
                         }
                     }
                 ]

--- a/packages/problemchild/manifest.yml
+++ b/packages/problemchild/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: problemchild
 title: "LotL Attack Detection"
-version: 0.0.3
+version: 0.0.4
 license: basic
 description: "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription."
 type: integration


### PR DESCRIPTION
## What does this PR do?
While testing changes made in [this](https://github.com/elastic/integrations/pull/3777) PR in the snapshot environment, we found that the ML jobs module for the LotL Attack Detection package does not show up if no malicious events were seen by the ingest pipeline. This is not expected behavior. This PR fixes that.

## Checklist
- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally
- Build the latest ProblemChild package from this branch
- Stand up a cluster using elastic-package
- Add the LotL Attack Detection integration
- Create a test index with the default index pipeline as the ProblemChild ingest pipeline and mappings for the problemchild prediction and blocklist fields
- Ingest a dummy Windows process event document in the test index which is known to produce a prediction of 0 from the ProblemChild supervised model
- Create a data view for the test index
- Select the test index at the Create Job stage in the Anomaly Detection UI
- Ensure that you see the ProblemChild module appear
- Enable the jobs and make sure they start without errors

## Screenshots
- Test index with no malicious events
<img width="1771" alt="Screen Shot 2022-08-15 at 1 06 35 PM" src="https://user-images.githubusercontent.com/30438249/184709593-e886d5f3-3e47-4f40-8981-8ea8490e2b96.png">

- Ensuring that the ProblemChild ML job module shows up for the data view corresponding to the test index
<img width="773" alt="Screen Shot 2022-08-15 at 1 06 56 PM" src="https://user-images.githubusercontent.com/30438249/184709680-1f57a3fd-f37c-42b6-9c8b-134d308654ef.png">

- Ensuring that all the jobs were enabled successfully
<img width="1516" alt="Screen Shot 2022-08-15 at 1 07 14 PM" src="https://user-images.githubusercontent.com/30438249/184709752-cebeac89-3eac-4271-bf99-0e0210d5082e.png">

 