### PR TITLE
[docs] Escape less than symbol (`<`)

### DIFF
--- a/packages/ti_cif3/_dev/build/docs/README.md
+++ b/packages/ti_cif3/_dev/build/docs/README.md
@@ -13,8 +13,8 @@ CIFv3 `confidence` field values (0..10) are converted to ECS confidence (None, L
 | CIFv3 Confidence | ECS Conversion |
 | ---------------- | -------------- |
 | Beyond Range     | None           |
-| 0 - <3           | Low            |
-| 3 - <7           | Medium         |
+| 0 - \<3          | Low            |
+| 3 - \<7          | Medium         |
 | 7 - 10           | High           |
 
 {{fields "feed"}}

--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Fix documentation build error
+      type: enhancement
+      link: TBD
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/ti_cif3/docs/README.md
+++ b/packages/ti_cif3/docs/README.md
@@ -13,8 +13,8 @@ CIFv3 `confidence` field values (0..10) are converted to ECS confidence (None, L
 | CIFv3 Confidence | ECS Conversion |
 | ---------------- | -------------- |
 | Beyond Range     | None           |
-| 0 - <3           | Low            |
-| 3 - <7           | Medium         |
+| 0 - \<3          | Low            |
+| 3 - \<7          | Medium         |
 | 7 - 10           | High           |
 
 **Exported fields**

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: 0.1.0
+version: 0.1.1
 release: beta
 license: basic
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."


### PR DESCRIPTION
## What does this PR do?

Escapes the less than symbol (`<`) used in the new Collective Intelligence Framework v3 Integration docs. 

The [Integration docs](https://docs.elastic.co/integrations) uses MDX (not plain Markdown). From the [MDX documentation](https://mdxjs.com/docs/what-is-mdx/#markdown):

>Unescaped left angle bracket / less than (`<`) and left curly brace (`{`) have to be escaped: `\<` or `\{` (or use expressions: `{'<'}`, `{'{'}`)

I used `\<` because it also renders correctly in plain Markdown (see **Screenshots** below).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Screenshots

<img width="963" alt="image" src="https://user-images.githubusercontent.com/10479155/192035250-aa7d9f6e-7c1e-4bac-91e2-4e1749195f52.png">