### PR TITLE
add threa_intel category to ti_cif3 integrations

### DIFF
--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Labelling with Threat Intelligence category
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4304
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,13 +1,14 @@
 format_version: 1.0.0
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: 0.1.0
+version: 0.2.0
 release: beta
 license: basic
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."
 type: integration
 categories:
   - security
+  - threat_intel
 conditions:
   kibana.version: "^8.0.0"
 icons:


### PR DESCRIPTION
## What does this PR do?
Tag Collective Intelligence Framework v3 integration with `threat_intel` category so it appears under Threat Intelligence category

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

