### PR TITLE
Fix EC2 dashboard for kibana 7.x

### DIFF
--- a/packages/aws/kibana/dashboard/aws-c5846400-f7fb-11e8-af03-c999c9dea608.json
+++ b/packages/aws/kibana/dashboard/aws-c5846400-f7fb-11e8-af03-c999c9dea608.json
@@ -18,7 +18,10 @@
         },
         "panelsJSON": [
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 15,
                     "i": "3",
@@ -27,11 +30,16 @@
                     "y": 27
                 },
                 "panelIndex": "3",
-                "panelRefName": "panel_0",
-                "version": "7.3.0"
+                "panelRefName": "panel_3",
+                "title": "EC2 DiskIO Write Bytes",
+                "type": "visualization",
+                "version": "7.15.0-SNAPSHOT"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 12,
                     "i": "5",
@@ -40,11 +48,16 @@
                     "y": 0
                 },
                 "panelIndex": "5",
-                "panelRefName": "panel_1",
-                "version": "7.3.0"
+                "panelRefName": "panel_5",
+                "title": "EC2 Status Check Failed",
+                "type": "visualization",
+                "version": "7.15.0-SNAPSHOT"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 15,
                     "i": "11",
@@ -53,11 +66,16 @@
                     "y": 42
                 },
                 "panelIndex": "11",
-                "panelRefName": "panel_2",
-                "version": "7.3.0"
+                "panelRefName": "panel_11",
+                "title": "EC2 Network In Bytes",
+                "type": "visualization",
+                "version": "7.15.0-SNAPSHOT"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 15,
                     "i": "12",
@@ -66,11 +84,16 @@
                     "y": 42
                 },
                 "panelIndex": "12",
-                "panelRefName": "panel_3",
-                "version": "7.3.0"
+                "panelRefName": "panel_12",
+                "title": "EC2 Network Out Bytes",
+                "type": "visualization",
+                "version": "7.15.0-SNAPSHOT"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 15,
                     "i": "15",
@@ -79,11 +102,16 @@
                     "y": 27
                 },
                 "panelIndex": "15",
-                "panelRefName": "panel_4",
-                "version": "7.3.0"
+                "panelRefName": "panel_15",
+                "title": "EC2 DiskIO Read Bytes",
+                "type": "visualization",
+                "version": "7.15.0-SNAPSHOT"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 15,
                     "i": "17",
@@ -92,11 +120,16 @@
                     "y": 12
                 },
                 "panelIndex": "17",
-                "panelRefName": "panel_5",
-                "version": "7.3.0"
+                "panelRefName": "panel_17",
+                "title": "EC2 CPU Utilization",
+                "type": "visualization",
+                "version": "7.15.0-SNAPSHOT"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 12,
                     "i": "18",
@@ -105,11 +138,16 @@
                     "y": 0
                 },
                 "panelIndex": "18",
-                "panelRefName": "panel_6",
-                "version": "7.3.0"
+                "panelRefName": "panel_18",
+                "title": "AWS Account Filter",
+                "type": "visualization",
+                "version": "7.15.0-SNAPSHOT"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 12,
                     "i": "19",
@@ -118,54 +156,60 @@
                     "y": 0
                 },
                 "panelIndex": "19",
-                "panelRefName": "panel_7",
-                "version": "7.3.0"
+                "panelRefName": "panel_19",
+                "title": "EC2 Instance State",
+                "type": "visualization",
+                "version": "7.15.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics AWS] EC2 Overview",
         "version": 1
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-c5846400-f7fb-11e8-af03-c999c9dea608",
+    "migrationVersion": {
+        "dashboard": "7.15.0"
+    },
     "references": [
         {
             "id": "aws-fed59380-f7f8-11e8-af03-c999c9dea608",
-            "name": "panel_0",
+            "name": "3:panel_3",
             "type": "visualization"
         },
         {
             "id": "aws-9e8c6030-f7f8-11e8-af03-c999c9dea608",
-            "name": "panel_1",
+            "name": "5:panel_5",
             "type": "visualization"
         },
         {
             "id": "aws-15818fd0-f7f9-11e8-af03-c999c9dea608",
-            "name": "panel_2",
+            "name": "11:panel_11",
             "type": "visualization"
         },
         {
             "id": "aws-233b3400-f7f9-11e8-af03-c999c9dea608",
-            "name": "panel_3",
+            "name": "12:panel_12",
             "type": "visualization"
         },
         {
             "id": "aws-f1db6ec0-f7f8-11e8-af03-c999c9dea608",
-            "name": "panel_4",
+            "name": "15:panel_15",
             "type": "visualization"
         },
         {
             "id": "aws-be8828d0-f7f6-11e8-af03-c999c9dea608",
-            "name": "panel_5",
+            "name": "17:panel_17",
             "type": "visualization"
         },
         {
             "id": "aws-deab0260-2981-11e9-86eb-a3a07a77f530",
-            "name": "panel_6",
+            "name": "18:panel_18",
             "type": "visualization"
         },
         {
             "id": "aws-09db13f0-2bdd-11e9-9fe1-cde861544141",
-            "name": "panel_7",
+            "name": "19:panel_19",
             "type": "visualization"
         }
     ],

--- a/packages/aws/kibana/visualization/aws-09db13f0-2bdd-11e9-9fe1-cde861544141.json
+++ b/packages/aws/kibana/visualization/aws-09db13f0-2bdd-11e9-9fe1-cde861544141.json
@@ -57,6 +57,7 @@
             "params": {
                 "addLegend": true,
                 "addTooltip": true,
+                "distinctColors": true,
                 "isDonut": false,
                 "labels": {
                     "last_level": true,
@@ -65,13 +66,21 @@
                     "values": true
                 },
                 "legendPosition": "right",
+                "palette": {
+                    "name": "kibana_palette",
+                    "type": "palette"
+                },
                 "type": "pie"
             },
             "title": "EC2 Instance State [Metrics AWS]",
             "type": "pie"
         }
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-09db13f0-2bdd-11e9-9fe1-cde861544141",
+    "migrationVersion": {
+        "visualization": "7.14.0"
+    },
     "references": [
         {
             "id": "metrics-*",

--- a/packages/aws/kibana/visualization/aws-15818fd0-f7f9-11e8-af03-c999c9dea608.json
+++ b/packages/aws/kibana/visualization/aws-15818fd0-f7f9-11e8-af03-c999c9dea608.json
@@ -30,9 +30,16 @@
                         "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
                     }
                 ],
+                "drop_last_bucket": 1,
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"aws.ec2_metrics\" "
+                },
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
-                "interval": "5m",
+                "interval": "\u003e=5m",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -40,13 +47,13 @@
                         "color": "rgba(104,188,0,1)",
                         "fill": "0",
                         "filter": "",
-                        "formatter": "number",
+                        "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "AWS EC2 Network In Bytes",
                         "line_width": 1,
                         "metrics": [
                             {
-                                "field": "aws.ec2.network.in.bytes",
+                                "field": "host.network.ingress.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }
@@ -54,25 +61,35 @@
                         "point_size": 1,
                         "separate_axis": 0,
                         "series_drop_last_bucket": 1,
+                        "series_index_pattern": "",
                         "split_color_mode": "rainbow",
                         "split_mode": "terms",
                         "stacked": "none",
                         "steps": 0,
                         "terms_field": "cloud.instance.id",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                        "terms_size": "5"
+                        "terms_size": "5",
+                        "type": "timeseries"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "AWS EC2 Network In Bytes",
+            "title": "EC2 Network In Bytes [Metrics AWS]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-15818fd0-f7f9-11e8-af03-c999c9dea608",
+    "migrationVersion": {
+        "visualization": "7.14.0"
+    },
     "references": [],
     "type": "visualization"
 }

--- a/packages/aws/kibana/visualization/aws-233b3400-f7f9-11e8-af03-c999c9dea608.json
+++ b/packages/aws/kibana/visualization/aws-233b3400-f7f9-11e8-af03-c999c9dea608.json
@@ -30,9 +30,16 @@
                         "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
                     }
                 ],
+                "drop_last_bucket": 1,
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"aws.ec2_metrics\" "
+                },
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
-                "interval": "5m",
+                "interval": "\u003e=5m",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -40,13 +47,13 @@
                         "color": "rgba(104,188,0,1)",
                         "fill": "0",
                         "filter": "",
-                        "formatter": "number",
+                        "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "AWS EC2 Network Out Bytes",
                         "line_width": 1,
                         "metrics": [
                             {
-                                "field": "aws.ec2.network.out.bytes",
+                                "field": "host.network.egress.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }
@@ -54,25 +61,35 @@
                         "point_size": 1,
                         "separate_axis": 0,
                         "series_drop_last_bucket": 1,
+                        "series_index_pattern": "",
                         "split_color_mode": "rainbow",
                         "split_mode": "terms",
                         "stacked": "none",
                         "steps": 0,
                         "terms_field": "cloud.instance.id",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                        "terms_size": "5"
+                        "terms_size": "5",
+                        "type": "timeseries"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "AWS EC2 Network Out Bytes",
+            "title": "EC2 Network Out Bytes [Metrics AWS]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-233b3400-f7f9-11e8-af03-c999c9dea608",
+    "migrationVersion": {
+        "visualization": "7.14.0"
+    },
     "references": [],
     "type": "visualization"
 }

--- a/packages/aws/kibana/visualization/aws-9e8c6030-f7f8-11e8-af03-c999c9dea608.json
+++ b/packages/aws/kibana/visualization/aws-9e8c6030-f7f8-11e8-af03-c999c9dea608.json
@@ -2,13 +2,7 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
+            "searchSourceJSON": {}
         },
         "title": "EC2 Status Check Failed [Metrics AWS]",
         "uiStateJSON": {},
@@ -29,6 +23,7 @@
                         "id": "ad6d62d0-f7f7-11e8-bff8-21537b07dd44"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "gauge_color_rules": [
                     {
                         "id": "b0c5b590-f7f7-11e8-bff8-21537b07dd44"
@@ -37,6 +32,7 @@
                 "gauge_inner_width": 10,
                 "gauge_style": "half",
                 "gauge_width": 10,
+                "hide_last_value_indicator": true,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -69,13 +65,18 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "metric"
+                "type": "metric",
+                "use_kibana_indexes": false
             },
             "title": "AWS EC2 Status Check Failed",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-9e8c6030-f7f8-11e8-af03-c999c9dea608",
+    "migrationVersion": {
+        "visualization": "7.14.0"
+    },
     "references": [],
     "type": "visualization"
 }

--- a/packages/aws/kibana/visualization/aws-be8828d0-f7f6-11e8-af03-c999c9dea608.json
+++ b/packages/aws/kibana/visualization/aws-be8828d0-f7f6-11e8-af03-c999c9dea608.json
@@ -30,9 +30,16 @@
                         "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
                     }
                 ],
+                "drop_last_bucket": 1,
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"aws.ec2_metrics\" "
+                },
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
-                "interval": "5m",
+                "interval": "\u003e=5m",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -46,7 +53,7 @@
                         "line_width": 1,
                         "metrics": [
                             {
-                                "field": "aws.ec2.cpu.total.pct",
+                                "field": "host.cpu.usage",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }
@@ -54,25 +61,35 @@
                         "point_size": 1,
                         "separate_axis": 0,
                         "series_drop_last_bucket": 1,
+                        "series_index_pattern": "",
                         "split_color_mode": "rainbow",
                         "split_mode": "terms",
                         "stacked": "none",
                         "steps": 0,
                         "terms_field": "cloud.instance.id",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                        "terms_size": "5"
+                        "terms_size": "5",
+                        "type": "timeseries"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "AWS EC2 CPU Utilization",
+            "title": "EC2 CPU Utilization [Metrics AWS]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-be8828d0-f7f6-11e8-af03-c999c9dea608",
+    "migrationVersion": {
+        "visualization": "7.14.0"
+    },
     "references": [],
     "type": "visualization"
 }

--- a/packages/aws/kibana/visualization/aws-deab0260-2981-11e9-86eb-a3a07a77f530.json
+++ b/packages/aws/kibana/visualization/aws-deab0260-2981-11e9-86eb-a3a07a77f530.json
@@ -41,7 +41,11 @@
             "type": "input_control_vis"
         }
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-deab0260-2981-11e9-86eb-a3a07a77f530",
+    "migrationVersion": {
+        "visualization": "7.14.0"
+    },
     "references": [
         {
             "id": "metrics-*",

--- a/packages/aws/kibana/visualization/aws-f1db6ec0-f7f8-11e8-af03-c999c9dea608.json
+++ b/packages/aws/kibana/visualization/aws-f1db6ec0-f7f8-11e8-af03-c999c9dea608.json
@@ -30,9 +30,16 @@
                         "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
                     }
                 ],
+                "drop_last_bucket": 1,
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"aws.ec2_metrics\" "
+                },
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
-                "interval": "5m",
+                "interval": "\u003e=5m",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -40,13 +47,13 @@
                         "color": "rgba(104,188,0,1)",
                         "fill": "0",
                         "filter": "",
-                        "formatter": "number",
+                        "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "AWS EC2 DiskIO Read Bytes",
                         "line_width": 1,
                         "metrics": [
                             {
-                                "field": "aws.ec2.diskio.read.bytes",
+                                "field": "host.disk.read.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }
@@ -54,25 +61,35 @@
                         "point_size": 1,
                         "separate_axis": 0,
                         "series_drop_last_bucket": 1,
+                        "series_index_pattern": "",
                         "split_color_mode": "rainbow",
                         "split_mode": "terms",
                         "stacked": "none",
                         "steps": 0,
                         "terms_field": "cloud.instance.id",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                        "terms_size": "5"
+                        "terms_size": "5",
+                        "type": "timeseries"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "AWS EC2 DiskIO Read Bytes",
+            "title": "EC2 DiskIO Read Bytes [Metrics AWS]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-f1db6ec0-f7f8-11e8-af03-c999c9dea608",
+    "migrationVersion": {
+        "visualization": "7.14.0"
+    },
     "references": [],
     "type": "visualization"
 }

--- a/packages/aws/kibana/visualization/aws-fed59380-f7f8-11e8-af03-c999c9dea608.json
+++ b/packages/aws/kibana/visualization/aws-fed59380-f7f8-11e8-af03-c999c9dea608.json
@@ -30,9 +30,16 @@
                         "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
                     }
                 ],
+                "drop_last_bucket": 1,
+                "filter": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset : \"aws.ec2_metrics\" "
+                },
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
-                "interval": "5m",
+                "interval": "\u003e=5m",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -40,13 +47,13 @@
                         "color": "rgba(104,188,0,1)",
                         "fill": "0",
                         "filter": "",
-                        "formatter": "number",
+                        "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "AWS EC2 DiskIO Write Bytes",
                         "line_width": 1,
                         "metrics": [
                             {
-                                "field": "aws.ec2.diskio.write.bytes",
+                                "field": "host.disk.write.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }
@@ -54,25 +61,35 @@
                         "point_size": 1,
                         "separate_axis": 0,
                         "series_drop_last_bucket": 1,
+                        "series_index_pattern": "",
                         "split_color_mode": "rainbow",
                         "split_mode": "terms",
                         "stacked": "none",
                         "steps": 0,
                         "terms_field": "cloud.instance.id",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                        "terms_size": "5"
+                        "terms_size": "5",
+                        "type": "timeseries"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "AWS EC2 DiskIO Write Bytes",
+            "title": "EC2 DiskIO Write Bytes [Metrics AWS]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "7.15.0",
     "id": "aws-fed59380-f7f8-11e8-af03-c999c9dea608",
+    "migrationVersion": {
+        "visualization": "7.14.0"
+    },
     "references": [],
     "type": "visualization"
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix EC2 dashboard for kibana 7.x and publish a new release version 1.19.6.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).