### PR TITLE
infoblox_nios: allow configuration of timezone

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Allow configuration of timezone.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4201
 - version: "1.2.0"
   changes:
     - description: Add support for file inputs.

--- a/packages/infoblox_nios/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/infoblox_nios/data_stream/log/agent/stream/log.yml.hbs
@@ -13,6 +13,12 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
+{{#if tz_offset}}
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: {{tz_offset}}
+{{/if}}
 processors:
 - add_locale: ~
 {{#if processors}}

--- a/packages/infoblox_nios/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/infoblox_nios/data_stream/log/agent/stream/tcp.yml.hbs
@@ -12,6 +12,12 @@ publisher_pipeline.disable_host: true
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if tz_offset}}
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: {{tz_offset}}
+{{/if}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/infoblox_nios/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/infoblox_nios/data_stream/log/agent/stream/udp.yml.hbs
@@ -9,6 +9,12 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
+{{#if tz_offset}}
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: {{tz_offset}}
+{{/if}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -14,6 +14,12 @@ processors:
         - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+%{NOTSPACE:host.domain}\\s+%{IP:host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
         - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+(%{IP:host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
         - "^%{GREEDYDATA:message}$"
+  - rename:
+      field: _conf.tz_offset
+      target_field: event.timezone
+      if: "ctx?._conf?.tz_offset != null && ctx._conf.tz_offset != 'local'"
+      ignore_missing: true
+      ignore_failure: true
   - date:
       field: event.created
       target_field: event.created
@@ -23,6 +29,18 @@ processors:
         - MMM d HH:mm:ss
         - dd-MMM-yyyy HH:mm:ss.SSS
       ignore_failure: true
+      timezone: "{{{event.timezone}}}"
+      if: ctx.event?.timezone != null   
+  - date:
+      field: event.created
+      target_field: event.created
+      formats:
+        - MMM  d HH:mm:ss
+        - MMM dd HH:mm:ss
+        - MMM d HH:mm:ss
+        - dd-MMM-yyyy HH:mm:ss.SSS
+      ignore_failure: true
+      if: ctx.event?.timezone == null
   - set:
       field: infoblox_nios.log.type
       value: 'DHCP'
@@ -86,6 +104,10 @@ processors:
   - remove:
       field: event.original
       if: "ctx.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
+  - remove:
+      field: _conf
       ignore_failure: true
       ignore_missing: true
 on_failure:

--- a/packages/infoblox_nios/data_stream/log/manifest.yml
+++ b/packages/infoblox_nios/data_stream/log/manifest.yml
@@ -29,6 +29,15 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone Offset
+        multi: false
+        required: true
+        show_user: true
+        default: local
+        description: >-
+          By default, datetimes in the logs will be interpreted as relative to the timezone configured in the host where the agent is running. If ingesting logs from a host on a different timezone, use this field to set the timezone offset so that datetimes are correctly parsed. Acceptable timezone formats are: a canonical ID (e.g. "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential (e.g. "-05:00") from UCT.
       - name: processors
         type: yaml
         title: Processors
@@ -59,6 +68,15 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone Offset
+        multi: false
+        required: true
+        show_user: true
+        default: local
+        description: >-
+          By default, datetimes in the logs will be interpreted as relative to the timezone configured in the host where the agent is running. If ingesting logs from a host on a different timezone, use this field to set the timezone offset so that datetimes are correctly parsed. Acceptable timezone formats are: a canonical ID (e.g. "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential (e.g. "-05:00") from UCT.
       - name: processors
         type: yaml
         title: Processors
@@ -89,6 +107,15 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone Offset
+        multi: false
+        required: true
+        show_user: true
+        default: local
+        description: >-
+          By default, datetimes in the logs will be interpreted as relative to the timezone configured in the host where the agent is running. If ingesting logs from a host on a different timezone, use this field to set the timezone offset so that datetimes are correctly parsed. Acceptable timezone formats are: a canonical ID (e.g. "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential (e.g. "-05:00") from UCT.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.2.0"
+version: "1.3.0"
 license: basic
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This adds the ability to configure the timezone for event ingestion.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4184

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
