### PR TITLE
Add configuration for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,76 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 365
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 180
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels: []
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: Stalled
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  Hi!
+  We just realized that we haven't looked into this issue in a while. We're
+  sorry!
+  We're labeling this issue as `Stale` to make it hit our filters and
+  make sure we get back to it as soon as possible. In the meantime, it'd
+  be extremely helpful if you could take a look at it as well and confirm its
+  relevance. A simple comment with a nice emoji will be enough `:+1`.
+  Thank you for your contribution!
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  daysUntilStale: 30
+  daysUntilClose: 30
+  markComment: >
+    Hi!
+    We just realized that we haven't looked into this PR in a while. We're
+    sorry!
+    We're labeling this issue as `Stale` to make it hit our filters and
+    make sure we get back to it as soon as possible. In the meantime, it'd
+    be extremely helpful if you could take a look at it as well and confirm its
+    relevance. A simple comment with a nice emoji will be enough `:+1`.
+    Thank you for your contribution!
+  closeComment: >
+    Hi!
+    This PR has been stale for a while and we're going to close it as part of
+    our cleanup procedure.
+    We appreciate your contribution and would like to apologize if we have not
+    been able to review it, due to the current heavy load of the team.
+    Feel free to re-open this PR if you think it should stay open and is worth rebasing.
+    Thank you for your contribution!
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
Starting discussion about automatically marking issues as stale, as a form of reminder for people working on PRs or issues to continue with them if they are still relevant.

Current configuration is basically copied [from beats](https://github.com/elastic/beats/blob/a659f8b2334271ca9d5324427de3467b98675ed0/.github/stale.yml), with some modifications:
* Remove the exception for issues on flaky tests.
* Remove the exception for issues with assignees.
* Reduced days until stale for PR from 60 to 30 days.

@elastic/observablt-robots do you know if we need something else to enable this bot after adding the config?