### PR TITLE
[GCP] support multiple regions when gathering metrics

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.0"
+  changes:
+    - description: Support multiple regions for metrics data streams
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4197
 - version: "2.14.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: "2.15.0"
   changes:
+    - description: Remove support for Kibana 7.17.x
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4197
     - description: Support multiple regions for metrics data streams
       type: enhancement
       link: https://github.com/elastic/integrations/pull/4197

--- a/packages/gcp/data_stream/compute/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/compute/agent/stream/stream.yml.hbs
@@ -13,6 +13,12 @@ region: {{region}}
 {{#if zone}}
 zone: {{zone}}
 {{/if}}
+{{#if regions}}
+regions:
+{{#each regions as |region i|}}
+- {{region}}
+{{/each}}
+{{/if}}
 exclude_labels: {{exclude_labels}}
 metrics:
   - service: compute

--- a/packages/gcp/data_stream/compute/manifest.yml
+++ b/packages/gcp/data_stream/compute/manifest.yml
@@ -14,6 +14,7 @@ streams:
       - name: region
         type: text
         title: GCP Region
+        description: deprecated, use regions instead
         multi: false
         required: false
         show_user: true

--- a/packages/gcp/data_stream/compute/manifest.yml
+++ b/packages/gcp/data_stream/compute/manifest.yml
@@ -11,12 +11,6 @@ streams:
         multi: false
         required: false
         show_user: true
-      - name: region
-        type: text
-        title: GCP Region
-        multi: false
-        required: false
-        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/compute/manifest.yml
+++ b/packages/gcp/data_stream/compute/manifest.yml
@@ -11,6 +11,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: region
+        type: text
+        title: GCP Region
+        multi: false
+        required: false
+        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/compute/manifest.yml
+++ b/packages/gcp/data_stream/compute/manifest.yml
@@ -17,6 +17,13 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: regions
+        type: text
+        title: GCP Regions
+        description: A list of GCP regions to pull data from
+        multi: true
+        required: false
+        show_user: true
       - name: period
         type: text
         title: Period

--- a/packages/gcp/data_stream/dataproc/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/dataproc/agent/stream/stream.yml.hbs
@@ -10,6 +10,12 @@ credentials_json: '{{credentials_json}}'
 {{#if region}}
 region: {{region}}
 {{/if}}
+{{#if regions}}
+regions:
+{{#each regions as |region i|}}
+- {{region}}
+{{/each}}
+{{/if}}
 exclude_labels: {{exclude_labels}}
 metrics:
   - service: dataproc

--- a/packages/gcp/data_stream/dataproc/manifest.yml
+++ b/packages/gcp/data_stream/dataproc/manifest.yml
@@ -12,6 +12,13 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: regions
+        type: text
+        title: GCP Regions
+        description: A list of GCP regions to pull data from
+        multi: true
+        required: false
+        show_user: true
       - name: period
         type: text
         title: Period

--- a/packages/gcp/data_stream/dataproc/manifest.yml
+++ b/packages/gcp/data_stream/dataproc/manifest.yml
@@ -8,6 +8,7 @@ streams:
       - name: region
         type: text
         title: GCP Region
+        description: deprecated, use regions instead
         multi: false
         required: false
         show_user: true

--- a/packages/gcp/data_stream/firestore/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/firestore/agent/stream/stream.yml.hbs
@@ -13,6 +13,12 @@ region: {{region}}
 {{#if zone}}
 zone: {{zone}}
 {{/if}}
+{{#if regions}}
+regions:
+{{#each regions as |region i|}}
+- {{region}}
+{{/each}}
+{{/if}}
 exclude_labels: {{exclude_labels}}
 metrics:
   - service: firestore

--- a/packages/gcp/data_stream/firestore/manifest.yml
+++ b/packages/gcp/data_stream/firestore/manifest.yml
@@ -14,6 +14,7 @@ streams:
       - name: region
         type: text
         title: GCP Region
+        description: deprecated, use regions instead
         multi: false
         required: false
         show_user: true

--- a/packages/gcp/data_stream/firestore/manifest.yml
+++ b/packages/gcp/data_stream/firestore/manifest.yml
@@ -11,12 +11,6 @@ streams:
         multi: false
         required: false
         show_user: true
-      - name: region
-        type: text
-        title: GCP Region
-        multi: false
-        required: false
-        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/firestore/manifest.yml
+++ b/packages/gcp/data_stream/firestore/manifest.yml
@@ -11,6 +11,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: region
+        type: text
+        title: GCP Region
+        multi: false
+        required: false
+        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/firestore/manifest.yml
+++ b/packages/gcp/data_stream/firestore/manifest.yml
@@ -17,6 +17,13 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: regions
+        type: text
+        title: GCP Regions
+        description: A list of GCP regions to pull data from
+        multi: true
+        required: false
+        show_user: true
       - name: period
         type: text
         title: Period

--- a/packages/gcp/data_stream/gke/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/gke/agent/stream/stream.yml.hbs
@@ -13,6 +13,12 @@ region: {{region}}
 {{#if zone}}
 zone: {{zone}}
 {{/if}}
+{{#if regions}}
+regions:
+{{#each regions as |region i|}}
+- {{region}}
+{{/each}}
+{{/if}}
 exclude_labels: {{exclude_labels}}
 metrics:
   - service: gke

--- a/packages/gcp/data_stream/gke/manifest.yml
+++ b/packages/gcp/data_stream/gke/manifest.yml
@@ -14,6 +14,7 @@ streams:
       - name: region
         type: text
         title: GCP Region
+        description: deprecated, use regions instead
         multi: false
         required: false
         show_user: true

--- a/packages/gcp/data_stream/gke/manifest.yml
+++ b/packages/gcp/data_stream/gke/manifest.yml
@@ -11,12 +11,6 @@ streams:
         multi: false
         required: false
         show_user: true
-      - name: region
-        type: text
-        title: GCP Region
-        multi: false
-        required: false
-        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/gke/manifest.yml
+++ b/packages/gcp/data_stream/gke/manifest.yml
@@ -11,6 +11,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: region
+        type: text
+        title: GCP Region
+        multi: false
+        required: false
+        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/gke/manifest.yml
+++ b/packages/gcp/data_stream/gke/manifest.yml
@@ -17,6 +17,13 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: regions
+        type: text
+        title: GCP Regions
+        description: A list of GCP regions to pull data from
+        multi: true
+        required: false
+        show_user: true
       - name: period
         type: text
         title: Period

--- a/packages/gcp/data_stream/loadbalancing_metrics/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/loadbalancing_metrics/agent/stream/stream.yml.hbs
@@ -13,6 +13,12 @@ region: {{region}}
 {{#if zone}}
 zone: {{zone}}
 {{/if}}
+{{#if regions}}
+regions:
+{{#each regions as |region i|}}
+- {{region}}
+{{/each}}
+{{/if}}
 exclude_labels: {{exclude_labels}}
 metrics:
   - service: loadbalancing

--- a/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
@@ -14,6 +14,7 @@ streams:
       - name: region
         type: text
         title: GCP Region
+        description: deprecated, use regions instead
         multi: false
         required: false
         show_user: true

--- a/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
@@ -11,12 +11,6 @@ streams:
         multi: false
         required: false
         show_user: true
-      - name: region
-        type: text
-        title: GCP Region
-        multi: false
-        required: false
-        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
@@ -11,6 +11,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: region
+        type: text
+        title: GCP Region
+        multi: false
+        required: false
+        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
@@ -17,6 +17,13 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: regions
+        type: text
+        title: GCP Regions
+        description: A list of GCP regions to pull data from
+        multi: true
+        required: false
+        show_user: true
       - name: period
         type: text
         title: Period

--- a/packages/gcp/data_stream/redis/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/redis/agent/stream/stream.yml.hbs
@@ -13,6 +13,12 @@ region: {{region}}
 {{#if zone}}
 zone: {{zone}}
 {{/if}}
+{{#if regions}}
+regions:
+{{#each regions as |region i|}}
+- {{region}}
+{{/each}}
+{{/if}}
 exclude_labels: {{exclude_labels}}
 metrics:
   - service: redis

--- a/packages/gcp/data_stream/redis/manifest.yml
+++ b/packages/gcp/data_stream/redis/manifest.yml
@@ -14,6 +14,7 @@ streams:
       - name: region
         type: text
         title: GCP Region
+        description: deprecated, use regions instead
         multi: false
         required: false
         show_user: true

--- a/packages/gcp/data_stream/redis/manifest.yml
+++ b/packages/gcp/data_stream/redis/manifest.yml
@@ -17,6 +17,13 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: regions
+        type: text
+        title: GCP Regions
+        description: A list of GCP regions to pull data from
+        multi: true
+        required: false
+        show_user: true
       - name: period
         type: text
         title: Period

--- a/packages/gcp/data_stream/storage/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/storage/agent/stream/stream.yml.hbs
@@ -13,6 +13,12 @@ region: {{region}}
 {{#if zone}}
 zone: {{zone}}
 {{/if}}
+{{#if regions}}
+regions:
+{{#each regions as |region i|}}
+- {{region}}
+{{/each}}
+{{/if}}
 exclude_labels: {{exclude_labels}}
 metrics:
   - service: storage

--- a/packages/gcp/data_stream/storage/manifest.yml
+++ b/packages/gcp/data_stream/storage/manifest.yml
@@ -14,6 +14,7 @@ streams:
       - name: region
         type: text
         title: GCP Region
+        description: deprecated, use regions instead
         multi: false
         required: false
         show_user: true

--- a/packages/gcp/data_stream/storage/manifest.yml
+++ b/packages/gcp/data_stream/storage/manifest.yml
@@ -11,12 +11,6 @@ streams:
         multi: false
         required: false
         show_user: true
-      - name: region
-        type: text
-        title: GCP Region
-        multi: false
-        required: false
-        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/storage/manifest.yml
+++ b/packages/gcp/data_stream/storage/manifest.yml
@@ -11,6 +11,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: region
+        type: text
+        title: GCP Region
+        multi: false
+        required: false
+        show_user: true
       - name: regions
         type: text
         title: GCP Regions

--- a/packages/gcp/data_stream/storage/manifest.yml
+++ b/packages/gcp/data_stream/storage/manifest.yml
@@ -17,6 +17,13 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: regions
+        type: text
+        title: GCP Regions
+        description: A list of GCP regions to pull data from
+        multi: true
+        required: false
+        show_user: true
       - name: period
         type: text
         title: Period

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.14.0"
+version: "2.15.0"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -15,7 +15,7 @@ categories:
   - google_cloud
   - cloud
 conditions:
-  kibana.version: ^8.3.0
+  kibana.version: ^8.5.0
 screenshots:
   - src: /img/filebeat-gcp-audit.png
     title: filebeat gcp audit


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
Add `regions` parameter to data streams.

It also updates Kibana min version to 8.5.0, as Metricbeat 8.5.0 is required for the underlying feature: https://github.com/elastic/beats/pull/32964

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
`regions` setting should be added to these data streams:
- [x] compute
- [x] dataproc
- [x] firestore
- [x] gke
- [x] loadbalancing_metrics
- [x] redis
- [x] storage

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
