### PR TITLE
Elastic Agent: Fix ECS fields resolution

### DIFF
--- a/packages/elastic_agent/_dev/build/build.yml
+++ b/packages/elastic_agent/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@v8.3.0

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix the external ECS fields not being properly resolved during the package build
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/4007
 - version: "1.3.4"
   changes:
     - description: Cloudbeat logs search support

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.5"
+  changes:
+    - description: Fix the external ECS fields not being properly resolved during the package build
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.3.4"
   changes:
     - description: Cloudbeat logs search support

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.3.4
+version: 1.3.5
 release: ga
 description: Collect logs and metrics from Elastic Agents.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds ECS dependency in order to fix ECS fields resolution in the package.
Addressed https://github.com/elastic/integrations/issues/3926

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes https://github.com/elastic/integrations/issues/3926

## Screenshots

Before the fix, the ECS field in the package is not resolved:
<img width="769" alt="Screen Shot 2022-08-16 at 12 03 11 PM" src="https://user-images.githubusercontent.com/872351/184927692-27e35de6-d89d-4219-9538-725bbefe3895.png">

After the fix, the ECS field in the package is resolved:
<img width="815" alt="Screen Shot 2022-08-16 at 12 03 28 PM" src="https://user-images.githubusercontent.com/872351/184927750-b146a448-c313-42e4-a76c-6bbae9fb09bd.png">

