### PR TITLE
[Stack Monitoring] add error.message mapping

### DIFF
--- a/packages/elasticsearch/data_stream/ccr/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/ccr/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/cluster_stats/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/cluster_stats/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/enrich/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/enrich/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/index/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/index/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/index_recovery/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/index_recovery/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/index_summary/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/index_summary/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/ml_job/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/ml_job/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/node/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/node/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/node_stats/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/node_stats/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/pending_tasks/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/pending_tasks/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/elasticsearch/data_stream/shard/fields/ecs.yml
+++ b/packages/elasticsearch/data_stream/shard/fields/ecs.yml
@@ -17,3 +17,5 @@
   external: ecs
 - name: service.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/kibana/data_stream/cluster_actions/fields/ecs.yml
+++ b/packages/kibana/data_stream/cluster_actions/fields/ecs.yml
@@ -20,3 +20,5 @@
   external: ecs
 - name: host.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/kibana/data_stream/cluster_rules/fields/ecs.yml
+++ b/packages/kibana/data_stream/cluster_rules/fields/ecs.yml
@@ -20,3 +20,5 @@
   external: ecs
 - name: host.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/kibana/data_stream/node_actions/fields/ecs.yml
+++ b/packages/kibana/data_stream/node_actions/fields/ecs.yml
@@ -20,3 +20,5 @@
   external: ecs
 - name: host.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/kibana/data_stream/node_rules/fields/ecs.yml
+++ b/packages/kibana/data_stream/node_rules/fields/ecs.yml
@@ -20,3 +20,5 @@
   external: ecs
 - name: host.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/kibana/data_stream/stats/fields/ecs.yml
+++ b/packages/kibana/data_stream/stats/fields/ecs.yml
@@ -20,3 +20,5 @@
   external: ecs
 - name: host.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/kibana/data_stream/status/fields/ecs.yml
+++ b/packages/kibana/data_stream/status/fields/ecs.yml
@@ -11,3 +11,5 @@
 - name: service.address
   type: keyword
   description: Address where data about this service was collected from.
+- name: error.message
+  external: ecs

--- a/packages/kibana/docs/README.md
+++ b/packages/kibana/docs/README.md
@@ -353,6 +353,7 @@ Cluster actions metrics documentation
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| error.message | Error message. | match_only_text |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
@@ -465,6 +466,7 @@ Cluster rules metrics
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| error.message | Error message. | match_only_text |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
@@ -577,6 +579,7 @@ Node actions metrics
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| error.message | Error message. | match_only_text |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
@@ -685,6 +688,7 @@ Node rules metrics
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| error.message | Error message. | match_only_text |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |

--- a/packages/logstash/data_stream/node/fields/ecs.yml
+++ b/packages/logstash/data_stream/node/fields/ecs.yml
@@ -23,3 +23,5 @@
   external: ecs
 - name: host.name
   external: ecs
+- name: error.message
+  external: ecs

--- a/packages/logstash/data_stream/node_stats/fields/ecs.yml
+++ b/packages/logstash/data_stream/node_stats/fields/ecs.yml
@@ -23,3 +23,5 @@
   external: ecs
 - name: host.name
   external: ecs
+- name: error.message
+  external: ecs


### PR DESCRIPTION
### Summary

Add mapping for the [error.message](https://www.elastic.co/guide/en/ecs/current/ecs-error.html#field-error-message) field. 
It will allow SM to filter erroneous documents for https://github.com/elastic/kibana/pull/140102 and https://github.com/elastic/integrations/issues/4011