### PR TITLE
[Enhancement] Cisco Aironet add Hashlookup for event.reason

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.3"
+  changes:
+    - description: Enhance event reasons with hashlookup
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/4235
 - version: "0.0.2"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,5 @@
 # newer versions go on top
+
 - version: "0.0.3"
   changes:
     - description: Enhance event reasons with hashlookup

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
@@ -207,6 +207,7 @@
                 "action": "ENTRY_CREATED",
                 "original": "\u003c134\u003eWLC001: *sisfSwitcherTask: Aug 20 11:26:35.845: %SISF-6-ENTRY_CREATED: sisf_shim_utils.c:485 Entry created A=fe80::1e24:cdff:fe11:2f90 V=0 I=wired:1 P=0000 M=",
                 "provider": "SISF",
+                "reason": "IPv6 Neighbor Discovery,A low rate of vetoed resolutions is not serious. If there is a high rate of vetos this might suggest that the link is under attack. Investigate the source of the packets driving these resolution requests",
                 "severity": "6"
             },
             "host": {
@@ -249,6 +250,7 @@
                 "action": "ENTRY_DELETED",
                 "original": "\u003c134\u003eWLC001: *SISF BT Process: Aug 20 11:25:50.157: %SISF-6-ENTRY_DELETED: sisf_shim_utils.c:482 Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
                 "provider": "SISF",
+                "reason": "Device Smart-Licensing status is out of compliance.",
                 "severity": "6"
             },
             "host": {
@@ -292,6 +294,7 @@
                 "action": "ENTRY_CHANGED",
                 "original": "\u003c134\u003eWLC001: *SISF BT Process: Aug 22 16:55:06.121: %SISF-6-ENTRY_CHANGED: sisf_shim_utils.c:488 Entry changed A=fe80::72ee:50ff:fe56:9999 V=0 I=wireless:0 P=0005 M=70:ee:50:56:99:99",
                 "provider": "SISF",
+                "reason": "An entry was created in the binding table",
                 "severity": "6"
             },
             "host": {
@@ -429,6 +432,7 @@
                 "action": "AAA_AUTH_ADMIN_USER",
                 "original": "\u003c133\u003eWLC001: *emWeb: Aug 22 18:11:40.438: %AAA-5-AAA_AUTH_ADMIN_USER: aaa.c:3083 Authentication succeeded for admin user 'cisco' on 89.160.20.112",
                 "provider": "AAA",
+                "reason": "Authentication for an admin user.",
                 "severity": "5"
             },
             "host": {
@@ -466,6 +470,7 @@
                 "action": "ADMIN_MODE_DISABLE",
                 "original": "\u003c131\u003eWLC001: *emWeb: Aug 22 18:14:03.172: %NIM-3-ADMIN_MODE_DISABLE: nim.c:1341 Port 3 Admin Mode is Disable!",
                 "provider": "NIM",
+                "reason": "Checksum Error on the config file",
                 "severity": "3"
             },
             "host": {
@@ -513,6 +518,7 @@
                 "kind": "alert",
                 "original": "\u003c132\u003eWLC001: *idsTrackEventTask: Aug 22 18:14:24.672: %WPS-4-SIG_ALARM_OFF: sig_event.c:656 AP 28:6F:7F:F8:64:E0 : Alarm OFF, standard sig Deauth flood, track=per-Mac preced=9 hits=300 slot=0 channel=6",
                 "provider": "WPS",
+                "reason": "Signature Alarm Off",
                 "severity": "4"
             },
             "host": {
@@ -590,6 +596,7 @@
                 "kind": "alert",
                 "original": "\u003c132\u003eWLC001: *spamApTask1: Aug 22 17:54:24.269: %LWAPP-4-SIG_INFO1: spam_lrad.c:56582 Signature information; AP 28:6f:7f:f8:64:e0, alarm ON, standard sig Deauth flood, track per-Macprecedence 9, hits 300, slot 0, channel 6, most offending MAC 4a:b8:cb:63:1d:bd",
                 "provider": "LWAPP",
+                "reason": "An internal error caused while freeing AID. This AID is used by some other client.",
                 "severity": "4"
             },
             "host": {
@@ -636,6 +643,7 @@
                 "action": "MAX_EAPOL_KEY_RETRANS",
                 "original": "\u003c132\u003eWLC001: *Dot1x_NW_MsgTask_4: Aug 21 22:15:34.710: %DOT1X-4-MAX_EAPOL_KEY_RETRANS: 1x_ptsm.c:550 Max EAPOL-key M3 retransmissions exceeded for client 80:7d:3a:9b:2f:fc",
                 "provider": "DOT1X",
+                "reason": "An unknown attribute-value pair was received during EAP processing. The AVP was ignored.",
                 "severity": "4"
             },
             "host": {
@@ -673,6 +681,7 @@
                 "action": "RRM_LOGMSG",
                 "original": "\u003c131\u003eWLC001: *RRM-DCLNT-5_0: Aug 21 20:12:58.040: %RRM-3-RRM_LOGMSG: rrmLrad.c:5135 RRM LOG: Client not found: CC:73:14:61:B0:8F",
                 "provider": "RRM",
+                "reason": "Load profile recovery",
                 "severity": "3"
             },
             "host": {
@@ -707,6 +716,7 @@
                 "action": "RRM_LOGMSG",
                 "original": "\u003c131\u003eWLC001: *apfMsConnTask_6: Aug 29 10:58:28.227: %RRM-3-RRM_LOGMSG: [PA]rrmLrad.c:5634 RRM LOG: Failed to lookup data rate for encoding 102237564, with channel width 20 on AP:  de:fb:48:7c:4f:f7 (0)",
                 "provider": "RRM",
+                "reason": "Load profile recovery",
                 "severity": "3"
             },
             "host": {
@@ -871,6 +881,7 @@
                 "action": "INVALID_WPA_KEY_STATE",
                 "original": "\u003c131\u003eWLC001: *Dot1x_NW_MsgTask_3: Aug 29 10:55:38.289: %DOT1X-3-INVALID_WPA_KEY_STATE: [PA]1x_eapkey.c:3026 Received EAPOL-key message while in invalid state (4) - version 1, type 3, descriptor 2, client de:fb:48:7c:4f:f7",
                 "provider": "DOT1X",
+                "reason": "Not able to verify PMKR1Name for the client. Try client association again.",
                 "severity": "3"
             },
             "host": {
@@ -908,6 +919,7 @@
                 "action": "WPA_SEND_STATE_ERR",
                 "original": "\u003c131\u003eWLC001: *dot1xMsgTask: Aug 29 10:58:54.242: %DOT1X-3-WPA_SEND_STATE_ERR: [PA]1x_kxsm.c:1736 Unable to send EAPOL-key msg  - invalid WPA state (0) - client de:fb:48:7c:4f:f7",
                 "provider": "DOT1X",
+                "reason": "A pre-authentication request message from a client was ignored",
                 "severity": "3"
             },
             "host": {
@@ -945,6 +957,7 @@
                 "action": "INVALID_REPLAY_CTR",
                 "original": "\u003c131\u003eWLC001: *Dot1x_NW_MsgTask_7: Aug 29 10:58:19.828: %DOT1X-3-INVALID_REPLAY_CTR: [PA]1x_eapkey.c:458 Invalid replay counter from client de:fb:48:7c:4f:f7 - got 00 00 00 00 00 00 00 00, expected 00 00 00 00 00 00 00 01",
                 "provider": "DOT1X",
+                "reason": "Error while calcualting PTK using KDF algo. for11r or 11w capable clients as Input Key Len is wrong.",
                 "severity": "3"
             },
             "host": {
@@ -979,6 +992,7 @@
                 "action": "REPLAY_ERR",
                 "original": "\u003c131\u003eWLC001: *spamApTask1: Aug 29 10:47:25.944: %LWAPP-3-REPLAY_ERR: [PA]spam_lrad.c:49337 The system has received replay error on slot 0, WLAN ID 1, count 1 from AP de:fb:48:7c:4f:f7",
                 "provider": "LWAPP",
+                "reason": "The controller has received a replay error on the specified AP and WLAN.",
                 "severity": "3"
             },
             "host": {
@@ -1016,6 +1030,7 @@
                 "action": "CLIENT_NOT_FOUND",
                 "original": "\u003c131\u003eWLC001: *Dot1x_NW_MsgTask_2: Aug 29 10:52:56.103: %DOT1X-3-CLIENT_NOT_FOUND: [PA]dot1x_msg_task.c:1847 Unable to process 802.1X 1 msg - client de:fb:48:7c:4f:f7 not found Previous message occurred 2 times.",
                 "provider": "DOT1X",
+                "reason": "AP's 802.1X interface was not allocated by WLC which is required for client association on dot1x WLAN. Hence Client association on dot1xWLAN with this AP will fail.",
                 "severity": "3"
             },
             "host": {
@@ -1081,6 +1096,7 @@
                 "action": "INVALID_REQUEST",
                 "original": "\u003c131\u003eWLC001: *radiusTransportThread: Aug 29 10:58:58.000: %AAA-3-INVALID_REQUEST: [PA]radius_db.c:3923 Invalid AAA request. unknown",
                 "provider": "AAA",
+                "reason": "The system has received an AAA request with a null or invalid payload.",
                 "severity": "3"
             },
             "host": {
@@ -1118,6 +1134,7 @@
                 "action": "AAA_AUTH_SEND_FAIL",
                 "original": "\u003c131\u003eWLC001: *Dot1x_NW_MsgTask_3: Aug 29 10:58:57.787: %DOT1X-3-AAA_AUTH_SEND_FAIL: [PA]1x_aaa.c:893 Unable to send AAA message for client de:fb:48:7c:4f:f7",
                 "provider": "DOT1X",
+                "reason": "Client authentication failed because an internal error occurred during authentication state transition.",
                 "severity": "3"
             },
             "host": {
@@ -1152,6 +1169,7 @@
                 "action": "MLD_INVALID_IPV6_PKT",
                 "original": "\u003c132\u003eWLC001: *bcastReceiveTask: Aug 20 14:55:28.577: %BCAST-4-MLD_INVALID_IPV6_PKT: bcastMld.c:2594  Received IPV6 packet which is not a valid MLD packet",
                 "provider": "BCAST",
+                "reason": "IPv6 MLD packets are must have nexthdr as zero and hop limit of 1 in the IPv6 header.",
                 "severity": "4"
             },
             "host": {
@@ -1186,6 +1204,7 @@
                 "action": "MOBILESTATION_NOT_FOUND",
                 "original": "\u003c132\u003eWLC001: *apfReceiveTask: Aug 22 10:24:20.959: %APF-4-MOBILESTATION_NOT_FOUND: apf_ms.c:8467 Could not find the mobile cc:73:14:61:b0:8f in internal database",
                 "provider": "APF",
+                "reason": "Could not find a particular mobile station in internal database",
                 "severity": "4"
             },
             "host": {

--- a/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -86,6 +86,35 @@ processors:
       formats:
         - "MMM d HH:mm:ss.SSS"
       timezone: '{{{_conf.tz_offset}}}'
+  # Hashlookup for event reasons
+  # taken from official documentation:
+  # https://www.cisco.com/c/en/us/support/wireless/wireless-lan-controller-software/products-system-message-guides-list.html
+  - script:
+      lang: painless
+      params:
+        "SISF-6-ENTRY_CREATED": "IPv6 Neighbor Discovery,A low rate of vetoed resolutions is not serious. If there is a high rate of vetos this might suggest that the link is under attack. Investigate the source of the packets driving these resolution requests"
+        "SISF-6-ENTRY_DELETED": "Device Smart-Licensing status is out of compliance."
+        "BCAST-4-MLD_INVALID_IPV6_PKT": "IPv6 MLD packets are must have nexthdr as zero and hop limit of 1 in the IPv6 header."
+        "NIM-3-ADMIN_MODE_DISABLE": "Checksum Error on the config file"
+        "WPS-4-SIG_ALARM_OFF": "Signature Alarm Off"
+        "AAA-5-AAA_AUTH_ADMIN_USER": "Authentication for an admin user."
+        "LWAPP-4-SIG_INFO1": "An internal error caused while freeing AID. This AID is used by some other client."
+        "SISF-6-ENTRY_CHANGED": "An entry was created in the binding table"
+        "APF-4-MOBILESTATION_NOT_FOUND": "Could not find a particular mobile station in internal database"
+        "DOT1X-4-MAX_EAPOL_KEY_RETRANS": "An unknown attribute-value pair was received during EAP processing. The AVP was ignored."
+        "RRM-3-RRM_LOGMSG": "Load profile recovery"
+        "AAA-3-INVALID_REQUEST": "The system has received an AAA request with a null or invalid payload."
+        "DOT1X-3-AAA_AUTH_SEND_FAIL": "Client authentication failed because an internal error occurred during authentication state transition."
+        "DOT1X-3-ABORT_AUTH": "A message on an internal queue could not be processed because the client indicated in the message was not found in the internal database."
+        "DOT1X-3-INVALID_WPA_KEY_STATE": "Not able to verify PMKR1Name for the client. Try client association again."
+        "DOT1X-3-WPA_SEND_STATE_ERR": "A pre-authentication request message from a client was ignored"
+        "DOT1X-3-INVALID_REPLAY_CTR": "Error while calcualting PTK using KDF algo. for11r or 11w capable clients as Input Key Len is wrong."
+        "LWAPP-3-REPLAY_ERR": "The controller has received a replay error on the specified AP and WLAN."
+        "DOT1X-3-CLIENT_NOT_FOUND": "AP's 802.1X interface was not allocated by WLC which is required for client association on dot1x WLAN. Hence Client association on dot1xWLAN with this AP will fail."
+      source: |
+        if (ctx._temp_?.reason != null && params.get(ctx._temp_?.reason) != null) {
+          ctx.event.reason = params.get(ctx._temp_?.reason);
+        }
 
   # Adding information to event types
   - grok:

--- a/packages/cisco_aironet/data_stream/log/sample_event.json
+++ b/packages/cisco_aironet/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-08-20T11:25:50.157Z",
     "agent": {
-        "ephemeral_id": "df000191-6494-448e-9b24-396a3762094a",
-        "id": "68e210ce-ee67-482a-8fb4-c45055e6f2b2",
+        "ephemeral_id": "fecddc47-6793-4908-89d9-3a095191ce5b",
+        "id": "5e998d6f-74dd-4f0f-a016-13cc4145f146",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.3"
+        "version": "8.4.1"
     },
     "cisco": {
         "interface": {
@@ -24,15 +24,16 @@
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "68e210ce-ee67-482a-8fb4-c45055e6f2b2",
+        "id": "5e998d6f-74dd-4f0f-a016-13cc4145f146",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.4.1"
     },
     "event": {
         "action": "ENTRY_DELETED",
         "agent_id_status": "verified",
         "dataset": "cisco_aironet.log",
-        "ingested": "2022-09-09T08:30:39Z",
+        "description": "Device Smart-Licensing status is out of compliance.",
+        "ingested": "2022-09-20T07:07:42Z",
         "original": "\u003c134\u003eWLC001: *SISF BT Process: Aug 20 11:25:50.157: %SISF-6-ENTRY_DELETED: sisf_shim_utils.c:482 Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
         "provider": "SISF",
         "severity": "6",
@@ -47,7 +48,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.26.0.5:45299"
+            "address": "172.18.0.6:55134"
         },
         "syslog": {
             "facility": {

--- a/packages/cisco_aironet/data_stream/log/sample_event.json
+++ b/packages/cisco_aironet/data_stream/log/sample_event.json
@@ -1,7 +1,7 @@
 {
-    "@timestamp": "2022-08-20T11:25:50.157Z",
+    "@timestamp": "2022-08-20T11:26:35.845Z",
     "agent": {
-        "ephemeral_id": "fecddc47-6793-4908-89d9-3a095191ce5b",
+        "ephemeral_id": "0f03fbe8-472d-4275-8011-dd8adca1c384",
         "id": "5e998d6f-74dd-4f0f-a016-13cc4145f146",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -13,7 +13,7 @@
         }
     },
     "client": {
-        "ip": "fe80::aee2:d3ff:feba:56a4"
+        "ip": "fe80::1e24:cdff:fe11:2f90"
     },
     "data_stream": {
         "dataset": "cisco_aironet.log",
@@ -29,13 +29,13 @@
         "version": "8.4.1"
     },
     "event": {
-        "action": "ENTRY_DELETED",
+        "action": "ENTRY_CREATED",
         "agent_id_status": "verified",
         "dataset": "cisco_aironet.log",
-        "description": "Device Smart-Licensing status is out of compliance.",
-        "ingested": "2022-09-20T07:07:42Z",
-        "original": "\u003c134\u003eWLC001: *SISF BT Process: Aug 20 11:25:50.157: %SISF-6-ENTRY_DELETED: sisf_shim_utils.c:482 Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
+        "ingested": "2022-09-20T08:08:09Z",
+        "original": "\u003c134\u003eWLC001: *sisfSwitcherTask: Aug 20 11:26:35.845: %SISF-6-ENTRY_CREATED: sisf_shim_utils.c:485 Entry created A=fe80::1e24:cdff:fe11:2f90 V=0 I=wired:1 P=0000 M=",
         "provider": "SISF",
+        "reason": "IPv6 Neighbor Discovery,A low rate of vetoed resolutions is not serious. If there is a high rate of vetos this might suggest that the link is under attack. Investigate the source of the packets driving these resolution requests",
         "severity": "6",
         "timezone": "+00:00"
     },
@@ -48,7 +48,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.18.0.6:55134"
+            "address": "172.18.0.6:41709"
         },
         "syslog": {
             "facility": {
@@ -60,9 +60,9 @@
             }
         }
     },
-    "message": "Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
+    "message": "Entry created A=fe80::1e24:cdff:fe11:2f90 V=0 I=wired:1 P=0000 M=",
     "process": {
-        "name": "SISF BT Process"
+        "name": "sisfSwitcherTask"
     },
     "tags": [
         "preserve_original_event",

--- a/packages/cisco_aironet/docs/README.md
+++ b/packages/cisco_aironet/docs/README.md
@@ -16,9 +16,9 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-08-20T11:25:50.157Z",
+    "@timestamp": "2022-08-20T11:26:35.845Z",
     "agent": {
-        "ephemeral_id": "fecddc47-6793-4908-89d9-3a095191ce5b",
+        "ephemeral_id": "0f03fbe8-472d-4275-8011-dd8adca1c384",
         "id": "5e998d6f-74dd-4f0f-a016-13cc4145f146",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -30,7 +30,7 @@ An example event for `log` looks as following:
         }
     },
     "client": {
-        "ip": "fe80::aee2:d3ff:feba:56a4"
+        "ip": "fe80::1e24:cdff:fe11:2f90"
     },
     "data_stream": {
         "dataset": "cisco_aironet.log",
@@ -46,13 +46,13 @@ An example event for `log` looks as following:
         "version": "8.4.1"
     },
     "event": {
-        "action": "ENTRY_DELETED",
+        "action": "ENTRY_CREATED",
         "agent_id_status": "verified",
         "dataset": "cisco_aironet.log",
-        "description": "Device Smart-Licensing status is out of compliance.",
-        "ingested": "2022-09-20T07:07:42Z",
-        "original": "\u003c134\u003eWLC001: *SISF BT Process: Aug 20 11:25:50.157: %SISF-6-ENTRY_DELETED: sisf_shim_utils.c:482 Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
+        "ingested": "2022-09-20T08:08:09Z",
+        "original": "\u003c134\u003eWLC001: *sisfSwitcherTask: Aug 20 11:26:35.845: %SISF-6-ENTRY_CREATED: sisf_shim_utils.c:485 Entry created A=fe80::1e24:cdff:fe11:2f90 V=0 I=wired:1 P=0000 M=",
         "provider": "SISF",
+        "reason": "IPv6 Neighbor Discovery,A low rate of vetoed resolutions is not serious. If there is a high rate of vetos this might suggest that the link is under attack. Investigate the source of the packets driving these resolution requests",
         "severity": "6",
         "timezone": "+00:00"
     },
@@ -65,7 +65,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.18.0.6:55134"
+            "address": "172.18.0.6:41709"
         },
         "syslog": {
             "facility": {
@@ -77,9 +77,9 @@ An example event for `log` looks as following:
             }
         }
     },
-    "message": "Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
+    "message": "Entry created A=fe80::1e24:cdff:fe11:2f90 V=0 I=wired:1 P=0000 M=",
     "process": {
-        "name": "SISF BT Process"
+        "name": "sisfSwitcherTask"
     },
     "tags": [
         "preserve_original_event",

--- a/packages/cisco_aironet/docs/README.md
+++ b/packages/cisco_aironet/docs/README.md
@@ -18,11 +18,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2022-08-20T11:25:50.157Z",
     "agent": {
-        "ephemeral_id": "df000191-6494-448e-9b24-396a3762094a",
-        "id": "68e210ce-ee67-482a-8fb4-c45055e6f2b2",
+        "ephemeral_id": "fecddc47-6793-4908-89d9-3a095191ce5b",
+        "id": "5e998d6f-74dd-4f0f-a016-13cc4145f146",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.3"
+        "version": "8.4.1"
     },
     "cisco": {
         "interface": {
@@ -41,15 +41,16 @@ An example event for `log` looks as following:
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "68e210ce-ee67-482a-8fb4-c45055e6f2b2",
+        "id": "5e998d6f-74dd-4f0f-a016-13cc4145f146",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.4.1"
     },
     "event": {
         "action": "ENTRY_DELETED",
         "agent_id_status": "verified",
         "dataset": "cisco_aironet.log",
-        "ingested": "2022-09-09T08:30:39Z",
+        "description": "Device Smart-Licensing status is out of compliance.",
+        "ingested": "2022-09-20T07:07:42Z",
         "original": "\u003c134\u003eWLC001: *SISF BT Process: Aug 20 11:25:50.157: %SISF-6-ENTRY_DELETED: sisf_shim_utils.c:482 Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
         "provider": "SISF",
         "severity": "6",
@@ -64,7 +65,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.26.0.5:45299"
+            "address": "172.18.0.6:55134"
         },
         "syslog": {
             "facility": {

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_aironet
 title: "Cisco Aironet"
-version: 0.0.2
+version: 0.0.3
 release: beta
 license: basic
 description: "Integration for Cisco Aironet WLC Logs"


### PR DESCRIPTION
## What does this PR do?
This PR adds a hashlookup table for event.reasons
The reasons are gathered from the [Cisco Documentation](https://www.cisco.com/c/en/us/support/wireless/wireless-lan-controller-software/products-system-message-guides-list.html)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).