### PR TITLE
okta: mark api_key config field as required

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Mark api_key config option as a required field
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4127
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: 1.10.0
+version: 1.10.1
 release: ga
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
@@ -30,7 +30,7 @@ policy_templates:
             type: text
             title: API Key
             multi: false
-            required: false
+            required: true
             show_user: true
           - name: http_client_timeout
             type: text


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes the configuration requirements for the okta api_key.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #4105

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
