### PR TITLE
Elastic Agent: Version bump

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.6"
+  changes:
+    - description: Version bump in order to release to the snapshot for kibana bundling process. No changes.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.3.5"
   changes:
     - description: Fix the external ECS fields not being properly resolved during the package build

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Version bump in order to release to the snapshot for kibana bundling process. No changes.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/4089
 - version: "1.3.5"
   changes:
     - description: Fix the external ECS fields not being properly resolved during the package build

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.3.5
+version: 1.3.6
 release: ga
 description: Collect logs and metrics from Elastic Agents.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Bumping up the version in order to release the package to the snapshot repo for kibana bundling process

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/integrations/pull/4007#issuecomment-1230276558
