### PR TITLE
Update kibana logo

### DIFF
--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: "2.0.0"
   changes:
+    - description: Fix logo
+      type: bug
+      link: https://github.com/elastic/integrations/pull/4298
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement
       link: https://github.com/elastic/integrations/pull/4018

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.0.0"
   changes:
     - description: Fix logo
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/4298
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/kibana/img/logo_kibana.svg
+++ b/packages/kibana/img/logo_kibana.svg
@@ -1,7 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
-  <g fill="none" fill-rule="evenodd" transform="translate(4)">
-    <polygon fill="#F04E98" points="0 0 0 28.789 24.935 .017"/>
-    <path class="euiIcon__fillNegative" d="M0,12 L0,28.789 L11.906,15.051 C8.368,13.115 4.317,12 0,12"/>
-    <path fill="#00BFB3" d="M14.4785,16.664 L2.2675,30.754 L1.1945,31.991 L24.3865,31.991 C23.1345,25.699 19.5035,20.272 14.4785,16.664"/>
-  </g>
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11 25.2499V53.5809L31.137 30.3919C25.149 27.1299 18.299 25.2499 11 25.2499Z" fill="#343741"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11 4.99991V25.2499C18.299 25.2499 25.149 27.1299 31.137 30.3919L53.188 4.99991H11Z" fill="#F04E98"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M35.4434 33.059L14.7754 56.86L12.9164 59H52.3414C50.1784 48.342 43.9924 39.149 35.4434 33.059Z" fill="#00BFB3"/>
 </svg>


### PR DESCRIPTION
## What does this PR do?

Replaces the kibana package logo with the one from https://brand.elastic.co/302f66895/p/41ff52-solution-logos/b/14d954/i/11013297

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

It's a little complicated. See https://github.com/elastic/integrations/pull/4175 for instructions.

## Related issues

Closes https://github.com/elastic/integrations/issues/4297

## Screenshots

![Screen Shot 2022-09-26 at 13 24 21](https://user-images.githubusercontent.com/690/192193509-af957e53-e116-4d8c-92e0-4b49703792f4.png)

