### PR TITLE
carbon_black_cloud,sentinel_one: ensure consistent ordering of arrays

### DIFF
--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Ensure stability of related.hash array ordering.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/4296
 - version: "1.2.1"
   changes:
     - description: Remove unused visualizations

--- a/packages/carbon_black_cloud/data_stream/alert/sample_event.json
+++ b/packages/carbon_black_cloud/data_stream/alert/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2020-11-17T22:05:13.000Z",
     "agent": {
-        "ephemeral_id": "56053d91-103c-4c77-8f15-0a1006a80102",
-        "hostname": "docker-fleet-agent",
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "ephemeral_id": "cc329655-90f8-4dc9-8014-e152f2b949da",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "carbon_black_cloud": {
         "alert": {
@@ -54,20 +53,20 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-04-14T11:46:13.154Z",
+        "created": "2022-09-26T01:58:04.610Z",
         "dataset": "carbon_black_cloud.alert",
         "end": "2020-11-17T22:02:16Z",
         "id": "test1",
-        "ingested": "2022-04-14T11:46:14Z",
+        "ingested": "2022-09-26T01:58:05Z",
         "kind": "alert",
         "original": "{\"alert_url\":\"https://defense-eap01.conferdeploy.net/alerts?orgId=1889976\",\"category\":\"WARNING\",\"create_time\":\"2020-11-17T22:05:13Z\",\"device_external_ip\":\"81.2.69.143\",\"device_id\":2,\"device_internal_ip\":\"81.2.69.144\",\"device_location\":\"UNKNOWN\",\"device_name\":\"DESKTOP-002\",\"device_os\":\"WINDOWS\",\"device_os_version\":\"Windows 10 x64\",\"device_username\":\"test34@demo.com\",\"first_event_time\":\"2020-11-17T22:02:16Z\",\"id\":\"test1\",\"last_event_time\":\"2020-11-17T22:02:16Z\",\"last_update_time\":\"2020-11-17T22:05:13Z\",\"legacy_alert_id\":\"C8EB7306-AF26-4A9A-B677-814B3AF69720\",\"org_key\":\"ABCD6X3T\",\"policy_applied\":\"APPLIED\",\"policy_id\":6997287,\"policy_name\":\"Standard\",\"product_id\":\"0x5406\",\"product_name\":\"U3 Cruzer Micro\",\"reason\":\"Access attempted on unapproved USB device SanDisk U3 Cruzer Micro (SN: 0875920EF7C2A304). A Deny Policy Action was applied.\",\"reason_code\":\"6D578342-9DE5-4353-9C25-1D3D857BFC5B:DCAEB1FA-513C-4026-9AB6-37A935873FBC\",\"run_state\":\"DID_NOT_RUN\",\"sensor_action\":\"DENY\",\"serial_number\":\"0875920EF7C2A304\",\"severity\":3,\"target_value\":\"MEDIUM\",\"threat_cause_cause_event_id\":\"FCEE2AF0-D832-4C9F-B988-F11B46028C9E\",\"threat_cause_threat_category\":\"NON_MALWARE\",\"threat_cause_vector\":\"REMOVABLE_MEDIA\",\"threat_id\":\"t5678\",\"type\":\"DEVICE_CONTROL\",\"vendor_id\":\"0x0781\",\"vendor_name\":\"SanDisk\",\"workflow\":{\"changed_by\":\"Carbon Black\",\"comment\":\"\",\"last_update_time\":\"2020-11-17T22:02:16Z\",\"remediation\":\"\",\"state\":\"OPEN\"}}",
         "reason": "Access attempted on unapproved USB device SanDisk U3 Cruzer Micro (SN: 0875920EF7C2A304). A Deny Policy Action was applied.",

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/sample_event.json
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/sample_event.json
@@ -1,12 +1,11 @@
 {
-    "@timestamp": "2022-04-14T11:47:25.371Z",
+    "@timestamp": "2022-09-26T01:58:41.710Z",
     "agent": {
-        "ephemeral_id": "377d9292-c7d0-4c30-bbee-faf4848d30d8",
-        "hostname": "docker-fleet-agent",
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "ephemeral_id": "818ffeea-8e73-497b-bc16-b13e6bb3010c",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "carbon_black_cloud": {
         "asset_vulnerability_summary": {
@@ -30,18 +29,18 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-04-14T11:47:25.371Z",
+        "created": "2022-09-26T01:58:41.710Z",
         "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "ingested": "2022-04-14T11:47:26Z",
+        "ingested": "2022-09-26T01:58:45Z",
         "original": "{\"cve_ids\":null,\"device_id\":8,\"highest_risk_score\":10,\"host_name\":\"DESKTOP-008\",\"last_sync_ts\":\"2022-01-17T08:33:37.384932Z\",\"name\":\"DESKTOP-008KK\",\"os_info\":{\"os_arch\":\"64-bit\",\"os_name\":\"Microsoft Windows 10 Education\",\"os_type\":\"WINDOWS\",\"os_version\":\"10.0.17763\"},\"severity\":\"CRITICAL\",\"sync_status\":\"COMPLETED\",\"sync_type\":\"SCHEDULED\",\"type\":\"ENDPOINT\",\"vm_id\":\"\",\"vm_name\":\"\",\"vuln_count\":1770}"
     },
     "host": {

--- a/packages/carbon_black_cloud/data_stream/audit/sample_event.json
+++ b/packages/carbon_black_cloud/data_stream/audit/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2022-02-10T16:04:30.263Z",
     "agent": {
-        "ephemeral_id": "6472e86c-fc7c-478a-a6fd-12ed19fe05c9",
-        "hostname": "docker-fleet-agent",
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "ephemeral_id": "a332765e-1e1f-4ec7-b24e-ae2d0dd5d74f",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "carbon_black_cloud": {
         "audit": {
@@ -26,19 +25,19 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-04-14T11:48:30.094Z",
+        "created": "2022-09-26T01:59:24.724Z",
         "dataset": "carbon_black_cloud.audit",
         "id": "2122f8ce8xxxxxxxxxxxxx",
-        "ingested": "2022-04-14T11:48:31Z",
+        "ingested": "2022-09-26T01:59:25Z",
         "kind": "event",
         "original": "{\"clientIp\":\"10.10.10.10\",\"description\":\"Logged in successfully\",\"eventId\":\"2122f8ce8xxxxxxxxxxxxx\",\"eventTime\":1644509070263,\"flagged\":false,\"loginName\":\"abc@demo.com\",\"orgName\":\"cb-xxxx-xxxx.com\",\"requestUrl\":null,\"verbose\":false}",
         "outcome": "success",

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/_dev/test/pipeline/test-endpoint-event.log-expected.json
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/_dev/test/pipeline/test-endpoint-event.log-expected.json
@@ -79,10 +79,10 @@
             },
             "related": {
                 "hash": [
-                    "dfbea9e8c316d9bc118b454b0c722cd674c30d0a256340200e2c3a7480cba674",
-                    "3d7752ec3169dcd04d37de36a69abf89",
                     "3a55487d9a9247d7848785d1a8c76d1b9ed15d72137d81f7474be0a31ba523d0",
-                    "d8e577bf078c45954f4531885478d5a9"
+                    "3d7752ec3169dcd04d37de36a69abf89",
+                    "d8e577bf078c45954f4531885478d5a9",
+                    "dfbea9e8c316d9bc118b454b0c722cd674c30d0a256340200e2c3a7480cba674"
                 ],
                 "hosts": [
                     "DESKTOP-001",
@@ -181,10 +181,10 @@
             },
             "related": {
                 "hash": [
-                    "dfbea9e8c316d9bc118b454b0c722cd674c30d0a256340200e2c3a7480cba674",
-                    "3d7752ec3169dcd04d37de36a69abf89",
                     "3a55487d9a9247d7848785d1a8c76d1b9ed15d72137d81f7474be0a31ba523d0",
-                    "d8e577bf078c45954f4531885478d5a9"
+                    "3d7752ec3169dcd04d37de36a69abf89",
+                    "d8e577bf078c45954f4531885478d5a9",
+                    "dfbea9e8c316d9bc118b454b0c722cd674c30d0a256340200e2c3a7480cba674"
                 ],
                 "hosts": [
                     "DESKTOP-002"
@@ -301,12 +301,12 @@
             },
             "related": {
                 "hash": [
-                    "fae441a6ec7fd8f55a404797a25c8910",
-                    "9520a99e77d6196d0d09833146424113",
-                    "70d7571253e091f646f78a4dd078ce7fe8d796625bfa3c0a466df03971175fb4",
-                    "9e9c7696859b94b1c33a532fa4d5c648226cf3361121dd899e502b8949fb11a6",
                     "2498272dc48446891182747428d02a30",
-                    "dd191a5b23df92e12a8852291f9fb5ed594b76a28a5a464418442584afd1e048"
+                    "70d7571253e091f646f78a4dd078ce7fe8d796625bfa3c0a466df03971175fb4",
+                    "9520a99e77d6196d0d09833146424113",
+                    "9e9c7696859b94b1c33a532fa4d5c648226cf3361121dd899e502b8949fb11a6",
+                    "dd191a5b23df92e12a8852291f9fb5ed594b76a28a5a464418442584afd1e048",
+                    "fae441a6ec7fd8f55a404797a25c8910"
                 ],
                 "hosts": [
                     "DESKTOP-003"
@@ -424,10 +424,10 @@
             },
             "related": {
                 "hash": [
-                    "baf97b2a629723947539cff84e896cd29565ab4bb68b0cec515eb5c5d6637b69",
                     "2445dece99deedbd701dc6dfe10e648e",
-                    "c5e9b1d1103edcea2e408e9497a5a88f",
-                    "5a780d6630639ffb7fd3d295c182eaa2a7cad2c70248c5ba8f334bb3803353ca"
+                    "5a780d6630639ffb7fd3d295c182eaa2a7cad2c70248c5ba8f334bb3803353ca",
+                    "baf97b2a629723947539cff84e896cd29565ab4bb68b0cec515eb5c5d6637b69",
+                    "c5e9b1d1103edcea2e408e9497a5a88f"
                 ],
                 "hosts": [
                     "DESKTOP-004"
@@ -543,12 +543,12 @@
             },
             "related": {
                 "hash": [
-                    "baf97b2a629723947539cff84e896cd29565ab4bb68b0cec515eb5c5d6637b69",
-                    "353f8d4e647a11f235f4262d913f7bac4c4f266eac4601ea416e861afd611912",
-                    "e202dd92848c5103c9abf8ecd22bc539",
                     "2445dece99deedbd701dc6dfe10e648e",
+                    "353f8d4e647a11f235f4262d913f7bac4c4f266eac4601ea416e861afd611912",
+                    "5a780d6630639ffb7fd3d295c182eaa2a7cad2c70248c5ba8f334bb3803353ca",
+                    "baf97b2a629723947539cff84e896cd29565ab4bb68b0cec515eb5c5d6637b69",
                     "c5e9b1d1103edcea2e408e9497a5a88f",
-                    "5a780d6630639ffb7fd3d295c182eaa2a7cad2c70248c5ba8f334bb3803353ca"
+                    "e202dd92848c5103c9abf8ecd22bc539"
                 ],
                 "hosts": [
                     "DESKTOP-005"
@@ -664,12 +664,12 @@
             },
             "related": {
                 "hash": [
-                    "70cc03d968b1e7446d30af1037c228bf",
                     "03dd698da2671383c9b4f868c9931879",
-                    "cad38c9348fca41ffd0c2e4d66a1ff5b7ea16db4928b464aa69b1c166dab039f",
-                    "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5",
+                    "28aba00ae4f5f93b6b60ffcd9037167880eff26ff8116086342a22841d69fd6b",
                     "2f9444b55cdc2c66cd692d6088091ef4",
-                    "28aba00ae4f5f93b6b60ffcd9037167880eff26ff8116086342a22841d69fd6b"
+                    "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5",
+                    "70cc03d968b1e7446d30af1037c228bf",
+                    "cad38c9348fca41ffd0c2e4d66a1ff5b7ea16db4928b464aa69b1c166dab039f"
                 ],
                 "hosts": [
                     "DESKTOP-006"
@@ -785,12 +785,12 @@
             },
             "related": {
                 "hash": [
-                    "fae441a6ec7fd8f55a404797a25c8910",
                     "03dd698da2671383c9b4f868c9931879",
-                    "70d7571253e091f646f78a4dd078ce7fe8d796625bfa3c0a466df03971175fb4",
                     "2445dece99deedbd701dc6dfe10e648e",
+                    "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5",
                     "5a780d6630639ffb7fd3d295c182eaa2a7cad2c70248c5ba8f334bb3803353ca",
-                    "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5"
+                    "70d7571253e091f646f78a4dd078ce7fe8d796625bfa3c0a466df03971175fb4",
+                    "fae441a6ec7fd8f55a404797a25c8910"
                 ],
                 "hosts": [
                     "DESKTOP-007"
@@ -906,12 +906,12 @@
             },
             "related": {
                 "hash": [
-                    "fae441a6ec7fd8f55a404797a25c8910",
-                    "70cc03d968b1e7446d30af1037c228bf",
                     "03dd698da2671383c9b4f868c9931879",
-                    "70d7571253e091f646f78a4dd078ce7fe8d796625bfa3c0a466df03971175fb4",
+                    "28aba00ae4f5f93b6b60ffcd9037167880eff26ff8116086342a22841d69fd6b",
                     "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5",
-                    "28aba00ae4f5f93b6b60ffcd9037167880eff26ff8116086342a22841d69fd6b"
+                    "70cc03d968b1e7446d30af1037c228bf",
+                    "70d7571253e091f646f78a4dd078ce7fe8d796625bfa3c0a466df03971175fb4",
+                    "fae441a6ec7fd8f55a404797a25c8910"
                 ],
                 "hosts": [
                     "DESKTOP-008"
@@ -1007,10 +1007,10 @@
             },
             "related": {
                 "hash": [
-                    "baf97b2a629723947539cff84e896cd29565ab4bb68b0cec515eb5c5d6637b69",
+                    "28aba00ae4f5f93b6b60ffcd9037167880eff26ff8116086342a22841d69fd6b",
                     "70cc03d968b1e7446d30af1037c228bf",
-                    "c5e9b1d1103edcea2e408e9497a5a88f",
-                    "28aba00ae4f5f93b6b60ffcd9037167880eff26ff8116086342a22841d69fd6b"
+                    "baf97b2a629723947539cff84e896cd29565ab4bb68b0cec515eb5c5d6637b69",
+                    "c5e9b1d1103edcea2e408e9497a5a88f"
                 ],
                 "hosts": [
                     "DESKTOP-009"
@@ -1106,10 +1106,10 @@
             },
             "related": {
                 "hash": [
-                    "9e9c7696859b94b1c33a532fa4d5c648226cf3361121dd899e502b8949fb11a6",
                     "03dd698da2671383c9b4f868c9931879",
                     "2498272dc48446891182747428d02a30",
-                    "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5"
+                    "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5",
+                    "9e9c7696859b94b1c33a532fa4d5c648226cf3361121dd899e502b8949fb11a6"
                 ],
                 "hosts": [
                     "DESKTOP-010"
@@ -1204,10 +1204,10 @@
             },
             "related": {
                 "hash": [
-                    "fae441a6ec7fd8f55a404797a25c8910",
                     "03dd698da2671383c9b4f868c9931879",
+                    "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5",
                     "70d7571253e091f646f78a4dd078ce7fe8d796625bfa3c0a466df03971175fb4",
-                    "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5"
+                    "fae441a6ec7fd8f55a404797a25c8910"
                 ],
                 "hosts": [
                     "DESKTOP-011"
@@ -1302,10 +1302,10 @@
             },
             "related": {
                 "hash": [
-                    "cc18cc5d6af91226548e9049d0ea87ca",
                     "472829d6813a5a85e3017db7d1c0d67e",
+                    "8d6ce40a49b5469a7c77aa9806be32b7d50f8f3ab8a89541750aaa0ae74b7c32",
                     "903ae6b93c722f8862cc774068f284ba0d6daa823499212f1048db98255fb395",
-                    "8d6ce40a49b5469a7c77aa9806be32b7d50f8f3ab8a89541750aaa0ae74b7c32"
+                    "cc18cc5d6af91226548e9049d0ea87ca"
                 ],
                 "hosts": [
                     "DESKTOP-012"
@@ -1405,10 +1405,10 @@
             },
             "related": {
                 "hash": [
-                    "cc18cc5d6af91226548e9049d0ea87ca",
                     "472829d6813a5a85e3017db7d1c0d67e",
+                    "8d6ce40a49b5469a7c77aa9806be32b7d50f8f3ab8a89541750aaa0ae74b7c32",
                     "903ae6b93c722f8862cc774068f284ba0d6daa823499212f1048db98255fb395",
-                    "8d6ce40a49b5469a7c77aa9806be32b7d50f8f3ab8a89541750aaa0ae74b7c32"
+                    "cc18cc5d6af91226548e9049d0ea87ca"
                 ],
                 "hosts": [
                     "DESKTOP-013"
@@ -1513,10 +1513,10 @@
             },
             "related": {
                 "hash": [
-                    "dfbea9e8c316d9bc118b454b0c722cd674c30d0a256340200e2c3a7480cba674",
+                    "2ad7d1a17ee2dd897a5a45515e5ae46f8b6b61d3f67c90c1fa0c7910f06d0515",
                     "6174da1a2dd7594456bbb3ae50ac5587",
                     "d8e577bf078c45954f4531885478d5a9",
-                    "2ad7d1a17ee2dd897a5a45515e5ae46f8b6b61d3f67c90c1fa0c7910f06d0515"
+                    "dfbea9e8c316d9bc118b454b0c722cd674c30d0a256340200e2c3a7480cba674"
                 ],
                 "hosts": [
                     "DESKTOP-014"
@@ -1626,10 +1626,10 @@
             },
             "related": {
                 "hash": [
-                    "ae37fd1b642e797b36b9ffcec8a6e986732d011681061800c6b74426c28a9d03",
-                    "f66196626700ae0728c0269febf2c194f9b73c49dfe7f4fa869d3b96334e5d89",
                     "24590bf74bbbbfd7d7ac070f4e3c44fd",
-                    "2d287989c6f60fa434a345b79b919755"
+                    "2d287989c6f60fa434a345b79b919755",
+                    "ae37fd1b642e797b36b9ffcec8a6e986732d011681061800c6b74426c28a9d03",
+                    "f66196626700ae0728c0269febf2c194f9b73c49dfe7f4fa869d3b96334e5d89"
                 ],
                 "hosts": [
                     "DESKTOP-015"

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/elasticsearch/ingest_pipeline/default.yml
@@ -573,13 +573,19 @@ processors:
       lang: painless
       source: |
         if (ctx?.related?.user != null) {
-            ctx.related.user = new HashSet(ctx.related.user)
-        }
-        if (ctx?.related?.hash != null) {
-            ctx.related.hash = new HashSet(ctx.related.hash)
+          ctx.related.user = new HashSet(ctx.related.user)
         }
         if (ctx?.related?.ip != null) {
-            ctx.related.ip = new HashSet(ctx.related.ip)
+          ctx.related.ip = new HashSet(ctx.related.ip)
+        }
+        if (ctx?.related?.hash != null) {
+          def hashes = new HashSet(ctx.related.hash);
+          def hash = new ArrayList();
+          for (def h: hashes) {
+            hash.add(h);
+          }
+          Collections.sort(hash);
+          ctx.related.hash = hash;
         }
 on_failure:
   - set:

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/_dev/test/pipeline/test-watchlist-hit.log-expected.json
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/_dev/test/pipeline/test-watchlist-hit.log-expected.json
@@ -108,10 +108,10 @@
             },
             "related": {
                 "hash": [
+                    "15ddf210388994b8dc34d5e941b80da74198684e23c7991c06c3672cb7da9c0d",
                     "2a390bdaad6bb1f2e0e9b84ffaa309ec",
-                    "f4f684066175b77e0c3a000549d2922c",
                     "935c1861df1f4018d698e8b65abfa02d7e9037d8f68ca3c2065b6ca165d44ad2",
-                    "15ddf210388994b8dc34d5e941b80da74198684e23c7991c06c3672cb7da9c0d"
+                    "f4f684066175b77e0c3a000549d2922c"
                 ],
                 "hosts": [
                     "DESKTOP-001",
@@ -246,8 +246,8 @@
                 "hash": [
                     "4d89fc34d5f0f9babd022271c585a9477bf41e834e46b991deaa0530fdb25e22",
                     "4fe6d9eb8109fb79ff645138de7cff37906867aade589bd68afa503a9ab3cfb2",
-                    "d9d7684b8431a0d10d0e76fe9f5ffec8",
-                    "d0fce3afa6aa1d58ce9fa336cc2b675b"
+                    "d0fce3afa6aa1d58ce9fa336cc2b675b",
+                    "d9d7684b8431a0d10d0e76fe9f5ffec8"
                 ],
                 "hosts": [
                     "DESKTOP-002"
@@ -374,10 +374,10 @@
             },
             "related": {
                 "hash": [
-                    "70cc03d968b1e7446d30af1037c228bf",
                     "03dd698da2671383c9b4f868c9931879",
+                    "28aba00ae4f5f93b6b60ffcd9037167880eff26ff8116086342a22841d69fd6b",
                     "44a1975b2197484bb22a0eb673e67e7ee9ec20265e9f6347f5e06b6447ac82c5",
-                    "28aba00ae4f5f93b6b60ffcd9037167880eff26ff8116086342a22841d69fd6b"
+                    "70cc03d968b1e7446d30af1037c228bf"
                 ],
                 "hosts": [
                     "DESKTOP-003"
@@ -496,10 +496,10 @@
             },
             "related": {
                 "hash": [
+                    "171cd60a9d4a2e4b07f310359f455c2fc8dc982b5a63a660a7db06d834918a64",
                     "89fc067027af832c316ed9e519cb0219",
-                    "fefc26105685c70d7260170489b5b520",
                     "930f44f9a599937bdb23cf0c7ea4d158991b837d2a0975c15686cdd4198808e8",
-                    "171cd60a9d4a2e4b07f310359f455c2fc8dc982b5a63a660a7db06d834918a64"
+                    "fefc26105685c70d7260170489b5b520"
                 ],
                 "hosts": [
                     "DESKTOP-004"
@@ -618,8 +618,8 @@
             "related": {
                 "hash": [
                     "25f6cb27d0a5a22ca0e114e1aaa6db3d",
-                    "c926606c9372da3b8033307011dbee69879ed374024d8dacea405d05c724f244",
                     "41ffb778aa9f045b578b25ae6f13403e",
+                    "c926606c9372da3b8033307011dbee69879ed374024d8dacea405d05c724f244",
                     "e011c4da168f956342a50c4cf6926f74b5ec159b23f411b9dcf55dceb62da665"
                 ],
                 "hosts": [

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/elasticsearch/ingest_pipeline/default.yml
@@ -282,10 +282,16 @@ processors:
       lang: painless
       source: |
         if (ctx?.related?.user != null) {
-            ctx.related.user = new HashSet(ctx.related.user)
+          ctx.related.user = new HashSet(ctx.related.user)
         }
         if (ctx?.related?.hash != null) {
-            ctx.related.hash = new HashSet(ctx.related.hash)
+          def hashes = new HashSet(ctx.related.hash);
+          def hash = new ArrayList();
+          for (def h: hashes) {
+            hash.add(h);
+          }
+          Collections.sort(hash);
+          ctx.related.hash = hash;
         }
 on_failure:
   - set:

--- a/packages/carbon_black_cloud/docs/README.md
+++ b/packages/carbon_black_cloud/docs/README.md
@@ -50,12 +50,11 @@ An example event for `audit` looks as following:
 {
     "@timestamp": "2022-02-10T16:04:30.263Z",
     "agent": {
-        "ephemeral_id": "6472e86c-fc7c-478a-a6fd-12ed19fe05c9",
-        "hostname": "docker-fleet-agent",
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "ephemeral_id": "a332765e-1e1f-4ec7-b24e-ae2d0dd5d74f",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "carbon_black_cloud": {
         "audit": {
@@ -75,19 +74,19 @@ An example event for `audit` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-04-14T11:48:30.094Z",
+        "created": "2022-09-26T01:59:24.724Z",
         "dataset": "carbon_black_cloud.audit",
         "id": "2122f8ce8xxxxxxxxxxxxx",
-        "ingested": "2022-04-14T11:48:31Z",
+        "ingested": "2022-09-26T01:59:25Z",
         "kind": "event",
         "original": "{\"clientIp\":\"10.10.10.10\",\"description\":\"Logged in successfully\",\"eventId\":\"2122f8ce8xxxxxxxxxxxxx\",\"eventTime\":1644509070263,\"flagged\":false,\"loginName\":\"abc@demo.com\",\"orgName\":\"cb-xxxx-xxxx.com\",\"requestUrl\":null,\"verbose\":false}",
         "outcome": "success",
@@ -182,12 +181,11 @@ An example event for `alert` looks as following:
 {
     "@timestamp": "2020-11-17T22:05:13.000Z",
     "agent": {
-        "ephemeral_id": "56053d91-103c-4c77-8f15-0a1006a80102",
-        "hostname": "docker-fleet-agent",
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "ephemeral_id": "cc329655-90f8-4dc9-8014-e152f2b949da",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "carbon_black_cloud": {
         "alert": {
@@ -235,20 +233,20 @@ An example event for `alert` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-04-14T11:46:13.154Z",
+        "created": "2022-09-26T01:58:04.610Z",
         "dataset": "carbon_black_cloud.alert",
         "end": "2020-11-17T22:02:16Z",
         "id": "test1",
-        "ingested": "2022-04-14T11:46:14Z",
+        "ingested": "2022-09-26T01:58:05Z",
         "kind": "alert",
         "original": "{\"alert_url\":\"https://defense-eap01.conferdeploy.net/alerts?orgId=1889976\",\"category\":\"WARNING\",\"create_time\":\"2020-11-17T22:05:13Z\",\"device_external_ip\":\"81.2.69.143\",\"device_id\":2,\"device_internal_ip\":\"81.2.69.144\",\"device_location\":\"UNKNOWN\",\"device_name\":\"DESKTOP-002\",\"device_os\":\"WINDOWS\",\"device_os_version\":\"Windows 10 x64\",\"device_username\":\"test34@demo.com\",\"first_event_time\":\"2020-11-17T22:02:16Z\",\"id\":\"test1\",\"last_event_time\":\"2020-11-17T22:02:16Z\",\"last_update_time\":\"2020-11-17T22:05:13Z\",\"legacy_alert_id\":\"C8EB7306-AF26-4A9A-B677-814B3AF69720\",\"org_key\":\"ABCD6X3T\",\"policy_applied\":\"APPLIED\",\"policy_id\":6997287,\"policy_name\":\"Standard\",\"product_id\":\"0x5406\",\"product_name\":\"U3 Cruzer Micro\",\"reason\":\"Access attempted on unapproved USB device SanDisk U3 Cruzer Micro (SN: 0875920EF7C2A304). A Deny Policy Action was applied.\",\"reason_code\":\"6D578342-9DE5-4353-9C25-1D3D857BFC5B:DCAEB1FA-513C-4026-9AB6-37A935873FBC\",\"run_state\":\"DID_NOT_RUN\",\"sensor_action\":\"DENY\",\"serial_number\":\"0875920EF7C2A304\",\"severity\":3,\"target_value\":\"MEDIUM\",\"threat_cause_cause_event_id\":\"FCEE2AF0-D832-4C9F-B988-F11B46028C9E\",\"threat_cause_threat_category\":\"NON_MALWARE\",\"threat_cause_vector\":\"REMOVABLE_MEDIA\",\"threat_id\":\"t5678\",\"type\":\"DEVICE_CONTROL\",\"vendor_id\":\"0x0781\",\"vendor_name\":\"SanDisk\",\"workflow\":{\"changed_by\":\"Carbon Black\",\"comment\":\"\",\"last_update_time\":\"2020-11-17T22:02:16Z\",\"remediation\":\"\",\"state\":\"OPEN\"}}",
         "reason": "Access attempted on unapproved USB device SanDisk U3 Cruzer Micro (SN: 0875920EF7C2A304). A Deny Policy Action was applied.",
@@ -910,14 +908,13 @@ An example event for `asset_vulnerability_summary` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-04-14T11:47:25.371Z",
+    "@timestamp": "2022-09-26T01:58:41.710Z",
     "agent": {
-        "ephemeral_id": "377d9292-c7d0-4c30-bbee-faf4848d30d8",
-        "hostname": "docker-fleet-agent",
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "ephemeral_id": "818ffeea-8e73-497b-bc16-b13e6bb3010c",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "carbon_black_cloud": {
         "asset_vulnerability_summary": {
@@ -941,18 +938,18 @@ An example event for `asset_vulnerability_summary` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "4f53bc01-9d14-4e27-b716-9b41958e11e0",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-04-14T11:47:25.371Z",
+        "created": "2022-09-26T01:58:41.710Z",
         "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "ingested": "2022-04-14T11:47:26Z",
+        "ingested": "2022-09-26T01:58:45Z",
         "original": "{\"cve_ids\":null,\"device_id\":8,\"highest_risk_score\":10,\"host_name\":\"DESKTOP-008\",\"last_sync_ts\":\"2022-01-17T08:33:37.384932Z\",\"name\":\"DESKTOP-008KK\",\"os_info\":{\"os_arch\":\"64-bit\",\"os_name\":\"Microsoft Windows 10 Education\",\"os_type\":\"WINDOWS\",\"os_version\":\"10.0.17763\"},\"severity\":\"CRITICAL\",\"sync_status\":\"COMPLETED\",\"sync_type\":\"SCHEDULED\",\"type\":\"ENDPOINT\",\"vm_id\":\"\",\"vm_name\":\"\",\"vuln_count\":1770}"
     },
     "host": {

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "1.2.1"
+version: "1.2.2"
 license: basic
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Ensure stability of related.hash array ordering.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/4296
 - version: "1.2.1"
   changes:
     - description: Enrich the event.category, event.type, event.kind and event.outcome field based on activity.

--- a/packages/sentinel_one/data_stream/activity/_dev/test/pipeline/test-pipeline-activity.log-expected.json
+++ b/packages/sentinel_one/data_stream/activity/_dev/test/pipeline/test-pipeline-activity.log-expected.json
@@ -444,8 +444,8 @@
                 "kind": "event",
                 "original": "{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activityType\":1234,\"agentId\":null,\"agentUpdatedVersion\":null,\"comments\":null,\"createdAt\":\"2022-04-06T08:45:43.122415Z\",\"data\":{\"accountName\":\"Default\",\"description\":null,\"fileContentHash\":\"aaf4c61ddcc5e8a2dabede0f3b482cxxxxxxxxxx\",\"fullScopeDetails\":\"Site Default site of Account Default\",\"fullScopeDetailsPath\":\"test/default\",\"groupName\":null,\"osFamily\":\"osname\",\"scopeLevel\":\"Site\",\"scopeName\":\"Default site\",\"siteName\":\"Default site\",\"username\":\"unknown\"},\"description\":null,\"groupId\":null,\"groupName\":null,\"hash\":\"aaf4c61ddcc5e8a2dabede0f3b482cxxxxxxxxxx\",\"id\":\"1234567890123456789\",\"osFamily\":\"osname\",\"primaryDescription\":\"Cloud added or modified osname blacklist hash.\",\"secondaryDescription\":\"6a264eda96e766b41bc14a3c9e9xxxxxxxxxxx\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"threatId\":null,\"updatedAt\":\"2022-04-06T08:45:43.112319Z\",\"userId\":null}",
                 "type": [
-                    "creation",
-                    "change"
+                    "change",
+                    "creation"
                 ]
             },
             "file": {
@@ -899,8 +899,8 @@
                 "kind": "event",
                 "original": "{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activityType\":1234,\"agentId\":null,\"agentUpdatedVersion\":null,\"comments\":null,\"createdAt\":\"2022-04-06T08:46:08.135397Z\",\"data\":{\"accountName\":\"Default\",\"description\":null,\"fileContentHash\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fullScopeDetails\":\"Site Default site of Account Default\",\"fullScopeDetailsPath\":\"/path/test / Default site\",\"groupName\":null,\"osFamily\":\"linux\",\"scopeLevel\":\"Site\",\"scopeName\":\"Default site\",\"siteName\":\"Default site\",\"username\":\"unknown\"},\"description\":null,\"groupId\":null,\"groupName\":null,\"hash\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"id\":\"1234567890123456789\",\"osFamily\":\"linux\",\"primaryDescription\":\"Cloud added or modified linux blacklist hash.\",\"secondaryDescription\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"threatId\":null,\"updatedAt\":\"2022-04-06T08:46:08.124972Z\",\"userId\":null}",
                 "type": [
-                    "creation",
-                    "change"
+                    "change",
+                    "creation"
                 ]
             },
             "file": {
@@ -1412,8 +1412,8 @@
                 "kind": "event",
                 "original": "{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activityType\":1234,\"agentId\":null,\"agentUpdatedVersion\":null,\"comments\":null,\"createdAt\":\"2022-04-06T09:00:33.115424Z\",\"data\":{\"accountName\":\"Default\",\"description\":null,\"fileContentHash\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fullScopeDetails\":\"Account Default\",\"fullScopeDetailsPath\":\"test/path\",\"groupName\":null,\"osFamily\":\"linux\",\"scopeLevel\":\"Site\",\"scopeName\":\"Default site\",\"siteName\":\"Default site\",\"username\":\"unknown\"},\"description\":null,\"groupId\":null,\"groupName\":null,\"hash\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"id\":\"1234567890123456789\",\"osFamily\":\"linux\",\"primaryDescription\":\"Cloud added or modified linux blacklist hash.\",\"secondaryDescription\":\"b06930c9809ab5e4cb6659089ac6fcec470c9c16\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"threatId\":null,\"updatedAt\":\"2022-04-06T09:00:33.104735Z\",\"userId\":null}",
                 "type": [
-                    "creation",
-                    "change"
+                    "change",
+                    "creation"
                 ]
             },
             "file": {

--- a/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
@@ -72,10 +72,20 @@ processors:
               }
           }
           if (!eventCategory.isEmpty()) {
-              ctx.event.category = eventCategory;
+              def category = new ArrayList();
+              for (def c: eventCategory) {
+                category.add(c);
+              }
+              Collections.sort(category);
+              ctx.event.category = category;
           }
           if (!eventType.isEmpty()) {
-              ctx.event.type = eventType;
+              def type = new ArrayList();
+              for (def t: eventType) {
+                type.add(t);
+              }
+              Collections.sort(type);
+              ctx.event.type = type;
           }
           if (['suspicious', 'malicious'].contains(ctx.json?.data?.confidenceLevel)) {
               ctx.event.kind = 'alert';

--- a/packages/sentinel_one/data_stream/activity/sample_event.json
+++ b/packages/sentinel_one/data_stream/activity/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-04-05T16:01:56.995Z",
     "agent": {
-        "ephemeral_id": "ae5f82c9-7ac3-4176-8ef4-992f59fc32c2",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "fa8409d5-7599-4d01-a29f-b9375742abc3",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "sentinel_one.activity",
@@ -16,18 +16,18 @@
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "configuration"
         ],
-        "created": "2022-08-17T10:01:51.788Z",
+        "created": "2022-09-26T01:54:28.433Z",
         "dataset": "sentinel_one.activity",
-        "ingested": "2022-08-17T10:01:53Z",
+        "ingested": "2022-09-26T01:54:29Z",
         "kind": "event",
         "original": "{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activityType\":1234,\"agentId\":null,\"agentUpdatedVersion\":null,\"comments\":null,\"createdAt\":\"2022-04-05T16:01:56.995120Z\",\"data\":{\"accountId\":1234567890123456800,\"accountName\":\"Default\",\"fullScopeDetails\":\"Account Default\",\"fullScopeDetailsPath\":\"test/path\",\"groupName\":null,\"scopeLevel\":\"Account\",\"scopeName\":\"Default\",\"siteName\":null,\"username\":\"test user\"},\"description\":null,\"groupId\":null,\"groupName\":null,\"hash\":null,\"id\":\"1234567890123456789\",\"osFamily\":null,\"primaryDescription\":\"created Default account.\",\"secondaryDescription\":null,\"siteId\":null,\"siteName\":null,\"threatId\":null,\"updatedAt\":\"2022-04-05T16:01:56.992136Z\",\"userId\":\"1234567890123456789\"}",
         "type": [

--- a/packages/sentinel_one/data_stream/agent/sample_event.json
+++ b/packages/sentinel_one/data_stream/agent/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-04-07T08:31:47.481Z",
     "agent": {
-        "ephemeral_id": "428efbea-2c83-48fe-8b94-9d7695618d02",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "75ba6397-6106-475c-a560-f92de9e8ce2e",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "sentinel_one.agent",
@@ -16,18 +16,18 @@
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "host"
         ],
-        "created": "2022-08-17T10:02:49.377Z",
+        "created": "2022-09-26T01:55:05.976Z",
         "dataset": "sentinel_one.agent",
-        "ingested": "2022-08-17T10:02:52Z",
+        "ingested": "2022-09-26T01:55:07Z",
         "kind": "event",
         "original": "{\"accountId\":\"12345123451234512345\",\"accountName\":\"Account Name\",\"activeDirectory\":{\"computerDistinguishedName\":null,\"computerMemberOf\":[],\"lastUserDistinguishedName\":null,\"lastUserMemberOf\":[]},\"activeThreats\":7,\"agentVersion\":\"12.x.x.x\",\"allowRemoteShell\":true,\"appsVulnerabilityStatus\":\"not_applicable\",\"cloudProviders\":{},\"computerName\":\"user-test\",\"consoleMigrationStatus\":\"N/A\",\"coreCount\":2,\"cpuCount\":2,\"cpuId\":\"CPU Name\",\"createdAt\":\"2022-03-18T09:12:00.519500Z\",\"detectionState\":null,\"domain\":\"WORKGROUP\",\"encryptedApplications\":false,\"externalId\":\"\",\"externalIp\":\"81.2.69.143\",\"firewallEnabled\":true,\"firstFullModeTime\":null,\"groupId\":\"1234567890123456789\",\"groupIp\":\"81.2.69.x\",\"groupName\":\"Default Group\",\"id\":\"13491234512345\",\"inRemoteShellSession\":false,\"infected\":true,\"installerType\":\".msi\",\"isActive\":true,\"isDecommissioned\":false,\"isPendingUninstall\":false,\"isUninstalled\":false,\"isUpToDate\":true,\"lastActiveDate\":\"2022-03-17T09:51:28.506000Z\",\"lastIpToMgmt\":\"81.2.69.145\",\"lastLoggedInUserName\":\"\",\"licenseKey\":\"\",\"locationEnabled\":true,\"locationType\":\"not_applicable\",\"locations\":null,\"machineType\":\"server\",\"mitigationMode\":\"detect\",\"mitigationModeSuspicious\":\"detect\",\"modelName\":\"Compute Engine\",\"networkInterfaces\":[{\"gatewayIp\":\"81.2.69.145\",\"gatewayMacAddress\":\"00-00-5E-00-53-00\",\"id\":\"1234567890123456789\",\"inet\":[\"81.2.69.144\"],\"inet6\":[\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\"],\"name\":\"Ethernet\",\"physical\":\"00-00-5E-00-53-00\"}],\"networkQuarantineEnabled\":false,\"networkStatus\":\"connected\",\"operationalState\":\"na\",\"operationalStateExpiration\":null,\"osArch\":\"64 bit\",\"osName\":\"Linux Server\",\"osRevision\":\"1234\",\"osStartTime\":\"2022-04-06T08:27:14Z\",\"osType\":\"linux\",\"osUsername\":null,\"rangerStatus\":\"Enabled\",\"rangerVersion\":\"21.x.x.x\",\"registeredAt\":\"2022-04-06T08:26:45.515278Z\",\"remoteProfilingState\":\"disabled\",\"remoteProfilingStateExpiration\":null,\"scanAbortedAt\":null,\"scanFinishedAt\":\"2022-04-06T09:18:21.090855Z\",\"scanStartedAt\":\"2022-04-06T08:26:52.838047Z\",\"scanStatus\":\"finished\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"storageName\":null,\"storageType\":null,\"tags\":{\"sentinelone\":[{\"assignedAt\":\"2018-02-27T04:49:26.257525Z\",\"assignedBy\":\"test-user\",\"assignedById\":\"123456789012345678\",\"id\":\"123456789012345678\",\"key\":\"key123\",\"value\":\"value123\"}]},\"threatRebootRequired\":false,\"totalMemory\":1234,\"updatedAt\":\"2022-04-07T08:31:47.481227Z\",\"userActionsNeeded\":[\"reboot_needed\"],\"uuid\":\"XXX35XXX8Xfb4aX0X1X8X12X343X8X30\"}",
         "type": [

--- a/packages/sentinel_one/data_stream/alert/sample_event.json
+++ b/packages/sentinel_one/data_stream/alert/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2018-02-27T04:49:26.257Z",
     "agent": {
-        "ephemeral_id": "6c1e4a74-ca87-4268-ac4c-b5ce2d6a2df5",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "e13a5cfd-1c28-4abc-b09c-940f6d1dfc6f",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "container": {
         "id": "string",
@@ -38,19 +38,19 @@
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "malware"
         ],
-        "created": "2022-08-17T10:03:47.879Z",
+        "created": "2022-09-26T01:55:44.088Z",
         "dataset": "sentinel_one.alert",
         "id": "123456789123456789",
-        "ingested": "2022-08-17T10:03:51Z",
+        "ingested": "2022-09-26T01:55:47Z",
         "kind": "event",
         "original": "{\"agentDetectionInfo\":{\"machineType\":\"string\",\"name\":\"string\",\"osFamily\":\"string\",\"osName\":\"string\",\"osRevision\":\"string\",\"siteId\":\"123456789123456789\",\"uuid\":\"string\",\"version\":\"3.x.x.x\"},\"alertInfo\":{\"alertId\":\"123456789123456789\",\"analystVerdict\":\"string\",\"createdAt\":\"2018-02-27T04:49:26.257525Z\",\"dnsRequest\":\"string\",\"dnsResponse\":\"string\",\"dstIp\":\"0.0.0.0\",\"dstPort\":\"1234\",\"dvEventId\":\"string\",\"eventType\":\"string\",\"hitType\":\"Events\",\"incidentStatus\":\"string\",\"indicatorCategory\":\"string\",\"indicatorDescription\":\"string\",\"indicatorName\":\"string\",\"loginAccountDomain\":\"string\",\"loginAccountSid\":\"string\",\"loginIsAdministratorEquivalent\":\"string\",\"loginIsSuccessful\":\"string\",\"loginType\":\"string\",\"loginsUserName\":\"string\",\"modulePath\":\"string\",\"moduleSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"netEventDirection\":\"string\",\"registryKeyPath\":\"string\",\"registryOldValue\":\"string\",\"registryOldValueType\":\"string\",\"registryPath\":\"string\",\"registryValue\":\"string\",\"reportedAt\":\"2018-02-27T04:49:26.257525Z\",\"source\":\"string\",\"srcIp\":\"0.0.0.0\",\"srcMachineIp\":\"0.0.0.0\",\"srcPort\":\"string\",\"tiIndicatorComparisonMethod\":\"string\",\"tiIndicatorSource\":\"string\",\"tiIndicatorType\":\"string\",\"tiIndicatorValue\":\"string\",\"updatedAt\":\"2018-02-27T04:49:26.257525Z\"},\"containerInfo\":{\"id\":\"string\",\"image\":\"string\",\"labels\":\"string\",\"name\":\"string\"},\"kubernetesInfo\":{\"cluster\":\"string\",\"controllerKind\":\"string\",\"controllerLabels\":\"string\",\"controllerName\":\"string\",\"namespace\":\"string\",\"namespaceLabels\":\"string\",\"node\":\"string\",\"pod\":\"string\",\"podLabels\":\"string\"},\"ruleInfo\":{\"description\":\"string\",\"id\":\"string\",\"name\":\"string\",\"scopeLevel\":\"string\",\"severity\":\"Low\",\"treatAsThreat\":\"UNDEFINED\"},\"sourceParentProcessInfo\":{\"commandline\":\"string\",\"fileHashMd5\":\"5d41402abc4b2a76b9719d911017c592\",\"fileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"filePath\":\"string\",\"fileSignerIdentity\":\"string\",\"integrityLevel\":\"unknown\",\"name\":\"string\",\"pid\":\"12345\",\"pidStarttime\":\"2018-02-27T04:49:26.257525Z\",\"storyline\":\"string\",\"subsystem\":\"unknown\",\"uniqueId\":\"string\",\"user\":\"string\"},\"sourceProcessInfo\":{\"commandline\":\"string\",\"fileHashMd5\":\"5d41402abc4b2a76b9719d911017c592\",\"fileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"filePath\":\"string\",\"fileSignerIdentity\":\"string\",\"integrityLevel\":\"unknown\",\"name\":\"string\",\"pid\":\"12345\",\"pidStarttime\":\"2018-02-27T04:49:26.257525Z\",\"storyline\":\"string\",\"subsystem\":\"unknown\",\"uniqueId\":\"string\",\"user\":\"string\"},\"targetProcessInfo\":{\"tgtFileCreatedAt\":\"2018-02-27T04:49:26.257525Z\",\"tgtFileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"tgtFileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"tgtFileId\":\"string\",\"tgtFileIsSigned\":\"string\",\"tgtFileModifiedAt\":\"2018-02-27T04:49:26.257525Z\",\"tgtFileOldPath\":\"string\",\"tgtFilePath\":\"string\",\"tgtProcCmdLine\":\"string\",\"tgtProcImagePath\":\"string\",\"tgtProcIntegrityLevel\":\"unknown\",\"tgtProcName\":\"string\",\"tgtProcPid\":\"12345\",\"tgtProcSignedStatus\":\"string\",\"tgtProcStorylineId\":\"string\",\"tgtProcUid\":\"string\",\"tgtProcessStartTime\":\"2018-02-27T04:49:26.257525Z\"}}",
         "type": [

--- a/packages/sentinel_one/data_stream/group/sample_event.json
+++ b/packages/sentinel_one/data_stream/group/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-04-05T16:01:57.564Z",
     "agent": {
-        "ephemeral_id": "a337c798-57fc-4f69-bfdb-8780c09ab04c",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "73e9a896-4008-48cb-8ee4-ac49f5d15e32",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "sentinel_one.group",
@@ -16,18 +16,18 @@
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "iam"
         ],
-        "created": "2022-08-17T10:04:43.707Z",
+        "created": "2022-09-26T01:56:24.112Z",
         "dataset": "sentinel_one.group",
-        "ingested": "2022-08-17T10:04:47Z",
+        "ingested": "2022-09-26T01:56:27Z",
         "kind": "event",
         "original": "{\"createdAt\":\"2022-04-05T16:01:56.928383Z\",\"creator\":\"Test User\",\"creatorId\":\"1234567890123456789\",\"filterId\":null,\"filterName\":null,\"id\":\"1234567890123456789\",\"inherits\":true,\"isDefault\":true,\"name\":\"Default Group\",\"rank\":null,\"registrationToken\":\"eyxxxxxxxxxxxxxxxxxxxxkixZxx1xxxxx8xxx2xODA0ZxxxxTIwNjhxxxxxxxxxxxxxxiMWYxx1Ixxnxxxx0=\",\"siteId\":\"1234567890123456789\",\"totalAgents\":1,\"type\":\"static\",\"updatedAt\":\"2022-04-05T16:01:57.564266Z\"}",
         "type": [

--- a/packages/sentinel_one/data_stream/threat/sample_event.json
+++ b/packages/sentinel_one/data_stream/threat/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-04-06T08:54:17.194Z",
     "agent": {
-        "ephemeral_id": "9325d073-c433-4f92-b589-588d7997d48a",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "7562adce-b104-46d3-bc7b-c9e79060ca40",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "sentinel_one.threat",
@@ -16,9 +16,9 @@
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "action": "SentinelOne Cloud",
@@ -26,9 +26,9 @@
         "category": [
             "malware"
         ],
-        "created": "2022-08-17T10:05:38.379Z",
+        "created": "2022-09-26T01:57:04.978Z",
         "dataset": "sentinel_one.threat",
-        "ingested": "2022-08-17T10:05:41Z",
+        "ingested": "2022-09-26T01:57:08Z",
         "kind": "alert",
         "original": "{\"agentDetectionInfo\":{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"agentDetectionState\":null,\"agentDomain\":\"WORKGROUP\",\"agentIpV4\":\"10.0.0.1\",\"agentIpV6\":\"XX80::7X59:X6X9:9X72:XXXX\",\"agentLastLoggedInUpn\":null,\"agentLastLoggedInUserMail\":null,\"agentLastLoggedInUserName\":\"\",\"agentMitigationMode\":\"protect\",\"agentOsName\":\"linux\",\"agentOsRevision\":\"1234\",\"agentRegisteredAt\":\"2022-04-06T08:26:45.515278Z\",\"agentUuid\":\"fwfbxxxxxxxxxxqcfjfnxxxxxxxxx\",\"agentVersion\":\"21.x.x\",\"cloudProviders\":{},\"externalIp\":\"81.2.69.143\",\"groupId\":\"1234567890123456789\",\"groupName\":\"Default Group\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\"},\"agentRealtimeInfo\":{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activeThreats\":7,\"agentComputerName\":\"test-LINUX\",\"agentDecommissionedAt\":null,\"agentDomain\":\"WORKGROUP\",\"agentId\":\"1234567890123456789\",\"agentInfected\":true,\"agentIsActive\":true,\"agentIsDecommissioned\":false,\"agentMachineType\":\"server\",\"agentMitigationMode\":\"detect\",\"agentNetworkStatus\":\"connected\",\"agentOsName\":\"linux\",\"agentOsRevision\":\"1234\",\"agentOsType\":\"linux\",\"agentUuid\":\"fwfbxxxxxxxxxxqcfjfnxxxxxxxxx\",\"agentVersion\":\"21.x.x.1234\",\"groupId\":\"1234567890123456789\",\"groupName\":\"Default Group\",\"networkInterfaces\":[{\"id\":\"1234567890123456789\",\"inet\":[\"10.0.0.1\"],\"inet6\":[\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\"],\"name\":\"Ethernet\",\"physical\":\"X2:0X:0X:X6:00:XX\"}],\"operationalState\":\"na\",\"rebootRequired\":false,\"scanAbortedAt\":null,\"scanFinishedAt\":\"2022-04-06T09:18:21.090855Z\",\"scanStartedAt\":\"2022-04-06T08:26:52.838047Z\",\"scanStatus\":\"finished\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"storageName\":null,\"storageType\":null,\"userActionsNeeded\":[]},\"containerInfo\":{\"id\":null,\"image\":null,\"labels\":null,\"name\":null},\"id\":\"1234567890123456789\",\"indicators\":[],\"kubernetesInfo\":{\"cluster\":null,\"controllerKind\":null,\"controllerLabels\":null,\"controllerName\":null,\"namespace\":null,\"namespaceLabels\":null,\"node\":null,\"pod\":null,\"podLabels\":null},\"mitigationStatus\":[{\"action\":\"unquarantine\",\"actionsCounters\":{\"failed\":0,\"notFound\":0,\"pendingReboot\":0,\"success\":1,\"total\":1},\"agentSupportsReport\":true,\"groupNotFound\":false,\"lastUpdate\":\"2022-04-06T08:54:17.198002Z\",\"latestReport\":\"/threats/mitigation-report\",\"mitigationEndedAt\":\"2022-04-06T08:54:17.101000Z\",\"mitigationStartedAt\":\"2022-04-06T08:54:17.101000Z\",\"status\":\"success\"},{\"action\":\"kill\",\"actionsCounters\":null,\"agentSupportsReport\":true,\"groupNotFound\":false,\"lastUpdate\":\"2022-04-06T08:45:55.303355Z\",\"latestReport\":null,\"mitigationEndedAt\":\"2022-04-06T08:45:55.297364Z\",\"mitigationStartedAt\":\"2022-04-06T08:45:55.297363Z\",\"status\":\"success\"}],\"threatInfo\":{\"analystVerdict\":\"undefined\",\"analystVerdictDescription\":\"Undefined\",\"automaticallyResolved\":false,\"browserType\":null,\"certificateId\":\"\",\"classification\":\"Trojan\",\"classificationSource\":\"Cloud\",\"cloudFilesHashVerdict\":\"black\",\"collectionId\":\"1234567890123456789\",\"confidenceLevel\":\"malicious\",\"createdAt\":\"2022-04-06T08:45:54.519988Z\",\"detectionEngines\":[{\"key\":\"sentinelone_cloud\",\"title\":\"SentinelOne Cloud\"}],\"detectionType\":\"static\",\"engines\":[\"SentinelOne Cloud\"],\"externalTicketExists\":false,\"externalTicketId\":null,\"failedActions\":false,\"fileExtension\":\"EXE\",\"fileExtensionType\":\"Executable\",\"filePath\":\"default.exe\",\"fileSize\":1234,\"fileVerificationType\":\"NotSigned\",\"identifiedAt\":\"2022-04-06T08:45:53.968000Z\",\"incidentStatus\":\"unresolved\",\"incidentStatusDescription\":\"Unresolved\",\"initiatedBy\":\"agent_policy\",\"initiatedByDescription\":\"Agent Policy\",\"initiatingUserId\":null,\"initiatingUsername\":null,\"isFileless\":false,\"isValidCertificate\":false,\"maliciousProcessArguments\":null,\"md5\":null,\"mitigatedPreemptively\":false,\"mitigationStatus\":\"not_mitigated\",\"mitigationStatusDescription\":\"Not mitigated\",\"originatorProcess\":\"default.exe\",\"pendingActions\":false,\"processUser\":\"test user\",\"publisherName\":\"\",\"reachedEventsLimit\":false,\"rebootRequired\":false,\"sha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"sha256\":null,\"storyline\":\"D0XXXXXXXXXXAF4D\",\"threatId\":\"1234567890123456789\",\"threatName\":\"default.exe\",\"updatedAt\":\"2022-04-06T08:54:17.194122Z\"},\"whiteningOptions\":[\"hash\"]}",
         "type": [

--- a/packages/sentinel_one/docs/README.md
+++ b/packages/sentinel_one/docs/README.md
@@ -31,11 +31,11 @@ An example event for `activity` looks as following:
 {
     "@timestamp": "2022-04-05T16:01:56.995Z",
     "agent": {
-        "ephemeral_id": "ae5f82c9-7ac3-4176-8ef4-992f59fc32c2",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "fa8409d5-7599-4d01-a29f-b9375742abc3",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "sentinel_one.activity",
@@ -46,18 +46,18 @@ An example event for `activity` looks as following:
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "configuration"
         ],
-        "created": "2022-08-17T10:01:51.788Z",
+        "created": "2022-09-26T01:54:28.433Z",
         "dataset": "sentinel_one.activity",
-        "ingested": "2022-08-17T10:01:53Z",
+        "ingested": "2022-09-26T01:54:29Z",
         "kind": "event",
         "original": "{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activityType\":1234,\"agentId\":null,\"agentUpdatedVersion\":null,\"comments\":null,\"createdAt\":\"2022-04-05T16:01:56.995120Z\",\"data\":{\"accountId\":1234567890123456800,\"accountName\":\"Default\",\"fullScopeDetails\":\"Account Default\",\"fullScopeDetailsPath\":\"test/path\",\"groupName\":null,\"scopeLevel\":\"Account\",\"scopeName\":\"Default\",\"siteName\":null,\"username\":\"test user\"},\"description\":null,\"groupId\":null,\"groupName\":null,\"hash\":null,\"id\":\"1234567890123456789\",\"osFamily\":null,\"primaryDescription\":\"created Default account.\",\"secondaryDescription\":null,\"siteId\":null,\"siteName\":null,\"threatId\":null,\"updatedAt\":\"2022-04-05T16:01:56.992136Z\",\"userId\":\"1234567890123456789\"}",
         "type": [
@@ -249,11 +249,11 @@ An example event for `agent` looks as following:
 {
     "@timestamp": "2022-04-07T08:31:47.481Z",
     "agent": {
-        "ephemeral_id": "428efbea-2c83-48fe-8b94-9d7695618d02",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "75ba6397-6106-475c-a560-f92de9e8ce2e",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "sentinel_one.agent",
@@ -264,18 +264,18 @@ An example event for `agent` looks as following:
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "host"
         ],
-        "created": "2022-08-17T10:02:49.377Z",
+        "created": "2022-09-26T01:55:05.976Z",
         "dataset": "sentinel_one.agent",
-        "ingested": "2022-08-17T10:02:52Z",
+        "ingested": "2022-09-26T01:55:07Z",
         "kind": "event",
         "original": "{\"accountId\":\"12345123451234512345\",\"accountName\":\"Account Name\",\"activeDirectory\":{\"computerDistinguishedName\":null,\"computerMemberOf\":[],\"lastUserDistinguishedName\":null,\"lastUserMemberOf\":[]},\"activeThreats\":7,\"agentVersion\":\"12.x.x.x\",\"allowRemoteShell\":true,\"appsVulnerabilityStatus\":\"not_applicable\",\"cloudProviders\":{},\"computerName\":\"user-test\",\"consoleMigrationStatus\":\"N/A\",\"coreCount\":2,\"cpuCount\":2,\"cpuId\":\"CPU Name\",\"createdAt\":\"2022-03-18T09:12:00.519500Z\",\"detectionState\":null,\"domain\":\"WORKGROUP\",\"encryptedApplications\":false,\"externalId\":\"\",\"externalIp\":\"81.2.69.143\",\"firewallEnabled\":true,\"firstFullModeTime\":null,\"groupId\":\"1234567890123456789\",\"groupIp\":\"81.2.69.x\",\"groupName\":\"Default Group\",\"id\":\"13491234512345\",\"inRemoteShellSession\":false,\"infected\":true,\"installerType\":\".msi\",\"isActive\":true,\"isDecommissioned\":false,\"isPendingUninstall\":false,\"isUninstalled\":false,\"isUpToDate\":true,\"lastActiveDate\":\"2022-03-17T09:51:28.506000Z\",\"lastIpToMgmt\":\"81.2.69.145\",\"lastLoggedInUserName\":\"\",\"licenseKey\":\"\",\"locationEnabled\":true,\"locationType\":\"not_applicable\",\"locations\":null,\"machineType\":\"server\",\"mitigationMode\":\"detect\",\"mitigationModeSuspicious\":\"detect\",\"modelName\":\"Compute Engine\",\"networkInterfaces\":[{\"gatewayIp\":\"81.2.69.145\",\"gatewayMacAddress\":\"00-00-5E-00-53-00\",\"id\":\"1234567890123456789\",\"inet\":[\"81.2.69.144\"],\"inet6\":[\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\"],\"name\":\"Ethernet\",\"physical\":\"00-00-5E-00-53-00\"}],\"networkQuarantineEnabled\":false,\"networkStatus\":\"connected\",\"operationalState\":\"na\",\"operationalStateExpiration\":null,\"osArch\":\"64 bit\",\"osName\":\"Linux Server\",\"osRevision\":\"1234\",\"osStartTime\":\"2022-04-06T08:27:14Z\",\"osType\":\"linux\",\"osUsername\":null,\"rangerStatus\":\"Enabled\",\"rangerVersion\":\"21.x.x.x\",\"registeredAt\":\"2022-04-06T08:26:45.515278Z\",\"remoteProfilingState\":\"disabled\",\"remoteProfilingStateExpiration\":null,\"scanAbortedAt\":null,\"scanFinishedAt\":\"2022-04-06T09:18:21.090855Z\",\"scanStartedAt\":\"2022-04-06T08:26:52.838047Z\",\"scanStatus\":\"finished\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"storageName\":null,\"storageType\":null,\"tags\":{\"sentinelone\":[{\"assignedAt\":\"2018-02-27T04:49:26.257525Z\",\"assignedBy\":\"test-user\",\"assignedById\":\"123456789012345678\",\"id\":\"123456789012345678\",\"key\":\"key123\",\"value\":\"value123\"}]},\"threatRebootRequired\":false,\"totalMemory\":1234,\"updatedAt\":\"2022-04-07T08:31:47.481227Z\",\"userActionsNeeded\":[\"reboot_needed\"],\"uuid\":\"XXX35XXX8Xfb4aX0X1X8X12X343X8X30\"}",
         "type": [
@@ -595,11 +595,11 @@ An example event for `alert` looks as following:
 {
     "@timestamp": "2018-02-27T04:49:26.257Z",
     "agent": {
-        "ephemeral_id": "6c1e4a74-ca87-4268-ac4c-b5ce2d6a2df5",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "e13a5cfd-1c28-4abc-b09c-940f6d1dfc6f",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "container": {
         "id": "string",
@@ -632,19 +632,19 @@ An example event for `alert` looks as following:
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "malware"
         ],
-        "created": "2022-08-17T10:03:47.879Z",
+        "created": "2022-09-26T01:55:44.088Z",
         "dataset": "sentinel_one.alert",
         "id": "123456789123456789",
-        "ingested": "2022-08-17T10:03:51Z",
+        "ingested": "2022-09-26T01:55:47Z",
         "kind": "event",
         "original": "{\"agentDetectionInfo\":{\"machineType\":\"string\",\"name\":\"string\",\"osFamily\":\"string\",\"osName\":\"string\",\"osRevision\":\"string\",\"siteId\":\"123456789123456789\",\"uuid\":\"string\",\"version\":\"3.x.x.x\"},\"alertInfo\":{\"alertId\":\"123456789123456789\",\"analystVerdict\":\"string\",\"createdAt\":\"2018-02-27T04:49:26.257525Z\",\"dnsRequest\":\"string\",\"dnsResponse\":\"string\",\"dstIp\":\"0.0.0.0\",\"dstPort\":\"1234\",\"dvEventId\":\"string\",\"eventType\":\"string\",\"hitType\":\"Events\",\"incidentStatus\":\"string\",\"indicatorCategory\":\"string\",\"indicatorDescription\":\"string\",\"indicatorName\":\"string\",\"loginAccountDomain\":\"string\",\"loginAccountSid\":\"string\",\"loginIsAdministratorEquivalent\":\"string\",\"loginIsSuccessful\":\"string\",\"loginType\":\"string\",\"loginsUserName\":\"string\",\"modulePath\":\"string\",\"moduleSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"netEventDirection\":\"string\",\"registryKeyPath\":\"string\",\"registryOldValue\":\"string\",\"registryOldValueType\":\"string\",\"registryPath\":\"string\",\"registryValue\":\"string\",\"reportedAt\":\"2018-02-27T04:49:26.257525Z\",\"source\":\"string\",\"srcIp\":\"0.0.0.0\",\"srcMachineIp\":\"0.0.0.0\",\"srcPort\":\"string\",\"tiIndicatorComparisonMethod\":\"string\",\"tiIndicatorSource\":\"string\",\"tiIndicatorType\":\"string\",\"tiIndicatorValue\":\"string\",\"updatedAt\":\"2018-02-27T04:49:26.257525Z\"},\"containerInfo\":{\"id\":\"string\",\"image\":\"string\",\"labels\":\"string\",\"name\":\"string\"},\"kubernetesInfo\":{\"cluster\":\"string\",\"controllerKind\":\"string\",\"controllerLabels\":\"string\",\"controllerName\":\"string\",\"namespace\":\"string\",\"namespaceLabels\":\"string\",\"node\":\"string\",\"pod\":\"string\",\"podLabels\":\"string\"},\"ruleInfo\":{\"description\":\"string\",\"id\":\"string\",\"name\":\"string\",\"scopeLevel\":\"string\",\"severity\":\"Low\",\"treatAsThreat\":\"UNDEFINED\"},\"sourceParentProcessInfo\":{\"commandline\":\"string\",\"fileHashMd5\":\"5d41402abc4b2a76b9719d911017c592\",\"fileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"filePath\":\"string\",\"fileSignerIdentity\":\"string\",\"integrityLevel\":\"unknown\",\"name\":\"string\",\"pid\":\"12345\",\"pidStarttime\":\"2018-02-27T04:49:26.257525Z\",\"storyline\":\"string\",\"subsystem\":\"unknown\",\"uniqueId\":\"string\",\"user\":\"string\"},\"sourceProcessInfo\":{\"commandline\":\"string\",\"fileHashMd5\":\"5d41402abc4b2a76b9719d911017c592\",\"fileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"fileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"filePath\":\"string\",\"fileSignerIdentity\":\"string\",\"integrityLevel\":\"unknown\",\"name\":\"string\",\"pid\":\"12345\",\"pidStarttime\":\"2018-02-27T04:49:26.257525Z\",\"storyline\":\"string\",\"subsystem\":\"unknown\",\"uniqueId\":\"string\",\"user\":\"string\"},\"targetProcessInfo\":{\"tgtFileCreatedAt\":\"2018-02-27T04:49:26.257525Z\",\"tgtFileHashSha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"tgtFileHashSha256\":\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\",\"tgtFileId\":\"string\",\"tgtFileIsSigned\":\"string\",\"tgtFileModifiedAt\":\"2018-02-27T04:49:26.257525Z\",\"tgtFileOldPath\":\"string\",\"tgtFilePath\":\"string\",\"tgtProcCmdLine\":\"string\",\"tgtProcImagePath\":\"string\",\"tgtProcIntegrityLevel\":\"unknown\",\"tgtProcName\":\"string\",\"tgtProcPid\":\"12345\",\"tgtProcSignedStatus\":\"string\",\"tgtProcStorylineId\":\"string\",\"tgtProcUid\":\"string\",\"tgtProcessStartTime\":\"2018-02-27T04:49:26.257525Z\"}}",
         "type": [
@@ -1042,11 +1042,11 @@ An example event for `group` looks as following:
 {
     "@timestamp": "2022-04-05T16:01:57.564Z",
     "agent": {
-        "ephemeral_id": "a337c798-57fc-4f69-bfdb-8780c09ab04c",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "73e9a896-4008-48cb-8ee4-ac49f5d15e32",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "sentinel_one.group",
@@ -1057,18 +1057,18 @@ An example event for `group` looks as following:
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "iam"
         ],
-        "created": "2022-08-17T10:04:43.707Z",
+        "created": "2022-09-26T01:56:24.112Z",
         "dataset": "sentinel_one.group",
-        "ingested": "2022-08-17T10:04:47Z",
+        "ingested": "2022-09-26T01:56:27Z",
         "kind": "event",
         "original": "{\"createdAt\":\"2022-04-05T16:01:56.928383Z\",\"creator\":\"Test User\",\"creatorId\":\"1234567890123456789\",\"filterId\":null,\"filterName\":null,\"id\":\"1234567890123456789\",\"inherits\":true,\"isDefault\":true,\"name\":\"Default Group\",\"rank\":null,\"registrationToken\":\"eyxxxxxxxxxxxxxxxxxxxxkixZxx1xxxxx8xxx2xODA0ZxxxxTIwNjhxxxxxxxxxxxxxxiMWYxx1Ixxnxxxx0=\",\"siteId\":\"1234567890123456789\",\"totalAgents\":1,\"type\":\"static\",\"updatedAt\":\"2022-04-05T16:01:57.564266Z\"}",
         "type": [
@@ -1195,11 +1195,11 @@ An example event for `threat` looks as following:
 {
     "@timestamp": "2022-04-06T08:54:17.194Z",
     "agent": {
-        "ephemeral_id": "9325d073-c433-4f92-b589-588d7997d48a",
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "ephemeral_id": "7562adce-b104-46d3-bc7b-c9e79060ca40",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "sentinel_one.threat",
@@ -1210,9 +1210,9 @@ An example event for `threat` looks as following:
         "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "bfa179ae-7011-4b14-81a1-5bf0d0eb3c00",
+        "id": "15b19080-249c-49a5-801a-edf25c28dcfe",
         "snapshot": false,
-        "version": "8.1.3"
+        "version": "8.4.1"
     },
     "event": {
         "action": "SentinelOne Cloud",
@@ -1220,9 +1220,9 @@ An example event for `threat` looks as following:
         "category": [
             "malware"
         ],
-        "created": "2022-08-17T10:05:38.379Z",
+        "created": "2022-09-26T01:57:04.978Z",
         "dataset": "sentinel_one.threat",
-        "ingested": "2022-08-17T10:05:41Z",
+        "ingested": "2022-09-26T01:57:08Z",
         "kind": "alert",
         "original": "{\"agentDetectionInfo\":{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"agentDetectionState\":null,\"agentDomain\":\"WORKGROUP\",\"agentIpV4\":\"10.0.0.1\",\"agentIpV6\":\"XX80::7X59:X6X9:9X72:XXXX\",\"agentLastLoggedInUpn\":null,\"agentLastLoggedInUserMail\":null,\"agentLastLoggedInUserName\":\"\",\"agentMitigationMode\":\"protect\",\"agentOsName\":\"linux\",\"agentOsRevision\":\"1234\",\"agentRegisteredAt\":\"2022-04-06T08:26:45.515278Z\",\"agentUuid\":\"fwfbxxxxxxxxxxqcfjfnxxxxxxxxx\",\"agentVersion\":\"21.x.x\",\"cloudProviders\":{},\"externalIp\":\"81.2.69.143\",\"groupId\":\"1234567890123456789\",\"groupName\":\"Default Group\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\"},\"agentRealtimeInfo\":{\"accountId\":\"1234567890123456789\",\"accountName\":\"Default\",\"activeThreats\":7,\"agentComputerName\":\"test-LINUX\",\"agentDecommissionedAt\":null,\"agentDomain\":\"WORKGROUP\",\"agentId\":\"1234567890123456789\",\"agentInfected\":true,\"agentIsActive\":true,\"agentIsDecommissioned\":false,\"agentMachineType\":\"server\",\"agentMitigationMode\":\"detect\",\"agentNetworkStatus\":\"connected\",\"agentOsName\":\"linux\",\"agentOsRevision\":\"1234\",\"agentOsType\":\"linux\",\"agentUuid\":\"fwfbxxxxxxxxxxqcfjfnxxxxxxxxx\",\"agentVersion\":\"21.x.x.1234\",\"groupId\":\"1234567890123456789\",\"groupName\":\"Default Group\",\"networkInterfaces\":[{\"id\":\"1234567890123456789\",\"inet\":[\"10.0.0.1\"],\"inet6\":[\"2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6\"],\"name\":\"Ethernet\",\"physical\":\"X2:0X:0X:X6:00:XX\"}],\"operationalState\":\"na\",\"rebootRequired\":false,\"scanAbortedAt\":null,\"scanFinishedAt\":\"2022-04-06T09:18:21.090855Z\",\"scanStartedAt\":\"2022-04-06T08:26:52.838047Z\",\"scanStatus\":\"finished\",\"siteId\":\"1234567890123456789\",\"siteName\":\"Default site\",\"storageName\":null,\"storageType\":null,\"userActionsNeeded\":[]},\"containerInfo\":{\"id\":null,\"image\":null,\"labels\":null,\"name\":null},\"id\":\"1234567890123456789\",\"indicators\":[],\"kubernetesInfo\":{\"cluster\":null,\"controllerKind\":null,\"controllerLabels\":null,\"controllerName\":null,\"namespace\":null,\"namespaceLabels\":null,\"node\":null,\"pod\":null,\"podLabels\":null},\"mitigationStatus\":[{\"action\":\"unquarantine\",\"actionsCounters\":{\"failed\":0,\"notFound\":0,\"pendingReboot\":0,\"success\":1,\"total\":1},\"agentSupportsReport\":true,\"groupNotFound\":false,\"lastUpdate\":\"2022-04-06T08:54:17.198002Z\",\"latestReport\":\"/threats/mitigation-report\",\"mitigationEndedAt\":\"2022-04-06T08:54:17.101000Z\",\"mitigationStartedAt\":\"2022-04-06T08:54:17.101000Z\",\"status\":\"success\"},{\"action\":\"kill\",\"actionsCounters\":null,\"agentSupportsReport\":true,\"groupNotFound\":false,\"lastUpdate\":\"2022-04-06T08:45:55.303355Z\",\"latestReport\":null,\"mitigationEndedAt\":\"2022-04-06T08:45:55.297364Z\",\"mitigationStartedAt\":\"2022-04-06T08:45:55.297363Z\",\"status\":\"success\"}],\"threatInfo\":{\"analystVerdict\":\"undefined\",\"analystVerdictDescription\":\"Undefined\",\"automaticallyResolved\":false,\"browserType\":null,\"certificateId\":\"\",\"classification\":\"Trojan\",\"classificationSource\":\"Cloud\",\"cloudFilesHashVerdict\":\"black\",\"collectionId\":\"1234567890123456789\",\"confidenceLevel\":\"malicious\",\"createdAt\":\"2022-04-06T08:45:54.519988Z\",\"detectionEngines\":[{\"key\":\"sentinelone_cloud\",\"title\":\"SentinelOne Cloud\"}],\"detectionType\":\"static\",\"engines\":[\"SentinelOne Cloud\"],\"externalTicketExists\":false,\"externalTicketId\":null,\"failedActions\":false,\"fileExtension\":\"EXE\",\"fileExtensionType\":\"Executable\",\"filePath\":\"default.exe\",\"fileSize\":1234,\"fileVerificationType\":\"NotSigned\",\"identifiedAt\":\"2022-04-06T08:45:53.968000Z\",\"incidentStatus\":\"unresolved\",\"incidentStatusDescription\":\"Unresolved\",\"initiatedBy\":\"agent_policy\",\"initiatedByDescription\":\"Agent Policy\",\"initiatingUserId\":null,\"initiatingUsername\":null,\"isFileless\":false,\"isValidCertificate\":false,\"maliciousProcessArguments\":null,\"md5\":null,\"mitigatedPreemptively\":false,\"mitigationStatus\":\"not_mitigated\",\"mitigationStatusDescription\":\"Not mitigated\",\"originatorProcess\":\"default.exe\",\"pendingActions\":false,\"processUser\":\"test user\",\"publisherName\":\"\",\"reachedEventsLimit\":false,\"rebootRequired\":false,\"sha1\":\"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\",\"sha256\":null,\"storyline\":\"D0XXXXXXXXXXAF4D\",\"threatId\":\"1234567890123456789\",\"threatName\":\"default.exe\",\"updatedAt\":\"2022-04-06T08:54:17.194122Z\"},\"whiteningOptions\":[\"hash\"]}",
         "type": [

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sentinel_one
 title: SentinelOne
-version: "1.2.1"
+version: "1.2.2"
 license: basic
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration


### PR DESCRIPTION
There has been a change in behaviour in the set iteration order between v8.3.3 and v8.4.1, so sort the array to ensure a stable order for testing.

In carbon_black the multiple argument appends with allow_duplicates=false also leads to a change in array ordering. The cause for this is less clear, but sort the array to work around the issue.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This ensures that arrays which showed unstable ordering between v8.3.3 and v8.4.1 are consistently ordered explicitly.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
