### PR TITLE
infoblox_nios: fix configuration page

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Fix config page options for file inputs.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4233
 - version: "1.3.0"
   changes:
     - description: Allow configuration of timezone.

--- a/packages/infoblox_nios/data_stream/log/_dev/test/system/test-logfile-config.yml
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/system/test-logfile-config.yml
@@ -1,7 +1,8 @@
 service: infoblox_nios-log-logfile
 input: logfile
+vars:
+  paths:
+    - "{{SERVICE_LOGS_DIR}}/*.log"
 data_stream:
   vars:
-    paths:
-      - "{{SERVICE_LOGS_DIR}}/*.log"
     preserve_original_event: true

--- a/packages/infoblox_nios/data_stream/log/manifest.yml
+++ b/packages/infoblox_nios/data_stream/log/manifest.yml
@@ -6,12 +6,6 @@ streams:
     description: Collect Infoblox NIOS logs via file input.
     template_path: log.yml.hbs
     vars:
-      - name: paths
-        type: text
-        title: Paths
-        multi: true
-        required: true
-        show_user: true
       - name: tags
         type: text
         title: Tags

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.3.0"
+version: "1.3.1"
 license: basic
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
@@ -33,8 +33,8 @@ policy_templates:
             multi: true
             required: true
             show_user: true
-        title: Infoblox NIOS logs
-        description: Collect Infoblox NIOS logs via file input.
+        title: Collect logs from Infoblox NIOS via File input
+        description: Collecting syslog from Infoblox NIOS via File input.
       - type: tcp
         vars:
           - name: listen_address


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes a duplication of the log file input path in the configuration page for `infoblox_nios`. It also harmonises the input title for the file input with the two others. See screenshots below.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

Before this change:
<img width="714" alt="Screenshot 2022-09-19 at 12 14 09" src="https://user-images.githubusercontent.com/90160302/191157739-000b06f1-5f70-43ce-9c56-13d05fc86af1.png">

After this change:
<img width="701" alt="Screen Shot 2022-09-20 at 12 25 36" src="https://user-images.githubusercontent.com/90160302/191157777-e19b390b-8c8a-4374-8770-60ac169c325e.png">
