### PR TITLE
Fix duplicated processor in syslog

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.5"
+  changes:
+    - description: Fix duplicated processor field in syslog
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4084
 - version: "1.19.4"
   changes:
     - description: Add missing field mapping for `error.code` and `error.message`

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix duplicated processor field in syslog
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4084
+      link: https://github.com/elastic/integrations/pull/4180
 - version: "1.19.4"
   changes:
     - description: Add missing field mapping for `error.code` and `error.message`

--- a/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
+++ b/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
@@ -9,7 +9,6 @@ multiline:
 processors:
   - add_locale: ~
 {{#if processors.length}}
-processors:
 {{processors}}
 {{/if}}
 {{#if tags.length}}

--- a/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
+++ b/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
@@ -7,7 +7,7 @@ multiline:
   pattern: "^\\s"
   match: after
 processors:
-  - add_locale: ~
+- add_locale: ~
 {{#if processors.length}}
 {{processors}}
 {{/if}}

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.19.4
+version: 1.19.5
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This removes a duplicated `processors` line in the syslog datastream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
