### PR TITLE
[activemq] Add ECS fields

### DIFF
--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add additional ECS fields.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4104
 - version: "0.4.2"
   changes:
     - description: Remove unnecessary fields from fields.yml

--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,5 +1,9 @@
 # newer versions go on top
-
+- version: "0.4.3"
+  changes:
+    - description: Add additional ECS fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.4.2"
   changes:
     - description: Remove unnecessary fields from fields.yml

--- a/packages/activemq/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/activemq/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -11,8 +11,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:28.474344882Z",
+                "ingested": "2022-08-31T07:43:37.654335852Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "INFO  | anonymous called org.apache.activemq.broker.jmx.QueueView.retryMessages[] at 27-11-2019 08:45:57,213 | qtp443290224-47",
                 "type": "info"
             },
@@ -38,8 +39,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:28.474358832Z",
+                "ingested": "2022-08-31T07:43:37.654346880Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "INFO  | admin called org.apache.activemq.broker.jmx.QueueView.retryMessages[] at 27-11-2019 08:45:57,229 | qtp443290224-45",
                 "type": "info"
             },
@@ -65,8 +67,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:28.474362082Z",
+                "ingested": "2022-08-31T07:43:37.654352920Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "WARN  | admin requested /admin/createDestination.action [JMSDestination='test' JMSDestinationType='queue' secret='4eb0bc3e-9d7a-4256-844c-24f40fda98f1' ] from 127.0.0.1 | qtp12205619-39",
                 "type": "error"
             },
@@ -92,8 +95,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:28.474364902Z",
+                "ingested": "2022-08-31T07:43:37.654358118Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "INFO  | guest requested /admin/purgeDestination.action [JMSDestination='test' JMSDestinationType='queue' secret='eff6a932-1b58-45da-a64a-1b30b246cfc9' ] from 127.0.0.1 | qtp12205619-36",
                 "type": "info"
             },

--- a/packages/activemq/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/activemq/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -11,11 +11,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:37.654335852Z",
+                "ingested": "2022-09-15T08:36:15.107072383Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "INFO  | anonymous called org.apache.activemq.broker.jmx.QueueView.retryMessages[] at 27-11-2019 08:45:57,213 | qtp443290224-47",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -39,11 +41,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:37.654346880Z",
+                "ingested": "2022-09-15T08:36:15.107087694Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "INFO  | admin called org.apache.activemq.broker.jmx.QueueView.retryMessages[] at 27-11-2019 08:45:57,229 | qtp443290224-45",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -67,11 +71,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:37.654352920Z",
+                "ingested": "2022-09-15T08:36:15.107091313Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "WARN  | admin requested /admin/createDestination.action [JMSDestination='test' JMSDestinationType='queue' secret='4eb0bc3e-9d7a-4256-844c-24f40fda98f1' ] from 127.0.0.1 | qtp12205619-39",
-                "type": "error"
+                "type": [
+                    "error"
+                ]
             },
             "log": {
                 "level": "WARN"
@@ -95,11 +101,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:37.654358118Z",
+                "ingested": "2022-09-15T08:36:15.107094261Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "INFO  | guest requested /admin/purgeDestination.action [JMSDestination='test' JMSDestinationType='queue' secret='eff6a932-1b58-45da-a64a-1b30b246cfc9' ] from 127.0.0.1 | qtp12205619-36",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"

--- a/packages/activemq/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -40,9 +40,9 @@ processors:
       source: >-
         def err_levels = ["FATAL", "ERROR", "WARN"];
         if (err_levels.contains(ctx.log.level)) {
-          ctx.event.type = "error";
+          ctx.event.type = ["error"];
         } else {
-          ctx.event.type = "info";
+          ctx.event.type = ["info"];
         }
   - script:
       description: Drops null/empty values recursively

--- a/packages/activemq/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,11 @@ processors:
       ignore_empty_value: true
       ignore_failure: true
   - set:
+      field: event.module
+      value: activemq
+      ignore_empty_value: true
+      ignore_failure: true
+  - set:
       field: event.original
       value: "{{{message}}}"
       ignore_empty_value: true

--- a/packages/activemq/data_stream/audit/fields/ecs.yml
+++ b/packages/activemq/data_stream/audit/fields/ecs.yml
@@ -5,6 +5,8 @@
 - external: ecs
   name: event.kind
 - external: ecs
+  name: event.module
+- external: ecs
   name: event.original
 - external: ecs
   name: log.file.path

--- a/packages/activemq/data_stream/audit/sample_event.json
+++ b/packages/activemq/data_stream/audit/sample_event.json
@@ -1,16 +1,16 @@
 {
-    "@timestamp": "2022-08-31T07:49:38.002Z",
+    "@timestamp": "2022-09-15T08:37:04.078Z",
     "activemq": {
         "audit": {
             "thread": "RMI TCP Connection(1)-127.0.0.1"
         }
     },
     "agent": {
-        "ephemeral_id": "61c2b31a-a18f-4b21-8541-b96c219f2d49",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "15ca0b7d-0d28-4688-abd6-0b827bc3fa0f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.audit",
@@ -21,17 +21,19 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.audit",
-        "ingested": "2022-08-31T07:49:41Z",
+        "ingested": "2022-09-15T08:37:07Z",
         "kind": "event",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "name": "docker-fleet-agent"

--- a/packages/activemq/data_stream/audit/sample_event.json
+++ b/packages/activemq/data_stream/audit/sample_event.json
@@ -1,16 +1,16 @@
 {
-    "@timestamp": "2022-06-29T16:07:25.492Z",
+    "@timestamp": "2022-08-31T07:49:38.002Z",
     "activemq": {
         "audit": {
             "thread": "RMI TCP Connection(1)-127.0.0.1"
         }
     },
     "agent": {
-        "ephemeral_id": "34d3eca2-8de6-4429-8ec7-7c470857b23e",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "61c2b31a-a18f-4b21-8541-b96c219f2d49",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.audit",
@@ -21,15 +21,16 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.audit",
-        "ingested": "2022-06-29T16:07:29Z",
+        "ingested": "2022-08-31T07:49:41Z",
         "kind": "event",
+        "module": "activemq",
         "type": "info"
     },
     "host": {

--- a/packages/activemq/data_stream/broker/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/broker/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,21 @@ processors:
   - set:
       field: ecs.version
       value: 8.2.0
+  - set:
+      field: event.category
+      value: [web]
+      ignore_failure: true
+      ignore_empty_value: true
+  - set:
+      field: event.kind
+      value: metric
+      ignore_empty_value: true
+      ignore_failure: true
+  - set:
+      field: event.type
+      value: info
+      ignore_empty_value: true
+      ignore_failure: true
   - script:
       description: Drops null/empty values recursively
       lang: painless

--- a/packages/activemq/data_stream/broker/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/broker/elasticsearch/ingest_pipeline/default.yml
@@ -16,7 +16,7 @@ processors:
       ignore_failure: true
   - set:
       field: event.type
-      value: info
+      value: [info]
       ignore_empty_value: true
       ignore_failure: true
   - script:

--- a/packages/activemq/data_stream/broker/fields/ecs.yml
+++ b/packages/activemq/data_stream/broker/fields/ecs.yml
@@ -1,9 +1,21 @@
 - external: ecs
+  name: ecs.version
+- external: ecs
+  name: error.message
+- external: ecs
+  name: event.category
+- external: ecs
+  name: event.dataset
+- external: ecs
+  name: event.duration
+- external: ecs
+  name: event.ingested
+- external: ecs
   name: event.kind
 - external: ecs
-  name: event.type
+  name: event.module
 - external: ecs
-  name: ecs.version
+  name: event.type
 - external: ecs
   name: service.address
 - external: ecs

--- a/packages/activemq/data_stream/broker/sample_event.json
+++ b/packages/activemq/data_stream/broker/sample_event.json
@@ -1,5 +1,5 @@
 {
-    "@timestamp": "2022-06-29T16:08:49.982Z",
+    "@timestamp": "2022-08-31T07:51:21.986Z",
     "activemq": {
         "broker": {
             "connections": {
@@ -36,11 +36,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "2de2c614-b1b2-42a6-adb9-9ecddfc0dc07",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "14728cc6-6b6e-4f7b-89aa-d7be43a5eb46",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.broker",
@@ -51,32 +51,37 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "web"
+        ],
         "dataset": "activemq.broker",
-        "duration": 18482338,
-        "ingested": "2022-06-29T16:08:53Z",
-        "module": "activemq"
+        "duration": 16085740,
+        "ingested": "2022-08-31T07:51:25Z",
+        "kind": "metric",
+        "module": "activemq",
+        "type": "info"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.19.0.7"
+            "172.25.0.7"
         ],
         "mac": [
-            "02:42:ac:13:00:07"
+            "02:42:ac:19:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.66.1.el7.x86_64",
+            "kernel": "3.10.0-1160.71.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/activemq/data_stream/broker/sample_event.json
+++ b/packages/activemq/data_stream/broker/sample_event.json
@@ -1,9 +1,9 @@
 {
-    "@timestamp": "2022-08-31T07:51:21.986Z",
+    "@timestamp": "2022-09-15T08:40:01.593Z",
     "activemq": {
         "broker": {
             "connections": {
-                "count": 17
+                "count": 18
             },
             "consumers": {
                 "count": 0
@@ -21,12 +21,12 @@
                 }
             },
             "messages": {
-                "count": 17,
+                "count": 18,
                 "dequeue": {
                     "count": 0
                 },
                 "enqueue": {
-                    "count": 36
+                    "count": 38
                 }
             },
             "name": "localhost",
@@ -36,11 +36,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "14728cc6-6b6e-4f7b-89aa-d7be43a5eb46",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "610c5ccb-2a67-4fcc-83fc-aa5904971538",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.broker",
@@ -51,9 +51,9 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -61,21 +61,23 @@
             "web"
         ],
         "dataset": "activemq.broker",
-        "duration": 16085740,
-        "ingested": "2022-08-31T07:51:25Z",
+        "duration": 14118688,
+        "ingested": "2022-09-15T08:40:05Z",
         "kind": "metric",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.25.0.7"
+            "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:19:00:07"
+            "02:42:ac:12:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {

--- a/packages/activemq/data_stream/log/_dev/test/pipeline/test-activemq.log-expected.json
+++ b/packages/activemq/data_stream/log/_dev/test/pipeline/test-activemq.log-expected.json
@@ -12,11 +12,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039215809Z",
+                "ingested": "2022-09-15T08:36:17.048391747Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,491 | INFO  | KahaDB is version 6 | org.apache.activemq.store.kahadb.MessageDatabase | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -38,11 +40,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039227376Z",
+                "ingested": "2022-09-15T08:36:17.048401891Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,531 | INFO  | PListStore:[/opt/activemq/data/localhost/tmp_storage] started | org.apache.activemq.store.kahadb.plist.PListStoreImpl | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -64,11 +68,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039233236Z",
+                "ingested": "2022-09-15T08:36:17.048404970Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,538 | INFO  | Page File: /opt/activemq/data/kahadb/db.data. Recovered pageFile free list of size: 0 | org.apache.activemq.store.kahadb.disk.page.PageFile | KahaDB Index Free Page Recovery",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -90,11 +96,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039238514Z",
+                "ingested": "2022-09-15T08:36:17.048407867Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,690 | INFO  | Apache ActiveMQ 5.15.9 (localhost, ID:5338986a6080-37033-1574867374550-0:1) is starting | org.apache.activemq.broker.BrokerService | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -119,11 +127,13 @@
                 "stack_trace": "at org.apache.activemq.util.IOExceptionSupport.create(IOExceptionSupport.java:28)[activemq-client-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.registerConnectorMBean(BrokerService.java:2264)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startTransportConnector(BrokerService.java:2744)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startAllConnectors(BrokerService.java:2640)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.doStartBroker(BrokerService.java:771)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startBroker(BrokerService.java:733)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.start(BrokerService.java:636)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.xbean.XBeanBrokerService.afterPropertiesSet(XBeanBrokerService.java:73)[activemq-spring-5.15.9.jar:5.15.9]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.8.0_212]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)[:1.8.0_212]\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.8.0_212]\n\tat java.lang.reflect.Method.invoke(Method.java:498)[:1.8.0_212]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1763)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1700)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039243567Z",
+                "ingested": "2022-09-15T08:36:17.048410776Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,712 | ERROR | Failed to start Apache ActiveMQ (localhost, ID:5338986a6080-37033-1574867374550-0:1) | org.apache.activemq.broker.BrokerService | main\n\tat org.apache.activemq.util.IOExceptionSupport.create(IOExceptionSupport.java:28)[activemq-client-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.registerConnectorMBean(BrokerService.java:2264)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startTransportConnector(BrokerService.java:2744)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startAllConnectors(BrokerService.java:2640)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.doStartBroker(BrokerService.java:771)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startBroker(BrokerService.java:733)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.start(BrokerService.java:636)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.xbean.XBeanBrokerService.afterPropertiesSet(XBeanBrokerService.java:73)[activemq-spring-5.15.9.jar:5.15.9]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.8.0_212]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)[:1.8.0_212]\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.8.0_212]\n\tat java.lang.reflect.Method.invoke(Method.java:498)[:1.8.0_212]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1763)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1700)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]",
-                "type": "error"
+                "type": [
+                    "error"
+                ]
             },
             "log": {
                 "level": "ERROR"
@@ -145,11 +155,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039248497Z",
+                "ingested": "2022-09-15T08:36:17.048413672Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,716 | INFO  | Apache ActiveMQ 5.15.9 (localhost, ID:5338986a6080-37033-1574867374550-0:1) is shutting down | org.apache.activemq.broker.BrokerService | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -171,11 +183,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039253372Z",
+                "ingested": "2022-09-15T08:36:17.048416604Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,718 | INFO  | Connector openwire stopped | org.apache.activemq.broker.TransportConnector | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -197,11 +211,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039258312Z",
+                "ingested": "2022-09-15T08:36:17.048419441Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,719 | INFO  | Connector amqp stopped | org.apache.activemq.broker.TransportConnector | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -223,11 +239,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039263349Z",
+                "ingested": "2022-09-15T08:36:17.048422257Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,721 | INFO  | Connector stomp stopped | org.apache.activemq.broker.TransportConnector | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -249,11 +267,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039268356Z",
+                "ingested": "2022-09-15T08:36:17.048435312Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,722 | INFO  | Connector mqtt stopped | org.apache.activemq.broker.TransportConnector | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -275,11 +295,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039273243Z",
+                "ingested": "2022-09-15T08:36:17.048439934Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,723 | INFO  | Connector ws stopped | org.apache.activemq.broker.TransportConnector | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -301,11 +323,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039278857Z",
+                "ingested": "2022-09-15T08:36:17.048443338Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,727 | INFO  | PListStore:[/opt/activemq/data/localhost/tmp_storage] stopped | org.apache.activemq.store.kahadb.plist.PListStoreImpl | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -327,11 +351,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039284174Z",
+                "ingested": "2022-09-15T08:36:17.048446262Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,728 | INFO  | Stopping async queue tasks | org.apache.activemq.store.kahadb.KahaDBStore | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -353,11 +379,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039289305Z",
+                "ingested": "2022-09-15T08:36:17.048449080Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,730 | INFO  | Stopping async topic tasks | org.apache.activemq.store.kahadb.KahaDBStore | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -379,11 +407,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039294211Z",
+                "ingested": "2022-09-15T08:36:17.048451962Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-29 10:59:49,515 | INFO  | No Spring WebApplicationInitializer types detected on classpath | /admin | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -405,11 +435,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039299302Z",
+                "ingested": "2022-09-15T08:36:17.048454982Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-29 10:59:49,779 | INFO  | Initializing Spring FrameworkServlet 'dispatcher' | /admin | main",
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "INFO"
@@ -431,11 +463,13 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-08-31T07:43:38.039304859Z",
+                "ingested": "2022-09-15T08:36:17.048458141Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2022-06-17 12:19:13,443 | ERROR | Failed to load: class path resource [activemq.xml], reason: Configuration problem: Unexpected failure during bean definition parsing\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'; nested exception is org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host' | org.apache.activemq.xbean.XBeanBrokerFactory | main org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Unexpected failure during bean definition parsing\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'; nested exception is org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host'\\n\\tat org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:70)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:118)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.error(BeanDefinitionParserDelegate.java:308)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:561)\\n\\tat org.apache.xbean.spring.context.v2c.XBeanBeanDefinitionParserDelegate.parseBeanDefinitionElement(XBeanBeanDefinitionParserDelegate.java:58)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:459)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:428)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.processBeanDefinition(XBeanBeanDefinitionDocumentReader.java:188)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseDefaultElement(XBeanBeanDefinitionDocumentReader.java:115)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseBeanDefinitions(XBeanBeanDefinitionDocumentReader.java:95)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:142)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:94)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:508)\\n\\tat org.apache.xbean.spring.context.v2.XBeanXmlBeanDefinitionReader.registerBeanDefinitions(XBeanXmlBeanDefinitionReader.java:79)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:392)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:336)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:304)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.importBeanDefinitionResource(XBeanBeanDefinitionDocumentReader.java:143)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseDefaultElement(XBeanBeanDefinitionDocumentReader.java:109)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseBeanDefinitions(XBeanBeanDefinitionDocumentReader.java:95)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:142)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:94)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:508)\\n\\tat org.apache.xbean.spring.context.v2.XBeanXmlBeanDefinitionReader.registerBeanDefinitions(XBeanXmlBeanDefinitionReader.java:79)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:392)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:336)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:304)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.loadBeanDefinitions(ResourceXmlApplicationContext.java:116)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.loadBeanDefinitions(ResourceXmlApplicationContext.java:104)\\n\\tat org.springframework.context.support.AbstractRefreshableApplicationContext.refreshBeanFactory(AbstractRefreshableApplicationContext.java:126)\\n\\tat org.springframework.context.support.AbstractApplicationContext.obtainFreshBeanFactory(AbstractApplicationContext.java:614)\\n\\tat org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:514)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.\u003cinit\u003e(ResourceXmlApplicationContext.java:64)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.\u003cinit\u003e(ResourceXmlApplicationContext.java:52)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory$1.\u003cinit\u003e(XBeanBrokerFactory.java:104)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory.createApplicationContext(XBeanBrokerFactory.java:104)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory.createBroker(XBeanBrokerFactory.java:67)\\n\\tat org.apache.activemq.broker.BrokerFactory.createBroker(BrokerFactory.java:71)\\n\\tat org.apache.activemq.broker.BrokerFactory.createBroker(BrokerFactory.java:54)\\n\\tat org.apache.activemq.console.command.StartCommand.runTask(StartCommand.java:87)\\n\\tat org.apache.activemq.console.command.AbstractCommand.execute(AbstractCommand.java:63)\\n\\tat org.apache.activemq.console.command.ShellCommand.runTask(ShellCommand.java:154)\\n\\tat org.apache.activemq.console.command.AbstractCommand.execute(AbstractCommand.java:63)\\n\\tat org.apache.activemq.console.command.ShellCommand.main(ShellCommand.java:104)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\n\\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\n\\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\\n\\tat org.apache.activemq.console.Main.runTaskClass(Main.java:262)\\n\\tat org.apache.activemq.console.Main.main(Main.java:115)\\nCaused by: org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host'\\n\\tat org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:70)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:118)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:110)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.error(BeanDefinitionParserDelegate.java:301)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parsePropertyElement(BeanDefinitionParserDelegate.java:897)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parsePropertyElements(BeanDefinitionParserDelegate.java:761)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:546)\\n\\t... 46 more",
-                "type": "error"
+                "type": [
+                    "error"
+                ]
             },
             "log": {
                 "level": "ERROR"

--- a/packages/activemq/data_stream/log/_dev/test/pipeline/test-activemq.log-expected.json
+++ b/packages/activemq/data_stream/log/_dev/test/pipeline/test-activemq.log-expected.json
@@ -12,8 +12,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265270623Z",
+                "ingested": "2022-08-31T07:43:38.039215809Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,491 | INFO  | KahaDB is version 6 | org.apache.activemq.store.kahadb.MessageDatabase | main",
                 "type": "info"
             },
@@ -37,8 +38,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265278088Z",
+                "ingested": "2022-08-31T07:43:38.039227376Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,531 | INFO  | PListStore:[/opt/activemq/data/localhost/tmp_storage] started | org.apache.activemq.store.kahadb.plist.PListStoreImpl | main",
                 "type": "info"
             },
@@ -62,8 +64,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265281088Z",
+                "ingested": "2022-08-31T07:43:38.039233236Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,538 | INFO  | Page File: /opt/activemq/data/kahadb/db.data. Recovered pageFile free list of size: 0 | org.apache.activemq.store.kahadb.disk.page.PageFile | KahaDB Index Free Page Recovery",
                 "type": "info"
             },
@@ -87,8 +90,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265283655Z",
+                "ingested": "2022-08-31T07:43:38.039238514Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,690 | INFO  | Apache ActiveMQ 5.15.9 (localhost, ID:5338986a6080-37033-1574867374550-0:1) is starting | org.apache.activemq.broker.BrokerService | main",
                 "type": "info"
             },
@@ -115,8 +119,9 @@
                 "stack_trace": "at org.apache.activemq.util.IOExceptionSupport.create(IOExceptionSupport.java:28)[activemq-client-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.registerConnectorMBean(BrokerService.java:2264)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startTransportConnector(BrokerService.java:2744)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startAllConnectors(BrokerService.java:2640)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.doStartBroker(BrokerService.java:771)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startBroker(BrokerService.java:733)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.start(BrokerService.java:636)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.xbean.XBeanBrokerService.afterPropertiesSet(XBeanBrokerService.java:73)[activemq-spring-5.15.9.jar:5.15.9]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.8.0_212]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)[:1.8.0_212]\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.8.0_212]\n\tat java.lang.reflect.Method.invoke(Method.java:498)[:1.8.0_212]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1763)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1700)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265286228Z",
+                "ingested": "2022-08-31T07:43:38.039243567Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,712 | ERROR | Failed to start Apache ActiveMQ (localhost, ID:5338986a6080-37033-1574867374550-0:1) | org.apache.activemq.broker.BrokerService | main\n\tat org.apache.activemq.util.IOExceptionSupport.create(IOExceptionSupport.java:28)[activemq-client-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.registerConnectorMBean(BrokerService.java:2264)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startTransportConnector(BrokerService.java:2744)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startAllConnectors(BrokerService.java:2640)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.doStartBroker(BrokerService.java:771)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startBroker(BrokerService.java:733)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.start(BrokerService.java:636)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.xbean.XBeanBrokerService.afterPropertiesSet(XBeanBrokerService.java:73)[activemq-spring-5.15.9.jar:5.15.9]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.8.0_212]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)[:1.8.0_212]\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.8.0_212]\n\tat java.lang.reflect.Method.invoke(Method.java:498)[:1.8.0_212]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1763)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1700)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]",
                 "type": "error"
             },
@@ -140,8 +145,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265288716Z",
+                "ingested": "2022-08-31T07:43:38.039248497Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,716 | INFO  | Apache ActiveMQ 5.15.9 (localhost, ID:5338986a6080-37033-1574867374550-0:1) is shutting down | org.apache.activemq.broker.BrokerService | main",
                 "type": "info"
             },
@@ -165,8 +171,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265291302Z",
+                "ingested": "2022-08-31T07:43:38.039253372Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,718 | INFO  | Connector openwire stopped | org.apache.activemq.broker.TransportConnector | main",
                 "type": "info"
             },
@@ -190,8 +197,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265293995Z",
+                "ingested": "2022-08-31T07:43:38.039258312Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,719 | INFO  | Connector amqp stopped | org.apache.activemq.broker.TransportConnector | main",
                 "type": "info"
             },
@@ -215,8 +223,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265296582Z",
+                "ingested": "2022-08-31T07:43:38.039263349Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,721 | INFO  | Connector stomp stopped | org.apache.activemq.broker.TransportConnector | main",
                 "type": "info"
             },
@@ -240,8 +249,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265299124Z",
+                "ingested": "2022-08-31T07:43:38.039268356Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,722 | INFO  | Connector mqtt stopped | org.apache.activemq.broker.TransportConnector | main",
                 "type": "info"
             },
@@ -265,8 +275,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265301632Z",
+                "ingested": "2022-08-31T07:43:38.039273243Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,723 | INFO  | Connector ws stopped | org.apache.activemq.broker.TransportConnector | main",
                 "type": "info"
             },
@@ -290,8 +301,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265304483Z",
+                "ingested": "2022-08-31T07:43:38.039278857Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,727 | INFO  | PListStore:[/opt/activemq/data/localhost/tmp_storage] stopped | org.apache.activemq.store.kahadb.plist.PListStoreImpl | main",
                 "type": "info"
             },
@@ -315,8 +327,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265306936Z",
+                "ingested": "2022-08-31T07:43:38.039284174Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,728 | INFO  | Stopping async queue tasks | org.apache.activemq.store.kahadb.KahaDBStore | main",
                 "type": "info"
             },
@@ -340,8 +353,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265309449Z",
+                "ingested": "2022-08-31T07:43:38.039289305Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-27 15:09:34,730 | INFO  | Stopping async topic tasks | org.apache.activemq.store.kahadb.KahaDBStore | main",
                 "type": "info"
             },
@@ -365,8 +379,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265311959Z",
+                "ingested": "2022-08-31T07:43:38.039294211Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-29 10:59:49,515 | INFO  | No Spring WebApplicationInitializer types detected on classpath | /admin | main",
                 "type": "info"
             },
@@ -390,8 +405,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265314383Z",
+                "ingested": "2022-08-31T07:43:38.039299302Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2019-11-29 10:59:49,779 | INFO  | Initializing Spring FrameworkServlet 'dispatcher' | /admin | main",
                 "type": "info"
             },
@@ -415,8 +431,9 @@
                 "version": "8.2.0"
             },
             "event": {
-                "ingested": "2022-06-29T16:06:29.265317078Z",
+                "ingested": "2022-08-31T07:43:38.039304859Z",
                 "kind": "event",
+                "module": "activemq",
                 "original": "2022-06-17 12:19:13,443 | ERROR | Failed to load: class path resource [activemq.xml], reason: Configuration problem: Unexpected failure during bean definition parsing\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'; nested exception is org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host' | org.apache.activemq.xbean.XBeanBrokerFactory | main org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Unexpected failure during bean definition parsing\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'; nested exception is org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host'\\n\\tat org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:70)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:118)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.error(BeanDefinitionParserDelegate.java:308)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:561)\\n\\tat org.apache.xbean.spring.context.v2c.XBeanBeanDefinitionParserDelegate.parseBeanDefinitionElement(XBeanBeanDefinitionParserDelegate.java:58)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:459)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:428)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.processBeanDefinition(XBeanBeanDefinitionDocumentReader.java:188)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseDefaultElement(XBeanBeanDefinitionDocumentReader.java:115)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseBeanDefinitions(XBeanBeanDefinitionDocumentReader.java:95)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:142)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:94)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:508)\\n\\tat org.apache.xbean.spring.context.v2.XBeanXmlBeanDefinitionReader.registerBeanDefinitions(XBeanXmlBeanDefinitionReader.java:79)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:392)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:336)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:304)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.importBeanDefinitionResource(XBeanBeanDefinitionDocumentReader.java:143)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseDefaultElement(XBeanBeanDefinitionDocumentReader.java:109)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseBeanDefinitions(XBeanBeanDefinitionDocumentReader.java:95)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:142)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:94)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:508)\\n\\tat org.apache.xbean.spring.context.v2.XBeanXmlBeanDefinitionReader.registerBeanDefinitions(XBeanXmlBeanDefinitionReader.java:79)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:392)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:336)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:304)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.loadBeanDefinitions(ResourceXmlApplicationContext.java:116)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.loadBeanDefinitions(ResourceXmlApplicationContext.java:104)\\n\\tat org.springframework.context.support.AbstractRefreshableApplicationContext.refreshBeanFactory(AbstractRefreshableApplicationContext.java:126)\\n\\tat org.springframework.context.support.AbstractApplicationContext.obtainFreshBeanFactory(AbstractApplicationContext.java:614)\\n\\tat org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:514)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.\u003cinit\u003e(ResourceXmlApplicationContext.java:64)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.\u003cinit\u003e(ResourceXmlApplicationContext.java:52)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory$1.\u003cinit\u003e(XBeanBrokerFactory.java:104)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory.createApplicationContext(XBeanBrokerFactory.java:104)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory.createBroker(XBeanBrokerFactory.java:67)\\n\\tat org.apache.activemq.broker.BrokerFactory.createBroker(BrokerFactory.java:71)\\n\\tat org.apache.activemq.broker.BrokerFactory.createBroker(BrokerFactory.java:54)\\n\\tat org.apache.activemq.console.command.StartCommand.runTask(StartCommand.java:87)\\n\\tat org.apache.activemq.console.command.AbstractCommand.execute(AbstractCommand.java:63)\\n\\tat org.apache.activemq.console.command.ShellCommand.runTask(ShellCommand.java:154)\\n\\tat org.apache.activemq.console.command.AbstractCommand.execute(AbstractCommand.java:63)\\n\\tat org.apache.activemq.console.command.ShellCommand.main(ShellCommand.java:104)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\n\\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\n\\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\\n\\tat org.apache.activemq.console.Main.runTaskClass(Main.java:262)\\n\\tat org.apache.activemq.console.Main.main(Main.java:115)\\nCaused by: org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host'\\n\\tat org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:70)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:118)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:110)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.error(BeanDefinitionParserDelegate.java:301)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parsePropertyElement(BeanDefinitionParserDelegate.java:897)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parsePropertyElements(BeanDefinitionParserDelegate.java:761)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:546)\\n\\t... 46 more",
                 "type": "error"
             },

--- a/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,11 @@ processors:
       ignore_empty_value: true
       ignore_failure: true
   - set:
+      field: event.module
+      value: activemq
+      ignore_empty_value: true
+      ignore_failure: true
+  - set:
       field: event.original
       value: "{{{message}}}"
       ignore_empty_value: true

--- a/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -55,9 +55,9 @@ processors:
       source: >-
         def err_levels = ["FATAL", "ERROR", "WARN"];
         if (err_levels.contains(ctx.log.level)) {
-          ctx.event.type = "error";
+          ctx.event.type = ["error"];
         } else {
-          ctx.event.type = "info";
+          ctx.event.type = ["info"];
         }
   - script:
       description: Drops null/empty values recursively

--- a/packages/activemq/data_stream/log/fields/ecs.yml
+++ b/packages/activemq/data_stream/log/fields/ecs.yml
@@ -7,6 +7,8 @@
 - external: ecs
   name: event.kind
 - external: ecs
+  name: event.module
+- external: ecs
   name: event.original
 - external: ecs
   name: log.file.path

--- a/packages/activemq/data_stream/log/sample_event.json
+++ b/packages/activemq/data_stream/log/sample_event.json
@@ -7,11 +7,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "e81b7006-6b63-43cf-916c-fd5e99bf1359",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "a6cef3a2-8ce9-432a-ae99-738b03dff6d3",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.log",
@@ -22,17 +22,19 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.log",
-        "ingested": "2022-08-31T07:53:23Z",
+        "ingested": "2022-09-15T08:42:26Z",
         "kind": "event",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "name": "docker-fleet-agent"

--- a/packages/activemq/data_stream/log/sample_event.json
+++ b/packages/activemq/data_stream/log/sample_event.json
@@ -7,11 +7,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "638481bc-60c8-45d2-9610-864f2b414cfa",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "e81b7006-6b63-43cf-916c-fd5e99bf1359",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.log",
@@ -22,15 +22,16 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.log",
-        "ingested": "2022-06-29T16:10:16Z",
+        "ingested": "2022-08-31T07:53:23Z",
         "kind": "event",
+        "module": "activemq",
         "type": "info"
     },
     "host": {

--- a/packages/activemq/data_stream/queue/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/queue/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,21 @@ processors:
   - set:
       field: ecs.version
       value: 8.2.0
+  - set:
+      field: event.category
+      value: [web]
+      ignore_failure: true
+      ignore_empty_value: true
+  - set:
+      field: event.kind
+      value: metric
+      ignore_empty_value: true
+      ignore_failure: true
+  - set:
+      field: event.type
+      value: info
+      ignore_empty_value: true
+      ignore_failure: true
   - script:
       description: Drops null/empty values recursively
       lang: painless

--- a/packages/activemq/data_stream/queue/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/queue/elasticsearch/ingest_pipeline/default.yml
@@ -16,7 +16,7 @@ processors:
       ignore_failure: true
   - set:
       field: event.type
-      value: info
+      value: [info]
       ignore_empty_value: true
       ignore_failure: true
   - script:

--- a/packages/activemq/data_stream/queue/fields/ecs.yml
+++ b/packages/activemq/data_stream/queue/fields/ecs.yml
@@ -1,7 +1,19 @@
 - external: ecs
   name: ecs.version
 - external: ecs
+  name: error.message
+- external: ecs
+  name: event.category
+- external: ecs
+  name: event.dataset
+- external: ecs
+  name: event.duration
+- external: ecs
+  name: event.ingested
+- external: ecs
   name: event.kind
+- external: ecs
+  name: event.module
 - external: ecs
   name: event.type
 - external: ecs

--- a/packages/activemq/data_stream/queue/sample_event.json
+++ b/packages/activemq/data_stream/queue/sample_event.json
@@ -1,5 +1,5 @@
 {
-    "@timestamp": "2022-08-31T07:55:00.002Z",
+    "@timestamp": "2022-09-15T08:45:02.912Z",
     "activemq": {
         "queue": {
             "consumers": {
@@ -44,11 +44,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "507afe70-d160-4cb1-9a5d-dbfd49d72c7e",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "5820de34-199e-4c76-82a1-ad1392613bac",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.queue",
@@ -59,9 +59,9 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -69,21 +69,23 @@
             "web"
         ],
         "dataset": "activemq.queue",
-        "duration": 8504220,
-        "ingested": "2022-08-31T07:55:03Z",
+        "duration": 13815751,
+        "ingested": "2022-09-15T08:45:06Z",
         "kind": "metric",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.25.0.7"
+            "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:19:00:07"
+            "02:42:ac:12:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {

--- a/packages/activemq/data_stream/queue/sample_event.json
+++ b/packages/activemq/data_stream/queue/sample_event.json
@@ -1,5 +1,5 @@
 {
-    "@timestamp": "2022-06-29T16:11:38.323Z",
+    "@timestamp": "2022-08-31T07:55:00.002Z",
     "activemq": {
         "queue": {
             "consumers": {
@@ -19,7 +19,7 @@
                     "count": 0
                 },
                 "enqueue": {
-                    "count": 18,
+                    "count": 15,
                     "time": {
                         "avg": 0,
                         "max": 0,
@@ -40,15 +40,15 @@
             "producers": {
                 "count": 0
             },
-            "size": 18
+            "size": 15
         }
     },
     "agent": {
-        "ephemeral_id": "ae634fb6-c546-4958-b1b4-5338a04bf27f",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "507afe70-d160-4cb1-9a5d-dbfd49d72c7e",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.queue",
@@ -59,32 +59,37 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "web"
+        ],
         "dataset": "activemq.queue",
-        "duration": 16655818,
-        "ingested": "2022-06-29T16:11:41Z",
-        "module": "activemq"
+        "duration": 8504220,
+        "ingested": "2022-08-31T07:55:03Z",
+        "kind": "metric",
+        "module": "activemq",
+        "type": "info"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.19.0.7"
+            "172.25.0.7"
         ],
         "mac": [
-            "02:42:ac:13:00:07"
+            "02:42:ac:19:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.66.1.el7.x86_64",
+            "kernel": "3.10.0-1160.71.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/activemq/data_stream/topic/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/topic/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,21 @@ processors:
   - set:
       field: ecs.version
       value: 8.2.0
+  - set:
+      field: event.category
+      value: [web]
+      ignore_failure: true
+      ignore_empty_value: true
+  - set:
+      field: event.kind
+      value: metric
+      ignore_empty_value: true
+      ignore_failure: true
+  - set:
+      field: event.type
+      value: info
+      ignore_empty_value: true
+      ignore_failure: true
   - script:
       description: Drops null/empty values recursively
       lang: painless

--- a/packages/activemq/data_stream/topic/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/topic/elasticsearch/ingest_pipeline/default.yml
@@ -16,7 +16,7 @@ processors:
       ignore_failure: true
   - set:
       field: event.type
-      value: info
+      value: [info]
       ignore_empty_value: true
       ignore_failure: true
   - script:

--- a/packages/activemq/data_stream/topic/fields/ecs.yml
+++ b/packages/activemq/data_stream/topic/fields/ecs.yml
@@ -3,7 +3,17 @@
 - external: ecs
   name: error.message
 - external: ecs
+  name: event.category
+- external: ecs
+  name: event.dataset
+- external: ecs
+  name: event.duration
+- external: ecs
+  name: event.ingested
+- external: ecs
   name: event.kind
+- external: ecs
+  name: event.module
 - external: ecs
   name: event.type
 - external: ecs

--- a/packages/activemq/data_stream/topic/sample_event.json
+++ b/packages/activemq/data_stream/topic/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-08-31T07:56:45.860Z",
+    "@timestamp": "2022-09-15T08:47:37.794Z",
     "activemq": {
         "topic": {
             "consumers": {
                 "count": 0
             },
-            "mbean": "org.apache.activemq:brokerName=localhost,destinationName=ActiveMQ.Advisory.MasterBroker,destinationType=Topic,type=Broker",
+            "mbean": "org.apache.activemq:brokerName=localhost,destinationName=ActiveMQ.Advisory.Queue,destinationType=Topic,type=Broker",
             "memory": {
                 "broker": {
                     "pct": 0
@@ -36,18 +36,18 @@
                     "avg": 1024
                 }
             },
-            "name": "ActiveMQ.Advisory.MasterBroker",
+            "name": "ActiveMQ.Advisory.Queue",
             "producers": {
                 "count": 0
             }
         }
     },
     "agent": {
-        "ephemeral_id": "11eb25ea-ac70-41d3-83b5-394fade438e0",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "7bd82d33-1d0a-4b91-a2b5-5fe43a1a3bec",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.topic",
@@ -58,9 +58,9 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -68,21 +68,23 @@
             "web"
         ],
         "dataset": "activemq.topic",
-        "duration": 15184708,
-        "ingested": "2022-08-31T07:56:49Z",
+        "duration": 9457166,
+        "ingested": "2022-09-15T08:47:41Z",
         "kind": "metric",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.25.0.7"
+            "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:19:00:07"
+            "02:42:ac:12:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {

--- a/packages/activemq/data_stream/topic/sample_event.json
+++ b/packages/activemq/data_stream/topic/sample_event.json
@@ -1,5 +1,5 @@
 {
-    "@timestamp": "2022-06-29T16:13:05.413Z",
+    "@timestamp": "2022-08-31T07:56:45.860Z",
     "activemq": {
         "topic": {
             "consumers": {
@@ -43,11 +43,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "97eb0219-9f47-414b-9e73-6b806294b181",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "11eb25ea-ac70-41d3-83b5-394fade438e0",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.topic",
@@ -58,32 +58,37 @@
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "web"
+        ],
         "dataset": "activemq.topic",
-        "duration": 16295694,
-        "ingested": "2022-06-29T16:13:08Z",
-        "module": "activemq"
+        "duration": 15184708,
+        "ingested": "2022-08-31T07:56:49Z",
+        "kind": "metric",
+        "module": "activemq",
+        "type": "info"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.19.0.7"
+            "172.25.0.7"
         ],
         "mac": [
-            "02:42:ac:13:00:07"
+            "02:42:ac:19:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.66.1.el7.x86_64",
+            "kernel": "3.10.0-1160.71.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/activemq/docs/README.md
+++ b/packages/activemq/docs/README.md
@@ -25,11 +25,11 @@ An example event for `log` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "e81b7006-6b63-43cf-916c-fd5e99bf1359",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "a6cef3a2-8ce9-432a-ae99-738b03dff6d3",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.log",
@@ -40,17 +40,19 @@ An example event for `log` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.log",
-        "ingested": "2022-08-31T07:53:23Z",
+        "ingested": "2022-09-15T08:42:26Z",
         "kind": "event",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "name": "docker-fleet-agent"
@@ -107,18 +109,18 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-08-31T07:49:38.002Z",
+    "@timestamp": "2022-09-15T08:37:04.078Z",
     "activemq": {
         "audit": {
             "thread": "RMI TCP Connection(1)-127.0.0.1"
         }
     },
     "agent": {
-        "ephemeral_id": "61c2b31a-a18f-4b21-8541-b96c219f2d49",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "15ca0b7d-0d28-4688-abd6-0b827bc3fa0f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.audit",
@@ -129,17 +131,19 @@ An example event for `audit` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.audit",
-        "ingested": "2022-08-31T07:49:41Z",
+        "ingested": "2022-09-15T08:37:07Z",
         "kind": "event",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "name": "docker-fleet-agent"
@@ -229,11 +233,11 @@ An example event for `broker` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-08-31T07:51:21.986Z",
+    "@timestamp": "2022-09-15T08:40:01.593Z",
     "activemq": {
         "broker": {
             "connections": {
-                "count": 17
+                "count": 18
             },
             "consumers": {
                 "count": 0
@@ -251,12 +255,12 @@ An example event for `broker` looks as following:
                 }
             },
             "messages": {
-                "count": 17,
+                "count": 18,
                 "dequeue": {
                     "count": 0
                 },
                 "enqueue": {
-                    "count": 36
+                    "count": 38
                 }
             },
             "name": "localhost",
@@ -266,11 +270,11 @@ An example event for `broker` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "14728cc6-6b6e-4f7b-89aa-d7be43a5eb46",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "610c5ccb-2a67-4fcc-83fc-aa5904971538",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.broker",
@@ -281,9 +285,9 @@ An example event for `broker` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -291,21 +295,23 @@ An example event for `broker` looks as following:
             "web"
         ],
         "dataset": "activemq.broker",
-        "duration": 16085740,
-        "ingested": "2022-08-31T07:51:25Z",
+        "duration": 14118688,
+        "ingested": "2022-09-15T08:40:05Z",
         "kind": "metric",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.25.0.7"
+            "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:19:00:07"
+            "02:42:ac:12:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -374,7 +380,7 @@ An example event for `queue` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-08-31T07:55:00.002Z",
+    "@timestamp": "2022-09-15T08:45:02.912Z",
     "activemq": {
         "queue": {
             "consumers": {
@@ -419,11 +425,11 @@ An example event for `queue` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "507afe70-d160-4cb1-9a5d-dbfd49d72c7e",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "5820de34-199e-4c76-82a1-ad1392613bac",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.queue",
@@ -434,9 +440,9 @@ An example event for `queue` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -444,21 +450,23 @@ An example event for `queue` looks as following:
             "web"
         ],
         "dataset": "activemq.queue",
-        "duration": 8504220,
-        "ingested": "2022-08-31T07:55:03Z",
+        "duration": 13815751,
+        "ingested": "2022-09-15T08:45:06Z",
         "kind": "metric",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.25.0.7"
+            "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:19:00:07"
+            "02:42:ac:12:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -531,13 +539,13 @@ An example event for `topic` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-08-31T07:56:45.860Z",
+    "@timestamp": "2022-09-15T08:47:37.794Z",
     "activemq": {
         "topic": {
             "consumers": {
                 "count": 0
             },
-            "mbean": "org.apache.activemq:brokerName=localhost,destinationName=ActiveMQ.Advisory.MasterBroker,destinationType=Topic,type=Broker",
+            "mbean": "org.apache.activemq:brokerName=localhost,destinationName=ActiveMQ.Advisory.Queue,destinationType=Topic,type=Broker",
             "memory": {
                 "broker": {
                     "pct": 0
@@ -568,18 +576,18 @@ An example event for `topic` looks as following:
                     "avg": 1024
                 }
             },
-            "name": "ActiveMQ.Advisory.MasterBroker",
+            "name": "ActiveMQ.Advisory.Queue",
             "producers": {
                 "count": 0
             }
         }
     },
     "agent": {
-        "ephemeral_id": "11eb25ea-ac70-41d3-83b5-394fade438e0",
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "ephemeral_id": "7bd82d33-1d0a-4b91-a2b5-5fe43a1a3bec",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "activemq.topic",
@@ -590,9 +598,9 @@ An example event for `topic` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
+        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -600,21 +608,23 @@ An example event for `topic` looks as following:
             "web"
         ],
         "dataset": "activemq.topic",
-        "duration": 15184708,
-        "ingested": "2022-08-31T07:56:49Z",
+        "duration": 9457166,
+        "ingested": "2022-09-15T08:47:41Z",
         "kind": "metric",
         "module": "activemq",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.25.0.7"
+            "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:19:00:07"
+            "02:42:ac:12:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {

--- a/packages/activemq/docs/README.md
+++ b/packages/activemq/docs/README.md
@@ -25,11 +25,11 @@ An example event for `log` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "638481bc-60c8-45d2-9610-864f2b414cfa",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "e81b7006-6b63-43cf-916c-fd5e99bf1359",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.log",
@@ -40,15 +40,16 @@ An example event for `log` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.log",
-        "ingested": "2022-06-29T16:10:16Z",
+        "ingested": "2022-08-31T07:53:23Z",
         "kind": "event",
+        "module": "activemq",
         "type": "info"
     },
     "host": {
@@ -87,6 +88,7 @@ An example event for `log` looks as following:
 | error.stack_trace | The stack trace of this error in plain text. | wildcard |
 | error.stack_trace.text | Multi-field of `error.stack_trace`. | match_only_text |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
+| event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | event.original | Raw text message of entire event. Used to demonstrate log integrity or where the full log message (before splitting it up in multiple parts) may be required, e.g. for reindex. This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`. If users wish to override this and index this field, please see `Field data types` in the `Elasticsearch Reference`. | keyword |
 | input.type | Input type | keyword |
 | log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
@@ -105,18 +107,18 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-06-29T16:07:25.492Z",
+    "@timestamp": "2022-08-31T07:49:38.002Z",
     "activemq": {
         "audit": {
             "thread": "RMI TCP Connection(1)-127.0.0.1"
         }
     },
     "agent": {
-        "ephemeral_id": "34d3eca2-8de6-4429-8ec7-7c470857b23e",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "61c2b31a-a18f-4b21-8541-b96c219f2d49",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.audit",
@@ -127,15 +129,16 @@ An example event for `audit` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.audit",
-        "ingested": "2022-06-29T16:07:29Z",
+        "ingested": "2022-08-31T07:49:41Z",
         "kind": "event",
+        "module": "activemq",
         "type": "info"
     },
     "host": {
@@ -187,6 +190,7 @@ An example event for `audit` looks as following:
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | error.message | Error message. | match_only_text |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
+| event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | event.original | Raw text message of entire event. Used to demonstrate log integrity or where the full log message (before splitting it up in multiple parts) may be required, e.g. for reindex. This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`. If users wish to override this and index this field, please see `Field data types` in the `Elasticsearch Reference`. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
@@ -225,7 +229,7 @@ An example event for `broker` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-06-29T16:08:49.982Z",
+    "@timestamp": "2022-08-31T07:51:21.986Z",
     "activemq": {
         "broker": {
             "connections": {
@@ -262,11 +266,11 @@ An example event for `broker` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "2de2c614-b1b2-42a6-adb9-9ecddfc0dc07",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "14728cc6-6b6e-4f7b-89aa-d7be43a5eb46",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.broker",
@@ -277,32 +281,37 @@ An example event for `broker` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "web"
+        ],
         "dataset": "activemq.broker",
-        "duration": 18482338,
-        "ingested": "2022-06-29T16:08:53Z",
-        "module": "activemq"
+        "duration": 16085740,
+        "ingested": "2022-08-31T07:51:25Z",
+        "kind": "metric",
+        "module": "activemq",
+        "type": "info"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.19.0.7"
+            "172.25.0.7"
         ],
         "mac": [
-            "02:42:ac:13:00:07"
+            "02:42:ac:19:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.66.1.el7.x86_64",
+            "kernel": "3.10.0-1160.71.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -344,7 +353,13 @@ An example event for `broker` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |
 | data_stream.type | Data stream type. | constant_keyword |  |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| error.message | Error message. | match_only_text |  |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |  |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |  |
+| event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |  |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |  |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |  |
+| event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |  |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
@@ -359,7 +374,7 @@ An example event for `queue` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-06-29T16:11:38.323Z",
+    "@timestamp": "2022-08-31T07:55:00.002Z",
     "activemq": {
         "queue": {
             "consumers": {
@@ -379,7 +394,7 @@ An example event for `queue` looks as following:
                     "count": 0
                 },
                 "enqueue": {
-                    "count": 18,
+                    "count": 15,
                     "time": {
                         "avg": 0,
                         "max": 0,
@@ -400,15 +415,15 @@ An example event for `queue` looks as following:
             "producers": {
                 "count": 0
             },
-            "size": 18
+            "size": 15
         }
     },
     "agent": {
-        "ephemeral_id": "ae634fb6-c546-4958-b1b4-5338a04bf27f",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "507afe70-d160-4cb1-9a5d-dbfd49d72c7e",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.queue",
@@ -419,32 +434,37 @@ An example event for `queue` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "web"
+        ],
         "dataset": "activemq.queue",
-        "duration": 16655818,
-        "ingested": "2022-06-29T16:11:41Z",
-        "module": "activemq"
+        "duration": 8504220,
+        "ingested": "2022-08-31T07:55:03Z",
+        "kind": "metric",
+        "module": "activemq",
+        "type": "info"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.19.0.7"
+            "172.25.0.7"
         ],
         "mac": [
-            "02:42:ac:13:00:07"
+            "02:42:ac:19:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.66.1.el7.x86_64",
+            "kernel": "3.10.0-1160.71.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -490,7 +510,13 @@ An example event for `queue` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |
 | data_stream.type | Data stream type. | constant_keyword |  |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| error.message | Error message. | match_only_text |  |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |  |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |  |
+| event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |  |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |  |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |  |
+| event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |  |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
@@ -505,7 +531,7 @@ An example event for `topic` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-06-29T16:13:05.413Z",
+    "@timestamp": "2022-08-31T07:56:45.860Z",
     "activemq": {
         "topic": {
             "consumers": {
@@ -549,11 +575,11 @@ An example event for `topic` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "97eb0219-9f47-414b-9e73-6b806294b181",
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "ephemeral_id": "11eb25ea-ac70-41d3-83b5-394fade438e0",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "data_stream": {
         "dataset": "activemq.topic",
@@ -564,32 +590,37 @@ An example event for `topic` looks as following:
         "version": "8.2.0"
     },
     "elastic_agent": {
-        "id": "4052b5b6-59e4-4711-8a2c-f6c667f81bbd",
+        "id": "728e85f2-d5f4-42f2-8dde-3efe59b4d89f",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.3.2"
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "web"
+        ],
         "dataset": "activemq.topic",
-        "duration": 16295694,
-        "ingested": "2022-06-29T16:13:08Z",
-        "module": "activemq"
+        "duration": 15184708,
+        "ingested": "2022-08-31T07:56:49Z",
+        "kind": "metric",
+        "module": "activemq",
+        "type": "info"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.19.0.7"
+            "172.25.0.7"
         ],
         "mac": [
-            "02:42:ac:13:00:07"
+            "02:42:ac:19:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.66.1.el7.x86_64",
+            "kernel": "3.10.0-1160.71.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -635,7 +666,12 @@ An example event for `topic` looks as following:
 | data_stream.type | Data stream type. | constant_keyword |  |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
 | error.message | Error message. | match_only_text |  |
+| event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |  |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |  |
+| event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |  |
+| event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` \< `event.created` \< `event.ingested`. | date |  |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |  |
+| event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |  |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,6 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: 0.4.2
+version: 0.4.3
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
- Enhancement

## What does this PR do?
This pull request is raised to add some ECS fields to ActiveMQ package which could be useful for user experience. Following changes are made to enhance package.

- Added event.category
- Added event.kind
- Added event.type
- Updated ecs.yml with all the fields
- Updated version to 0.4.3 in manifest.yml

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/activemq directory.
- Run the following command to run tests.
