### PR TITLE
cisco_meraki,fortinet_fortigate: fix ECS issues

### DIFF
--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.2"
+  changes:
+    - description: Fix MAC address formatting.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/4283
 - version: "1.1.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-events.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-events.log-expected.json
@@ -50,7 +50,7 @@
                 }
             },
             "client": {
-                "mac": "E5:A4:98:71:9A:FE"
+                "mac": "E5-A4-98-71-9A-FE"
             },
             "ecs": {
                 "version": "8.4.0"

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/events.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/events.yml
@@ -58,16 +58,6 @@ processors:
     field: cisco_meraki.event_subtype
     value: dhcp_no_offer
     if: ctx?.msgtype.toLowerCase() == "dhcp" && ctx?._temp?.dhcp_op.toLowerCase() == 'no' && ctx?._temp?.dhcp_op2.toLowerCase() == 'offers'
-- gsub:
-    field: client.mac
-    pattern: '[-:.]'
-    replacement: '-'
-    if: ctx?.msgtype.toLowerCase() == "dhcp"
-- gsub:
-    field: server.mac
-    pattern: '[-:.]'
-    replacement: '-'
-    if: ctx?.msgtype.toLowerCase() == "dhcp" && ctx?._temp.dhcp_op == 'lease'
 ####################################################
 # Handle Site-to-Site VPN message
 ####################################################
@@ -124,11 +114,6 @@ processors:
 - rename:
     field: cisco_meraki.multiple_dhcp_servers_detected.original_server_mac
     target_field: server.mac
-    if: ctx?.cisco_meraki?.event_subtype == 'multiple_dhcp_servers_detected'
-- gsub:
-    field: server.mac
-    pattern: '[-:.]'
-    replacement: '-'
     if: ctx?.cisco_meraki?.event_subtype == 'multiple_dhcp_servers_detected'
 # process original_server_ip
 - grok:
@@ -200,3 +185,22 @@ processors:
     target_field: client.ip
     if: ctx?._temp?.client_ip != null
     ignore_failure: true
+
+# Make MAC addresses conform to ECS spec.
+- gsub:
+    field: client.mac
+    pattern: '[:.]'
+    replacement: '-'
+    ignore_missing: true
+- uppercase:
+    field: client.mac
+    ignore_missing: true
+- gsub:
+    field: server.mac
+    pattern: '[:.]'
+    replacement: '-'
+    ignore_missing: true
+- uppercase:
+    field: server.mac
+    ignore_missing: true
+

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_meraki
 title: Cisco Meraki
-version: 1.1.1
+version: 1.1.2
 license: basic
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Ensure network.direction values conform to ECS.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/4283
 - version: "1.2.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/fortinet_fortigate/data_stream/log/_dev/test/pipeline/test-fortinet.log-expected.json
+++ b/packages/fortinet_fortigate/data_stream/log/_dev/test/pipeline/test-fortinet.log-expected.json
@@ -3650,7 +3650,7 @@
                 }
             },
             "network": {
-                "direction": "session_origin",
+                "direction": "unknown",
                 "iana_number": "6",
                 "transport": "tcp"
             },

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -417,6 +417,13 @@ processors:
       value: "{{dns.question.name}}"
       if: "ctx.dns?.question?.name != null"
       allow_duplicates: false
+
+  # Fix up network direction field to match ECS-allowable values.
+  - set:
+      field: network.direction
+      value: unknown
+      if: "ctx.network?.direction != null && !(['ingress', 'egress', 'inbound', 'outbound', 'internal', 'external'].contains(ctx.network.direction))"
+
   - script:
       lang: painless
       source: |

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: 1.2.1
+version: 1.2.2
 release: ga
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes issues in ECS compliance in the cisco_meraki and fortinet_fortigate packages.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #4284

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
