### PR TITLE
[MongoDB]Added system test for the integration package

### DIFF
--- a/packages/mongodb/_dev/deploy/docker/Dockerfile
+++ b/packages/mongodb/_dev/deploy/docker/Dockerfile
@@ -4,7 +4,4 @@ RUN sed -i "/jessie-updates/d" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y netcat
 COPY init.js .
 COPY adduser.js .
-RUN touch /var/log/mongodb/mongod.log && \
-    chown -R mongodb:mongodb /var/log/mongodb/ && \
-    chmod -R 777 /var/log/mongodb/mongod.log
 HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 27017

--- a/packages/mongodb/_dev/deploy/docker/Dockerfile
+++ b/packages/mongodb/_dev/deploy/docker/Dockerfile
@@ -1,0 +1,7 @@
+ARG MONGODB_VERSION
+FROM mongo:${MONGODB_VERSION}
+RUN sed -i "/jessie-updates/d" /etc/apt/sources.list
+RUN apt-get update && apt-get install -y netcat
+COPY init.js .
+COPY adduser.js .
+HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 27017

--- a/packages/mongodb/_dev/deploy/docker/Dockerfile
+++ b/packages/mongodb/_dev/deploy/docker/Dockerfile
@@ -4,4 +4,7 @@ RUN sed -i "/jessie-updates/d" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y netcat
 COPY init.js .
 COPY adduser.js .
+RUN touch /var/log/mongodb/mongod.log && \
+    chown -R mongodb:mongodb /var/log/mongodb/ && \
+    chmod -R 777 /var/log/mongodb/mongod.log
 HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 27017

--- a/packages/mongodb/_dev/deploy/docker/adduser.js
+++ b/packages/mongodb/_dev/deploy/docker/adduser.js
@@ -1,0 +1,8 @@
+db = db.getSiblingDB('admin');
+db.createUser(
+    {
+        user: "beats",
+        pwd: "pass",
+        roles: ["clusterMonitor"]
+    }
+);

--- a/packages/mongodb/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mongodb/_dev/deploy/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.3'
 services:
   mongodb:
     image: docker.elastic.co/integrations-ci/beats-mongodb:${MONGODB_VERSION:-5.0}
+    user: root
     build:
       context: .
       args:

--- a/packages/mongodb/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mongodb/_dev/deploy/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2.3'
+services:
+  mongodb:
+    image: docker.elastic.co/integrations-ci/beats-mongodb:${MONGODB_VERSION:-5.0}
+    build:
+      context: .
+      args:
+        MONGODB_VERSION: ${MONGODB_VERSION:-5.0}
+    command:
+      - '--replSet'
+      - 'beats'
+      - '--logpath'
+      - '/var/log/mongodb/mongod.log'
+    ports:
+      - 27017
+    volumes:
+      - ./setup.sh:/docker-entrypoint-initdb.d/setup.sh
+      - ${SERVICE_LOGS_DIR}:/var/log/mongodb

--- a/packages/mongodb/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mongodb/_dev/deploy/docker/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2.3'
 services:
   mongodb:
     image: docker.elastic.co/integrations-ci/beats-mongodb:${MONGODB_VERSION:-5.0}
-    user: mongodb
     build:
       context: .
       args:

--- a/packages/mongodb/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mongodb/_dev/deploy/docker/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       context: .
       args:
         MONGODB_VERSION: ${MONGODB_VERSION:-5.0}
+    volumes:
+      - ./setup.sh:/docker-entrypoint-initdb.d/setup.sh
+      - ${SERVICE_LOGS_DIR}:/var/log/mongodb
     command:
       - '--replSet'
       - 'beats'
@@ -13,6 +16,3 @@ services:
       - '/var/log/mongodb/mongod.log'
     ports:
       - 27017
-    volumes:
-      - ./setup.sh:/docker-entrypoint-initdb.d/setup.sh
-      - ${SERVICE_LOGS_DIR}:/var/log/mongodb

--- a/packages/mongodb/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mongodb/_dev/deploy/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 services:
   mongodb:
     image: docker.elastic.co/integrations-ci/beats-mongodb:${MONGODB_VERSION:-5.0}
-    user: root
+    user: mongodb
     build:
       context: .
       args:

--- a/packages/mongodb/_dev/deploy/docker/init.js
+++ b/packages/mongodb/_dev/deploy/docker/init.js
@@ -1,0 +1,1 @@
+rs.initiate();

--- a/packages/mongodb/_dev/deploy/docker/setup.sh
+++ b/packages/mongodb/_dev/deploy/docker/setup.sh
@@ -1,0 +1,4 @@
+sleep 30 | echo Sleeping
+mongo mongodb://localhost:27017 init.js
+sleep 30 | echo Sleeping
+mongo mongodb://localhost:27017 adduser.js

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.3"
+  changes:
+    - description: Added System test and Updated with hostname to use FQDN 
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2917
 - version: "1.3.2"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,8 +1,8 @@
 - version: "1.3.3"
   changes:
-    - description: Added System test and Updated with hostname to use FQDN 
+    - description: Added System test and Updated with hostname to use FQDN
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2917
+      link: https://github.com/elastic/integrations/pull/4151
 - version: "1.3.2"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/mongodb/data_stream/collstats/_dev/test/system/test-collstats-config.yml
+++ b/packages/mongodb/data_stream/collstats/_dev/test/system/test-collstats-config.yml
@@ -1,0 +1,5 @@
+vars:
+  hosts:
+    - "{{Hostname}}"
+username: beats
+password: pass

--- a/packages/mongodb/data_stream/collstats/sample_event.json
+++ b/packages/mongodb/data_stream/collstats/sample_event.json
@@ -1,35 +1,68 @@
 {
-    "@timestamp": "2020-06-29T21:20:51.459Z",
+    "@timestamp": "2022-09-06T11:05:04.348Z",
+    "agent": {
+        "ephemeral_id": "405fac7e-5dda-4c3b-9342-5832c6684d4b",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
+    },
+    "data_stream": {
+        "dataset": "mongodb.collstats",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "snapshot": false,
+        "version": "8.4.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "mongodb.collstats",
+        "duration": 12585576506,
+        "ingested": "2022-09-06T11:05:17Z",
+        "module": "mongodb"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.20.0.7"
+        ],
+        "mac": [
+            "02:42:ac:14:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.124-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
+    },
     "metricset": {
         "name": "collstats",
         "period": 10000
     },
-    "service": {
-        "address": "localhost:27017",
-        "type": "mongodb"
-    },
-    "agent": {
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a",
-        "name": "KaiyanMacBookPro"
-    },
-    "event": {
-        "dataset": "mongodb.collstats",
-        "module": "mongodb",
-        "duration": 3378520
-    },
     "mongodb": {
         "collstats": {
-            "collection": "startup_log",
+            "collection": "external_validation_keys",
             "commands": {
                 "count": 0,
                 "time": {
                     "us": 0
                 }
             },
-            "db": "local",
+            "db": "config",
             "getmore": {
                 "count": 0,
                 "time": {
@@ -44,23 +77,23 @@
             },
             "lock": {
                 "read": {
-                    "count": 74,
+                    "count": 3,
                     "time": {
-                        "us": 443
+                        "us": 1111
                     }
                 },
                 "write": {
-                    "count": 1,
+                    "count": 0,
                     "time": {
-                        "us": 8
+                        "us": 0
                     }
                 }
             },
-            "name": "local.startup_log",
+            "name": "config.external_validation_keys",
             "queries": {
-                "count": 0,
+                "count": 3,
                 "time": {
-                    "us": 0
+                    "us": 1111
                 }
             },
             "remove": {
@@ -70,9 +103,9 @@
                 }
             },
             "total": {
-                "count": 75,
+                "count": 3,
                 "time": {
-                    "us": 451
+                    "us": 1111
                 }
             },
             "update": {
@@ -83,7 +116,8 @@
             }
         }
     },
-    "ecs": {
-        "version": "1.5.0"
+    "service": {
+        "address": "mongodb://elastic-package-service-mongodb-1",
+        "type": "mongodb"
     }
 }

--- a/packages/mongodb/data_stream/dbstats/_dev/test/system/test-dbstats-config.yml
+++ b/packages/mongodb/data_stream/dbstats/_dev/test/system/test-dbstats-config.yml
@@ -1,0 +1,5 @@
+vars:
+  hosts:
+    - "{{Hostname}}"
+username: beats
+password: pass

--- a/packages/mongodb/data_stream/dbstats/sample_event.json
+++ b/packages/mongodb/data_stream/dbstats/sample_event.json
@@ -1,49 +1,82 @@
 {
-    "@timestamp": "2020-06-29T21:20:51.459Z",
+    "@timestamp": "2022-09-06T11:06:33.498Z",
+    "agent": {
+        "ephemeral_id": "a554de8f-c161-4ed6-88e9-b411bfbcb7fb",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
+    },
+    "data_stream": {
+        "dataset": "mongodb.dbstats",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "snapshot": false,
+        "version": "8.4.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "mongodb.dbstats",
+        "duration": 21551686426,
+        "ingested": "2022-09-06T11:06:56Z",
+        "module": "mongodb"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.20.0.7"
+        ],
+        "mac": [
+            "02:42:ac:14:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.124-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
+    },
     "metricset": {
         "name": "dbstats",
         "period": 10000
     },
-    "service": {
-        "address": "localhost:27017",
-        "type": "mongodb"
-    },
-    "agent": {
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a",
-        "name": "KaiyanMacBookPro"
-    },
-    "event": {
-        "dataset": "mongodb.dbstats",
-        "module": "mongodb",
-        "duration": 3378520
-    },
     "mongodb": {
         "dbstats": {
+            "avg_obj_size": {
+                "bytes": 161.6
+            },
+            "collections": 3,
+            "data_size": {
+                "bytes": 808
+            },
+            "db": "admin",
             "file_size": {},
             "index_size": {
-                "bytes": 20480
+                "bytes": 98304
             },
+            "indexes": 4,
             "ns_size_mb": {},
+            "objects": 5,
             "storage_size": {
-                "bytes": 20480
-            },
-            "num_extents": 0,
-            "collections": 1,
-            "objects": 1,
-            "db": "admin",
-            "data_size": {
-                "bytes": 59
-            },
-            "indexes": 1,
-            "avg_obj_size": {
-                "bytes": 59
+                "bytes": 77824
             }
         }
     },
-    "ecs": {
-        "version": "1.5.0"
+    "service": {
+        "address": "mongodb://elastic-package-service-mongodb-1",
+        "type": "mongodb"
     }
 }

--- a/packages/mongodb/data_stream/log/_dev/test/pipeline/test-mongodb-debian.log-expected.json
+++ b/packages/mongodb/data_stream/log/_dev/test/pipeline/test-mongodb-debian.log-expected.json
@@ -2,25 +2,25 @@
     "expected": [
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894242470Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "git version: 009580ad490190ba33d1c6253ebd8d91808923e4",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658200718Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -29,25 +29,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894251345Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "modules: none",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658203228Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -56,25 +56,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "OpenSSL version: OpenSSL 1.0.2l  25 May 2017",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658204319Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894252637Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "OpenSSL version: OpenSSL 1.0.2l  25 May 2017",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -83,25 +83,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.677Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894253720Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "wiredtiger_open config: create,cache_size=8G,session_max=20000,eviction=(threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658205305Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "STORAGE"
+                    "component": "STORAGE",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -110,25 +110,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.724Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894254678Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "Initializing full-time diagnostic data capture with directory '/var/lib/mongodb/diagnostic.data'",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658206206Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "FTDC"
+                    "component": "FTDC",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -137,25 +137,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.724Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "Starting hostname canonicalization worker",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658207127Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894255762Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "Starting hostname canonicalization worker",
             "mongodb": {
                 "log": {
-                    "context": "HostnameCanonicalizationWorker",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "HostnameCanonicalizationWorker"
                 }
             },
             "tags": [
@@ -164,25 +164,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.744Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "waiting for connections on port 27017",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658208042Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894256720Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "waiting for connections on port 27017",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -191,25 +191,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:50:55.170Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "end connection 127.0.0.1:55404 (0 connections now open)",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658208948Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894257637Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "end connection 127.0.0.1:55404 (0 connections now open)",
             "mongodb": {
                 "log": {
-                    "context": "conn1",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "conn1"
                 }
             },
             "tags": [
@@ -218,25 +218,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:50:55.487Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894258678Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "connection accepted from 127.0.0.1:55406 #2 (1 connection now open)",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658209848Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -245,25 +245,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.606Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894259637Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "now exiting",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658210746Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -272,25 +272,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.606Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894260678Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "closing listening socket: 7",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658211650Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -299,25 +299,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.606Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894261678Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "removing socket file: /run/mongodb/mongodb-27017.sock",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658212709Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -326,25 +326,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.606Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894262720Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "shutdown: going to flush diaglog...",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658213652Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -353,25 +353,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.606Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "shutdown: going to close sockets...",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658214561Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894263637Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "shutdown: going to close sockets...",
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -380,25 +380,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.688Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894264595Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "shutdown: removing fs lock...",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658215467Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "STORAGE"
+                    "component": "STORAGE",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -407,25 +407,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894265595Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "db version v3.2.11",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658216369Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -434,25 +434,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894266553Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "build environment:",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658217378Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -461,25 +461,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894267595Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "distarch: x86_64",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658218285Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -488,25 +488,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "options: { config: \"/etc/mongodb.conf\", net: { bindIp: \"127.0.0.1\", unixDomainSocket: { pathPrefix: \"/run/mongodb\" } }, storage: { dbPath: \"/var/lib/mongodb\", journal: { enabled: true } }, systemLog: { destination: \"file\", logAppend: true, path: \"/var/log/mongodb/mongodb.log\" } }",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658219189Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894268553Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "options: { config: \"/etc/mongodb.conf\", net: { bindIp: \"127.0.0.1\", unixDomainSocket: { pathPrefix: \"/run/mongodb\" } }, storage: { dbPath: \"/var/lib/mongodb\", journal: { enabled: true } }, systemLog: { destination: \"file\", logAppend: true, path: \"/var/log/mongodb/mongodb.log\" } }",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -515,25 +515,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:50:55.170Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "connection accepted from 127.0.0.1:55404 #1 (1 connection now open)",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658220107Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894269512Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "connection accepted from 127.0.0.1:55404 #1 (1 connection now open)",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -542,25 +542,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:50:56.180Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "end connection 127.0.0.1:55414 (0 connections now open)",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658221006Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894270428Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "end connection 127.0.0.1:55414 (0 connections now open)",
             "mongodb": {
                 "log": {
-                    "context": "conn3",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "conn3"
                 }
             },
             "tags": [
@@ -569,25 +569,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:15:42.095Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894271470Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "end connection 127.0.0.1:58336 (0 connections now open)",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658221904Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "conn4",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "conn4"
                 }
             },
             "tags": [
@@ -596,25 +596,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.606Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894272637Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "shutdown: going to close listening sockets...",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658222813Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -623,25 +623,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.606Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "WiredTigerKVEngine shutting down",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658223831Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894273637Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "WiredTigerKVEngine shutting down",
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "STORAGE"
+                    "component": "STORAGE",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -650,25 +650,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.688Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894274553Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "dbexit:  rc: 0",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658224728Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -677,25 +677,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894275512Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "MongoDB starting : pid=29803 port=27017 dbpath=/var/lib/mongodb 64-bit host=sleipnir",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658225630Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -704,25 +704,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894276428Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "allocator: tcmalloc",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658226535Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -731,25 +731,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:44:56.657Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "target_arch: x86_64",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658227436Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894277470Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "target_arch: x86_64",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -758,25 +758,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:50:55.487Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "end connection 127.0.0.1:55406 (0 connections now open)",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658228335Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894278512Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "end connection 127.0.0.1:55406 (0 connections now open)",
             "mongodb": {
                 "log": {
-                    "context": "conn2",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "conn2"
                 }
             },
             "tags": [
@@ -785,25 +785,25 @@
         },
         {
             "@timestamp": "2018-02-05T12:50:56.180Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "connection accepted from 127.0.0.1:55414 #3 (1 connection now open)",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658229232Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894279512Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "connection accepted from 127.0.0.1:55414 #3 (1 connection now open)",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -812,25 +812,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:11:41.401Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894280470Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "connection accepted from 127.0.0.1:58336 #4 (1 connection now open)",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658230143Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -839,25 +839,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.605Z",
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "created": "2020-04-28T11:07:58.223Z",
+                "ingested": "2022-09-06T11:02:58.894281637Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
+            },
             "log": {
                 "level": "I"
             },
             "message": "got signal 15 (Terminated), will terminate after current cmd ends",
-            "event": {
-                "ingested": "2022-01-11T04:39:50.658231031Z",
-                "type": [
-                    "info"
-                ],
-                "category": [
-                    "database"
-                ],
-                "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
-            },
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "CONTROL"
+                    "component": "CONTROL",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -866,25 +866,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.605Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "Shutting down full-time diagnostic data capture",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658231931Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894282595Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "Shutting down full-time diagnostic data capture",
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "FTDC"
+                    "component": "FTDC",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -893,25 +893,25 @@
         },
         {
             "@timestamp": "2018-02-05T13:49:45.606Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "closing listening socket: 6",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658232828Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894283637Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "closing listening socket: 6",
             "mongodb": {
                 "log": {
-                    "context": "signalProcessingThread",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "signalProcessingThread"
                 }
             },
             "tags": [
@@ -920,25 +920,25 @@
         },
         {
             "@timestamp": "2019-03-07T15:10:26.960Z",
-            "log": {
-                "level": "I"
-            },
-            "message": "Successfully connected to dbbox7:27017, took 10ms (1 connections now open to dbbox7:27017)",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658233847Z",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894284595Z",
+                "kind": "event",
+                "type": [
+                    "info"
+                ]
             },
+            "log": {
+                "level": "I"
+            },
+            "message": "Successfully connected to dbbox7:27017, took 10ms (1 connections now open to dbbox7:27017)",
             "mongodb": {
                 "log": {
-                    "context": "NetworkInterfaceASIO-Replication-0",
-                    "component": "ASIO"
+                    "component": "ASIO",
+                    "context": "NetworkInterfaceASIO-Replication-0"
                 }
             },
             "tags": [
@@ -947,26 +947,26 @@
         },
         {
             "@timestamp": "2020-03-31T21:19:46.942Z",
-            "log": {
-                "level": "E"
-            },
-            "message": "** ERROR: A write operation resulted in an error. E11000 duplicate key error index: test.people.$_id_ dup key: { : 0 }",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658234752Z",
-                "type": [
-                    "change",
-                    "error"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894285553Z",
+                "kind": "event",
+                "type": [
+                    "change",
+                    "error"
+                ]
             },
+            "log": {
+                "level": "E"
+            },
+            "message": "** ERROR: A write operation resulted in an error. E11000 duplicate key error index: test.people.$_id_ dup key: { : 0 }",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "WRITE"
+                    "component": "WRITE",
+                    "context": "initandlisten"
                 }
             },
             "tags": [
@@ -975,26 +975,26 @@
         },
         {
             "@timestamp": "2020-03-31T21:19:47.420Z",
-            "log": {
-                "level": "E"
-            },
-            "message": "** ERROR: No connection could be made because the target machine actively refused it 127.0.0.1:27017 at System.Net.Sockets.Socket.EndConnect",
             "event": {
-                "ingested": "2022-01-11T04:39:50.658235658Z",
-                "type": [
-                    "info",
-                    "error"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.894286470Z",
+                "kind": "event",
+                "type": [
+                    "info",
+                    "error"
+                ]
             },
+            "log": {
+                "level": "E"
+            },
+            "message": "** ERROR: No connection could be made because the target machine actively refused it 127.0.0.1:27017 at System.Net.Sockets.Socket.EndConnect",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "NETWORK"
+                    "component": "NETWORK",
+                    "context": "initandlisten"
                 }
             },
             "tags": [

--- a/packages/mongodb/data_stream/log/_dev/test/pipeline/test-mongodb-ubuntu-4-4-4.log-expected.json
+++ b/packages/mongodb/data_stream/log/_dev/test/pipeline/test-mongodb-ubuntu-4-4-4.log-expected.json
@@ -2,34 +2,34 @@
     "expected": [
         {
             "@timestamp": "2021-03-22T21:21:20.349Z",
-            "log": {
-                "level": "I"
-            },
             "event": {
-                "ingested": "2022-01-11T04:39:51.673756010Z",
-                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:20.349+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":4615611, \"ctx\":\"initandlisten\",\"msg\":\"MongoDB starting\",\"attr\":{\"pid\":1,\"port\":27017,\"dbPath\":\"/data/db\",\"architecture\":\"64-bit\",\"host\":\"6150fe65a89c\"}}",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.952683928Z",
+                "kind": "event",
+                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:20.349+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":4615611, \"ctx\":\"initandlisten\",\"msg\":\"MongoDB starting\",\"attr\":{\"pid\":1,\"port\":27017,\"dbPath\":\"/data/db\",\"architecture\":\"64-bit\",\"host\":\"6150fe65a89c\"}}",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "I"
             },
             "message": "MongoDB starting",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "STORAGE",
-                    "id": 4615611,
                     "attr": {
+                        "architecture": "64-bit",
+                        "dbPath": "/data/db",
                         "host": "6150fe65a89c",
                         "pid": 1,
-                        "dbPath": "/data/db",
-                        "port": 27017,
-                        "architecture": "64-bit"
-                    }
+                        "port": 27017
+                    },
+                    "component": "STORAGE",
+                    "context": "initandlisten",
+                    "id": 4615611
                 }
             },
             "tags": [
@@ -38,41 +38,41 @@
         },
         {
             "@timestamp": "2021-03-22T21:21:20.350Z",
-            "log": {
-                "level": "I"
-            },
             "event": {
-                "ingested": "2022-01-11T04:39:51.673772020Z",
-                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:20.350+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":23403,   \"ctx\":\"initandlisten\",\"msg\":\"Build Info\",\"attr\":{\"buildInfo\":{\"version\":\"4.4.4\",\"gitVersion\":\"8db30a63db1a9d84bdcad0c83369623f708e0397\",\"openSSLVersion\":\"OpenSSL 1.1.1  11 Sep 2018\",\"modules\":[],\"allocator\":\"tcmalloc\",\"environment\":{\"distmod\":\"ubuntu1804\",\"distarch\":\"x86_64\",\"target_arch\":\"x86_64\"}}}}",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.952694178Z",
+                "kind": "event",
+                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:20.350+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":23403,   \"ctx\":\"initandlisten\",\"msg\":\"Build Info\",\"attr\":{\"buildInfo\":{\"version\":\"4.4.4\",\"gitVersion\":\"8db30a63db1a9d84bdcad0c83369623f708e0397\",\"openSSLVersion\":\"OpenSSL 1.1.1  11 Sep 2018\",\"modules\":[],\"allocator\":\"tcmalloc\",\"environment\":{\"distmod\":\"ubuntu1804\",\"distarch\":\"x86_64\",\"target_arch\":\"x86_64\"}}}}",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "I"
             },
             "message": "Build Info",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "CONTROL",
-                    "id": 23403,
                     "attr": {
                         "buildInfo": {
-                            "openSSLVersion": "OpenSSL 1.1.1  11 Sep 2018",
-                            "gitVersion": "8db30a63db1a9d84bdcad0c83369623f708e0397",
+                            "allocator": "tcmalloc",
                             "environment": {
                                 "distarch": "x86_64",
                                 "distmod": "ubuntu1804",
                                 "target_arch": "x86_64"
                             },
-                            "allocator": "tcmalloc",
-                            "version": "4.4.4",
-                            "modules": []
+                            "gitVersion": "8db30a63db1a9d84bdcad0c83369623f708e0397",
+                            "modules": [],
+                            "openSSLVersion": "OpenSSL 1.1.1  11 Sep 2018",
+                            "version": "4.4.4"
                         }
-                    }
+                    },
+                    "component": "CONTROL",
+                    "context": "initandlisten",
+                    "id": 23403
                 }
             },
             "tags": [
@@ -81,35 +81,35 @@
         },
         {
             "@timestamp": "2021-03-22T21:21:26.240Z",
-            "log": {
-                "level": "I"
-            },
             "event": {
-                "ingested": "2022-01-11T04:39:51.673773332Z",
-                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.240+00:00\"},\"s\":\"I\",  \"c\":\"RECOVERY\", \"id\":23987,   \"ctx\":\"initandlisten\",\"msg\":\"WiredTiger recoveryTimestamp\",\"attr\":{\"recoveryTimestamp\":{\"$timestamp\":{\"t\":0,\"i\":0}}}}",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.952695678Z",
+                "kind": "event",
+                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.240+00:00\"},\"s\":\"I\",  \"c\":\"RECOVERY\", \"id\":23987,   \"ctx\":\"initandlisten\",\"msg\":\"WiredTiger recoveryTimestamp\",\"attr\":{\"recoveryTimestamp\":{\"$timestamp\":{\"t\":0,\"i\":0}}}}",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "I"
             },
             "message": "WiredTiger recoveryTimestamp",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "RECOVERY",
-                    "id": 23987,
                     "attr": {
                         "recoveryTimestamp": {
                             "$timestamp": {
-                                "t": 0,
-                                "i": 0
+                                "i": 0,
+                                "t": 0
                             }
                         }
-                    }
+                    },
+                    "component": "RECOVERY",
+                    "context": "initandlisten",
+                    "id": 23987
                 }
             },
             "tags": [
@@ -118,27 +118,24 @@
         },
         {
             "@timestamp": "2021-03-22T21:21:26.363Z",
-            "log": {
-                "level": "I"
-            },
             "event": {
-                "ingested": "2022-01-11T04:39:51.673774255Z",
-                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.363+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"admin.system.version\",\"uuidDisposition\":\"provided\",\"uuid\":{\"uuid\":{\"$uuid\":\"b383f03c-b97c-4584-87ae-ab1b8ea399c3\"}},\"options\":{\"uuid\":{\"$uuid\":\"b383f03c-b97c-4584-87ae-ab1b8ea399c3\"}}}}",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.952696762Z",
+                "kind": "event",
+                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.363+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"admin.system.version\",\"uuidDisposition\":\"provided\",\"uuid\":{\"uuid\":{\"$uuid\":\"b383f03c-b97c-4584-87ae-ab1b8ea399c3\"}},\"options\":{\"uuid\":{\"$uuid\":\"b383f03c-b97c-4584-87ae-ab1b8ea399c3\"}}}}",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "I"
             },
             "message": "createCollection",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "STORAGE",
-                    "id": 20320,
                     "attr": {
                         "namespace": "admin.system.version",
                         "options": {
@@ -146,13 +143,16 @@
                                 "$uuid": "b383f03c-b97c-4584-87ae-ab1b8ea399c3"
                             }
                         },
-                        "uuidDisposition": "provided",
                         "uuid": {
                             "uuid": {
                                 "$uuid": "b383f03c-b97c-4584-87ae-ab1b8ea399c3"
                             }
-                        }
-                    }
+                        },
+                        "uuidDisposition": "provided"
+                    },
+                    "component": "STORAGE",
+                    "context": "initandlisten",
+                    "id": 20320
                 }
             },
             "tags": [
@@ -161,38 +161,38 @@
         },
         {
             "@timestamp": "2021-03-22T21:21:26.410Z",
-            "log": {
-                "level": "I"
-            },
             "event": {
-                "ingested": "2022-01-11T04:39:51.673775167Z",
-                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.410+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"namespace\":\"admin.system.version\",\"index\":\"_id_\",\"commitTimestamp\":{\"$timestamp\":{\"t\":0,\"i\":0}}}}",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.952697762Z",
+                "kind": "event",
+                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.410+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"namespace\":\"admin.system.version\",\"index\":\"_id_\",\"commitTimestamp\":{\"$timestamp\":{\"t\":0,\"i\":0}}}}",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "I"
             },
             "message": "Index build: done building",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "INDEX",
-                    "id": 20345,
                     "attr": {
-                        "namespace": "admin.system.version",
-                        "index": "_id_",
+                        "buildUUID": null,
                         "commitTimestamp": {
                             "$timestamp": {
-                                "t": 0,
-                                "i": 0
+                                "i": 0,
+                                "t": 0
                             }
                         },
-                        "buildUUID": null
-                    }
+                        "index": "_id_",
+                        "namespace": "admin.system.version"
+                    },
+                    "component": "INDEX",
+                    "context": "initandlisten",
+                    "id": 20345
                 }
             },
             "tags": [
@@ -201,30 +201,30 @@
         },
         {
             "@timestamp": "2021-03-22T21:21:26.412Z",
-            "log": {
-                "level": "I"
-            },
             "event": {
-                "ingested": "2022-01-11T04:39:51.673776065Z",
-                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.412+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20459,   \"ctx\":\"initandlisten\",\"msg\":\"Setting featureCompatibilityVersion\",\"attr\":{\"newVersion\":\"4.4\"}}",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.952698803Z",
+                "kind": "event",
+                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.412+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20459,   \"ctx\":\"initandlisten\",\"msg\":\"Setting featureCompatibilityVersion\",\"attr\":{\"newVersion\":\"4.4\"}}",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "I"
             },
             "message": "Setting featureCompatibilityVersion",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "COMMAND",
-                    "id": 20459,
                     "attr": {
                         "newVersion": "4.4"
-                    }
+                    },
+                    "component": "COMMAND",
+                    "context": "initandlisten",
+                    "id": 20459
                 }
             },
             "tags": [
@@ -233,30 +233,30 @@
         },
         {
             "@timestamp": "2021-03-22T21:21:26.451Z",
-            "log": {
-                "level": "I"
-            },
             "event": {
-                "ingested": "2022-01-11T04:39:51.673776960Z",
-                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.451+00:00\"},\"s\":\"I\",  \"c\":\"FTDC\",     \"id\":20625,   \"ctx\":\"initandlisten\",\"msg\":\"Initializing full-time diagnostic data capture\",\"attr\":{\"dataDirectory\":\"/data/db/diagnostic.data\"}}",
-                "type": [
-                    "info"
-                ],
                 "category": [
                     "database"
                 ],
                 "created": "2020-04-28T11:07:58.223Z",
-                "kind": "event"
+                "ingested": "2022-09-06T11:02:58.952699803Z",
+                "kind": "event",
+                "original": "{\"t\":{\"$date\":\"2021-03-22T21:21:26.451+00:00\"},\"s\":\"I\",  \"c\":\"FTDC\",     \"id\":20625,   \"ctx\":\"initandlisten\",\"msg\":\"Initializing full-time diagnostic data capture\",\"attr\":{\"dataDirectory\":\"/data/db/diagnostic.data\"}}",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "I"
             },
             "message": "Initializing full-time diagnostic data capture",
             "mongodb": {
                 "log": {
-                    "context": "initandlisten",
-                    "component": "FTDC",
-                    "id": 20625,
                     "attr": {
                         "dataDirectory": "/data/db/diagnostic.data"
-                    }
+                    },
+                    "component": "FTDC",
+                    "context": "initandlisten",
+                    "id": 20625
                 }
             },
             "tags": [

--- a/packages/mongodb/data_stream/log/_dev/test/system/test-log-config.yml
+++ b/packages/mongodb/data_stream/log/_dev/test/system/test-log-config.yml
@@ -1,0 +1,5 @@
+vars: ~
+data_stream:
+  vars:
+    paths:
+      - "{{SERVICE_LOGS_DIR}}/mongod*"

--- a/packages/mongodb/data_stream/log/_dev/test/system/test-log-config.yml
+++ b/packages/mongodb/data_stream/log/_dev/test/system/test-log-config.yml
@@ -2,4 +2,4 @@ vars: ~
 data_stream:
   vars:
     paths:
-      - "{{SERVICE_LOGS_DIR}}/mongod.log"
+      - "{{SERVICE_LOGS_DIR}}/mongo*"

--- a/packages/mongodb/data_stream/log/_dev/test/system/test-log-config.yml
+++ b/packages/mongodb/data_stream/log/_dev/test/system/test-log-config.yml
@@ -2,4 +2,4 @@ vars: ~
 data_stream:
   vars:
     paths:
-      - "{{SERVICE_LOGS_DIR}}/mongod*"
+      - "{{SERVICE_LOGS_DIR}}/mongod.log"

--- a/packages/mongodb/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mongodb/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4,9 +4,9 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - grok:
     field: message
     patterns:
@@ -25,6 +25,26 @@ processors:
 - append:
     field: event.category
     value: database
+- append:
+    field: related.user
+    value: "{{{ user.name }}}"
+    allow_duplicates: false
+    if: ctx.user?.name != null && ctx.user?.name != ''
+- append:
+    field: related.user
+    value: "{{{ user.effective.name }}}"
+    allow_duplicates: false
+    if: ctx.user?.effective?.name != null && ctx.user?.effective?.name != ''
+- append:
+    field: related.ip
+    value: "{{{ source.ip }}}"
+    allow_duplicates: false
+    if: ctx.source?.ip != null && ctx.source?.ip != ''
+- append:
+    field: related.hosts
+    value: "{{{ host.hostname }}}"
+    allow_duplicates: false
+    if: ctx.host?.hostname != null && ctx.host?.hostname != ''
 - remove:
     field:
     - first_char

--- a/packages/mongodb/data_stream/log/fields/base-fields.yml
+++ b/packages/mongodb/data_stream/log/fields/base-fields.yml
@@ -15,6 +15,15 @@
   type: constant_keyword
   description: Event dataset
   value: mongodb.log
+- name: input.type
+  description: Type of Filebeat input.
+  type: keyword
+- name: log.flags
+  type: keyword
+  description: This field contains the flags of the event.
+- name: log.offset
+  description: Offset of the entry in the log file.
+  type: long
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/mongodb/data_stream/log/fields/ecs.yml
+++ b/packages/mongodb/data_stream/log/fields/ecs.yml
@@ -14,3 +14,19 @@
   name: service.type
 - external: ecs
   name: tags
+- external: ecs
+  name: related.hosts
+- external: ecs
+  name: related.ip
+- external: ecs
+  name: related.user
+- external: ecs
+  name: user.effective.name
+- external: ecs
+  name: user.id
+- external: ecs
+  name: user.name
+- external: ecs
+  name: source.ip
+- external: ecs
+  name: source.port

--- a/packages/mongodb/data_stream/log/fields/fields.yml
+++ b/packages/mongodb/data_stream/log/fields/fields.yml
@@ -4,14 +4,14 @@
     - name: component
       type: keyword
       description: |
-        Functional categorization of message
+        Functional categorization of message.
     - name: context
       type: keyword
       description: |
         Context of message
     - name: id
       description: |
-        Integer representing the unique identifier of the log statement
+        Integer representing the unique identifier of the log statement.
       example: 4615611
       type: long
     - name: attr

--- a/packages/mongodb/data_stream/log/sample_event.json
+++ b/packages/mongodb/data_stream/log/sample_event.json
@@ -1,39 +1,102 @@
 {
-    "container": {
-        "id": "mongodb"
-    },
+    "@timestamp": "2022-09-06T11:08:21.832Z",
     "agent": {
-        "name": "KaiyanMacBookPro",
-        "id": "8e0c8cfc-69bd-4f15-a2e0-7c6ed1f0963a",
-        "ephemeral_id": "a82d1c90-90b8-44e6-94ac-d0ca900b4948",
+        "ephemeral_id": "2ee80bc4-513a-4887-9c2f-c3008b0c6c3e",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "name": "docker-fleet-agent",
         "type": "filebeat",
+        "version": "8.4.0"
+    },
+    "data_stream": {
+        "dataset": "mongodb.log",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "ecs": {
         "version": "8.0.0"
     },
-    "log": {
-        "file": {
-            "path": "/usr/local/var/log/mongodb/mongo.log"
-        },
-        "level": "I"
-    },
-    "message": "end connection 127.0.0.1:60764 (1 connection now open)",
-    "@timestamp": "2020-06-29T21:17:11.459Z",
-    "ecs": {
-        "version": "1.5.0"
+    "elastic_agent": {
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "snapshot": false,
+        "version": "8.4.0"
     },
     "event": {
-        "created": "2020-06-29T21:17:12.442Z",
-        "kind": "event",
+        "agent_id_status": "verified",
         "category": [
             "database"
         ],
+        "created": "2022-09-06T11:08:31.181Z",
+        "dataset": "mongodb.log",
+        "ingested": "2022-09-06T11:08:32Z",
+        "kind": "event",
+        "original": "{\"t\":{\"$date\":\"2022-09-06T11:08:21.832+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":4915701, \"ctx\":\"-\",\"msg\":\"Initialized wire specification\",\"attr\":{\"spec\":{\"incomingExternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":13},\"incomingInternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":13},\"outgoing\":{\"minWireVersion\":0,\"maxWireVersion\":13},\"isInternalClient\":true}}}",
         "type": [
             "info"
         ]
     },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.20.0.7"
+        ],
+        "mac": [
+            "02:42:ac:14:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.124-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
+    },
+    "input": {
+        "type": "log"
+    },
+    "log": {
+        "file": {
+            "path": "/tmp/service_logs/mongod.log"
+        },
+        "level": "I",
+        "offset": 0
+    },
+    "message": "Initialized wire specification",
     "mongodb": {
         "log": {
+            "attr": {
+                "spec": {
+                    "incomingExternalClient": {
+                        "maxWireVersion": 13,
+                        "minWireVersion": 0
+                    },
+                    "incomingInternalClient": {
+                        "maxWireVersion": 13,
+                        "minWireVersion": 0
+                    },
+                    "isInternalClient": true,
+                    "outgoing": {
+                        "maxWireVersion": 13,
+                        "minWireVersion": 0
+                    }
+                }
+            },
             "component": "NETWORK",
-            "context": "conn2180"
+            "context": "-",
+            "id": 4915701
         }
-    }
+    },
+    "related": {
+        "hosts": [
+            "docker-fleet-agent"
+        ]
+    },
+    "tags": [
+        "mongodb-logs"
+    ]
 }

--- a/packages/mongodb/data_stream/metrics/_dev/test/system/test-metrics-config.yml
+++ b/packages/mongodb/data_stream/metrics/_dev/test/system/test-metrics-config.yml
@@ -1,0 +1,5 @@
+vars:
+  hosts:
+    - "{{Hostname}}"
+username: beats
+password: pass

--- a/packages/mongodb/data_stream/metrics/sample_event.json
+++ b/packages/mongodb/data_stream/metrics/sample_event.json
@@ -1,32 +1,218 @@
 {
-    "@timestamp": "2020-06-29T21:20:51.459Z",
+    "@timestamp": "2022-09-06T11:09:57.291Z",
+    "agent": {
+        "ephemeral_id": "61e37719-d2a1-4ae5-9d82-17db42ac6986",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
+    },
+    "data_stream": {
+        "dataset": "mongodb.metrics",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "snapshot": false,
+        "version": "8.4.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "mongodb.metrics",
+        "duration": 12572294588,
+        "ingested": "2022-09-06T11:10:10Z",
+        "module": "mongodb"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.20.0.7"
+        ],
+        "mac": [
+            "02:42:ac:14:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.124-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
+    },
+    "metricset": {
+        "name": "metrics",
+        "period": 10000
+    },
     "mongodb": {
         "metrics": {
+            "commands": {
+                "aggregate": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "build_info": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "coll_stats": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "connection_pool_stats": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "count": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "db_stats": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "distinct": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "find": {
+                    "failed": 0,
+                    "total": 11
+                },
+                "get_cmd_line_opts": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "get_last_error": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "get_log": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "get_more": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "get_parameter": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "host_info": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "insert": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "is_master": {
+                    "failed": 0,
+                    "total": 3
+                },
+                "is_self": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "last_collections": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "last_commands": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "list_databased": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "list_indexes": {
+                    "failed": 1,
+                    "total": 1
+                },
+                "ping": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "profile": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "replset_get_rbid": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "replset_get_status": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "replset_heartbeat": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "replset_update_position": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "server_status": {
+                    "failed": 0,
+                    "total": 1
+                },
+                "update": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "whatsmyuri": {
+                    "failed": 0,
+                    "total": 0
+                }
+            },
+            "cursor": {
+                "open": {
+                    "no_timeout": 0,
+                    "pinned": 0,
+                    "total": 0
+                },
+                "timed_out": 0
+            },
+            "document": {
+                "deleted": 0,
+                "inserted": 0,
+                "returned": 2,
+                "updated": 0
+            },
+            "get_last_error": {
+                "write_timeouts": 0,
+                "write_wait": {
+                    "count": 1,
+                    "ms": 0
+                }
+            },
+            "operation": {
+                "scan_and_order": 3,
+                "write_conflicts": 0
+            },
+            "query_executor": {
+                "scanned_documents": {
+                    "count": 2
+                },
+                "scanned_indexes": {
+                    "count": 0
+                }
+            },
             "replication": {
-                "network": {
-                    "ops": 0,
-                    "reders_created": 0,
-                    "bytes": 0,
-                    "getmores": {
-                        "count": 0,
-                        "time": {
-                            "ms": 0
-                        }
-                    }
-                },
-                "executor": {
-                    "shutting_down": false,
-                    "network_interface": "DEPRECATED: getDiagnosticString is deprecated in NetworkInterfaceTL",
-                    "queues": {
-                        "in_progress": {
-                            "network": 0
-                        },
-                        "sleepers": 0
-                    },
-                    "unsignaled_events": 0
-                },
                 "apply": {
-                    "attempts_to_become_secondary": 0,
+                    "attempts_to_become_secondary": 1,
                     "batches": {
                         "count": 0,
                         "time": {
@@ -36,206 +222,53 @@
                     "ops": 0
                 },
                 "buffer": {
+                    "count": 0,
                     "max_size": {
-                        "bytes": 0
+                        "bytes": 268435456
                     },
                     "size": {
                         "bytes": 0
+                    }
+                },
+                "executor": {
+                    "queues": {
+                        "in_progress": {
+                            "network": 0
+                        },
+                        "sleepers": 0
                     },
-                    "count": 0
+                    "shutting_down": false,
+                    "unsignaled_events": 0
                 },
                 "initial_sync": {
                     "completed": 0,
                     "failed_attempts": 0,
                     "failures": 0
+                },
+                "network": {
+                    "bytes": 0,
+                    "getmores": {
+                        "count": 0,
+                        "time": {
+                            "ms": 0
+                        }
+                    },
+                    "ops": 0,
+                    "reders_created": 0
                 }
             },
             "ttl": {
-                "passes": {
-                    "count": 433
-                },
                 "deleted_documents": {
-                    "count": 3
-                }
-            },
-            "commands": {
-                "replset_heartbeat": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "connection_pool_stats": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "host_info": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "aggregate": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "replset_update_position": {
-                    "total": 0,
-                    "failed": 0
-                },
-                "last_collections": {
-                    "failed": 0,
-                    "total": 458
-                },
-                "list_databased": {
-                    "total": 466,
-                    "failed": 0
-                },
-                "whatsmyuri": {
-                    "total": 2,
-                    "failed": 0
-                },
-                "profile": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "insert": {
-                    "failed": 0,
-                    "total": 7
-                },
-                "count": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "is_master": {
-                    "failed": 0,
-                    "total": 2332
-                },
-                "distinct": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "replset_get_status": {
-                    "failed": 2,
-                    "total": 2
-                },
-                "find": {
-                    "failed": 0,
-                    "total": 94
-                },
-                "replset_get_rbid": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "get_parameter": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "coll_stats": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "build_info": {
-                    "total": 6,
-                    "failed": 0
-                },
-                "last_commands": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "update": {
-                    "failed": 0,
-                    "total": 5
-                },
-                "is_self": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "db_stats": {
-                    "failed": 0,
-                    "total": 2044
-                },
-                "get_cmd_line_opts": {
-                    "failed": 0,
-                    "total": 2
-                },
-                "ping": {
-                    "total": 2290,
-                    "failed": 0
-                },
-                "server_status": {
-                    "total": 916,
-                    "failed": 0
-                },
-                "get_last_error": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "get_more": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "get_log": {
-                    "failed": 0,
-                    "total": 2
-                },
-                "list_indexes": {
-                    "failed": 0,
-                    "total": 174
-                }
-            },
-            "cursor": {
-                "timed_out": 0,
-                "open": {
-                    "pinned": 0,
-                    "total": 0,
-                    "no_timeout": 0
-                }
-            },
-            "get_last_error": {
-                "write_wait": {
-                    "ms": 0,
                     "count": 0
                 },
-                "write_timeouts": 0
-            },
-            "operation": {
-                "write_conflicts": 0,
-                "scan_and_order": 0
-            },
-            "document": {
-                "deleted": 15,
-                "inserted": 19,
-                "returned": 465,
-                "updated": 2
-            },
-            "query_executor": {
-                "scanned_indexes": {
-                    "count": 2
-                },
-                "scanned_documents": {
-                    "count": 24
+                "passes": {
+                    "count": 0
                 }
             }
         }
     },
-    "metricset": {
-        "period": 10000,
-        "name": "metrics"
-    },
-    "agent": {
-        "name": "KaiyanMacBookPro",
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a"
-    },
     "service": {
-        "address": "localhost:27017",
+        "address": "mongodb://elastic-package-service-mongodb-1",
         "type": "mongodb"
-    },
-    "event": {
-        "dataset": "mongodb.metrics",
-        "module": "mongodb",
-        "duration": 3039885
-    },
-    "ecs": {
-        "version": "1.5.0"
     }
 }

--- a/packages/mongodb/data_stream/replstatus/_dev/test/system/test-repl-config.yml
+++ b/packages/mongodb/data_stream/replstatus/_dev/test/system/test-repl-config.yml
@@ -1,0 +1,5 @@
+vars:
+  hosts:
+    - "{{Hostname}}"
+username: beats
+password: pass

--- a/packages/mongodb/data_stream/replstatus/fields/fields.yml
+++ b/packages/mongodb/data_stream/replstatus/fields/fields.yml
@@ -83,7 +83,7 @@
           description: |
             Host address of the primary
         - name: primary.optime
-          type: keyword
+          type: long
           description: |
             Optime of primary
         - name: secondary.hosts
@@ -91,7 +91,7 @@
           description: |
             List of secondary hosts
         - name: secondary.optimes
-          type: keyword
+          type: long
           description: |
             Optimes of secondaries
         - name: secondary.count

--- a/packages/mongodb/data_stream/replstatus/sample_event.json
+++ b/packages/mongodb/data_stream/replstatus/sample_event.json
@@ -1,80 +1,125 @@
 {
-    "@timestamp": "2020-06-29T21:20:51.457Z",
-    "service": {
-        "address": "localhost:27017",
-        "type": "mongodb"
+    "@timestamp": "2022-09-06T11:11:29.046Z",
+    "agent": {
+        "ephemeral_id": "3c8683b0-a63e-4892-9c17-f990f6545ddc",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
     },
-    "mongodb": {
-        "replstatus": {
-            "members": {
-                "arbiter": {
-                    "count": 0
-                },
-                "down": {
-                    "count": 0
-                },
-                "primary": {
-                    "host": "22b4e1fb8197:27017",
-                    "optime": 1550700559
-                },
-                "recovering": {
-                    "count": 0
-                },
-                "rollback": {
-                    "count": 0
-                },
-                "secondary": {
-                    "count": 0
-                },
-                "startup2": {
-                    "count": 0
-                },
-                "unhealthy": {
-                    "count": 0
-                },
-                "unknown": {
-                    "count": 0
-                }
-            },
-            "oplog": {
-                "first": {
-                    "timestamp": 1550700557
-                },
-                "last": {
-                    "timestamp": 1550700559
-                },
-                "size": {
-                    "allocated": 40572728934,
-                    "used": 180
-                },
-                "window": 2
-            },
-            "optimes": {
-                "applied": 1550700559,
-                "durable": 1550700559,
-                "last_committed": 1550700559
-            },
-            "server_date": "2019-02-20T23:09:23.733+01:00",
-            "set_name": "beats"
-        }
+    "data_stream": {
+        "dataset": "mongodb.replstatus",
+        "namespace": "ep",
+        "type": "metrics"
     },
     "ecs": {
-        "version": "1.5.0"
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "snapshot": false,
+        "version": "8.4.0"
     },
     "event": {
+        "agent_id_status": "verified",
         "dataset": "mongodb.replstatus",
-        "module": "mongodb",
-        "duration": 1962467
+        "duration": 20071592925,
+        "ingested": "2022-09-06T11:11:50Z",
+        "module": "mongodb"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.20.0.7"
+        ],
+        "mac": [
+            "02:42:ac:14:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.124-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
     },
     "metricset": {
         "name": "replstatus",
         "period": 10000
     },
-    "agent": {
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a",
-        "name": "KaiyanMacBookPro",
-        "type": "metricbeat",
-        "version": "8.0.0"
+    "mongodb": {
+        "replstatus": {
+            "headroom": {},
+            "lag": {},
+            "members": {
+                "arbiter": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "down": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "primary": {
+                    "host": "127.0.0.1:27017",
+                    "optime": 1662462708
+                },
+                "recovering": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "rollback": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "secondary": {
+                    "count": 0,
+                    "hosts": [],
+                    "optimes": []
+                },
+                "startup2": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "unhealthy": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "unknown": {
+                    "count": 0,
+                    "hosts": []
+                }
+            },
+            "oplog": {
+                "first": {
+                    "timestamp": 1662462668
+                },
+                "last": {
+                    "timestamp": 1662462668
+                },
+                "size": {
+                    "allocated": 1038090240,
+                    "used": 4304
+                },
+                "window": 0
+            },
+            "optimes": {
+                "applied": 1662462708,
+                "durable": 1662462708,
+                "last_committed": 1662462708
+            },
+            "server_date": "2022-09-06T11:11:49.112Z",
+            "set_name": "beats"
+        }
+    },
+    "service": {
+        "address": "mongodb://elastic-package-service-mongodb-1",
+        "type": "mongodb"
     }
 }

--- a/packages/mongodb/data_stream/status/_dev/test/system/test-status-config.yml
+++ b/packages/mongodb/data_stream/status/_dev/test/system/test-status-config.yml
@@ -1,0 +1,5 @@
+vars:
+  hosts:
+    - "{{Hostname}}"
+username: beats
+password: pass

--- a/packages/mongodb/data_stream/status/sample_event.json
+++ b/packages/mongodb/data_stream/status/sample_event.json
@@ -1,204 +1,247 @@
 {
-    "@timestamp": "2020-06-29T21:20:01.455Z",
+    "@timestamp": "2022-09-06T11:13:06.293Z",
     "agent": {
-        "version": "8.0.0",
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a",
-        "name": "KaiyanMacBookPro",
-        "type": "metricbeat"
+        "ephemeral_id": "4c7d338a-8465-4f02-8883-3d473ec1db9a",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
     },
-    "process": {
-        "name": "mongod"
+    "data_stream": {
+        "dataset": "mongodb.status",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
+        "snapshot": false,
+        "version": "8.4.0"
     },
     "event": {
-        "duration": 3581045,
+        "agent_id_status": "verified",
         "dataset": "mongodb.status",
+        "duration": 11067899422,
+        "ingested": "2022-09-06T11:13:18Z",
         "module": "mongodb"
     },
-    "mongodb": {
-        "status": {
-            "locks": {
-                "global": {
-                    "acquire": {
-                        "count": {
-                            "w": 458,
-                            "W": 4,
-                            "r": 56961
-                        }
-                    },
-                    "wait": {},
-                    "deadlock": {}
-                },
-                "database": {
-                    "deadlock": {},
-                    "acquire": {
-                        "count": {
-                            "w": 453,
-                            "W": 5,
-                            "r": 5238
-                        }
-                    },
-                    "wait": {}
-                },
-                "collection": {
-                    "wait": {},
-                    "deadlock": {},
-                    "acquire": {
-                        "count": {
-                            "W": 3,
-                            "r": 8221,
-                            "w": 450
-                        }
-                    }
-                }
-            },
-            "network": {
-                "in": {
-                    "bytes": 687306
-                },
-                "out": {
-                    "bytes": 32519464
-                },
-                "requests": 11607
-            },
-            "extra_info": {
-                "page_faults": 0,
-                "heap_usage": {}
-            },
-            "local_time": "2020-06-29T21:20:01.457Z",
-            "storage_engine": {
-                "name": "wiredTiger"
-            },
-            "asserts": {
-                "user": 9,
-                "rollovers": 0,
-                "regular": 0,
-                "warning": 0,
-                "msg": 0
-            },
-            "global_lock": {
-                "total_time": {
-                    "us": 26003338000
-                },
-                "current_queue": {
-                    "total": 0,
-                    "readers": 0,
-                    "writers": 0
-                },
-                "active_clients": {
-                    "total": 1,
-                    "readers": 1,
-                    "writers": 0
-                }
-            },
-            "wired_tiger": {
-                "log": {
-                    "syncs": 67,
-                    "size": {
-                        "bytes": 33554432
-                    },
-                    "write": {
-                        "bytes": 46976
-                    },
-                    "max_file_size": {
-                        "bytes": 104857600
-                    },
-                    "flushes": 152183,
-                    "writes": 140,
-                    "scans": 6
-                },
-                "concurrent_transactions": {
-                    "write": {
-                        "out": 0,
-                        "available": 128,
-                        "total_tickets": 128
-                    },
-                    "read": {
-                        "available": 128,
-                        "total_tickets": 128,
-                        "out": 0
-                    }
-                },
-                "cache": {
-                    "dirty": {
-                        "bytes": 0
-                    },
-                    "pages": {
-                        "evicted": 0,
-                        "read": 14,
-                        "write": 111
-                    },
-                    "maximum": {
-                        "bytes": 16642998272
-                    },
-                    "used": {
-                        "bytes": 89236
-                    }
-                }
-            },
-            "memory": {
-                "mapped_with_journal": {},
-                "bits": 64,
-                "resident": {
-                    "mb": 44
-                },
-                "virtual": {
-                    "mb": 6971
-                },
-                "mapped": {}
-            },
-            "connections": {
-                "total_created": 2266,
-                "current": 5,
-                "available": 3271
-            },
-            "ops": {
-                "counters": {
-                    "delete": 3,
-                    "getmore": 452,
-                    "command": 11314,
-                    "insert": 19,
-                    "query": 94,
-                    "update": 5
-                },
-                "replicated": {
-                    "delete": 0,
-                    "getmore": 0,
-                    "command": 0,
-                    "insert": 0,
-                    "query": 0,
-                    "update": 0
-                },
-                "latencies": {
-                    "writes": {
-                        "latency": 103455,
-                        "count": 9
-                    },
-                    "commands": {
-                        "latency": 2055949,
-                        "count": 11138
-                    },
-                    "reads": {
-                        "latency": 14259,
-                        "count": 458
-                    }
-                }
-            },
-            "uptime": {
-                "ms": 26003340
-            }
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.20.0.7"
+        ],
+        "mac": [
+            "02:42:ac:14:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.124-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
-    },
-    "service": {
-        "version": "4.2.0",
-        "address": "localhost:27017",
-        "type": "mongodb"
     },
     "metricset": {
         "name": "status",
         "period": 10000
     },
-    "ecs": {
-        "version": "1.5.0"
+    "mongodb": {
+        "status": {
+            "asserts": {
+                "msg": 0,
+                "regular": 0,
+                "rollovers": 0,
+                "user": 10,
+                "warning": 0
+            },
+            "connections": {
+                "available": 838858,
+                "current": 2,
+                "total_created": 3
+            },
+            "extra_info": {
+                "heap_usage": {},
+                "page_faults": 0
+            },
+            "global_lock": {
+                "active_clients": {
+                    "readers": 0,
+                    "total": 0,
+                    "writers": 0
+                },
+                "current_queue": {
+                    "readers": 0,
+                    "total": 0,
+                    "writers": 0
+                },
+                "total_time": {
+                    "us": 1339000
+                }
+            },
+            "local_time": "2022-09-06T11:13:17.329Z",
+            "locks": {
+                "collection": {
+                    "acquire": {
+                        "count": {
+                            "W": 6,
+                            "r": 37,
+                            "w": 10
+                        }
+                    },
+                    "deadlock": {},
+                    "wait": {}
+                },
+                "database": {
+                    "acquire": {
+                        "count": {
+                            "W": 3,
+                            "r": 34,
+                            "w": 25
+                        }
+                    },
+                    "deadlock": {},
+                    "wait": {}
+                },
+                "global": {
+                    "acquire": {
+                        "count": {
+                            "W": 6,
+                            "r": 65,
+                            "w": 31
+                        }
+                    },
+                    "deadlock": {},
+                    "wait": {}
+                },
+                "oplog": {
+                    "acquire": {
+                        "count": {
+                            "w": 1
+                        }
+                    },
+                    "deadlock": {},
+                    "wait": {}
+                }
+            },
+            "memory": {
+                "bits": 64,
+                "mapped": {},
+                "mapped_with_journal": {},
+                "resident": {
+                    "mb": 101
+                },
+                "virtual": {
+                    "mb": 1727
+                }
+            },
+            "network": {
+                "in": {
+                    "bytes": 878
+                },
+                "out": {
+                    "bytes": 1498
+                },
+                "requests": 4
+            },
+            "ops": {
+                "counters": {
+                    "command": 8,
+                    "delete": 0,
+                    "getmore": 0,
+                    "insert": 0,
+                    "query": 11,
+                    "update": 0
+                },
+                "latencies": {
+                    "commands": {
+                        "count": 2,
+                        "latency": 2152
+                    },
+                    "reads": {
+                        "count": 0,
+                        "latency": 0
+                    },
+                    "writes": {
+                        "count": 0,
+                        "latency": 0
+                    }
+                },
+                "replicated": {
+                    "command": 0,
+                    "delete": 0,
+                    "getmore": 0,
+                    "insert": 0,
+                    "query": 0,
+                    "update": 0
+                }
+            },
+            "storage_engine": {
+                "name": "wiredTiger"
+            },
+            "uptime": {
+                "ms": 1331
+            },
+            "wired_tiger": {
+                "cache": {
+                    "dirty": {
+                        "bytes": 15719
+                    },
+                    "maximum": {
+                        "bytes": 7316963328
+                    },
+                    "pages": {
+                        "evicted": 0,
+                        "read": 40,
+                        "write": 5
+                    },
+                    "used": {
+                        "bytes": 177684
+                    }
+                },
+                "concurrent_transactions": {
+                    "read": {
+                        "available": 128,
+                        "out": 0,
+                        "total_tickets": 128
+                    },
+                    "write": {
+                        "available": 128,
+                        "out": 0,
+                        "total_tickets": 128
+                    }
+                },
+                "log": {
+                    "flushes": 6,
+                    "max_file_size": {
+                        "bytes": 104857600
+                    },
+                    "scans": 8,
+                    "size": {
+                        "bytes": 33554432
+                    },
+                    "syncs": 6,
+                    "write": {
+                        "bytes": 4224
+                    },
+                    "writes": 11
+                }
+            }
+        }
+    },
+    "process": {
+        "name": "mongod"
+    },
+    "service": {
+        "address": "mongodb://elastic-package-service-mongodb-1",
+        "type": "mongodb",
+        "version": "5.0.11"
     }
 }

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -92,9 +92,9 @@ The `log` dataset collects the MongoDB logs.
 | log.offset | Offset of the entry in the log file. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | mongodb.log.attr | Attributes related to the log message. | flattened |
-| mongodb.log.component | Functional categorization of message | keyword |
+| mongodb.log.component | Functional categorization of message. | keyword |
 | mongodb.log.context | Context of message | keyword |
-| mongodb.log.id | Integer representing the unique identifier of the log statement | long |
+| mongodb.log.id | Integer representing the unique identifier of the log statement. | long |
 | related.hosts | All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases. | keyword |
 | related.ip | All of the IPs seen on your event. | ip |
 | related.user | All the user names or other user identifiers seen on the event. | keyword |

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -85,16 +85,29 @@ The `log` dataset collects the MongoDB logs.
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
+| log.flags | This field contains the flags of the event. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
+| log.offset | Offset of the entry in the log file. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | mongodb.log.attr | Attributes related to the log message. | flattened |
 | mongodb.log.component | Functional categorization of message | keyword |
 | mongodb.log.context | Context of message | keyword |
 | mongodb.log.id | Integer representing the unique identifier of the log statement | long |
+| related.hosts | All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases. | keyword |
+| related.ip | All of the IPs seen on your event. | ip |
+| related.user | All the user names or other user identifiers seen on the event. | keyword |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
+| source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
+| user.effective.name | Short name or login of the user. | keyword |
+| user.effective.name.text | Multi-field of `user.effective.name`. | match_only_text |
+| user.id | Unique identifier of the user. | keyword |
+| user.name | Short name or login of the user. | keyword |
+| user.name.text | Multi-field of `user.name`. | match_only_text |
 
 
 ## Metrics
@@ -114,37 +127,70 @@ An example event for `collstats` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-06-29T21:20:51.459Z",
+    "@timestamp": "2022-09-05T10:33:12.057Z",
+    "agent": {
+        "ephemeral_id": "0f7ed4ab-eae1-44a8-8e7e-e8f48381f715",
+        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
+    },
+    "data_stream": {
+        "dataset": "mongodb.collstats",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "snapshot": false,
+        "version": "8.4.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "mongodb.collstats",
+        "duration": 13550152173,
+        "ingested": "2022-09-05T10:33:26Z",
+        "module": "mongodb"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.23.0.7"
+        ],
+        "mac": [
+            "02:42:ac:17:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.104-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
+    },
     "metricset": {
         "name": "collstats",
         "period": 10000
     },
-    "service": {
-        "address": "localhost:27017",
-        "type": "mongodb"
-    },
-    "agent": {
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a",
-        "name": "KaiyanMacBookPro"
-    },
-    "event": {
-        "dataset": "mongodb.collstats",
-        "module": "mongodb",
-        "duration": 3378520
-    },
     "mongodb": {
         "collstats": {
-            "collection": "startup_log",
+            "collection": "system.keys",
             "commands": {
                 "count": 0,
                 "time": {
                     "us": 0
                 }
             },
-            "db": "local",
+            "db": "admin",
             "getmore": {
                 "count": 0,
                 "time": {
@@ -159,23 +205,23 @@ An example event for `collstats` looks as following:
             },
             "lock": {
                 "read": {
-                    "count": 74,
+                    "count": 1,
                     "time": {
-                        "us": 443
+                        "us": 750
                     }
                 },
                 "write": {
-                    "count": 1,
+                    "count": 0,
                     "time": {
-                        "us": 8
+                        "us": 0
                     }
                 }
             },
-            "name": "local.startup_log",
+            "name": "admin.system.keys",
             "queries": {
-                "count": 0,
+                "count": 1,
                 "time": {
-                    "us": 0
+                    "us": 750
                 }
             },
             "remove": {
@@ -185,9 +231,9 @@ An example event for `collstats` looks as following:
                 }
             },
             "total": {
-                "count": 75,
+                "count": 1,
                 "time": {
-                    "us": 451
+                    "us": 750
                 }
             },
             "update": {
@@ -198,8 +244,9 @@ An example event for `collstats` looks as following:
             }
         }
     },
-    "ecs": {
-        "version": "1.5.0"
+    "service": {
+        "address": "mongodb://elastic-package-service-mongodb-1",
+        "type": "mongodb"
     }
 }
 ```
@@ -288,52 +335,85 @@ An example event for `dbstats` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-06-29T21:20:51.459Z",
+    "@timestamp": "2022-09-05T10:34:46.316Z",
+    "agent": {
+        "ephemeral_id": "1497a5b4-5a56-4529-b623-fa6a51fa6333",
+        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
+    },
+    "data_stream": {
+        "dataset": "mongodb.dbstats",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "snapshot": false,
+        "version": "8.4.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "mongodb.dbstats",
+        "duration": 15589374215,
+        "ingested": "2022-09-05T10:35:03Z",
+        "module": "mongodb"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.23.0.7"
+        ],
+        "mac": [
+            "02:42:ac:17:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.104-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
+    },
     "metricset": {
         "name": "dbstats",
         "period": 10000
     },
-    "service": {
-        "address": "localhost:27017",
-        "type": "mongodb"
-    },
-    "agent": {
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a",
-        "name": "KaiyanMacBookPro"
-    },
-    "event": {
-        "dataset": "mongodb.dbstats",
-        "module": "mongodb",
-        "duration": 3378520
-    },
     "mongodb": {
         "dbstats": {
+            "avg_obj_size": {
+                "bytes": 161.6
+            },
+            "collections": 3,
+            "data_size": {
+                "bytes": 808
+            },
+            "db": "admin",
             "file_size": {},
             "index_size": {
-                "bytes": 20480
+                "bytes": 98304
             },
+            "indexes": 4,
             "ns_size_mb": {},
+            "objects": 5,
             "storage_size": {
-                "bytes": 20480
-            },
-            "num_extents": 0,
-            "collections": 1,
-            "objects": 1,
-            "db": "admin",
-            "data_size": {
-                "bytes": 59
-            },
-            "indexes": 1,
-            "avg_obj_size": {
-                "bytes": 59
+                "bytes": 77824
             }
         }
     },
-    "ecs": {
-        "version": "1.5.0"
+    "service": {
+        "address": "mongodb://elastic-package-service-mongodb-1",
+        "type": "mongodb"
     }
 }
 ```
@@ -411,34 +491,220 @@ An example event for `metrics` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-06-29T21:20:51.459Z",
+    "@timestamp": "2022-09-05T10:36:19.246Z",
+    "agent": {
+        "ephemeral_id": "5fe8b354-50a9-4ac8-b7e5-2224e1b4e7e1",
+        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
+    },
+    "data_stream": {
+        "dataset": "mongodb.metrics",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "snapshot": false,
+        "version": "8.4.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "mongodb.metrics",
+        "duration": 21081021385,
+        "ingested": "2022-09-05T10:36:41Z",
+        "module": "mongodb"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.23.0.7"
+        ],
+        "mac": [
+            "02:42:ac:17:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.104-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
+    },
+    "metricset": {
+        "name": "metrics",
+        "period": 10000
+    },
     "mongodb": {
         "metrics": {
+            "commands": {
+                "aggregate": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "build_info": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "coll_stats": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "connection_pool_stats": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "count": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "db_stats": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "distinct": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "find": {
+                    "failed": 0,
+                    "total": 11
+                },
+                "get_cmd_line_opts": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "get_last_error": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "get_log": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "get_more": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "get_parameter": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "host_info": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "insert": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "is_master": {
+                    "failed": 0,
+                    "total": 3
+                },
+                "is_self": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "last_collections": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "last_commands": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "list_databased": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "list_indexes": {
+                    "failed": 1,
+                    "total": 1
+                },
+                "ping": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "profile": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "replset_get_rbid": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "replset_get_status": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "replset_heartbeat": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "replset_update_position": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "server_status": {
+                    "failed": 0,
+                    "total": 1
+                },
+                "update": {
+                    "failed": 0,
+                    "total": 0
+                },
+                "whatsmyuri": {
+                    "failed": 0,
+                    "total": 0
+                }
+            },
+            "cursor": {
+                "open": {
+                    "no_timeout": 0,
+                    "pinned": 0,
+                    "total": 0
+                },
+                "timed_out": 0
+            },
+            "document": {
+                "deleted": 0,
+                "inserted": 0,
+                "returned": 2,
+                "updated": 0
+            },
+            "get_last_error": {
+                "write_timeouts": 0,
+                "write_wait": {
+                    "count": 1,
+                    "ms": 0
+                }
+            },
+            "operation": {
+                "scan_and_order": 3,
+                "write_conflicts": 0
+            },
+            "query_executor": {
+                "scanned_documents": {
+                    "count": 2
+                },
+                "scanned_indexes": {
+                    "count": 0
+                }
+            },
             "replication": {
-                "network": {
-                    "ops": 0,
-                    "reders_created": 0,
-                    "bytes": 0,
-                    "getmores": {
-                        "count": 0,
-                        "time": {
-                            "ms": 0
-                        }
-                    }
-                },
-                "executor": {
-                    "shutting_down": false,
-                    "network_interface": "DEPRECATED: getDiagnosticString is deprecated in NetworkInterfaceTL",
-                    "queues": {
-                        "in_progress": {
-                            "network": 0
-                        },
-                        "sleepers": 0
-                    },
-                    "unsignaled_events": 0
-                },
                 "apply": {
-                    "attempts_to_become_secondary": 0,
+                    "attempts_to_become_secondary": 1,
                     "batches": {
                         "count": 0,
                         "time": {
@@ -448,207 +714,54 @@ An example event for `metrics` looks as following:
                     "ops": 0
                 },
                 "buffer": {
+                    "count": 0,
                     "max_size": {
-                        "bytes": 0
+                        "bytes": 268435456
                     },
                     "size": {
                         "bytes": 0
+                    }
+                },
+                "executor": {
+                    "queues": {
+                        "in_progress": {
+                            "network": 0
+                        },
+                        "sleepers": 0
                     },
-                    "count": 0
+                    "shutting_down": false,
+                    "unsignaled_events": 0
                 },
                 "initial_sync": {
                     "completed": 0,
                     "failed_attempts": 0,
                     "failures": 0
+                },
+                "network": {
+                    "bytes": 0,
+                    "getmores": {
+                        "count": 0,
+                        "time": {
+                            "ms": 0
+                        }
+                    },
+                    "ops": 0,
+                    "reders_created": 0
                 }
             },
             "ttl": {
-                "passes": {
-                    "count": 433
-                },
                 "deleted_documents": {
-                    "count": 3
-                }
-            },
-            "commands": {
-                "replset_heartbeat": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "connection_pool_stats": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "host_info": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "aggregate": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "replset_update_position": {
-                    "total": 0,
-                    "failed": 0
-                },
-                "last_collections": {
-                    "failed": 0,
-                    "total": 458
-                },
-                "list_databased": {
-                    "total": 466,
-                    "failed": 0
-                },
-                "whatsmyuri": {
-                    "total": 2,
-                    "failed": 0
-                },
-                "profile": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "insert": {
-                    "failed": 0,
-                    "total": 7
-                },
-                "count": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "is_master": {
-                    "failed": 0,
-                    "total": 2332
-                },
-                "distinct": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "replset_get_status": {
-                    "failed": 2,
-                    "total": 2
-                },
-                "find": {
-                    "failed": 0,
-                    "total": 94
-                },
-                "replset_get_rbid": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "get_parameter": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "coll_stats": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "build_info": {
-                    "total": 6,
-                    "failed": 0
-                },
-                "last_commands": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "update": {
-                    "failed": 0,
-                    "total": 5
-                },
-                "is_self": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "db_stats": {
-                    "failed": 0,
-                    "total": 2044
-                },
-                "get_cmd_line_opts": {
-                    "failed": 0,
-                    "total": 2
-                },
-                "ping": {
-                    "total": 2290,
-                    "failed": 0
-                },
-                "server_status": {
-                    "total": 916,
-                    "failed": 0
-                },
-                "get_last_error": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "get_more": {
-                    "failed": 0,
-                    "total": 0
-                },
-                "get_log": {
-                    "failed": 0,
-                    "total": 2
-                },
-                "list_indexes": {
-                    "failed": 0,
-                    "total": 174
-                }
-            },
-            "cursor": {
-                "timed_out": 0,
-                "open": {
-                    "pinned": 0,
-                    "total": 0,
-                    "no_timeout": 0
-                }
-            },
-            "get_last_error": {
-                "write_wait": {
-                    "ms": 0,
                     "count": 0
                 },
-                "write_timeouts": 0
-            },
-            "operation": {
-                "write_conflicts": 0,
-                "scan_and_order": 0
-            },
-            "document": {
-                "deleted": 15,
-                "inserted": 19,
-                "returned": 465,
-                "updated": 2
-            },
-            "query_executor": {
-                "scanned_indexes": {
-                    "count": 2
-                },
-                "scanned_documents": {
-                    "count": 24
+                "passes": {
+                    "count": 0
                 }
             }
         }
     },
-    "metricset": {
-        "period": 10000,
-        "name": "metrics"
-    },
-    "agent": {
-        "name": "KaiyanMacBookPro",
-        "type": "metricbeat",
-        "version": "8.0.0",
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a"
-    },
     "service": {
-        "address": "localhost:27017",
+        "address": "mongodb://elastic-package-service-mongodb-1",
         "type": "mongodb"
-    },
-    "event": {
-        "dataset": "mongodb.metrics",
-        "module": "mongodb",
-        "duration": 3039885
-    },
-    "ecs": {
-        "version": "1.5.0"
     }
 }
 ```
@@ -831,83 +944,128 @@ An example event for `replstatus` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-06-29T21:20:51.457Z",
-    "service": {
-        "address": "localhost:27017",
-        "type": "mongodb"
+    "@timestamp": "2022-09-05T11:16:58.994Z",
+    "agent": {
+        "ephemeral_id": "0cf61535-03dd-4749-8437-f3e67e735e46",
+        "id": "a0cf38ee-4d58-485e-ae50-3ad504666e57",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
     },
-    "mongodb": {
-        "replstatus": {
-            "members": {
-                "arbiter": {
-                    "count": 0
-                },
-                "down": {
-                    "count": 0
-                },
-                "primary": {
-                    "host": "22b4e1fb8197:27017",
-                    "optime": 1550700559
-                },
-                "recovering": {
-                    "count": 0
-                },
-                "rollback": {
-                    "count": 0
-                },
-                "secondary": {
-                    "count": 0
-                },
-                "startup2": {
-                    "count": 0
-                },
-                "unhealthy": {
-                    "count": 0
-                },
-                "unknown": {
-                    "count": 0
-                }
-            },
-            "oplog": {
-                "first": {
-                    "timestamp": 1550700557
-                },
-                "last": {
-                    "timestamp": 1550700559
-                },
-                "size": {
-                    "allocated": 40572728934,
-                    "used": 180
-                },
-                "window": 2
-            },
-            "optimes": {
-                "applied": 1550700559,
-                "durable": 1550700559,
-                "last_committed": 1550700559
-            },
-            "server_date": "2019-02-20T23:09:23.733+01:00",
-            "set_name": "beats"
-        }
+    "data_stream": {
+        "dataset": "mongodb.replstatus",
+        "namespace": "ep",
+        "type": "metrics"
     },
     "ecs": {
-        "version": "1.5.0"
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "a0cf38ee-4d58-485e-ae50-3ad504666e57",
+        "snapshot": false,
+        "version": "8.4.0"
     },
     "event": {
+        "agent_id_status": "verified",
         "dataset": "mongodb.replstatus",
-        "module": "mongodb",
-        "duration": 1962467
+        "duration": 10082342047,
+        "ingested": "2022-09-05T11:17:10Z",
+        "module": "mongodb"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.23.0.7"
+        ],
+        "mac": [
+            "02:42:ac:17:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.104-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
+        }
     },
     "metricset": {
         "name": "replstatus",
         "period": 10000
     },
-    "agent": {
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a",
-        "name": "KaiyanMacBookPro",
-        "type": "metricbeat",
-        "version": "8.0.0"
+    "mongodb": {
+        "replstatus": {
+            "headroom": {},
+            "lag": {},
+            "members": {
+                "arbiter": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "down": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "primary": {
+                    "host": "127.0.0.1:27017",
+                    "optime": 1662376628
+                },
+                "recovering": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "rollback": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "secondary": {
+                    "count": 0,
+                    "hosts": [],
+                    "optimes": []
+                },
+                "startup2": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "unhealthy": {
+                    "count": 0,
+                    "hosts": []
+                },
+                "unknown": {
+                    "count": 0,
+                    "hosts": []
+                }
+            },
+            "oplog": {
+                "first": {
+                    "timestamp": 1662376596
+                },
+                "last": {
+                    "timestamp": 1662376596
+                },
+                "size": {
+                    "allocated": 1038090240,
+                    "used": 4304
+                },
+                "window": 0
+            },
+            "optimes": {
+                "applied": 1662376628,
+                "durable": 1662376628,
+                "last_committed": 1662376628
+            },
+            "server_date": "2022-09-05T11:17:09.071Z",
+            "set_name": "beats"
+        }
+    },
+    "service": {
+        "address": "mongodb://elastic-package-service-mongodb-1",
+        "type": "mongodb"
     }
 }
 ```
@@ -964,14 +1122,14 @@ The fields reported are:
 | mongodb.replstatus.members.down.count | Count of `down` members | long |
 | mongodb.replstatus.members.down.hosts | List of `down` members hosts | keyword |
 | mongodb.replstatus.members.primary.host | Host address of the primary | keyword |
-| mongodb.replstatus.members.primary.optime | Optime of primary | keyword |
+| mongodb.replstatus.members.primary.optime | Optime of primary | long |
 | mongodb.replstatus.members.recovering.count | Count of members in the `recovering` state | long |
 | mongodb.replstatus.members.recovering.hosts | List of recovering members hosts | keyword |
 | mongodb.replstatus.members.rollback.count | Count of members in the `rollback` state | long |
 | mongodb.replstatus.members.rollback.hosts | List of members in the `rollback` state | keyword |
 | mongodb.replstatus.members.secondary.count |  | long |
 | mongodb.replstatus.members.secondary.hosts | List of secondary hosts | keyword |
-| mongodb.replstatus.members.secondary.optimes | Optimes of secondaries | keyword |
+| mongodb.replstatus.members.secondary.optimes | Optimes of secondaries | long |
 | mongodb.replstatus.members.startup2.count | Count of members in the `startup2` state | long |
 | mongodb.replstatus.members.startup2.hosts | List of initializing members hosts | keyword |
 | mongodb.replstatus.members.unhealthy.count | Count of unhealthy members | long |
@@ -1003,207 +1161,251 @@ An example event for `status` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-06-29T21:20:01.455Z",
+    "@timestamp": "2022-09-05T10:39:37.981Z",
     "agent": {
-        "version": "8.0.0",
-        "ephemeral_id": "9f6fc260-82b5-4630-95d8-df64f1379b55",
-        "id": "2281e192-85d5-4d68-b90a-36a31df7b29a",
-        "name": "KaiyanMacBookPro",
-        "type": "metricbeat"
+        "ephemeral_id": "7ed9a5c5-01f3-4938-9d67-3efb76c7a060",
+        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.4.0"
     },
-    "process": {
-        "name": "mongod"
+    "data_stream": {
+        "dataset": "mongodb.status",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "snapshot": false,
+        "version": "8.4.0"
     },
     "event": {
-        "duration": 3581045,
+        "agent_id_status": "verified",
         "dataset": "mongodb.status",
+        "duration": 17129285758,
+        "ingested": "2022-09-05T10:39:56Z",
         "module": "mongodb"
     },
-    "mongodb": {
-        "status": {
-            "locks": {
-                "global": {
-                    "acquire": {
-                        "count": {
-                            "w": 458,
-                            "W": 4,
-                            "r": 56961
-                        }
-                    },
-                    "wait": {},
-                    "deadlock": {}
-                },
-                "database": {
-                    "deadlock": {},
-                    "acquire": {
-                        "count": {
-                            "w": 453,
-                            "W": 5,
-                            "r": 5238
-                        }
-                    },
-                    "wait": {}
-                },
-                "collection": {
-                    "wait": {},
-                    "deadlock": {},
-                    "acquire": {
-                        "count": {
-                            "W": 3,
-                            "r": 8221,
-                            "w": 450
-                        }
-                    }
-                }
-            },
-            "network": {
-                "in": {
-                    "bytes": 687306
-                },
-                "out": {
-                    "bytes": 32519464
-                },
-                "requests": 11607
-            },
-            "extra_info": {
-                "page_faults": 0,
-                "heap_usage": {}
-            },
-            "local_time": "2020-06-29T21:20:01.457Z",
-            "storage_engine": {
-                "name": "wiredTiger"
-            },
-            "asserts": {
-                "user": 9,
-                "rollovers": 0,
-                "regular": 0,
-                "warning": 0,
-                "msg": 0
-            },
-            "global_lock": {
-                "total_time": {
-                    "us": 26003338000
-                },
-                "current_queue": {
-                    "total": 0,
-                    "readers": 0,
-                    "writers": 0
-                },
-                "active_clients": {
-                    "total": 1,
-                    "readers": 1,
-                    "writers": 0
-                }
-            },
-            "wired_tiger": {
-                "log": {
-                    "syncs": 67,
-                    "size": {
-                        "bytes": 33554432
-                    },
-                    "write": {
-                        "bytes": 46976
-                    },
-                    "max_file_size": {
-                        "bytes": 104857600
-                    },
-                    "flushes": 152183,
-                    "writes": 140,
-                    "scans": 6
-                },
-                "concurrent_transactions": {
-                    "write": {
-                        "out": 0,
-                        "available": 128,
-                        "total_tickets": 128
-                    },
-                    "read": {
-                        "available": 128,
-                        "total_tickets": 128,
-                        "out": 0
-                    }
-                },
-                "cache": {
-                    "dirty": {
-                        "bytes": 0
-                    },
-                    "pages": {
-                        "evicted": 0,
-                        "read": 14,
-                        "write": 111
-                    },
-                    "maximum": {
-                        "bytes": 16642998272
-                    },
-                    "used": {
-                        "bytes": 89236
-                    }
-                }
-            },
-            "memory": {
-                "mapped_with_journal": {},
-                "bits": 64,
-                "resident": {
-                    "mb": 44
-                },
-                "virtual": {
-                    "mb": 6971
-                },
-                "mapped": {}
-            },
-            "connections": {
-                "total_created": 2266,
-                "current": 5,
-                "available": 3271
-            },
-            "ops": {
-                "counters": {
-                    "delete": 3,
-                    "getmore": 452,
-                    "command": 11314,
-                    "insert": 19,
-                    "query": 94,
-                    "update": 5
-                },
-                "replicated": {
-                    "delete": 0,
-                    "getmore": 0,
-                    "command": 0,
-                    "insert": 0,
-                    "query": 0,
-                    "update": 0
-                },
-                "latencies": {
-                    "writes": {
-                        "latency": 103455,
-                        "count": 9
-                    },
-                    "commands": {
-                        "latency": 2055949,
-                        "count": 11138
-                    },
-                    "reads": {
-                        "latency": 14259,
-                        "count": 458
-                    }
-                }
-            },
-            "uptime": {
-                "ms": 26003340
-            }
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "5016511f0829451ea244f458eebf2212",
+        "ip": [
+            "172.23.0.7"
+        ],
+        "mac": [
+            "02:42:ac:17:00:07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.104-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.4 LTS (Focal Fossa)"
         }
-    },
-    "service": {
-        "version": "4.2.0",
-        "address": "localhost:27017",
-        "type": "mongodb"
     },
     "metricset": {
         "name": "status",
         "period": 10000
     },
-    "ecs": {
-        "version": "1.5.0"
+    "mongodb": {
+        "status": {
+            "asserts": {
+                "msg": 0,
+                "regular": 0,
+                "rollovers": 0,
+                "user": 8,
+                "warning": 0
+            },
+            "connections": {
+                "available": 838858,
+                "current": 2,
+                "total_created": 2
+            },
+            "extra_info": {
+                "heap_usage": {},
+                "page_faults": 0
+            },
+            "global_lock": {
+                "active_clients": {
+                    "readers": 0,
+                    "total": 0,
+                    "writers": 0
+                },
+                "current_queue": {
+                    "readers": 0,
+                    "total": 0,
+                    "writers": 0
+                },
+                "total_time": {
+                    "us": 1690000
+                }
+            },
+            "local_time": "2022-09-05T10:39:55.073Z",
+            "locks": {
+                "collection": {
+                    "acquire": {
+                        "count": {
+                            "W": 6,
+                            "r": 37,
+                            "w": 12
+                        }
+                    },
+                    "deadlock": {},
+                    "wait": {}
+                },
+                "database": {
+                    "acquire": {
+                        "count": {
+                            "W": 3,
+                            "r": 35,
+                            "w": 27
+                        }
+                    },
+                    "deadlock": {},
+                    "wait": {}
+                },
+                "global": {
+                    "acquire": {
+                        "count": {
+                            "W": 6,
+                            "r": 74,
+                            "w": 33
+                        }
+                    },
+                    "deadlock": {},
+                    "wait": {}
+                },
+                "oplog": {
+                    "acquire": {
+                        "count": {
+                            "r": 1,
+                            "w": 1
+                        }
+                    },
+                    "deadlock": {},
+                    "wait": {}
+                }
+            },
+            "memory": {
+                "bits": 64,
+                "mapped": {},
+                "mapped_with_journal": {},
+                "resident": {
+                    "mb": 109
+                },
+                "virtual": {
+                    "mb": 1732
+                }
+            },
+            "network": {
+                "in": {
+                    "bytes": 878
+                },
+                "out": {
+                    "bytes": 1498
+                },
+                "requests": 4
+            },
+            "ops": {
+                "counters": {
+                    "command": 8,
+                    "delete": 0,
+                    "getmore": 0,
+                    "insert": 0,
+                    "query": 14,
+                    "update": 0
+                },
+                "latencies": {
+                    "commands": {
+                        "count": 2,
+                        "latency": 11533
+                    },
+                    "reads": {
+                        "count": 0,
+                        "latency": 0
+                    },
+                    "writes": {
+                        "count": 0,
+                        "latency": 0
+                    }
+                },
+                "replicated": {
+                    "command": 0,
+                    "delete": 0,
+                    "getmore": 0,
+                    "insert": 0,
+                    "query": 0,
+                    "update": 0
+                }
+            },
+            "storage_engine": {
+                "name": "wiredTiger"
+            },
+            "uptime": {
+                "ms": 1677
+            },
+            "wired_tiger": {
+                "cache": {
+                    "dirty": {
+                        "bytes": 15719
+                    },
+                    "maximum": {
+                        "bytes": 7316963328
+                    },
+                    "pages": {
+                        "evicted": 0,
+                        "read": 40,
+                        "write": 5
+                    },
+                    "used": {
+                        "bytes": 177452
+                    }
+                },
+                "concurrent_transactions": {
+                    "read": {
+                        "available": 128,
+                        "out": 0,
+                        "total_tickets": 128
+                    },
+                    "write": {
+                        "available": 128,
+                        "out": 0,
+                        "total_tickets": 128
+                    }
+                },
+                "log": {
+                    "flushes": 8,
+                    "max_file_size": {
+                        "bytes": 104857600
+                    },
+                    "scans": 8,
+                    "size": {
+                        "bytes": 33554432
+                    },
+                    "syncs": 6,
+                    "write": {
+                        "bytes": 4224
+                    },
+                    "writes": 11
+                }
+            }
+        }
+    },
+    "process": {
+        "name": "mongod"
+    },
+    "service": {
+        "address": "mongodb://elastic-package-service-mongodb-1",
+        "type": "mongodb",
+        "version": "5.0.11"
     }
 }
 ```

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -315,7 +315,7 @@ The fields reported are:
 | mongodb.collstats.total.time.us | Total waiting time for locks in microseconds. | long |
 | mongodb.collstats.update.count | Number of document update events. | long |
 | mongodb.collstats.update.time.us | Time updating documents in microseconds. | long |
-| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
+| service.address | Address of the machine where the service is running. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
 
 

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -127,10 +127,10 @@ An example event for `collstats` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-05T10:33:12.057Z",
+    "@timestamp": "2022-09-06T11:05:04.348Z",
     "agent": {
-        "ephemeral_id": "0f7ed4ab-eae1-44a8-8e7e-e8f48381f715",
-        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "ephemeral_id": "405fac7e-5dda-4c3b-9342-5832c6684d4b",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
         "version": "8.4.0"
@@ -144,15 +144,15 @@ An example event for `collstats` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "snapshot": false,
         "version": "8.4.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "mongodb.collstats",
-        "duration": 13550152173,
-        "ingested": "2022-09-05T10:33:26Z",
+        "duration": 12585576506,
+        "ingested": "2022-09-06T11:05:17Z",
         "module": "mongodb"
     },
     "host": {
@@ -161,16 +161,16 @@ An example event for `collstats` looks as following:
         "hostname": "docker-fleet-agent",
         "id": "5016511f0829451ea244f458eebf2212",
         "ip": [
-            "172.23.0.7"
+            "172.20.0.7"
         ],
         "mac": [
-            "02:42:ac:17:00:07"
+            "02:42:ac:14:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.104-linuxkit",
+            "kernel": "5.10.124-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -183,14 +183,14 @@ An example event for `collstats` looks as following:
     },
     "mongodb": {
         "collstats": {
-            "collection": "system.keys",
+            "collection": "external_validation_keys",
             "commands": {
                 "count": 0,
                 "time": {
                     "us": 0
                 }
             },
-            "db": "admin",
+            "db": "config",
             "getmore": {
                 "count": 0,
                 "time": {
@@ -205,9 +205,9 @@ An example event for `collstats` looks as following:
             },
             "lock": {
                 "read": {
-                    "count": 1,
+                    "count": 3,
                     "time": {
-                        "us": 750
+                        "us": 1111
                     }
                 },
                 "write": {
@@ -217,11 +217,11 @@ An example event for `collstats` looks as following:
                     }
                 }
             },
-            "name": "admin.system.keys",
+            "name": "config.external_validation_keys",
             "queries": {
-                "count": 1,
+                "count": 3,
                 "time": {
-                    "us": 750
+                    "us": 1111
                 }
             },
             "remove": {
@@ -231,9 +231,9 @@ An example event for `collstats` looks as following:
                 }
             },
             "total": {
-                "count": 1,
+                "count": 3,
                 "time": {
-                    "us": 750
+                    "us": 1111
                 }
             },
             "update": {
@@ -335,10 +335,10 @@ An example event for `dbstats` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-05T10:34:46.316Z",
+    "@timestamp": "2022-09-06T11:06:33.498Z",
     "agent": {
-        "ephemeral_id": "1497a5b4-5a56-4529-b623-fa6a51fa6333",
-        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "ephemeral_id": "a554de8f-c161-4ed6-88e9-b411bfbcb7fb",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
         "version": "8.4.0"
@@ -352,15 +352,15 @@ An example event for `dbstats` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "snapshot": false,
         "version": "8.4.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "mongodb.dbstats",
-        "duration": 15589374215,
-        "ingested": "2022-09-05T10:35:03Z",
+        "duration": 21551686426,
+        "ingested": "2022-09-06T11:06:56Z",
         "module": "mongodb"
     },
     "host": {
@@ -369,16 +369,16 @@ An example event for `dbstats` looks as following:
         "hostname": "docker-fleet-agent",
         "id": "5016511f0829451ea244f458eebf2212",
         "ip": [
-            "172.23.0.7"
+            "172.20.0.7"
         ],
         "mac": [
-            "02:42:ac:17:00:07"
+            "02:42:ac:14:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.104-linuxkit",
+            "kernel": "5.10.124-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -491,10 +491,10 @@ An example event for `metrics` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-05T10:36:19.246Z",
+    "@timestamp": "2022-09-06T11:09:57.291Z",
     "agent": {
-        "ephemeral_id": "5fe8b354-50a9-4ac8-b7e5-2224e1b4e7e1",
-        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "ephemeral_id": "61e37719-d2a1-4ae5-9d82-17db42ac6986",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
         "version": "8.4.0"
@@ -508,15 +508,15 @@ An example event for `metrics` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "snapshot": false,
         "version": "8.4.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "mongodb.metrics",
-        "duration": 21081021385,
-        "ingested": "2022-09-05T10:36:41Z",
+        "duration": 12572294588,
+        "ingested": "2022-09-06T11:10:10Z",
         "module": "mongodb"
     },
     "host": {
@@ -525,16 +525,16 @@ An example event for `metrics` looks as following:
         "hostname": "docker-fleet-agent",
         "id": "5016511f0829451ea244f458eebf2212",
         "ip": [
-            "172.23.0.7"
+            "172.20.0.7"
         ],
         "mac": [
-            "02:42:ac:17:00:07"
+            "02:42:ac:14:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.104-linuxkit",
+            "kernel": "5.10.124-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -944,10 +944,10 @@ An example event for `replstatus` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-05T11:16:58.994Z",
+    "@timestamp": "2022-09-06T11:11:29.046Z",
     "agent": {
-        "ephemeral_id": "0cf61535-03dd-4749-8437-f3e67e735e46",
-        "id": "a0cf38ee-4d58-485e-ae50-3ad504666e57",
+        "ephemeral_id": "3c8683b0-a63e-4892-9c17-f990f6545ddc",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
         "version": "8.4.0"
@@ -961,15 +961,15 @@ An example event for `replstatus` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "a0cf38ee-4d58-485e-ae50-3ad504666e57",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "snapshot": false,
         "version": "8.4.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "mongodb.replstatus",
-        "duration": 10082342047,
-        "ingested": "2022-09-05T11:17:10Z",
+        "duration": 20071592925,
+        "ingested": "2022-09-06T11:11:50Z",
         "module": "mongodb"
     },
     "host": {
@@ -978,16 +978,16 @@ An example event for `replstatus` looks as following:
         "hostname": "docker-fleet-agent",
         "id": "5016511f0829451ea244f458eebf2212",
         "ip": [
-            "172.23.0.7"
+            "172.20.0.7"
         ],
         "mac": [
-            "02:42:ac:17:00:07"
+            "02:42:ac:14:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.104-linuxkit",
+            "kernel": "5.10.124-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -1013,7 +1013,7 @@ An example event for `replstatus` looks as following:
                 },
                 "primary": {
                     "host": "127.0.0.1:27017",
-                    "optime": 1662376628
+                    "optime": 1662462708
                 },
                 "recovering": {
                     "count": 0,
@@ -1043,10 +1043,10 @@ An example event for `replstatus` looks as following:
             },
             "oplog": {
                 "first": {
-                    "timestamp": 1662376596
+                    "timestamp": 1662462668
                 },
                 "last": {
-                    "timestamp": 1662376596
+                    "timestamp": 1662462668
                 },
                 "size": {
                     "allocated": 1038090240,
@@ -1055,11 +1055,11 @@ An example event for `replstatus` looks as following:
                 "window": 0
             },
             "optimes": {
-                "applied": 1662376628,
-                "durable": 1662376628,
-                "last_committed": 1662376628
+                "applied": 1662462708,
+                "durable": 1662462708,
+                "last_committed": 1662462708
             },
-            "server_date": "2022-09-05T11:17:09.071Z",
+            "server_date": "2022-09-06T11:11:49.112Z",
             "set_name": "beats"
         }
     },
@@ -1161,10 +1161,10 @@ An example event for `status` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-05T10:39:37.981Z",
+    "@timestamp": "2022-09-06T11:13:06.293Z",
     "agent": {
-        "ephemeral_id": "7ed9a5c5-01f3-4938-9d67-3efb76c7a060",
-        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "ephemeral_id": "4c7d338a-8465-4f02-8883-3d473ec1db9a",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
         "version": "8.4.0"
@@ -1178,15 +1178,15 @@ An example event for `status` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "44b5c9f4-dc38-4a41-a9cc-13ef3c97a02e",
+        "id": "b8e186ad-f4ee-4cea-93d9-b4e7ba29c8fa",
         "snapshot": false,
         "version": "8.4.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "mongodb.status",
-        "duration": 17129285758,
-        "ingested": "2022-09-05T10:39:56Z",
+        "duration": 11067899422,
+        "ingested": "2022-09-06T11:13:18Z",
         "module": "mongodb"
     },
     "host": {
@@ -1195,16 +1195,16 @@ An example event for `status` looks as following:
         "hostname": "docker-fleet-agent",
         "id": "5016511f0829451ea244f458eebf2212",
         "ip": [
-            "172.23.0.7"
+            "172.20.0.7"
         ],
         "mac": [
-            "02:42:ac:17:00:07"
+            "02:42:ac:14:00:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.104-linuxkit",
+            "kernel": "5.10.124-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -1221,13 +1221,13 @@ An example event for `status` looks as following:
                 "msg": 0,
                 "regular": 0,
                 "rollovers": 0,
-                "user": 8,
+                "user": 10,
                 "warning": 0
             },
             "connections": {
                 "available": 838858,
                 "current": 2,
-                "total_created": 2
+                "total_created": 3
             },
             "extra_info": {
                 "heap_usage": {},
@@ -1245,17 +1245,17 @@ An example event for `status` looks as following:
                     "writers": 0
                 },
                 "total_time": {
-                    "us": 1690000
+                    "us": 1339000
                 }
             },
-            "local_time": "2022-09-05T10:39:55.073Z",
+            "local_time": "2022-09-06T11:13:17.329Z",
             "locks": {
                 "collection": {
                     "acquire": {
                         "count": {
                             "W": 6,
                             "r": 37,
-                            "w": 12
+                            "w": 10
                         }
                     },
                     "deadlock": {},
@@ -1265,8 +1265,8 @@ An example event for `status` looks as following:
                     "acquire": {
                         "count": {
                             "W": 3,
-                            "r": 35,
-                            "w": 27
+                            "r": 34,
+                            "w": 25
                         }
                     },
                     "deadlock": {},
@@ -1276,8 +1276,8 @@ An example event for `status` looks as following:
                     "acquire": {
                         "count": {
                             "W": 6,
-                            "r": 74,
-                            "w": 33
+                            "r": 65,
+                            "w": 31
                         }
                     },
                     "deadlock": {},
@@ -1286,7 +1286,6 @@ An example event for `status` looks as following:
                 "oplog": {
                     "acquire": {
                         "count": {
-                            "r": 1,
                             "w": 1
                         }
                     },
@@ -1299,10 +1298,10 @@ An example event for `status` looks as following:
                 "mapped": {},
                 "mapped_with_journal": {},
                 "resident": {
-                    "mb": 109
+                    "mb": 101
                 },
                 "virtual": {
-                    "mb": 1732
+                    "mb": 1727
                 }
             },
             "network": {
@@ -1320,13 +1319,13 @@ An example event for `status` looks as following:
                     "delete": 0,
                     "getmore": 0,
                     "insert": 0,
-                    "query": 14,
+                    "query": 11,
                     "update": 0
                 },
                 "latencies": {
                     "commands": {
                         "count": 2,
-                        "latency": 11533
+                        "latency": 2152
                     },
                     "reads": {
                         "count": 0,
@@ -1350,7 +1349,7 @@ An example event for `status` looks as following:
                 "name": "wiredTiger"
             },
             "uptime": {
-                "ms": 1677
+                "ms": 1331
             },
             "wired_tiger": {
                 "cache": {
@@ -1366,7 +1365,7 @@ An example event for `status` looks as following:
                         "write": 5
                     },
                     "used": {
-                        "bytes": 177452
+                        "bytes": 177684
                     }
                 },
                 "concurrent_transactions": {
@@ -1382,7 +1381,7 @@ An example event for `status` looks as following:
                     }
                 },
                 "log": {
-                    "flushes": 8,
+                    "flushes": 6,
                     "max_file_size": {
                         "bytes": 104857600
                     },

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: 1.3.2
+version: 1.3.3
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

This PR adds the system test for all the below data-streams in mongodb integration package.
- collstats
- dbstats
- log
- metrics
- replstatus
- status

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/mongodb directory.
- Run the following command to run tests. 
> elastic-package test -v

## Related issues

- Closes #1440
- Closes #761
- Closes #3025


## Screenshots

<img width="1065" alt="Screenshot 2022-09-07 at 5 04 02 PM" src="https://user-images.githubusercontent.com/97392538/188868718-c6a0b93b-23f8-44e0-b4ba-b52c46c475c9.png">


<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
