### PR TITLE
[ci] Use Elastic Stack 8.5.0-SNAPSHOT in daily jobs

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -35,11 +35,11 @@ pipeline {
             )
           }
         }
-        stage('with stack v8.3') {
+        stage('with stack v8.5.0') {
           steps {
             build(
               job: env.INTEGRATION_JOB,
-              parameters: [stringParam(name: 'stackVersion', value: '8.3.0-SNAPSHOT')],
+              parameters: [stringParam(name: 'stackVersion', value: '8.5.0-SNAPSHOT')],
               quietPeriod: 0,
               wait: true,
               propagate: true,


### PR DESCRIPTION
Bump from 8.3.0-SNAPSHOT to 8.5.0-SNAPSHOT for daily test jobs.

This affects https://fleet-ci.elastic.co/job/Ingest-manager/job/integrations-daily/.

