### PR TITLE
Update documentation

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -40,7 +40,7 @@ The `_dev` directory is part of [the package spec](https://github.com/elastic/pa
 1. the package-level `_dev` folder contains files needed to setup the testing environment for that package. This environment setup is specified via folders/files in the `_dev/deploy` folder. For example, the `apache` package [specifies](https://github.com/elastic/integrations/tree/main/packages/apache/_dev/deploy) how to spin up an Apache Docker container for testing.
 1. the data stream-level `_dev` folder contains test configuration files for various types of tests. For example, see the [`_dev/test` folder](https://github.com/elastic/integrations/tree/main/packages/apache/data_stream/error/_dev/test) under the `apache/error` data stream.
 
-The integrations have also [asset](https://github.com/elastic/elastic-package/blob/master/docs/howto/asset_testing.md) and [static](https://github.com/elastic/elastic-package/blob/master/docs/howto/static_testing.md) tests. They don't require config files, but configs can be used to mark them as optional.
+The integrations have also [asset](https://github.com/elastic/elastic-package/blob/main/docs/howto/asset_testing.md) and [static](https://github.com/elastic/elastic-package/blob/main/docs/howto/static_testing.md) tests. They don't require config files, but configs can be used to mark them as optional.
 
 ## Migration from Beats Modules
 

--- a/docs/developer_workflow_design_build_test_integration.md
+++ b/docs/developer_workflow_design_build_test_integration.md
@@ -141,7 +141,6 @@ implement several changes across multiple PRs and then bump up the package versi
 or in a separate follow up PR. As an example, it could be followed this procedure:
 
 1. Add a new version entry in the changelog with the prerelease tag `next`. Example: `2.6.0-next`
-    - Other formats of prerelease are allowed: 2.6.0-rc1, 2.6.0-SNAPSHOT
    ```yaml
    - version: "2.6.0-next"
      changes:
@@ -150,7 +149,7 @@ or in a separate follow up PR. As an example, it could be followed this procedur
          link: https://github.com/elastic/integrations/pull/1
    - version: "2.5.0"
    ```
-2. Add the required Pull Requests under this entry.
+2. Add the required Pull Requests under this entry:
    ```yaml
    - version: "2.6.0-next"
      changes:
@@ -164,7 +163,7 @@ or in a separate follow up PR. As an example, it could be followed this procedur
          type: enhancement
          link: https://github.com/elastic/integrations/pull/3
    ```
-3. Once everything is merged, another PR is required to bump up the manifest version to be `2.6.0` and also replace the changelog entry to be `2.6.0`
+3. Once everything is merged, another PR is required to bump up the manifest version and replace the changelog entry to be `2.6.0`:
    ```yaml
    - version: "2.6.0"
      changes:

--- a/docs/developer_workflow_design_build_test_integration.md
+++ b/docs/developer_workflow_design_build_test_integration.md
@@ -133,8 +133,48 @@ When the PR is merged, the CI will kick off a build job for the main branch, whi
 the package-storage. It means that it will open a PR to the [Package Storage/snapshot](https://github.com/elastic/package-storage/tree/snapshot/packages) with
 the built integration if only the package version doesn't already exist in the storage (hasn't been released yet).
 
-When you are ready for your changes in the integration to be released, remember to bump up the package version.
+When you are ready for your changes in the integration to be released, remember to bump up the package version (changelog and manifest).
+
 It is up to you, as the package developer, to decide how many changes you want to release in a single version.
 For example, you could implement a change in a PR and bump up the package version in the same PR. Or you could
 implement several changes across multiple PRs and then bump up the package version in the last of these PRs
-or in a separate follow up PR.
+or in a separate follow up PR. As an example, it could be followed this procedure:
+
+1. Add a new version entry in the changelog with the prerelease tag `next`. Example: `2.6.0-next`
+    - Other formats of prerelease are allowed: 2.6.0-rc1, 2.6.0-SNAPSHOT
+   ```yaml
+   - version: "2.6.0-next"
+     changes:
+       - description: First PR
+         type: enhancement
+         link: https://github.com/elastic/integrations/pull/1
+   - version: "2.5.0"
+   ```
+2. Add the required Pull Requests under this entry.
+   ```yaml
+   - version: "2.6.0-next"
+     changes:
+       - description: First PR
+         type: enhancement
+         link: https://github.com/elastic/integrations/pull/1
+       - description: Second PR
+         type: enhancement
+         link: https://github.com/elastic/integrations/pull/2
+       - description: Third PR
+         type: enhancement
+         link: https://github.com/elastic/integrations/pull/3
+   ```
+3. Once everything is merged, another PR is required to bump up the manifest version to be `2.6.0` and also replace the changelog entry to be `2.6.0`
+   ```yaml
+   - version: "2.6.0"
+     changes:
+       - description: First PR
+         type: enhancement
+         link: https://github.com/elastic/integrations/pull/1
+       - description: Second PR
+         type: enhancement
+         link: https://github.com/elastic/integrations/pull/2
+       - description: Third PR
+         type: enhancement
+         link: https://github.com/elastic/integrations/pull/3
+   ```

--- a/docs/developer_workflow_promote_release_integration.md
+++ b/docs/developer_workflow_promote_release_integration.md
@@ -1,31 +1,43 @@
 # Developer workflow: Promote an integration update
 
-## Prerequisites
+## Using Package Storage
+
+### Prerequisites
 
 * `elastic-package` (builder tool) installed - follow the [Getting started](https://github.com/elastic/elastic-package#getting-started) guide to install the tool.
 * There is a PR open to the [Package Storage/snapshot](https://github.com/elastic/package-storage/tree/snapshot/packages) with your built integration. This will be done automatically by the Integrations repository CI when it detects an unreleased version of your package in the Integrations repository.
 * You have a fork of `https://github.com/elastic/package-storage` in your
   account.
-* Setup a Github token and place the hash in `$HOME/.elastic/github.token`. 
+* Setup a Github token and place the hash in `$HOME/.elastic/github.token`.
 
-## Steps
+### Steps
 
 
 1. Please review this PR on your own and if the CI is happy, merge it. Your PR will be made against a base branch that corresponds to the stage that you will be pushing this package into for testing/deployment (e.g. "snapshot", "staging", etc). This will be referred to in the following steps as your "target stage".
 2. Release changes to the stage using [1-click Jenkins form](https://fleet-ci.elastic.co/job/Ingest-manager/job/release-distribution/build?delay=0sec) (need to be signed in). Remember to wait until the build has finished before triggering a release. Note: triggering a release will push all changes that have been merged to the target stage branch.
 3. Test your package update - point a running Kibana at your target stage's [package registry URL](https://github.com/elastic/package-registry#docker) using [the Fleet Kibana settings](https://www.elastic.co/guide/en/kibana/master/fleet-settings-kb.html#fleet-data-visualizer-settings)
 4. Once happy with the changes in your target stage, promote your package to the next stage using [the elastic-package tool](https://github.com/elastic/elastic-package).
+   ```bash
+   elastic-package promote
+   ```
+   The tool will walk you through some options and open 2 PRs (promote and delete) to the package-storage: target and source branches.
 
-    ```bash
-    elastic-package promote
-    ```
-
-    
-    The tool will walk you through some options and open 2 PRs (promote and delete) to the package-storage: target and source branches.
-    
-    Please review both PRs on your own, check if CI is happy and merge - first target, then source. Once any PR is merged,
-    the CI will kick off a job to bake a new Docker image of package-storage ([tracking](https://fleet-ci.elastic.co/job/Ingest-manager/job/package-storage/)).
-    Ideally the "delete" PR should be merged once the CI job for "promote" is done, as the Docker image of previous stage
-    [depends on the later one](https://github.com/elastic/package-storage/blob/snapshot/Dockerfile#L5).
+   Please review both PRs on your own, check if CI is happy and merge - first target, then source. Once any PR is merged,
+   the CI will kick off a job to bake a new Docker image of package-storage ([tracking](https://fleet-ci.elastic.co/job/Ingest-manager/job/package-storage/)).
+   Ideally the "delete" PR should be merged once the CI job for "promote" is done, as the Docker image of previous stage
+   [depends on the later one](https://github.com/elastic/package-storage/blob/snapshot/Dockerfile#L5).
 
 4. GOTO Step 2
+
+## Using Package Storage V2
+
+Package Storage V2 is the successor of the [package-storage](https://github.com/elastic/package-storage) Git repository.
+You can find more info about this [here](https://github.com/elastic/elastic-packagei/blob/main/docs/howto/use_package_storage_v2.md#use-package-storage-v2).
+
+This new storage is already set up in this repository. Everytime a new version of a package is merged, that version is built and
+published into this storage. Jenkins stage: [Publish to Package Storage V2](../.ci/Jenkinsfile).
+
+This storage is based completely in [semantic versioning](https://semver.org) to release the packages as snapshots, technical previews or stable versions.
+More info about the versioning [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md#prerelease-and-stable-version).
+
+Considerations until Package Storage V1 is deprecated [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md#existing-packages)

--- a/docs/developer_workflow_promote_release_integration.md
+++ b/docs/developer_workflow_promote_release_integration.md
@@ -40,4 +40,4 @@ published into this storage. Jenkins stage: [Publish to Package Storage V2](../.
 This storage is based completely in [semantic versioning](https://semver.org) to release the packages as snapshots, technical previews or stable versions.
 More info about the versioning [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md#prerelease-and-stable-version).
 
-Considerations until Package Storage V1 is deprecated [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md#existing-packages)
+Considerations until Package Storage V1 is deprecated [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md#existing-packages).

--- a/docs/developer_workflow_promote_release_integration.md
+++ b/docs/developer_workflow_promote_release_integration.md
@@ -1,6 +1,6 @@
 # Developer workflow: Promote an integration update
 
-## Using Package Storage
+## Using Package Storage (V1)
 
 ### Prerequisites
 

--- a/docs/developer_workflow_promote_release_integration.md
+++ b/docs/developer_workflow_promote_release_integration.md
@@ -35,7 +35,7 @@ Package Storage V2 is the successor of the [package-storage](https://github.com/
 You can find more info about this [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md#use-package-storage-v2).
 
 This new storage is already set up in this repository. Everytime a new version of a package is merged, that version is built and
-published into this storage. Jenkins stage: [Publish to Package Storage V2](../.ci/Jenkinsfile).
+published into this storage automatically. Jenkins stage where this step is performed: [Publish to Package Storage V2](../.ci/Jenkinsfile).
 
 This storage is based completely in [semantic versioning](https://semver.org) to release the packages as snapshots, technical previews or stable versions.
 More info about the versioning [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md#prerelease-and-stable-version).

--- a/docs/developer_workflow_promote_release_integration.md
+++ b/docs/developer_workflow_promote_release_integration.md
@@ -32,7 +32,7 @@
 ## Using Package Storage V2
 
 Package Storage V2 is the successor of the [package-storage](https://github.com/elastic/package-storage) Git repository.
-You can find more info about this [here](https://github.com/elastic/elastic-packagei/blob/main/docs/howto/use_package_storage_v2.md#use-package-storage-v2).
+You can find more info about this [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md#use-package-storage-v2).
 
 This new storage is already set up in this repository. Everytime a new version of a package is merged, that version is built and
 published into this storage. Jenkins stage: [Publish to Package Storage V2](../.ci/Jenkinsfile).

--- a/docs/testing_and_validation.md
+++ b/docs/testing_and_validation.md
@@ -54,7 +54,7 @@
 The `elastic-package stack` provides an enrolled instance of the Elastic Agent. Use that one instead of a local application
 if you can run the service (you're integrating with) in the Docker network and you don't need to rebuild the Elastic-Agent
 or it's subprocesses (e.g. Filebeat or Metricbeat). The service Docker image can be used for [system
-testing](https://github.com/elastic/elastic-package/blob/master/docs/howto/system_testing.md). If you prefer to use a local
+testing](https://github.com/elastic/elastic-package/blob/main/docs/howto/system_testing.md). If you prefer to use a local
 instance of the Elastic Agent, proceed with steps 4 an 5:
 
 4. (Optional) Download the Elastic-Agent from https://www.elastic.co/downloads/elastic-agent
@@ -80,7 +80,7 @@ instance of the Elastic Agent, proceed with steps 4 an 5:
 
 ## Use test runners
 
-`elastic-package` provides different types of test runners. Review [howto](https://github.com/elastic/elastic-package/tree/master/docs/howto) guides
+`elastic-package` provides different types of test runners. Review [howto](https://github.com/elastic/elastic-package/tree/main/docs/howto) guides
 to learn about the various methods for testing packages.
 
 The `test` subcommand requires a reference to the live Elastic stack. Service endpoints can be defined via environment variables.

--- a/docs/tips_for_building_integrations.md
+++ b/docs/tips_for_building_integrations.md
@@ -34,7 +34,7 @@ $ ./elastic-package help
 
 3. Select one or two categories for the integration.
 
-   The list of available categories is present in the Package Registry source: https://github.com/elastic/package-registry/blob/e93e801a6dfbfa6f83c8b69f6e9405603151f937/util/package.go#L27-L51
+   The list of available categories is present in the Package Registry source: https://github.com/elastic/package-registry/blob/79e456c86a7a83b1da1f3f5b15d0ca59fdb48337/packages/package.go#L29-L54
 
 4. Make sure that the version condition for Kibana is set to `^7.10.0` and not `>=7.10.0`. Otherwise the package is also in 8.0.0 but we do not know today if it will actually be compatible with >= 8.0.0.
 


### PR DESCRIPTION
## What does this PR do?

Update docs adding information about:
- Release cycle: add example to include several PRs in the same version
- Delivery methodology: include information about Package Storage V2

From the issue #2145 there are some docs already for:
- Contribution guidelines: [docs/generic_guidelines](https://github.com/elastic/integrations/blob/main/docs/generic_guidelines.md) and [docs/documentation_guidelines](https://github.com/elastic/integrations/blob/main/docs/documentation_guidelines.md)
- Package Compatibility: There are already indication about for instance the definition of the required kibana version in the manifests (https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md#manifest-files)

This PR also update some outdated links (categories list and references to master branch).


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2145 

