### PR TITLE
Fix links for gcp 2.5.0 changelog

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -6,13 +6,13 @@
       link: https://github.com/elastic/integrations/pull/2308
     - description: Fix credentials_json escaping in loadbalancing_metrics
       type: bugfix
-      link: foobar
+      link: https://github.com/elastic/integrations/pull/3986
     - description: Update loadbalancing_metrics default period to 60s
       type: bugfix
-      link: foobar
+      link: https://github.com/elastic/integrations/pull/3986
     - description: Fix event.dataset for loadbalancing_metrics
       type: bugfix
-      link: foobar
+      link: https://github.com/elastic/integrations/pull/3986
 - version: "2.4.0"
   changes:
     - description: Update package to ECS 8.4.0


### PR DESCRIPTION
Fix the PR links in changelog added with PR https://github.com/elastic/integrations/pull/3986
