### PR TITLE
[ci] Add mage command to compare bench reports

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -162,6 +162,7 @@ def gitHubCommentWithBenchmarkReport() {
     def benchmarkResults = 'benchmark-results'
     def currentBenchmarkResults = "build/${benchmarkResults}"
     def baseline = "build/${env.CHANGE_TARGET}/${benchmarkResults}"
+    def detailLevel = "short"
     dir("${BASE_DIR}") {
       // download artifacts for this PR
       def bucketUri = getBenchmarkBucketURI() + "*.xml"
@@ -187,7 +188,7 @@ def gitHubCommentWithBenchmarkReport() {
 
       // run the benchmark diff generator
       withMageEnv(){
-        sh(label: 'mage BenchReport', script: "mage BenchReport ${currentBenchmarkResults} ${baseline} ${env.BENCHMARK_THRESHOLD} ${benchmarkGitHubFile}")
+        sh(label: 'mage GetGithubMarkdownBenchReport', script: "mage GetGithubMarkdownBenchReport ${currentBenchmarkResults} ${baseline} ${env.BENCHMARK_THRESHOLD} ${benchmarkGitHubFile} ${detailLevel}")
       }
 
       // report back with a github comment the benchmark diff

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -170,20 +170,28 @@ def gitHubCommentWithBenchmarkReport() {
       // download artifacts from the target branch if any
       if (env.CHANGE_TARGET) {
         try {
-          dir("build/${env.CHANGE_TARGET}") {
           projectName = env.JOB_NAME.replace(env.JOB_BASE_NAME, env.CHANGE_TARGET)
-          copyArtifacts(filter: "${currentBenchmarkResults}/*.*", flatten: true, optional: true, projectName: projectName, selector: lastWithArtifacts(), target: baseline)
-          }
+          copyArtifacts(filter: "${currentBenchmarkResults}/*.xml", flatten: true, optional: true, projectName: projectName, selector: lastWithArtifacts(), target: baseline)
         } catch(e) {
           log(level: 'INFO', text: 'gitHubCommentWithBenchmarkReport: it was not possible to copy the previous build.')
           return
         }
       }
 
+      // for debugging purposes
+      if (fileExists(currentBenchmarkResults)) {
+        sh(label: 'debug current benchmark', script: "ls -l ${currentBenchmarkResults}", returnStatus: true)
+      }
+      if (fileExists(currentBenchmarkResults)) {
+        sh(label: 'debug baseline benchmark', script: "ls -l ${baseline}", returnStatus: true)
+      }
+
       // run the benchmark diff generator
       withMageEnv(){
         sh(label: 'mage BenchReport', script: "mage BenchReport ${currentBenchmarkResults} ${baseline} ${env.BENCHMARK_THRESHOLD} ${benchmarkGitHubFile}")
       }
+
+      // report back with a github comment the benchmark diff
       try {
         if (fileExists("${benchmarkGitHubFile}")) {
           // TODO: existing githubPrComment signature was not done to comment based on a file, but of a string.

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -137,6 +137,16 @@ pipeline {
           }
         }
       }
+      post {
+        always {
+          dir("${BASE_DIR}"){
+            // download artifacts from the target branch if any
+            withMageEnv(){
+              sh(label: 'mage BenchReport', script: "mage BenchReport ./build/benchmark-results ./build/${env.TARGET_BRANCH}/benchmark-results 15 report.md")
+            }
+          }
+        }
+      }
     }
   }
   post {
@@ -145,7 +155,7 @@ pipeline {
       packageStoragePublish()
     }
     cleanup {
-      notifyBuildResult(prComment: true)
+      notifyBuildResult(prComment: true, githubCommentFile: "${BASE_DIR}/report.md")
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("${obltGitHubComments()}")
+    issueCommentTrigger("${obltGitHubComments()}|^/test benchmark fullreport")
   }
   parameters {
     string(name: 'stackVersion', defaultValue: '', description: 'Version of the stack to use for testing.')
@@ -163,6 +163,9 @@ def gitHubCommentWithBenchmarkReport() {
     def currentBenchmarkResults = "build/${benchmarkResults}"
     def baseline = "build/${env.CHANGE_TARGET}/${benchmarkResults}"
     def detailLevel = "short"
+    if (env.GITHUB_COMMENT?.contains('benchmark fullreport')) {
+      detailLevel = "full"
+    }
     dir("${BASE_DIR}") {
       // download artifacts for this PR
       def bucketUri = getBenchmarkBucketURI() + "*.xml"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -161,7 +161,7 @@ def gitHubCommentWithBenchmarkReport() {
     def benchmarkGitHubFile = 'report.md'
     def benchmarkResults = 'benchmark-results'
     def currentBenchmarkResults = "build/${benchmarkResults}"
-    def baseline = "build/${env.TARGET_BRANCH}/${benchmarkResults}"
+    def baseline = "build/${env.CHANGE_TARGET}/${benchmarkResults}"
     dir("${BASE_DIR}") {
       // download artifacts for this PR
       def bucketUri = getBenchmarkBucketURI() + "*.xml"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -170,8 +170,7 @@ def gitHubCommentWithBenchmarkReport() {
       // download artifacts from the target branch if any
       if (env.CHANGE_TARGET) {
         try {
-          projectName = env.JOB_NAME.replace(env.JOB_BASE_NAME, env.CHANGE_TARGET)
-          copyArtifacts(filter: "${currentBenchmarkResults}/*.xml", flatten: true, optional: true, projectName: projectName, selector: lastWithArtifacts(), target: baseline)
+          copyArtifacts(filter: "${currentBenchmarkResults}/*.xml", flatten: true, optional: true, projectName: getBaselineJobName(), selector: lastWithArtifacts(), target: baseline)
         } catch(e) {
           log(level: 'INFO', text: 'gitHubCommentWithBenchmarkReport: it was not possible to copy the previous build.')
           return
@@ -182,7 +181,7 @@ def gitHubCommentWithBenchmarkReport() {
       if (fileExists(currentBenchmarkResults)) {
         sh(label: 'debug current benchmark', script: "ls -l ${currentBenchmarkResults}", returnStatus: true)
       }
-      if (fileExists(currentBenchmarkResults)) {
+      if (fileExists(baseline)) {
         sh(label: 'debug baseline benchmark', script: "ls -l ${baseline}", returnStatus: true)
       }
 
@@ -203,6 +202,14 @@ def gitHubCommentWithBenchmarkReport() {
       }
     }
   }
+}
+
+def getBaselineJobName() {
+  // For a Jenkins Multibranch Pipeline, it's possible to know the current
+  // full job name with the env variable JOB_NAME.
+  // Let's get the full job name for the target branch, in other words
+  // the job name for the branch where the PR will be merged to.
+  return env.JOB_NAME.replace(env.JOB_BASE_NAME, env.CHANGE_TARGET)
 }
 
 def cleanup(){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("${obltGitHubComments()}|^/test benchmark fullreport")
+    issueCommentTrigger("(${obltGitHubComments()}|^/test benchmark fullreport)")
   }
   parameters {
     string(name: 'stackVersion', defaultValue: '', description: 'Version of the stack to use for testing.')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'fleet-ci-gcs-plugin'
     JOB_GCS_EXT_CREDENTIALS = 'fleet-ci-gcs-plugin-file-credentials'
     STACK_VERSION = "${params.stackVersion}"
-
+    BENCHMARK_THRESHOLD = '15'
     // Elastic package links definitions
     ELASTIC_PACKAGE_LINKS_FILE_PATH = "${env.HOME}/${env.BASE_DIR}/links_table.yml"
 
@@ -119,7 +119,7 @@ pipeline {
                         dir("${BASE_DIR}") {
                           archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
                           junit(allowEmptyResults: true, keepLongStdio: true, testResults: "build/test-results/*.xml")
-                          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/benchmark-results/*.xml')
+                          stashBenchmarkResults()
                           sh(label: "Collect Elastic stack logs", script: "build/elastic-package stack dump -v --output build/elastic-stack-dump/${it}")
                           archiveArtifacts(allowEmptyArchive: true, artifacts: "build/elastic-stack-dump/${it}/logs/*.log, build/elastic-stack-dump/${it}/logs/fleet-server-internal/*")
                           archiveArtifactsSafe("insecure-logs/${it}", "build/elastic-stack-dump/${it}/logs/elastic-agent-internal/*")
@@ -139,12 +139,7 @@ pipeline {
       }
       post {
         always {
-          dir("${BASE_DIR}"){
-            // download artifacts from the target branch if any
-            withMageEnv(){
-              sh(label: 'mage BenchReport', script: "mage BenchReport ./build/benchmark-results ./build/${env.TARGET_BRANCH}/benchmark-results 15 report.md")
-            }
-          }
+          gitHubCommentWithBenchmarkReport()
         }
       }
     }
@@ -155,7 +150,49 @@ pipeline {
       packageStoragePublish()
     }
     cleanup {
-      notifyBuildResult(prComment: true, githubCommentFile: "${BASE_DIR}/report.md")
+      notifyBuildResult(prComment: true)
+    }
+  }
+}
+
+def gitHubCommentWithBenchmarkReport() {
+  // report only on a PR basis for obvious reasons (github comments)
+  if (isPR()) {
+    def benchmarkGitHubFile = 'report.md'
+    def benchmarkResults = 'benchmark-results'
+    def currentBenchmarkResults = "build/${benchmarkResults}"
+    def baseline = "build/${env.TARGET_BRANCH}/${benchmarkResults}"
+    dir("${BASE_DIR}") {
+      // download artifacts for this PR
+      def bucketUri = getBenchmarkBucketURI() + "*.xml"
+      googleStorageDownload(bucketUri: bucketUri, credentialsId: "${JOB_GCS_CREDENTIALS}", localDirectory: currentBenchmarkResults, pathPrefix: getBenchmarkPathPrefix())
+
+      // download artifacts from the target branch if any
+      if (env.CHANGE_TARGET) {
+        try {
+          dir("build/${env.CHANGE_TARGET}") {
+          projectName = env.JOB_NAME.replace(env.JOB_BASE_NAME, env.CHANGE_TARGET)
+          copyArtifacts(filter: "${currentBenchmarkResults}/*.*", flatten: true, optional: true, projectName: projectName, selector: lastWithArtifacts(), target: baseline)
+          }
+        } catch(e) {
+          log(level: 'INFO', text: 'gitHubCommentWithBenchmarkReport: it was not possible to copy the previous build.')
+          return
+        }
+      }
+
+      // run the benchmark diff generator
+      withMageEnv(){
+        sh(label: 'mage BenchReport', script: "mage BenchReport ${currentBenchmarkResults} ${baseline} ${env.BENCHMARK_THRESHOLD} ${benchmarkGitHubFile}")
+      }
+      try {
+        if (fileExists("${benchmarkGitHubFile}")) {
+          // TODO: existing githubPrComment signature was not done to comment based on a file, but of a string.
+          //       hence commentFile needs to point to an unexisting file.
+          githubPrComment(message: readFile(benchmarkGitHubFile), commentFile: 'benchmark-report.md')
+        }
+      } catch(e) {
+        log(level: 'INFO', text: "gitHubCommentWithBenchmarkReport: it was not possible to send the message. ${e.toString()}")
+      }
     }
   }
 }
@@ -280,14 +317,26 @@ def prepareStack() {
   sh(label: "Boot up the Elastic stack", script: "../../build/elastic-package stack up -d ${stackArgs}")
 }
 
+def stashBenchmarkResults() {
+  def wildcard = 'build/benchmark-results/*.xml'
+  r = sh(label: "isBenchmarkResultsPresent", script: "ls ${wildcard}", returnStatus: true)
+  if (r != 0) {
+    echo "isBenchmarkResultsPresent: benchmark files not found, report won't be stashed"
+    return
+  }
+  archiveArtifacts(allowEmptyArchive: true, artifacts: wildcard)
+  googleStorageUploadExt(bucket: getBenchmarkBucketURI(), credentialsId: "${JOB_GCS_EXT_CREDENTIALS}", pattern: "${wildcard}")
+}
+
 def stashCoverageReport() {
-  r = sh(label: "isCoverageReportPresent", script: "ls build/test-coverage/*.xml", returnStatus: true)
+  def wildcard = 'build/test-coverage/*.xml'
+  r = sh(label: "isCoverageReportPresent", script: "ls ${wildcard}", returnStatus: true)
   if (r != 0) {
     echo "isCoverageReportPresent: coverage files not found, report won't be stashed"
     return
   }
 
-  googleStorageUploadExt(bucket: getCoverageBucketURI(), credentialsId: "${JOB_GCS_EXT_CREDENTIALS}", pattern: "build/test-coverage/*.xml")
+  googleStorageUploadExt(bucket: getCoverageBucketURI(), credentialsId: "${JOB_GCS_EXT_CREDENTIALS}", pattern: "${wildcard}")
 }
 
 def publishCoverageReports() {
@@ -298,6 +347,14 @@ def publishCoverageReports() {
       coverageReport('build/test-coverage')
     }
   }
+}
+
+def getBenchmarkBucketURI() {
+  return "gs://${JOB_GCS_BUCKET}/" + getBenchmarkPathPrefix()
+}
+
+def getBenchmarkPathPrefix() {
+  return "${env.JOB_NAME}-${env.BUILD_ID}/benchmark-results/"
 }
 
 def getCoverageBucketURI() {

--- a/dev/benchreport/benchmark.go
+++ b/dev/benchreport/benchmark.go
@@ -1,0 +1,58 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package benchreport
+
+import "strconv"
+
+type BenchmarkResult struct {
+	// Parameters used for this benchmark.
+	Parameters []BenchmarkValue `xml:"parameter"`
+
+	// Tests holds the results for the benchmark.
+	Tests []BenchmarkTest `xml:"test"`
+}
+
+func (r *BenchmarkResult) getEPS() float64 {
+	for _, test := range r.Tests {
+		for _, res := range test.Results {
+			if res.Name == "eps" {
+				v, _ := strconv.ParseFloat(res.Value, 64)
+				return v
+			}
+		}
+	}
+	return 0
+}
+
+func (r *BenchmarkResult) getPackageAndDatastream() (string, string) {
+	var pkg, ds string
+	for _, p := range r.Parameters {
+		switch p.Name {
+		case "package":
+			pkg = p.Value
+		case "data_stream":
+			ds = p.Value
+		}
+	}
+	return pkg, ds
+}
+
+// BenchmarkTest models a particular test performed during a benchmark.
+type BenchmarkTest struct {
+	// Name of this test.
+	Name string `xml:"name,attr"`
+	// Results of the test.
+	Results []BenchmarkValue `xml:"result"`
+}
+
+// BenchmarkValue represents a value (result or parameter)
+// with an optional associated unit.
+type BenchmarkValue struct {
+	// Name of the value.
+	Name string `xml:"name,attr"`
+
+	// Value is of any type, usually string or numeric.
+	Value string `xml:"value"`
+}

--- a/dev/benchreport/report.go
+++ b/dev/benchreport/report.go
@@ -1,0 +1,150 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package benchreport
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"text/template"
+)
+
+const (
+	reportExt = ".xml"
+	tpl       = `### :rocket: Benchmarks report
+{{range $package, $reports := .}}
+#### Package ` + "`" + `{{$package}}` + "`" + `
+
+Data stream | EPS | Diff (%) | Result
+----------- | --- | ------ | ------
+{{range $reports}}` + "`" + `{{.DataStream}}` + "`" + ` | {{.New}} | {{.Diff}} ({{.Percentage}}%) | {{getResult .Percentage}}
+{{end}}{{end}}`
+)
+
+type options struct {
+	sourceDir string
+	targetDir string
+	threshold float64
+}
+
+func (o *options) validate() error {
+	if _, err := os.Stat(o.sourceDir); err != nil {
+		return fmt.Errorf("stat file failed (path: %s): %w", o.sourceDir, err)
+	}
+
+	if _, err := os.Stat(o.targetDir); err != nil {
+		return fmt.Errorf("stat file failed (path: %s): %w", o.targetDir, err)
+	}
+
+	return nil
+}
+
+type report struct {
+	Package    string
+	DataStream string
+	Old        float64
+	New        float64
+	Diff       float64
+	Percentage float64
+}
+
+func GetBenchReport(sourceDir, targetDir string, threshold float64) ([]byte, error) {
+	opts := options{
+		sourceDir: sourceDir,
+		targetDir: targetDir,
+		threshold: threshold,
+	}
+
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	tpl, err := getReportTpl(opts.threshold)
+	if err != nil {
+		return nil, err
+	}
+
+	reports, err := run(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, reports); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func run(opts options) (map[string][]report, error) {
+	// get all results from source
+	srcResults, err := listAllDirResults(opts.sourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("listing source results failed: %w", err)
+	}
+
+	// get all results from target
+	tgtResults, err := listAllDirResultsAsMap(opts.targetDir)
+	if err != nil {
+		return nil, fmt.Errorf("listing target results failed: %w", err)
+	}
+
+	// lookup source reports in target and compare
+	reports := map[string][]report{}
+	for _, entry := range srcResults {
+		srcRes, err := readResult(opts.sourceDir, entry)
+		if err != nil {
+			return nil, fmt.Errorf("reading source result: %w", err)
+		}
+
+		pkg, _ := srcRes.getPackageAndDatastream()
+
+		var tgtRes BenchmarkResult
+		if tgtEntry, found := tgtResults[pkg]; found {
+			tgtRes, err = readResult(opts.targetDir, tgtEntry)
+			if err != nil {
+				return nil, fmt.Errorf("reading source result: %w", err)
+			}
+		}
+
+		report := createReport(srcRes, tgtRes)
+		reports[report.Package] = append(reports[report.Package], report)
+	}
+
+	return reports, nil
+}
+
+func createReport(src, tgt BenchmarkResult) report {
+	var r report
+	r.Package, r.DataStream = src.getPackageAndDatastream()
+
+	// we round all the values to 2 decimals approximations
+	r.New = roundFloat64(src.getEPS())
+	r.Old = roundFloat64(tgt.getEPS())
+	r.Diff = roundFloat64(r.New - r.Old)
+	r.Percentage = roundFloat64((r.Diff / r.New) * 100)
+
+	return r
+}
+
+func roundFloat64(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+
+func getReportTpl(threshold float64) (*template.Template, error) {
+	return template.New("result").Funcs(map[string]interface{}{
+		"getResult": func(p float64) string {
+			if p > threshold {
+				return ":broken_heart:"
+			}
+			if p < 0 && p < (threshold*-1) {
+				return ":green_heart:"
+			}
+			return ":+1:"
+		},
+	}).Parse(tpl)
+}

--- a/dev/benchreport/report.go
+++ b/dev/benchreport/report.go
@@ -144,9 +144,9 @@ func getReportTpl(threshold float64) (*template.Template, error) {
 			case oldValue == 0:
 				return ":+1:"
 			case p > threshold:
-				return ":broken_heart:"
-			case p < 0 && p < (threshold*-1):
 				return ":green_heart:"
+			case p < 0 && p < (threshold*-1):
+				return ":broken_heart:"
 			}
 		},
 	}).Parse(tpl)

--- a/dev/benchreport/report.go
+++ b/dev/benchreport/report.go
@@ -32,7 +32,7 @@ Data stream | Previous EPS | New EPS | Diff (%) | Result
 {{end}}{{end}}</details>{{end}}
 {{end}}
 
-To see the full report comment with ` + "`/test benchmark fullReport`\n"
+To see the full report comment with ` + "`/test benchmark fullreport`\n"
 )
 
 type options struct {

--- a/dev/benchreport/result.go
+++ b/dev/benchreport/result.go
@@ -30,20 +30,23 @@ func listAllDirResults(path string) ([]os.DirEntry, error) {
 	return filtered, nil
 }
 
-func listAllDirResultsAsMap(path string) (map[string]fs.DirEntry, error) {
+func listAllDirResultsAsMap(path string) (map[string]map[string]fs.DirEntry, error) {
 	entries, err := listAllDirResults(path)
 	if err != nil {
 		return nil, err
 	}
 
-	m := map[string]fs.DirEntry{}
+	m := map[string]map[string]fs.DirEntry{}
 	for _, entry := range entries {
 		res, err := readResult(path, entry)
 		if err != nil {
 			return nil, fmt.Errorf("reading result: %w", err)
 		}
-		pkg, _ := res.getPackageAndDatastream()
-		m[pkg] = entry
+		pkg, ds := res.getPackageAndDatastream()
+		if m[pkg] == nil {
+			m[pkg] = map[string]fs.DirEntry{}
+		}
+		m[pkg][ds] = entry
 	}
 
 	return m, nil

--- a/dev/benchreport/result.go
+++ b/dev/benchreport/result.go
@@ -1,0 +1,69 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package benchreport
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+func listAllDirResults(path string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading directory failed (path: %s): %w", path, err)
+	}
+
+	// only keep results, scan is not recursive
+	var filtered []os.DirEntry
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != reportExt {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+
+	return filtered, nil
+}
+
+func listAllDirResultsAsMap(path string) (map[string]fs.DirEntry, error) {
+	entries, err := listAllDirResults(path)
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[string]fs.DirEntry{}
+	for _, entry := range entries {
+		res, err := readResult(path, entry)
+		if err != nil {
+			return nil, fmt.Errorf("reading result: %w", err)
+		}
+		pkg, _ := res.getPackageAndDatastream()
+		m[pkg] = entry
+	}
+
+	return m, nil
+}
+
+func readResult(path string, e fs.DirEntry) (BenchmarkResult, error) {
+	fi, err := e.Info()
+	if err != nil {
+		return BenchmarkResult{}, fmt.Errorf("getting file info failed (file: %s): %w", e.Name(), err)
+	}
+
+	b, err := os.ReadFile(path + string(os.PathSeparator) + fi.Name())
+	if err != nil {
+		return BenchmarkResult{}, fmt.Errorf("reading result contents (file: %s): %w", fi.Name(), err)
+	}
+
+	var br BenchmarkResult
+	if err := xml.Unmarshal(b, &br); err != nil {
+		return BenchmarkResult{}, fmt.Errorf("decoding xml (file: %s): %w", fi.Name(), err)
+	}
+
+	return br, nil
+}

--- a/magefile.go
+++ b/magefile.go
@@ -53,12 +53,13 @@ func ImportBeats() error {
 	return sh.Run("go", args...)
 }
 
-func BenchReport(source, target, threshold, outputFile string) error {
+func GetGithubMarkdownBenchReport(source, target, threshold, outputFile, detailLevel string) error {
 	t, err := strconv.ParseFloat(threshold, 64)
 	if err != nil {
 		return err
 	}
-	report, err := benchreport.GetBenchReport(source, target, t)
+	isFull := detailLevel == "full"
+	report, err := benchreport.GetBenchReport(source, target, t, isFull)
 	if err != nil {
 		return err
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -10,11 +10,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 	"github.com/pkg/errors"
 
+	"github.com/elastic/integrations/dev/benchreport"
 	"github.com/elastic/integrations/dev/codeowners"
 )
 
@@ -49,6 +51,18 @@ func ImportBeats() error {
 	}
 	args = append(args, "*.go")
 	return sh.Run("go", args...)
+}
+
+func BenchReport(source, target, threshold, outputFile string) error {
+	t, err := strconv.ParseFloat(threshold, 64)
+	if err != nil {
+		return err
+	}
+	report, err := benchreport.GetBenchReport(source, target, t)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(outputFile, report, 0644)
 }
 
 func build() error {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds a mage target that will compare two given benchmark results folders.

The source folder will be compared against a target folder, and for any benchmark result in source it will generate a report, showing the variation between the two.

Example report:

### :rocket: Benchmarks report

#### Package `google_workspace`

Data stream | Previous EPS | New EPS | Diff (%) | Result
----------- | ------------ | ------- | -------- | ------
`admin` | 0 | 2906.13 | 2906.13 (100%) | :+1:
`drive` | 0 | 4882.81 | 4882.81 (100%) | :+1:
`groups` | 0 | 5232.86 | 5232.86 (100%) | :+1:
`login` | 0 | 4972.65 | 4972.65 (100%) | :+1:
`saml` | 0 | 6377.55 | 6377.55 (100%) | :+1:
`user_accounts` | 0 | 12626.26 | 12626.26 (100%) | :+1:

#### Package `windows`

Data stream | Previous EPS | New EPS | Diff (%) | Result
----------- | ------------ | ------- | -------- | ------
`forwarded` | 5854.8 | 3148.61 | -2706.19 (-85.95%) | :green_heart:
`powershell` | 5854.8 | 5263.16 | -591.64 (-11.24%) | :green_heart:
`powershell_operational` | 5854.8 | 7137.76 | 1282.96 (17.97%) | :broken_heart:
`sysmon_operational` | 5854.8 | 7107.32 | 1252.52 (17.62%) | :broken_heart:

----

The command is used as such:

`mage BenchReport "./build/benchmark-results" "/main/build/benchmark-results" 10 report.md`

The first argument is the source folder (the newest results), the second argument is the target folder (the previous results we want to compare against), the third argument is the thresholds, it indicates an expected % variance threshold where we assume nothing has changed and might be caused due to run-to-run factors, and the latest argument is the file name where the report will be saved.

The intention of this command is to be used in CI to generate useful information in PRs.


