### PR TITLE
Add goimports and go-licenser to tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.17
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/elastic/elastic-package v0.58.1
+	github.com/elastic/go-licenser v0.4.1
 	github.com/elastic/package-registry v1.11.0
 	github.com/magefile/mage v1.13.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/tools v0.1.12
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -43,7 +45,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/elastic/go-elasticsearch/v7 v7.17.1 // indirect
-	github.com/elastic/go-licenser v0.4.1 // indirect
 	github.com/elastic/go-sysinfo v1.7.1 // indirect
 	github.com/elastic/go-ucfg v0.8.6 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
@@ -160,7 +161,6 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
-	golang.org/x/tools v0.1.12 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/api v0.85.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/magefile.go
+++ b/magefile.go
@@ -70,7 +70,7 @@ func format() {
 }
 
 func addLicenseHeaders() error {
-	return sh.RunV("go-licenser", "-license", "Elastic")
+	return sh.RunV("go", "run", "github.com/elastic/go-licenser", "-license", "Elastic")
 }
 
 func goImports() error {
@@ -85,10 +85,10 @@ func goImports() error {
 	}
 
 	args := append(
-		[]string{"-local", GoImportsLocalPrefix, "-l", "-w"},
+		[]string{"run", "golang.org/x/tools/cmd/goimports", "-local", GoImportsLocalPrefix, "-l", "-w"},
 		goFiles...,
 	)
-	return sh.RunV("goimports", args...)
+	return sh.RunV("go", args...)
 }
 
 func goTest() error {

--- a/tools.go
+++ b/tools.go
@@ -7,6 +7,9 @@
 package main
 
 import (
+	_ "golang.org/x/tools/cmd/goimports"
+
 	_ "github.com/elastic/elastic-package"
+	_ "github.com/elastic/go-licenser"
 	_ "github.com/elastic/package-registry"
 )


### PR DESCRIPTION
Use go mod to keep track of these go tools.