### PR TITLE
[AWS] Update AWS cloud.region parsing

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update `cloud.region` parsing
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4024
 - version: "1.21.0"
   changes:
     - description: Add Security Hub Findings and Insights data streams

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Update `cloud.region` parsing
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.0"
   changes:
     - description: Add Security Hub Findings and Insights data streams

--- a/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
@@ -128,10 +128,10 @@ processors:
       field: json.eventCategory
       target_field: aws.cloudtrail.event_category
       ignore_failure: true
-  - rename:
-      field: json.awsRegion
-      target_field: cloud.region
-      ignore_failure: true
+  - set:
+      field: cloud.region
+      copy_from: json.awsRegion
+      ignore_empty_value: true
   - rename:
       field: json.sourceIPAddress
       target_field: source.address

--- a/packages/aws/data_stream/firewall_logs/_dev/test/pipeline/test-firewall.log-expected.json
+++ b/packages/aws/data_stream/firewall_logs/_dev/test/pipeline/test-firewall.log-expected.json
@@ -10,7 +10,8 @@
                 }
             },
             "cloud": {
-                "availability_zone": "us-east-2a"
+                "availability_zone": "us-east-2a",
+                "region": "us-east-2"
             },
             "destination": {
                 "address": "216.160.83.57",
@@ -136,7 +137,8 @@
                 }
             },
             "cloud": {
-                "availability_zone": "us-east-2a"
+                "availability_zone": "us-east-2a",
+                "region": "us-east-2"
             },
             "destination": {
                 "address": "89.160.20.156",

--- a/packages/aws/data_stream/firewall_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/firewall_logs/elasticsearch/ingest_pipeline/default.yml
@@ -28,6 +28,14 @@ processors:
       field: json.availability_zone
       target_field: cloud.availability_zone
       ignore_missing: true
+  - grok:
+      field: cloud.availability_zone
+      ignore_missing: true
+      ignore_failure: true
+      patterns:
+        - ^%{DATA:cloud.region}%{LETTER}$
+      pattern_definitions:
+        LETTER: '[a-z]+'
   - rename:
       field: json.firewall_name
       target_field: observer.name

--- a/packages/aws/data_stream/route53_resolver_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/elasticsearch/ingest_pipeline/default.yml
@@ -32,10 +32,10 @@ processors:
     ignore_failure: true
     formats:
     - ISO8601
-- rename:
-    field: json.region
-    target_field: cloud.region
-    ignore_missing: true
+- set:
+    field: cloud.region
+    copy_from: json.region
+    ignore_empty_value: true
 - rename:
     field: json.vpc_id
     target_field: aws.vpc_id

--- a/packages/aws/data_stream/s3access/_dev/test/pipeline/test-s3-server-access.log-expected.json
+++ b/packages/aws/data_stream/s3access/_dev/test/pipeline/test-s3-server-access.log-expected.json
@@ -30,7 +30,8 @@
                 }
             },
             "cloud": {
-                "provider": "aws"
+                "provider": "aws",
+                "region": "ap-southeast-1"
             },
             "ecs": {
                 "version": "8.0.0"
@@ -136,7 +137,8 @@
                 }
             },
             "cloud": {
-                "provider": "aws"
+                "provider": "aws",
+                "region": "ap-southeast-1"
             },
             "ecs": {
                 "version": "8.0.0"
@@ -243,7 +245,8 @@
                 }
             },
             "cloud": {
-                "provider": "aws"
+                "provider": "aws",
+                "region": "ap-southeast-1"
             },
             "ecs": {
                 "version": "8.0.0"
@@ -349,7 +352,8 @@
                 }
             },
             "cloud": {
-                "provider": "aws"
+                "provider": "aws",
+                "region": "ap-southeast-1"
             },
             "ecs": {
                 "version": "8.0.0"
@@ -453,7 +457,8 @@
                 }
             },
             "cloud": {
-                "provider": "aws"
+                "provider": "aws",
+                "region": "eu-central-1"
             },
             "ecs": {
                 "version": "8.0.0"
@@ -531,7 +536,8 @@
                 }
             },
             "cloud": {
-                "provider": "aws"
+                "provider": "aws",
+                "region": "ap-southeast-1"
             },
             "ecs": {
                 "version": "8.0.0"
@@ -609,7 +615,8 @@
                 }
             },
             "cloud": {
-                "provider": "aws"
+                "provider": "aws",
+                "region": "us-gov-west-1"
             },
             "ecs": {
                 "version": "8.0.0"

--- a/packages/aws/data_stream/s3access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/s3access/elasticsearch/ingest_pipeline/default.yml
@@ -41,6 +41,12 @@ processors:
         S3KEY: "[a-zA-Z0-9\\/_\\.\\-%+]+"
         S3ID: "[a-zA-Z0-9\\/_\\.\\-%+=]+"
         S3VERSION: "[a-zA-Z0-9.]+"
+  - grok:
+      field: aws.s3access.host_header
+      ignore_missing: true
+      ignore_failure: true
+      patterns:
+        - ^%{DATA}s3\.%{DATA:cloud.region}\.%{DATA}$        
   - script:
       description: Drops null/empty values recursively
       lang: painless

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.21.0
+version: 1.22.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

The AWS-S3 input sets the `cloud.region` field to the region the S3 bucket is located. This is not always the same as the region the event originated per https://discuss.elastic.co/t/filebeat-aws-cloudtrail-processor-parses-incorrect-aws-region-from-logs/312150.  The current ingest pipelines only use a rename processor which doesn't work if the field already exists.  This changes the processor a set to override from the input. Also adds additional parsing for datastreams that don't already have `cloud.region` set.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
