### PR TITLE
Kafka sasl mechanism

### DIFF
--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Support SASL mechanism
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/4154
 - version: "1.2.3"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.4"
+  changes:
+    - description: Support SASL mechanism
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "1.2.3"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/consumergroup/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if mechanism}}
+sasl.mechanism: {{mechanism}}
+{{/if}}
 {{#if ssl.certificate}}
 ssl.certificate: {{ssl.certificate}}
 {{/if}}

--- a/packages/kafka/data_stream/consumergroup/manifest.yml
+++ b/packages/kafka/data_stream/consumergroup/manifest.yml
@@ -19,3 +19,4 @@ streams:
       - name: mechanism
         type: text
         title: SASL mechanism
+        description: SASL authentication mechanism used. Can be one of PLAIN, SCRAM-SHA-256 or SCRAM-SHA-512 

--- a/packages/kafka/data_stream/consumergroup/manifest.yml
+++ b/packages/kafka/data_stream/consumergroup/manifest.yml
@@ -16,3 +16,6 @@ streams:
       - name: password
         type: password
         title: SASL password
+      - name: mechanism
+        type: text
+        title: SASL mechanism

--- a/packages/kafka/data_stream/partition/agent/stream/stream.yml.hbs
+++ b/packages/kafka/data_stream/partition/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if mechanism}}
+sasl.mechanism: {{mechanism}}
+{{/if}}
 {{#if ssl.certificate}}
 ssl.certificate: {{ssl.certificate}}
 {{/if}}

--- a/packages/kafka/data_stream/partition/manifest.yml
+++ b/packages/kafka/data_stream/partition/manifest.yml
@@ -19,3 +19,4 @@ streams:
       - name: mechanism
         type: text
         title: SASL mechanism
+        description: SASL authentication mechanism used. Can be one of PLAIN, SCRAM-SHA-256 or SCRAM-SHA-512 

--- a/packages/kafka/data_stream/partition/manifest.yml
+++ b/packages/kafka/data_stream/partition/manifest.yml
@@ -16,3 +16,6 @@ streams:
       - name: password
         type: password
         title: SASL password
+      - name: mechanism
+        type: text
+        title: SASL mechanism

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kafka
 title: Kafka
-version: 1.2.3
+version: 1.2.4
 license: basic
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration


### PR DESCRIPTION

## What does this PR do?

kafka integration will be passing down _**sasl.mechanism**_ for **consumergroup** & **partition** data_streams.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have added an entry to my package's `changelog.yml` file.

## Author's Checklist

- [X] Review Kafka metricbeat yml for sasl mechanism input 

## How to test this PR locally

- [X] Verify that the config is populated in the generated policy file.
- [X] No Kafka system test for now.

## Related issues

- Closes #3667

## Screenshots

```
      - id: kafka/metrics-kafka.partition-2b7de019-5e65-4fc2-a011-2e80100604bf
        data_stream:
          dataset: kafka.partition
          type: metrics
        metricsets:
          - partition
        period: 10s
        hosts:
          - 'localhost:9092'
        username: u1
        password: p1
        sasl.mechanism: SCRAM-SHA-256
```

