### PR TITLE
cisco_ise: map cisco_ise.log.avpair.task_id as keyword

### DIFF
--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Allow non-numeric task ID fields to be ingested
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4087
 - version: "1.0.0"
   changes:
     - description: Make GA

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-tacacs-accounting.log-expected.json
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-tacacs-accounting.log-expected.json
@@ -18,7 +18,7 @@
                     "avpair": {
                         "priv_lvl": 15,
                         "start_time": "2020-03-26T01:17:12.000Z",
-                        "task_id": 2962,
+                        "task_id": "2962",
                         "timezone": "GMT"
                     },
                     "category": {
@@ -175,7 +175,7 @@
                     "authen_method": "TacacsPlus",
                     "avpair": {
                         "start_time": "2020-03-26T11:30:45.000Z",
-                        "task_id": 35585,
+                        "task_id": "35585",
                         "timezone": "GMT"
                     },
                     "category": {
@@ -333,7 +333,7 @@
                         "pre_session_time": 0,
                         "start_time": "2020-03-26T11:30:45.000Z",
                         "stop_time": "2020-03-26T11:32:52.000Z",
-                        "task_id": 35585,
+                        "task_id": "35585",
                         "timezone": "GMT"
                     },
                     "category": {
@@ -503,7 +503,7 @@
                         "pre_session_time": 0,
                         "start_time": "2020-03-26T11:30:45.000Z",
                         "stop_time": "2020-03-26T11:32:52.000Z",
-                        "task_id": 35585,
+                        "task_id": "35585",
                         "timezone": "GMT"
                     },
                     "category": {

--- a/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_tacacs_accounting.yml
+++ b/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_tacacs_accounting.yml
@@ -113,11 +113,11 @@ processors:
       field: Authen-Method
       target_field: cisco_ise.log.authen_method
       ignore_missing: true
-  - convert:
+  - rename:
       field: AVPair.task_id
       target_field: cisco_ise.log.avpair.task_id
-      type: long
       ignore_missing: true
+      ignore_failure: true
   - rename:
       field: AVPair.timezone
       target_field: cisco_ise.log.avpair.timezone
@@ -233,13 +233,5 @@ processors:
         - RequestLatency
         - Privilege-Level
         - cisco_ise.log.log_details
-        - AVPair.start_time
-        - AVPair.priv-lvl
-        - AVPair.disc-cause
-        - AVPair.disc-cause-ext
-        - AVPair.pre-session-time
-        - AVPair.elapsed_time
-        - AVPair.stop_time
-        - AVPair.task_id
         - AVPair
       ignore_missing: true

--- a/packages/cisco_ise/data_stream/log/fields/fields.yml
+++ b/packages/cisco_ise/data_stream/log/fields/fields.yml
@@ -206,7 +206,7 @@
         - name: stop_time
           type: date
         - name: task_id
-          type: long
+          type: keyword
         - name: timezone
           type: keyword
     - name: called_station

--- a/packages/cisco_ise/data_stream/log/sample_event.json
+++ b/packages/cisco_ise/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-02-21T19:13:08.328Z",
     "agent": {
-        "ephemeral_id": "868c4a5a-ab3d-44f9-b28c-dd0da1bd08f8",
-        "id": "882c1c63-68d0-49f9-8411-0e89960d3b00",
+        "ephemeral_id": "4f4b968e-48f2-4442-984d-73a340e75b02",
+        "id": "bdb81c52-44a4-414c-996b-bcfa977c5f7a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.0"
+        "version": "8.3.3"
     },
     "cisco_ise": {
         "log": {
@@ -23,7 +23,7 @@
             "avpair": {
                 "priv_lvl": 15,
                 "start_time": "2020-03-26T01:17:12.000Z",
-                "task_id": 2962,
+                "task_id": "2962",
                 "timezone": "GMT"
             },
             "category": {
@@ -122,12 +122,12 @@
         "ip": "81.2.69.144"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "882c1c63-68d0-49f9-8411-0e89960d3b00",
-        "snapshot": true,
-        "version": "8.3.0"
+        "id": "bdb81c52-44a4-414c-996b-bcfa977c5f7a",
+        "snapshot": false,
+        "version": "8.3.3"
     },
     "event": {
         "action": "tacacs-accounting",
@@ -136,7 +136,7 @@
             "configuration"
         ],
         "dataset": "cisco_ise.log",
-        "ingested": "2022-04-15T15:33:23Z",
+        "ingested": "2022-08-29T04:16:29Z",
         "kind": "event",
         "sequence": 18415781,
         "timezone": "+00:00",
@@ -148,12 +148,12 @@
         "hostname": "cisco-ise-host"
     },
     "input": {
-        "type": "tcp"
+        "type": "udp"
     },
     "log": {
         "level": "notice",
         "source": {
-            "address": "172.25.0.1:51632"
+            "address": "192.168.144.4:53137"
         },
         "syslog": {
             "priority": 182,

--- a/packages/cisco_ise/docs/README.md
+++ b/packages/cisco_ise/docs/README.md
@@ -37,11 +37,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2020-02-21T19:13:08.328Z",
     "agent": {
-        "ephemeral_id": "868c4a5a-ab3d-44f9-b28c-dd0da1bd08f8",
-        "id": "882c1c63-68d0-49f9-8411-0e89960d3b00",
+        "ephemeral_id": "4f4b968e-48f2-4442-984d-73a340e75b02",
+        "id": "bdb81c52-44a4-414c-996b-bcfa977c5f7a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.0"
+        "version": "8.3.3"
     },
     "cisco_ise": {
         "log": {
@@ -59,7 +59,7 @@ An example event for `log` looks as following:
             "avpair": {
                 "priv_lvl": 15,
                 "start_time": "2020-03-26T01:17:12.000Z",
-                "task_id": 2962,
+                "task_id": "2962",
                 "timezone": "GMT"
             },
             "category": {
@@ -158,12 +158,12 @@ An example event for `log` looks as following:
         "ip": "81.2.69.144"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "882c1c63-68d0-49f9-8411-0e89960d3b00",
-        "snapshot": true,
-        "version": "8.3.0"
+        "id": "bdb81c52-44a4-414c-996b-bcfa977c5f7a",
+        "snapshot": false,
+        "version": "8.3.3"
     },
     "event": {
         "action": "tacacs-accounting",
@@ -172,7 +172,7 @@ An example event for `log` looks as following:
             "configuration"
         ],
         "dataset": "cisco_ise.log",
-        "ingested": "2022-04-15T15:33:23Z",
+        "ingested": "2022-08-29T04:16:29Z",
         "kind": "event",
         "sequence": 18415781,
         "timezone": "+00:00",
@@ -184,12 +184,12 @@ An example event for `log` looks as following:
         "hostname": "cisco-ise-host"
     },
     "input": {
-        "type": "tcp"
+        "type": "udp"
     },
     "log": {
         "level": "notice",
         "source": {
-            "address": "172.25.0.1:51632"
+            "address": "192.168.144.4:53137"
         },
         "syslog": {
             "priority": 182,
@@ -276,7 +276,7 @@ An example event for `log` looks as following:
 | cisco_ise.log.avpair.priv_lvl |  | long |
 | cisco_ise.log.avpair.start_time |  | date |
 | cisco_ise.log.avpair.stop_time |  | date |
-| cisco_ise.log.avpair.task_id |  | long |
+| cisco_ise.log.avpair.task_id |  | keyword |
 | cisco_ise.log.avpair.timezone |  | keyword |
 | cisco_ise.log.called_station.id |  | keyword |
 | cisco_ise.log.calling_station.id |  | keyword |

--- a/packages/cisco_ise/manifest.yml
+++ b/packages/cisco_ise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ise
 title: Cisco ISE
-version: "1.0.0"
+version: "1.1.0"
 license: basic
 description: Collect logs from Cisco ISE with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

In most documented cases cisco_ise.log.avpair.task_id appears to be a decimal
numeric value. However, in the wild hex, numerical and UUID values appear to
exist so map as a keyword.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4075

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
