### PR TITLE
jjbb: exclude branches which are not main or feature/backport in the upstream

### DIFF
--- a/.ci/jobs/integrations.yml
+++ b/.ci/jobs/integrations.yml
@@ -13,6 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
+          head-filter-regex: '(main|PR-.*|feature-.*|backport-.*)'
           notification-context: 'integrations'
           repo: integrations
           repo-owner: elastic


### PR DESCRIPTION


## What does this PR do?

Tidy up what branches from the upstream can be built in the CI. 

## Why

People contribute through their forked repositories, or origin Pull Requests, hence there is no need to build all the branches for this project but the ones following certain nomenclature `feature-.*` or `backport-.*` (see https://github.com/elastic/integrations/pull/4182)