### PR TITLE
cisco_{asa,ftd}: fix handling of 302020 messages

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.5"
+  changes:
+    - description: Fix handling of 302020 event messages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4209
 - version: "2.7.4"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -191,7 +191,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -201,7 +201,7 @@
                 "severity": 6,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "host": {
@@ -375,7 +375,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -385,7 +385,7 @@
                 "severity": 6,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "host": {
@@ -1035,7 +1035,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -1045,7 +1045,7 @@
                 "severity": 6,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "host": {
@@ -1102,7 +1102,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -1112,7 +1112,7 @@
                 "severity": 6,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "host": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -1036,7 +1036,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -1046,7 +1046,7 @@
                 "severity": 6,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "host": {
@@ -1110,7 +1110,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -1120,7 +1120,7 @@
                 "severity": 6,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "host": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -5403,7 +5403,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -5413,7 +5413,7 @@
                 "severity": 5,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "log": {
@@ -5498,7 +5498,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -5508,7 +5508,7 @@
                 "severity": 5,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "log": {
@@ -5597,7 +5597,7 @@
                 "version": "8.4.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -5607,7 +5607,7 @@
                 "severity": 5,
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "log": {

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -404,6 +404,11 @@ processors:
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
         DURATION: "%{INT}:%{MINUTE}:%{SECOND}"
+  - set:
+      if: '["302020"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.action"
+      value: "flow-creation"
+      description: "302020"
   - grok:
       if: "ctx._temp_.cisco.message_id == '302020'"
       field: "message"
@@ -901,10 +906,10 @@ processors:
   # Handle 302xxx messages (Flow expiration a.k.a "Teardown")
   #
   - set:
-      if: '["305012", "302014", "302016", "302018", "302020", "302021", "302036", "302304", "302306", "609001", "609002"].contains(ctx._temp_.cisco.message_id)'
+      if: '["305012", "302014", "302016", "302018", "302021", "302036", "302304", "302306", "609001", "609002"].contains(ctx._temp_.cisco.message_id)'
       field: "event.action"
       value: "flow-expiration"
-      description: "305012, 302014, 302016, 302018, 302020, 302021, 302036, 302304, 302306, 609001, 609002"
+      description: "305012, 302014, 302016, 302018, 302021, 302036, 302304, 302306, 609001, 609002"
   - grok:
       field: "message"
       if: '["302014", "302016", "302018", "302021", "302036", "302304", "302306"].contains(ctx._temp_.cisco.message_id)'
@@ -1963,6 +1968,13 @@ processors:
           category:
             - network
           type: []
+        flow-creation:
+          kind: event
+          category:
+            - network
+          type:
+            - connection
+            - start
         flow-expiration:
           kind: event
           category:

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.7.4"
+version: "2.7.5"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.3"
+  changes:
+    - description: Fix handling of 302020 event messages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4209
 - version: "2.4.2"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log
@@ -3,3 +3,4 @@ Apr 17 2020 14:00:31 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny icmp src Inside:10.12
 Apr 15 2013 09:36:50: %ASA-4-106023: Deny tcp src dmz:10.123.123.123/6316 dst outside:10.123.123.123/53 type 3, code 0, by access-group "acl_dmz" [0xe3afb522, 0x0]
 Apr 17 2020 14:16:20 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny udp src Inside:10.123.123.123/57621(LOCAL\Elastic) dst Outside:10.123.123.123/57621 by access-group "Inside_access_in" [0x0, 0x0]
 Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-2-106017: Deny IP due to Land Attack from 10.123.123.123 to 10.123.123.123
+May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 175.16.199.1/0 laddr 192.168.2.2/0 type 3 code 1

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -352,6 +352,73 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2022-05-05T17:51:17.000Z",
+            "cisco": {
+                "ftd": {
+                    "icmp_code": 1,
+                    "icmp_type": 3,
+                    "mapped_source_ip": "175.16.199.1"
+                }
+            },
+            "destination": {
+                "address": "10.10.10.10",
+                "ip": "10.10.10.10"
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "flow-creation",
+                "category": [
+                    "network"
+                ],
+                "code": "302020",
+                "kind": "event",
+                "original": "May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 175.16.199.1/0 laddr 192.168.2.2/0 type 3 code 1",
+                "severity": 6,
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "direction": "inbound",
+                "protocol": "icmp"
+            },
+            "observer": {
+                "hostname": "dev01",
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01"
+                ],
+                "ip": [
+                    "192.168.2.2",
+                    "175.16.199.1",
+                    "10.10.10.10"
+                ]
+            },
+            "source": {
+                "address": "192.168.2.2",
+                "ip": "192.168.2.2",
+                "nat": {
+                    "ip": "175.16.199.1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -347,6 +347,11 @@ processors:
       field: "message"
       description: "302012"
       pattern: "Teardown %{} %{network.transport} translation from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} duration %{_temp_.duration_hms}"
+  - set:
+      if: '["302020"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.action"
+      value: "flow-creation"
+      description: "302020"
   - grok:
       if: "ctx._temp_.cisco.message_id == '302020'"
       field: "message"
@@ -767,10 +772,10 @@ processors:
   # Handle 302xxx messages (Flow expiration a.k.a "Teardown")
   #
   - set:
-      if: '["302012", "302014", "302016", "302018", "302020", "302021", "302036", "302304", "302306", "609001", "609002"].contains(ctx._temp_.cisco.message_id)'
+      if: '["302012", "302014", "302016", "302018", "302021", "302036", "302304", "302306", "609001", "609002"].contains(ctx._temp_.cisco.message_id)'
       field: "event.action"
       value: "flow-expiration"
-      description: "302012, 302014, 302016, 302018, 302020, 302021, 302036, 302304, 302306, 609001, 609002"
+      description: "302012, 302014, 302016, 302018, 302021, 302036, 302304, 302306, 609001, 609002"
   - grok:
       field: "message"
       if: '["302014", "302016", "302018", "302021", "302036", "302304", "302306"].contains(ctx._temp_.cisco.message_id)'
@@ -1760,6 +1765,13 @@ processors:
             - network
           type:
             - info
+        flow-creation:
+          kind: event
+          category:
+            - network
+          type:
+            - connection
+            - start
         flow-expiration:
           kind: event
           category:

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ftd
 title: Cisco FTD
-version: "2.4.2"
+version: "2.4.3"
 license: basic
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes the handling of message type 302020 which was being incorrectly characterised as a termination event rather than a start event.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Updates #4199

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
