### PR TITLE
[Prometheus] Disable leader election; Remove default value for bearer token

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.0"
+  changes:
+    - description: Disable leader election by default, remove bearer token file default value
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/3891
 - version: "0.11.0"
   changes:
     - description: Fix histogram type in collector data_stream

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable leader election by default, remove bearer token file default value
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/3891
+      link: https://github.com/elastic/integrations/pull/4034
 - version: "0.11.0"
   changes:
     - description: Fix histogram type in collector data_stream

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -46,7 +46,7 @@ streams:
         description: Enable leaderelection between a set of Elastic Agents running on Kubernetes
         multi: false
         required: true
-        show_user: false
+        show_user: true
         default: false
       - name: bearer_token_file
         type: text

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -43,17 +43,18 @@ streams:
       - name: leaderelection
         type: bool
         title: Leader Election
+        description: Enable leaderelection between a set of Elastic Agents running on Kubernetes
         multi: false
         required: true
         show_user: false
-        default: true
+        default: false
       - name: bearer_token_file
         type: text
         title: Bearer Token File
+        description: Bearer token file path to authenticate API requests in Kubernetes
         multi: false
         required: false
         show_user: false
-        default: /var/run/secrets/kubernetes.io/serviceaccount/token
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities

--- a/packages/prometheus/data_stream/query/manifest.yml
+++ b/packages/prometheus/data_stream/query/manifest.yml
@@ -48,10 +48,11 @@ streams:
       - name: leaderelection
         type: bool
         title: Leader Election
+        description: Enable leaderelection between a set of Elastic Agents running on Kubernetes
         multi: false
         required: true
         show_user: false
-        default: true
+        default: false
     title: Prometheus query metrics
     enabled: false
     description: Collect Prometheus query metrics

--- a/packages/prometheus/data_stream/query/manifest.yml
+++ b/packages/prometheus/data_stream/query/manifest.yml
@@ -51,7 +51,7 @@ streams:
         description: Enable leaderelection between a set of Elastic Agents running on Kubernetes
         multi: false
         required: true
-        show_user: false
+        show_user: true
         default: false
     title: Prometheus query metrics
     enabled: false

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus Metrics
-version: 0.11.0
+version: 0.12.0
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

For cases when prometheus is running not on kubernetes, prometheus integration does not work:
- defined default value for bearer_token cause those errors:
``` 
{"log.level":"error","@timestamp":"2022-08-18T09:02:02.484Z","log.origin":{"file.name":"process/stdlogger.go","file.line":54},"message":"metricbeat_monitoring stderr: \"panic: close of closed channel\\n\\ngoroutine 2015 [running]:\\ngithub.com/elastic/beats/v7/metricbeat/beater.(*Metricbeat).Stop(0xc0009d44d0)\\n\\t/go/src/github.com/elastic/beats/metricbeat/beater/metricbeat.go:276 +0x28\\ngithub.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).launch.func5()\\n\\t/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:461 +0x68\\nsync.(*Once).doSlow(\"","agent.console.name":"metricbeat_monitoring","agent.console.type":"stderr","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2022-08-18T09:02:02.484Z","log.origin":{"file.name":"process/stdlogger.go","file.line":54},"message":"metricbeat_monitoring stderr: \"0xc0010807d0, 0xc001201c00)\\n\\t/usr/local/go/src/sync/once.go:68 +0x138\\nsync.(*Once).Do(0xc0010807d0, 0xc001201c00)\\n\\t/usr/local/go/src/sync/once.go:59 +0x45\\ngithub.com/elastic/elastic-agent-libs/service.HandleSignals.func1()\\n\\t/go/pkg/mod/github.com/elastic/elastic-agent-libs@v0.2.5/service/service.go:60 +0x20c\\ncreated by github.com/elastic/elastic-agent-libs/service.HandleSignals\\n\\t/go/pkg/mod/github.com/elastic/elastic-agent-libs@v0.2.5/service/service.go:49 +0x25c\\n\"","agent.console.name":"metricbeat_monitoring","agent.console.type":"stderr","ecs.version":"1.6.0"}
```
- enabled leader election works only on kubernetes

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes https://github.com/elastic/integrations/issues/3905

## Screenshots
Collector data_stream:

<img width="926" alt="Screenshot 2022-08-23 at 10 10 31" src="https://user-images.githubusercontent.com/28299531/186145917-918e31b6-12ca-4f6e-9bcb-a182899dfc2b.png">
<img width="909" alt="Screenshot 2022-08-23 at 10 10 46" src="https://user-images.githubusercontent.com/28299531/186145928-0a834f62-2155-4f3e-b748-cca9cc7e121f.png">

