### PR TITLE
Adding support for v1.25.0 k8s

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     AWS_ACCOUNT_SECRET = "secret/observability-team/ci/elastic-observability-aws-account-auth"
     HOME = "${env.WORKSPACE}"
     KIND_VERSION = "v0.14.0"
-    K8S_VERSION = "v1.24.0"
+    K8S_VERSION = "v1.25.0"
     JOB_GCS_BUCKET = 'beats-ci-temp'
     JOB_GCS_BUCKET_INTERNAL = 'beats-ci-temp-internal'
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'


### PR DESCRIPTION
## What does this PR do?

Adds the new version of v1.25.0 in the list of the supported/tested versions.

Part of https://github.com/elastic/observability-dev/issues/2195