### PR TITLE
Add kubernetes.audit.annotations.authorization_k8s_io/* fields

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add fields to audit logs data stream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4144
+      link: https://github.com/elastic/integrations/pull/4203
 - version: "1.23.1"
   changes:
     - description: Add missing dimension fields

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.0"
+  changes:
+    - description: Add fields to audit logs data stream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4144
 - version: "1.23.1"
   changes:
     - description: Add missing dimension fields

--- a/packages/kubernetes/data_stream/audit_logs/fields/fields.yml
+++ b/packages/kubernetes/data_stream/audit_logs/fields/fields.yml
@@ -211,8 +211,10 @@
     - name: stageTimestamp
       type: date
       description: Time the request reached current audit stage
-    - name: annotations.*
-      type: object
-      object_type: text
-      object_type_mapping_type: "*"
-      description: Audit event annotations
+    - name: annotations
+      type: group
+      fields:
+        - name: authorization_k8s_io/decision
+          type: keyword
+        - name: authorization_k8s_io/reason
+          type: text

--- a/packages/kubernetes/docs/audit-logs.md
+++ b/packages/kubernetes/docs/audit-logs.md
@@ -154,7 +154,8 @@ An example event for `audit` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of input. | keyword |
-| kubernetes.audit.annotations.\* | Audit event annotations | object |
+| kubernetes.audit.annotations.authorization_k8s_io/decision |  | keyword |
+| kubernetes.audit.annotations.authorization_k8s_io/reason |  | text |
 | kubernetes.audit.apiVersion | Audit event api version | keyword |
 | kubernetes.audit.auditID | Unique audit ID, generated for each request | keyword |
 | kubernetes.audit.impersonatedUser.extra.\* | Any additional information provided by the authenticator | object |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.23.1
+version: 1.24.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

Add audit logs fields to the mapping. More details why it was not possible to introduce it before - https://github.com/elastic/integrations/issues/3664#issuecomment-1227202756

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/3664

## Screenshots
<img width="972" alt="Screenshot 2022-09-13 at 13 48 19" src="https://user-images.githubusercontent.com/28299531/189893700-f9d5df1c-dd31-468c-afd5-9e36a4b68ee4.png">

