### PR TITLE
[Mattermost] Add product docs link

### DIFF
--- a/packages/mattermost/_dev/build/docs/README.md
+++ b/packages/mattermost/_dev/build/docs/README.md
@@ -1,6 +1,8 @@
 # Mattermost Integration
 
-The Mattermost integration collects logs from Mattermost servers.  This integration has been tested with Mattermost version 5.31.9 but is expected to work with other versions.
+The Mattermost integration collects logs from [Mattermost](
+https://docs.mattermost.com/) servers.  This integration has been tested with
+Mattermost version 5.31.9 but is expected to work with other versions.
 
 ## Logs
 

--- a/packages/mattermost/changelog.yml
+++ b/packages/mattermost/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.2"
+  changes:
+    - description: Add link to Mattermost documentation.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4247
 - version: "1.4.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/mattermost/docs/README.md
+++ b/packages/mattermost/docs/README.md
@@ -1,6 +1,8 @@
 # Mattermost Integration
 
-The Mattermost integration collects logs from Mattermost servers.  This integration has been tested with Mattermost version 5.31.9 but is expected to work with other versions.
+The Mattermost integration collects logs from [Mattermost](
+https://docs.mattermost.com/) servers.  This integration has been tested with
+Mattermost version 5.31.9 but is expected to work with other versions.
 
 ## Logs
 

--- a/packages/mattermost/manifest.yml
+++ b/packages/mattermost/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mattermost
 title: "Mattermost"
-version: 1.4.1
+version: 1.4.2
 license: basic
 description: Collect logs from Mattermost with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add link to product documentation for Mattermost.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Supersedes #3001
