### PR TITLE
fix condition on community_id processor

### DIFF
--- a/packages/traefik/changelog.yml
+++ b/packages/traefik/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.2"
+  changes:
+    - description: Fix the if condition on the community_id processor in the ingest pipeline
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/4074
 - version: "1.4.1"
   changes:
     - description: Remove unused visualizations

--- a/packages/traefik/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/traefik/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -96,7 +96,7 @@ processors:
       field: network.transport
       value: tcp
   - community_id:
-      if: "ctx?.source?.ip != null && ctx?.source?.port != null && ctx?.destination?.ip != null && ctx?.destination?.ip != null"
+      if: "ctx?.source?.ip != null && ctx?.source?.port != null && ctx?.destination?.ip != null && ctx?.destination?.port != null"
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"

--- a/packages/traefik/manifest.yml
+++ b/packages/traefik/manifest.yml
@@ -1,6 +1,6 @@
 name: traefik
 title: Traefik
-version: 1.4.1
+version: 1.4.2
 release: ga
 description: Collect logs and metrics from Traefik servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fix a `if` condition on the community_id processor on one of the ingest pipeline of the Traefik integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Check that ingest pipeline tests are passing

## How to test this PR locally

`cd packages/traefik && elastic-package test pipeline -v `
