### PR TITLE
[Bug] Box Events Integration was ignoring the `stream_type` parameter

### DIFF
--- a/packages/box_events/data_stream/anomalous_download_alerts/agent/stream/httpjson.yml.hbs
+++ b/packages/box_events/data_stream/anomalous_download_alerts/agent/stream/httpjson.yml.hbs
@@ -8,13 +8,17 @@ auth.oauth2:
     box_subject_id: "{{box_subject_id}}"
     box_subject_type: "{{box_subject_type}}"
     grant_type: "{{grant_type}}"
-    stream_type: "{{stream_type}}"
 request.url: "{{api_url}}/2.0/events"
 request.method: "GET"
 request.transforms:
   - set:
       target: url.params.stream_position
       value: '[[.cursor.next_stream_position]]'
+{{#if stream_type}}
+  - set:
+      target: url.params.stream_type
+      value: "{{stream_type}}"
+{{/if}}
 response.decode_as: application/json
 response.split:
   target: body.entries

--- a/packages/box_events/data_stream/anomalous_download_alerts/manifest.yml
+++ b/packages/box_events/data_stream/anomalous_download_alerts/manifest.yml
@@ -3,8 +3,8 @@ type: logs
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs
-    title: Box Shield Anomalous Download Alerts
-    description: Collect Box Shield Anomalous Download Alerts with appropriate Box Opt-in Settings
+    title: Box user and enterprise events
+    description: Collect user and enterprise events from the Box API
     vars:
       - name: interval
         type: text
@@ -15,14 +15,14 @@ streams:
         show_user: true
         default: 300s
       - name: stream_type
-        type: text
-        title: Stream Type
-        description: >-
-          To retrieve events for the entire enterprise, set the stream_type to admin_logs_streaming for live monitoring of new events, or admin_logs for querying across historical events. The user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked.
-        multi: false
         required: true
         show_user: true
-        default: admin_logs
+        title: Stream Type
+        description: >-
+          To retrieve events for a single user, set stream type to `all` (default). To select only events that may cause file tree changes such as file updates or collaborations, use `changes`. To select a subset of `changes` for synced folders, use `sync`. For `all`, `changes` or `sync`, the user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked. To retrieve events for the entire enterprise, you will need additional privileges (TBC). In this case, set the stream_type to `admin_logs_streaming` for live monitoring of new events, or `admin_logs` for querying across historical events.
+        type: text
+        multi: false
+        default: all
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/box_events/data_stream/events/agent/stream/httpjson.yml.hbs
+++ b/packages/box_events/data_stream/events/agent/stream/httpjson.yml.hbs
@@ -8,13 +8,17 @@ auth.oauth2:
     box_subject_id: "{{box_subject_id}}"
     box_subject_type: "{{box_subject_type}}"
     grant_type: "{{grant_type}}"
-    stream_type: "{{stream_type}}"
 request.url: "{{api_url}}/2.0/events"
 request.method: "GET"
 request.transforms:
   - set:
       target: url.params.stream_position
       value: '[[.cursor.next_stream_position]]'
+{{#if stream_type}}
+  - set:
+      target: url.params.stream_type
+      value: "{{stream_type}}"
+{{/if}}
 response.decode_as: application/json
 response.split:
   target: body.entries

--- a/packages/box_events/data_stream/events/manifest.yml
+++ b/packages/box_events/data_stream/events/manifest.yml
@@ -15,14 +15,14 @@ streams:
         show_user: true
         default: 300s
       - name: stream_type
-        type: text
-        title: Stream Type
-        description: >-
-          To retrieve events for the entire enterprise, set the stream_type to admin_logs_streaming for live monitoring of new events, or admin_logs for querying across historical events. The user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked.
-        multi: false
         required: true
         show_user: true
-        default: admin_logs
+        title: Stream Type
+        description: >-
+          To retrieve events for a single user, set stream type to `all` (default). To select only events that may cause file tree changes such as file updates or collaborations, use `changes`. To select a subset of `changes` for synced folders, use `sync`. For `all`, `changes` or `sync`, the user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked. To retrieve events for the entire enterprise, you will need additional privileges (TBC). In this case, set the stream_type to `admin_logs_streaming` for live monitoring of new events, or `admin_logs` for querying across historical events.
+        type: text
+        multi: false
+        default: all
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/box_events/data_stream/malicious_content_alerts/agent/stream/httpjson.yml.hbs
+++ b/packages/box_events/data_stream/malicious_content_alerts/agent/stream/httpjson.yml.hbs
@@ -8,13 +8,17 @@ auth.oauth2:
     box_subject_id: "{{box_subject_id}}"
     box_subject_type: "{{box_subject_type}}"
     grant_type: "{{grant_type}}"
-    stream_type: "{{stream_type}}"
 request.url: "{{api_url}}/2.0/events"
 request.method: "GET"
 request.transforms:
   - set:
       target: url.params.stream_position
       value: '[[.cursor.next_stream_position]]'
+{{#if stream_type}}
+  - set:
+      target: url.params.stream_type
+      value: "{{stream_type}}"
+{{/if}}
 response.decode_as: application/json
 response.split:
   target: body.entries

--- a/packages/box_events/data_stream/malicious_content_alerts/manifest.yml
+++ b/packages/box_events/data_stream/malicious_content_alerts/manifest.yml
@@ -3,8 +3,8 @@ type: logs
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs
-    title: Box Shield Malicious Content Alerts
-    description: Collect Box Shield Malicious Content Alerts with appropriate Box Opt-in Settings
+    title: Box user and enterprise events
+    description: Collect user and enterprise events from the Box API
     vars:
       - name: interval
         type: text
@@ -15,14 +15,14 @@ streams:
         show_user: true
         default: 300s
       - name: stream_type
-        type: text
-        title: Stream Type
-        description: >-
-          To retrieve events for the entire enterprise, set the stream_type to admin_logs_streaming for live monitoring of new events, or admin_logs for querying across historical events. The user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked.
-        multi: false
         required: true
         show_user: true
-        default: admin_logs
+        title: Stream Type
+        description: >-
+          To retrieve events for a single user, set stream type to `all` (default). To select only events that may cause file tree changes such as file updates or collaborations, use `changes`. To select a subset of `changes` for synced folders, use `sync`. For `all`, `changes` or `sync`, the user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked. To retrieve events for the entire enterprise, you will need additional privileges (TBC). In this case, set the stream_type to `admin_logs_streaming` for live monitoring of new events, or `admin_logs` for querying across historical events.
+        type: text
+        multi: false
+        default: all
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/box_events/data_stream/suspicious_locations_alerts/agent/stream/httpjson.yml.hbs
+++ b/packages/box_events/data_stream/suspicious_locations_alerts/agent/stream/httpjson.yml.hbs
@@ -8,13 +8,17 @@ auth.oauth2:
     box_subject_id: "{{box_subject_id}}"
     box_subject_type: "{{box_subject_type}}"
     grant_type: "{{grant_type}}"
-    stream_type: "{{stream_type}}"
 request.url: "{{api_url}}/2.0/events"
 request.method: "GET"
 request.transforms:
   - set:
       target: url.params.stream_position
       value: '[[.cursor.next_stream_position]]'
+{{#if stream_type}}
+  - set:
+      target: url.params.stream_type
+      value: "{{stream_type}}"
+{{/if}}
 response.decode_as: application/json
 response.split:
   target: body.entries

--- a/packages/box_events/data_stream/suspicious_locations_alerts/manifest.yml
+++ b/packages/box_events/data_stream/suspicious_locations_alerts/manifest.yml
@@ -3,8 +3,8 @@ type: logs
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs
-    title: Box Shield Suspicious Locations Alerts
-    description: Collect Box Shield Suspicious Locations Alerts with appropriate Box Opt-in Settings
+    title: Box user and enterprise events
+    description: Collect user and enterprise events from the Box API
     vars:
       - name: interval
         type: text
@@ -15,14 +15,14 @@ streams:
         show_user: true
         default: 300s
       - name: stream_type
-        type: text
-        title: Stream Type
-        description: >-
-          To retrieve events for the entire enterprise, set the stream_type to admin_logs_streaming for live monitoring of new events, or admin_logs for querying across historical events. The user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked.
-        multi: false
         required: true
         show_user: true
-        default: admin_logs
+        title: Stream Type
+        description: >-
+          To retrieve events for a single user, set stream type to `all` (default). To select only events that may cause file tree changes such as file updates or collaborations, use `changes`. To select a subset of `changes` for synced folders, use `sync`. For `all`, `changes` or `sync`, the user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked. To retrieve events for the entire enterprise, you will need additional privileges (TBC). In this case, set the stream_type to `admin_logs_streaming` for live monitoring of new events, or `admin_logs` for querying across historical events.
+        type: text
+        multi: false
+        default: all
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/box_events/data_stream/suspicious_sessions_alerts/agent/stream/httpjson.yml.hbs
+++ b/packages/box_events/data_stream/suspicious_sessions_alerts/agent/stream/httpjson.yml.hbs
@@ -8,13 +8,17 @@ auth.oauth2:
     box_subject_id: "{{box_subject_id}}"
     box_subject_type: "{{box_subject_type}}"
     grant_type: "{{grant_type}}"
-    stream_type: "{{stream_type}}"
 request.url: "{{api_url}}/2.0/events"
 request.method: "GET"
 request.transforms:
   - set:
       target: url.params.stream_position
       value: '[[.cursor.next_stream_position]]'
+{{#if stream_type}}
+  - set:
+      target: url.params.stream_type
+      value: "{{stream_type}}"
+{{/if}}
 response.decode_as: application/json
 response.split:
   target: body.entries

--- a/packages/box_events/data_stream/suspicious_sessions_alerts/manifest.yml
+++ b/packages/box_events/data_stream/suspicious_sessions_alerts/manifest.yml
@@ -3,8 +3,8 @@ type: logs
 streams:
   - input: httpjson
     template_path: httpjson.yml.hbs
-    title: Box Shield Suspicious Sessions Alerts
-    description: Collect Box Shield Suspicious Sessions Alerts with appropriate Box Opt-in Settings
+    title: Box user and enterprise events
+    description: Collect user and enterprise events from the Box API
     vars:
       - name: interval
         type: text
@@ -15,14 +15,14 @@ streams:
         show_user: true
         default: 300s
       - name: stream_type
-        type: text
-        title: Stream Type
-        description: >-
-          To retrieve events for the entire enterprise, set the stream_type to admin_logs_streaming for live monitoring of new events, or admin_logs for querying across historical events. The user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked.
-        multi: false
         required: true
         show_user: true
-        default: admin_logs
+        title: Stream Type
+        description: >-
+          To retrieve events for a single user, set stream type to `all` (default). To select only events that may cause file tree changes such as file updates or collaborations, use `changes`. To select a subset of `changes` for synced folders, use `sync`. For `all`, `changes` or `sync`, the user making the API call will need to have admin privileges, and the application will need to have the scope manage enterprise properties checked. To retrieve events for the entire enterprise, you will need additional privileges (TBC). In this case, set the stream_type to `admin_logs_streaming` for live monitoring of new events, or `admin_logs` for querying across historical events.
+        type: text
+        multi: false
+        default: all
       - name: preserve_original_event
         required: true
         show_user: true


### PR DESCRIPTION
## What does this PR do?

The Box Events Integration was ignoring the `stream_type` parameter owing to a template misconfiguration. This resulted in:

- issue where a user would be unable to correctly select which events to request from the Box API
- incomplete test results, since the admin-level events were not harvested
- in turn, the incomplete test results failed to expose an issue with Box API inadequate user privileges

This PR will:
- address the `stream_type` parameter 
- extend the test suite to validate
- document additional steps (TBC) regarding user privileges

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
