### PR TITLE
Ignore issues with kind delete cluster

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -243,7 +243,7 @@ def withKubernetes(Closure body) {
         throw error // rethrow error up if there is any, but delete k8s cluster first
       } finally {
         if (r == 0) {
-          sh(label: "Delete kind cluster", script: 'kind delete cluster')
+          sh(label: "Delete kind cluster", script: 'kind delete cluster || true')
         }
       }
     }


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

ignore issues with kind delete cluster, example: https://fleet-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/PR-4203/3/pipeline/

```
ERROR: failed to delete cluster "kind": failed to delete nodes: command "docker rm -f -v kind-control-plane" failed with error: exit status 1
```

similar to https://github.com/elastic/elastic-package/pull/967

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
