### PR TITLE
[kubernetes ] Add missing dimention fields

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.1"
+  changes:
+    - description: Add missing dimension fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4081
 - version: "1.23.0"
   changes:
     - description: Add fields to audit logs data stream

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add missing dimension fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4081
+      link: https://github.com/elastic/integrations/pull/4144
 - version: "1.23.0"
   changes:
     - description: Add fields to audit logs data stream

--- a/packages/kubernetes/data_stream/container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container/fields/base-fields.yml
@@ -31,6 +31,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
@@ -40,6 +40,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace
@@ -74,6 +75,7 @@
         Kubernetes node UID
 
     - name: namespace_uid
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace UID

--- a/packages/kubernetes/data_stream/pod/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/pod/fields/base-fields.yml
@@ -31,6 +31,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace
@@ -79,6 +80,7 @@
         Kubernetes node UID
 
     - name: namespace_uid
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace UID

--- a/packages/kubernetes/data_stream/state_container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_container/fields/base-fields.yml
@@ -31,6 +31,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/data_stream/state_cronjob/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/fields/base-fields.yml
@@ -31,6 +31,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/data_stream/state_daemonset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/fields/base-fields.yml
@@ -29,6 +29,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
@@ -92,7 +92,6 @@
         Name of the CronJob to which the Pod belongs
 
     - name: container.name
-      dimension: true
       type: keyword
       description: >
         Kubernetes container name

--- a/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
@@ -29,6 +29,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace
@@ -91,6 +92,7 @@
         Name of the CronJob to which the Pod belongs
 
     - name: container.name
+      dimension: true
       type: keyword
       description: >
         Kubernetes container name

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/fields/base-fields.yml
@@ -29,6 +29,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml
@@ -31,6 +31,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/data_stream/state_replicaset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/fields/base-fields.yml
@@ -29,6 +29,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace
@@ -65,13 +66,13 @@
         Kubernetes Service selectors map
 
     - name: replicaset.name
-      dimensiont: true
+      dimension: true
       type: keyword
       description: >
         Kubernetes replicaset name
 
     - name: deployment.name
-      dimensiont: true
+      dimension: true
       type: keyword
       description: >
         Kubernetes deployment name

--- a/packages/kubernetes/data_stream/state_resourcequota/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/fields/base-fields.yml
@@ -29,6 +29,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/data_stream/state_service/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_service/fields/base-fields.yml
@@ -29,6 +29,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/data_stream/state_statefulset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/fields/base-fields.yml
@@ -29,6 +29,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace
@@ -75,7 +76,7 @@
         Kubernetes deployment name
 
     - name: statefulset.name
-      dimensions: true
+      dimension: true
       type: keyword
       description: >
         Kubernetes statefulset name

--- a/packages/kubernetes/data_stream/volume/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/volume/fields/base-fields.yml
@@ -29,6 +29,7 @@
         Kubernetes pod IP
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         Kubernetes namespace

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.23.0
+version: 1.23.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

When working on another PR - https://github.com/elastic/integrations/pull/4095#discussion_r958218787, I've noticed that some dimension fields are missing - mainly for `namespace` field - at some point namespace related PR was reverted and all dimension fields were removed - https://github.com/elastic/integrations/pull/2209.
Also some fields had typos

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
