### PR TITLE
[panw] bug fix for adding processors

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.1.1"
+  changes:
+    - description: fix adding processors to tcp and udp configs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4091
 - version: "3.1.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/panw/data_stream/panos/agent/stream/tcp.yml.hbs
+++ b/packages/panw/data_stream/panos/agent/stream/tcp.yml.hbs
@@ -16,37 +16,37 @@ publisher_pipeline.disable_host: true
 ssl: {{ssl}}
 {{/if}}
 processors:
-  - add_locale: ~
-  {{#if preserve_original_event}}
-  - copy_fields:
-       fields:
-         - from: message
-           to: event.original
-  {{/if}}
-  - syslog:
-      field: message
-      format: auto
-      timezone: {{tz_offset}}
+- add_locale: ~
+{{#if preserve_original_event}}
+- copy_fields:
+    fields:
+    - from: message
+      to: event.original
+{{/if}}
+- syslog:
+    field: message
+    format: auto
+    timezone: {{tz_offset}}
 {{#if processors}}
-  {{processors}}
+{{processors}}
 {{/if}}
 {{#if internal_zones.length}}
-  - add_fields:
-      target: _conf
-      fields:
-        internal_zones:
-        {{#each internal_zones as |zone i|}}
-          - {{zone}}
-        {{/each}}
+- add_fields:
+    target: _conf
+    fields:
+      internal_zones:
+{{#each internal_zones as |zone i|}}
+      - {{zone}}
+{{/each}}
 {{/if}}
 {{#if external_zones.length}}
-  - add_fields:
-      target: _conf
-      fields:
-        external_zones:
-        {{#each external_zones as |zone i|}}
-          - {{zone}}
-        {{/each}}
+- add_fields:
+    target: _conf
+    fields:
+      external_zones:
+{{#each external_zones as |zone i|}}
+      - {{zone}}
+{{/each}}
 {{/if}}
 {{#if tcp_options}}
 {{tcp_options}}

--- a/packages/panw/data_stream/panos/agent/stream/udp.yml.hbs
+++ b/packages/panw/data_stream/panos/agent/stream/udp.yml.hbs
@@ -13,37 +13,37 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-  - add_locale: ~
-  {{#if preserve_original_event}}
-  - copy_fields:
-       fields:
-         - from: message
-           to: event.original
-  {{/if}}
-  - syslog:
-      field: message
-      format: auto
-      timezone: {{tz_offset}}
+- add_locale: ~
+{{#if preserve_original_event}}
+- copy_fields:
+     fields:
+       - from: message
+         to: event.original
+{{/if}}
+- syslog:
+    field: message
+    format: auto
+    timezone: {{tz_offset}}
 {{#if processors}}
-    {{processors}}
+{{processors}}
 {{/if}}
 {{#if internal_zones.length}}
-  - add_fields:
-      target: _conf
-      fields:
-        internal_zones:
-        {{#each internal_zones as |zone i|}}
-          - {{zone}}
-        {{/each}}
+- add_fields:
+    target: _conf
+    fields:
+      internal_zones:
+{{#each internal_zones as |zone i|}}
+      - {{zone}}
+{{/each}}
 {{/if}}
 {{#if external_zones.length}}
-  - add_fields:
-      target: _conf
-      fields:
-        external_zones:
-        {{#each external_zones as |zone i|}}
-          - {{zone}}
-        {{/each}}
+- add_fields:
+    target: _conf
+    fields:
+      external_zones:
+{{#each external_zones as |zone i|}}
+      - {{zone}}
+{{/each}}
 {{/if}}
 {{#if udp_options}}
 {{udp_options}}

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: 3.1.0
+version: 3.1.1
 release: ga
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

For panw changes whitespace so when templates are expanded the policy can be compiled.  Previously adding a processor broke compiling the policy.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~~- [ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

1. `elastic-package stack up -d`
2. Add `panw` integration to a policy
3. Add processors to TCP, UDP & file input types
4. Add integration

