### PR TITLE
Add agent.* fields to Elastic Agent ecs mapping

### DIFF
--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/ecs.yml
@@ -1,5 +1,6 @@
 - external: ecs
   name: ecs.version
+
 - name: log
   title: Log
   group: 2
@@ -12,3 +13,51 @@
       ignore_above: 1024
       description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
       example: error
+
+- name: agent
+  title: Agent
+  group: 2
+  description: "The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host."
+  type: group
+  fields:
+    - name: build.original
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Extended build information for the agent."
+      example: "8.4.1 (build: 8d78851925dbcadcc740ef25eeabe3afe67cf0d0 at 2022-08-26 15:23:22 +0000 UTC)"
+
+    - name: ephemeral_id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Ephemeral identifier of this agent (if one exists). This id normally changes across restarts, but `agent.id` does not."
+      example: "1c86fe8e-0368-4ee5-9bd3-6287a26517d0"
+
+    - name: id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Unique identifier of this agent (if one exists)."
+      example: "77026265-6097-4cc4-9518-bc64c3b7de5b"
+
+    - name: name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Custom name of the agent."
+      example: "myagent"
+
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Type of the agent."
+      example: "myagent"
+
+    - name: version
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Version of the agent."
+      example: "8.5.0"

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/ecs.yml
@@ -1,63 +1,18 @@
-- external: ecs
-  name: ecs.version
+- name: ecs.version
+  external: ecs
 
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
 
-- name: agent
-  title: Agent
-  group: 2
-  description: "The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host."
-  type: group
-  fields:
-    - name: build.original
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Extended build information for the agent."
-      example: "8.4.1 (build: 8d78851925dbcadcc740ef25eeabe3afe67cf0d0 at 2022-08-26 15:23:22 +0000 UTC)"
-
-    - name: ephemeral_id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Ephemeral identifier of this agent (if one exists). This id normally changes across restarts, but `agent.id` does not."
-      example: "1c86fe8e-0368-4ee5-9bd3-6287a26517d0"
-
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique identifier of this agent (if one exists)."
-      example: "77026265-6097-4cc4-9518-bc64c3b7de5b"
-
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Custom name of the agent."
-      example: "myagent"
-
-    - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of the agent."
-      example: "myagent"
-
-    - name: version
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Version of the agent."
-      example: "8.5.0"
+- name: log.level
+  external: ecs


### PR DESCRIPTION
## What does this PR do?

Adds the `agent.*` filed to the Elastic Agent ECS mapping. The mappings are taken from [filebeat](https://github.com/elastic/beats/blob/6a669aac5d95a42b7d6bfaf13d14c79b7fc94361/libbeat/ecs/agent.go#L26).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Install the Elastic Agent integration and verify the fileds `agent.*` in the `logs-*` index are indexed.


## Related issues

- Closes #4191

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
