### PR TITLE
cisco_asa: fix handling of non-canonical 113005 messages

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix handling of non-canonical 113005 messages.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4189
 - version: "2.7.2"
   changes:
     - description: Clean up grok pattern naming.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.3"
+  changes:
+    - description: Fix handling of non-canonical 113005 messages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.7.2"
   changes:
     - description: Clean up grok pattern naming.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -93,7 +93,7 @@ May  5 19:02:25 dev01: %ASA-4-733100: [     Port-5432 5432] drop rate-1 exceeded
 May  5 19:02:25 dev01: %ASA-4-733100: [           RDP 3389] drop rate-1 exceeded. Current burst rate is 63 per second, max configured rate is 10; Current average rate is 5 per second, max configured rate is 5; Cumulative total count is 3054
 May  5 19:02:25 dev01: %ASA-6-113004: AAA user authentication Successful: server = 81.2.69.144 , User = alice
 May  5 19:02:25 dev01: %ASA-6-113004: AAA user authorization Successful: server = 81.2.69.144 , User = alice
-May  5 19:02:25 dev01: %ASA-6-113005: AAA user authentication Rejected: reason = AAA failure: server = 81.2.69.144 : user = *****: user IP = 172.31.98.44
+May  5 19:02:25 dev01: %ASA-6-113005: AAA user authentication Rejected: reason = AAA failure: server = 81.2.69.144 : user = alice: user IP = 172.31.98.44
 May  5 19:02:25 dev01: %ASA-6-113012: AAA user authentication Successful: local database: user = alice
 May  5 19:02:25 dev01: %ASA-3-113021: Attempted console login failed. User eve did NOT have appropriate Admin Rights.
 May  5 19:02:25 dev01: %ASA-6-716039: Authentication: rejected, group = malcorp user = eve , Session Type: admin

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -6494,7 +6494,7 @@
                 ],
                 "code": "113005",
                 "kind": "event",
-                "original": "May  5 19:02:25 dev01: %ASA-6-113005: AAA user authentication Rejected: reason = AAA failure: server = 81.2.69.144 : user = *****: user IP = 172.31.98.44",
+                "original": "May  5 19:02:25 dev01: %ASA-6-113005: AAA user authentication Rejected: reason = AAA failure: server = 81.2.69.144 : user = alice: user IP = 172.31.98.44",
                 "outcome": "failure",
                 "severity": 6,
                 "type": [
@@ -6523,14 +6523,14 @@
                     "81.2.69.144"
                 ],
                 "user": [
-                    "*****"
+                    "alice"
                 ]
             },
             "source": {
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44",
                 "user": {
-                    "name": "*****"
+                    "name": "alice"
                 }
             },
             "tags": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log
@@ -17,3 +17,5 @@ Jul 14 01:45:09 81.2.69.142 %ASA-6-302021: Teardown ICMP connection for faddr et
 Jul 15 12:18:51 81.2.69.192 %ASA-6-113039: Group <novpn> User <nt\minsk> IP <216.160.83.56> AnyConnect parent session started.
 Jul  1 09:27:13 216.160.83.56 : %ASA-6-113039: Group <Group_VPN> User <support\column> IP <81.2.69.192> AnyConnect parent session started.
 Jun 14 01:22:47 81.2.69.142 %ASA-5-304001: 192.168.14.22 Accessed URL mirror:http://mirror.example.com/path/to/resource
+Jul  1 09:27:13 216.160.83.56 : AAA user authentication Rejected : reason = AAA failure : server = 81.2.69.142 : user = 123 : user IP = 89.160.20.112
+Jul  1 09:27:13 216.160.83.56 : AAA user authentication Rejected : reason = Account has been disabled : server = 81.2.69.144 : user = alice : user IP = 89.160.20.128

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -1528,6 +1528,78 @@
                 "path": "/path/to/resource",
                 "scheme": "http"
             }
+        },
+        {
+            "@timestamp": "2022-07-01T09:27:13.000Z",
+            "cisco": {
+                "asa": {
+                    "security": {}
+                }
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "code": "",
+                "original": "Jul  1 09:27:13 216.160.83.56 : AAA user authentication Rejected : reason = AAA failure : server = 81.2.69.142 : user = 123 : user IP = 89.160.20.112",
+                "severity": 7
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "debug"
+            },
+            "observer": {
+                "hostname": "216.160.83.56",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-07-01T09:27:13.000Z",
+            "cisco": {
+                "asa": {
+                    "security": {}
+                }
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "code": "",
+                "original": "Jul  1 09:27:13 216.160.83.56 : AAA user authentication Rejected : reason = Account has been disabled : server = 81.2.69.144 : user = alice : user IP = 89.160.20.128",
+                "severity": 7
+            },
+            "host": {
+                "hostname": "216.160.83.56"
+            },
+            "log": {
+                "level": "debug"
+            },
+            "observer": {
+                "hostname": "216.160.83.56",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "216.160.83.56"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -336,11 +336,15 @@ processors:
       field: "message"
       description: "113004"
       pattern: "AAA user %{_temp_.cisco.aaa_type} Successful: server = %{destination.address} , User = %{source.user.name}"
-  - dissect:
+  - grok:
       if: "ctx._temp_.cisco.message_id == '113005'"
-      field: "message"
       description: "113005"
-      pattern: "AAA user authentication Rejected: reason = AAA failure: server = %{destination.address} : user = %{source.user.name}: user IP = %{source.address}"
+      field: "message"
+      patterns: 
+      - "AAA user authentication Rejected: reason = %{REASON}: server = %{IP:destination.address} : user = ?%{CISCO_USER:source.user.name}: user IP = %{IP:source.address}"
+      pattern_definitions:
+        REASON: (AAA failure|Account has been disabled)
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
       if: "ctx._temp_.cisco.message_id == '113012'"
       field: "message"

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.7.2"
+version: "2.7.3"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This relaxes the parsing of 113005 messages that do not conform to the documented format but appear in the wild.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Note that this actually tightens the format requirement on usernames since they must now actually satisfy the Cisco username syntax while before any non-space would be accepted.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #4185 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
