### PR TITLE
[GCP] Remove lightweight module in gcp.pubsub data stream

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "2.11.4"
   changes:
-    - description: Move GKE lightweight module config into integration
+    - description: Move PubSub lightweight module config into integration
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4267
 - version: "2.11.3"
   changes:
     - description: Move GKE lightweight module config into integration

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.4"
+  changes:
+    - description: Move GKE lightweight module config into integration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.11.3"
   changes:
     - description: Move GKE lightweight module config into integration

--- a/packages/gcp/data_stream/pubsub/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/pubsub/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["pubsub"]
+metricsets: ["metrics"]
 period: {{period}}
 project_id: {{project_id}}
 {{#if credentials_file}}
@@ -14,3 +14,54 @@ region: {{region}}
 zone: {{zone}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+metrics:
+  - service: pubsub
+    metric_types:
+      - "snapshot/backlog_bytes"
+      - "snapshot/backlog_bytes_by_region"
+      - "snapshot/config_updates_count"
+      - "snapshot/num_messages"
+      - "snapshot/num_messages_by_region"
+      - "snapshot/oldest_message_age"
+      - "snapshot/oldest_message_age_by_region"
+      - "subscription/ack_message_count"
+      - "subscription/backlog_bytes"
+      - "subscription/byte_cost"
+      - "subscription/config_updates_count"
+      - "subscription/dead_letter_message_count"
+      - "subscription/mod_ack_deadline_message_count"
+      - "subscription/mod_ack_deadline_message_operation_count"
+      - "subscription/mod_ack_deadline_request_count"
+      - "subscription/num_outstanding_messages"
+      - "subscription/num_undelivered_messages"
+      - "subscription/oldest_retained_acked_message_age"
+      - "subscription/oldest_retained_acked_message_age_by_region"
+      - "subscription/oldest_unacked_message_age"
+      - "subscription/oldest_unacked_message_age_by_region"
+      - "subscription/pull_ack_message_operation_count"
+      - "subscription/pull_ack_request_count"
+      - "subscription/pull_message_operation_count"
+      - "subscription/pull_request_count"
+      - "subscription/push_request_count"
+      - "subscription/retained_acked_bytes"
+      - "subscription/retained_acked_bytes_by_region"
+      - "subscription/seek_request_count"
+      - "subscription/sent_message_count"
+      - "subscription/streaming_pull_ack_message_operation_count"
+      - "subscription/streaming_pull_ack_request_count"
+      - "subscription/streaming_pull_message_operation_count"
+      - "subscription/streaming_pull_mod_ack_deadline_message_operation_count"
+      - "subscription/streaming_pull_mod_ack_deadline_request_count"
+      - "subscription/streaming_pull_response_count"
+      - "subscription/unacked_bytes_by_region"
+      - "topic/byte_cost"
+      - "topic/config_updates_count"
+      - "topic/oldest_retained_acked_message_age_by_region"
+      - "topic/oldest_unacked_message_age_by_region"
+      - "topic/retained_acked_bytes_by_region"
+      - "topic/send_message_operation_count"
+      - "topic/send_request_count"
+      - "topic/unacked_bytes_by_region"
+      - "subscription/ack_latencies"
+      - "subscription/push_request_latencies"
+      - "topic/message_sizes"

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.11.3"
+version: "2.11.4"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Remove lightweight module in gcp.pubsub data stream

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4263

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
