### PR TITLE
set default endpoint in aws to empty string

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.23.4"
   changes:
-    - description: Fix default endpoint
+    - description: Set default endpoint to empty string
       type: bugfix
       link: https://github.com/elastic/integrations/pull/4103
 - version: "1.23.3"

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.4"
+  changes:
+    - description: Fix default endpoint
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.23.3"
   changes:
     - description: Fix Billing Dashboard

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix default endpoint
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/4103
 - version: "1.23.3"
   changes:
     - description: Fix Billing Dashboard

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.23.3
+version: 1.23.4
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration
@@ -65,7 +65,7 @@ vars:
     multi: false
     required: false
     show_user: false
-    default: "amazonaws.com"
+    default: ""
     description: URL of the entry point for an AWS web service
   - name: proxy_url
     type: text

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.2.5"
+  changes:
+    - description: Set default endpoint to empty string
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4103
 - version: "0.2.4"
   changes:
     - description: Fix proxy URL documentation rendering.

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: 0.2.4
+version: 0.2.5
 release: beta
 license: basic
 categories:
@@ -70,7 +70,7 @@ vars:
     multi: false
     required: false
     show_user: false
-    default: "amazonaws.com"
+    default: ""
     description: URL of the entry point for an AWS web service
   - name: proxy_url
     type: text

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Set default endpoint to empty string
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4103
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/cisco_umbrella/data_stream/log/manifest.yml
+++ b/packages/cisco_umbrella/data_stream/log/manifest.yml
@@ -97,7 +97,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: "amazonaws.com"
+        default: ""
         description: URL of the entry point for an AWS web service.
       - name: visibility_timeout
         type: text

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_umbrella
 title: Cisco Umbrella
-version: "1.3.0"
+version: "1.3.1"
 license: basic
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Set default endpoint to empty string
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4103
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -73,7 +73,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: "amazonaws.com"
+        default: ""
         description: URL of the entry point for an AWS web service
       - name: visibility_timeout
         type: text

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.5.0"
+version: "1.5.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
Bug
## What does this PR do?
Apply an hotfix for https://github.com/elastic/beats/issues/32888 directly in the aws integration package.
Proper fix downstream will be addressed in https://github.com/elastic/beats/pull/32921
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
