### PR TITLE
[kubernetes] remove overlapping field in state_job data_stream

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix overlapping fields in state_job data stream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/3825
+      link: https://github.com/elastic/integrations/pull/4095
 - version: "1.22.0"
   changes:
     - description: Update apiserver and controllermanaged deprecated fields and dashboards

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.1"
+  changes:
+    - description: Fix overlapping fields in state_job data stream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3825
 - version: "1.22.0"
   changes:
     - description: Update apiserver and controllermanaged deprecated fields and dashboards

--- a/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
@@ -80,6 +80,7 @@
         Kubernetes statefulset name
 
     - name: job.name
+      dimension: true
       type: keyword
       description: >
         Name of the Job to which the Pod belongs

--- a/packages/kubernetes/data_stream/state_job/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_job/fields/fields.yml
@@ -1,12 +1,6 @@
 - name: kubernetes.job
   type: group
   fields:
-    - name: name
-      dimension: true
-      type: keyword
-      description: >
-        The name of the job resource
-
     - name: pods
       type: group
       description: >

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.22.0
+version: 1.22.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

remove overlapping fields in state_job data_stream, that causes some inconsistency (like mentioned [here](https://github.com/elastic/integrations/pull/4081#issuecomment-1228695490))

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
