### PR TITLE
[cloudflare] Fix lookup of invalid key for pagination

### DIFF
--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix pagination issue.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/9999 # FIXME: Change to real PR
+      link: https://github.com/elastic/integrations/issues/4196
 - version: "2.2.1"
   changes:
     - description: Remove unused visualizations

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.2"
+  changes:
+    - description: Fix pagination issue.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/9999 # FIXME: Change to real PR
 - version: "2.2.1"
   changes:
     - description: Remove unused visualizations

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.2.2"
   changes:
     - description: Fix pagination issue.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/issues/4196
 - version: "2.2.1"
   changes:

--- a/packages/cloudflare/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/cloudflare/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -29,7 +29,7 @@ response.split:
 response.pagination:
 - set:
     target: url.params.page
-    value: '[[if (ne (len .last_response.body.response) 0)]][[add .last_response.page 1]][[end]]'
+    value: '[[if (ne (len .last_response.body.result) 0)]][[add .last_response.page 1]][[end]]'
     fail_on_template_error: true
           
 cursor:

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: 2.2.1
+version: 2.2.2
 release: ga
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

- Change lookup of key for array length from 'response' to 'result'

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #4195
