### PR TITLE
[auth0] - update ECS to 8.5.0 from 8.4.0

### DIFF
--- a/packages/auth0/_dev/build/build.yml
+++ b/packages/auth0/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.4.0-rc1
+    reference: git@v8.5.0-rc1

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Update package to ECS 8.5.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4285
 - version: "1.2.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-failure.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-failure.json-expected.json
@@ -38,7 +38,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "failed-login",
@@ -124,7 +124,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "failed-login",
@@ -211,7 +211,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "failed-login",
@@ -284,7 +284,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "invalid-username-or-email",
@@ -360,7 +360,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "incorrect-password",

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-login-success.json-expected.json
@@ -61,7 +61,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -189,7 +189,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -264,7 +264,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -390,7 +390,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -516,7 +516,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -630,7 +630,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -744,7 +744,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -858,7 +858,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -935,7 +935,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1051,7 +1051,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1179,7 +1179,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1295,7 +1295,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1411,7 +1411,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1527,7 +1527,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1643,7 +1643,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1759,7 +1759,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1875,7 +1875,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -1991,7 +1991,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -2107,7 +2107,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -2223,7 +2223,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -2351,7 +2351,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",
@@ -2479,7 +2479,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "successful-login",

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-logout-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-logout-success.json-expected.json
@@ -24,7 +24,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "user-logout-successful",
@@ -101,7 +101,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "user-logout-successful",
@@ -178,7 +178,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "user-logout-successful",

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-mgmt-api-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-mgmt-api-success.json-expected.json
@@ -54,7 +54,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -169,7 +169,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -309,7 +309,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -680,7 +680,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -780,7 +780,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -939,7 +939,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -1178,7 +1178,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -1280,7 +1280,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -1519,7 +1519,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -1623,7 +1623,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -1733,7 +1733,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -1972,7 +1972,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -2211,7 +2211,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -2320,7 +2320,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -2435,7 +2435,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -2544,7 +2544,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -2646,7 +2646,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -2761,7 +2761,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -2870,7 +2870,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -2972,7 +2972,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3065,7 +3065,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3175,7 +3175,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3284,7 +3284,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3377,7 +3377,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3487,7 +3487,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3580,7 +3580,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3690,7 +3690,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3805,7 +3805,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -3907,7 +3907,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -4006,7 +4006,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -4122,7 +4122,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -4361,7 +4361,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -4459,7 +4459,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -4688,7 +4688,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -4913,7 +4913,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -5013,7 +5013,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -5115,7 +5115,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -5223,7 +5223,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -5331,7 +5331,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -5433,7 +5433,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op",
@@ -5538,7 +5538,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op-secrets-returned",
@@ -5639,7 +5639,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-mgmt-api-op-secrets-returned",

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-signup-failure.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-signup-failure.json-expected.json
@@ -72,7 +72,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "user-signup-failed",

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-signup-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-signup-success.json-expected.json
@@ -27,7 +27,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-signup",
@@ -101,7 +101,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-signup",
@@ -181,7 +181,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-signup",
@@ -255,7 +255,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-signup",
@@ -329,7 +329,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-signup",

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-token-xchg-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-token-xchg-success.json-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -88,7 +88,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -158,7 +158,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -228,7 +228,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -298,7 +298,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -368,7 +368,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -438,7 +438,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -508,7 +508,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -578,7 +578,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -648,7 +648,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -718,7 +718,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -788,7 +788,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -858,7 +858,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -928,7 +928,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -998,7 +998,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -1068,7 +1068,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -1138,7 +1138,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -1208,7 +1208,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -1278,7 +1278,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -1348,7 +1348,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",
@@ -1418,7 +1418,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "success-exchange-auth-code-for-access-token",

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-user-behaviour-fail.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-user-behaviour-fail.json-expected.json
@@ -20,7 +20,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "failed-to-send-email-notification",
@@ -58,7 +58,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "failed-to-send-email-notification",

--- a/packages/auth0/data_stream/logs/_dev/test/pipeline/test-user-behaviour-success.json-expected.json
+++ b/packages/auth0/data_stream/logs/_dev/test/pipeline/test-user-behaviour-success.json-expected.json
@@ -35,7 +35,7 @@
                 }
             },
             "ecs": {
-                "version": "8.4.0"
+                "version": "8.5.0"
             },
             "event": {
                 "action": "sent-verification-email",

--- a/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for processing Auth0 log stream events
 processors:
 - set:
     field: ecs.version
-    value: '8.4.0'
+    value: '8.5.0'
 - set:
     field: auth0.logs.data
     copy_from: json.data

--- a/packages/auth0/data_stream/logs/sample_event.json
+++ b/packages/auth0/data_stream/logs/sample_event.json
@@ -84,7 +84,7 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.5.0"
     },
     "elastic_agent": {
         "id": "38ed1ea2-8c9a-4d5a-81ee-826cead96859",

--- a/packages/auth0/data_stream/logs/sample_event.json
+++ b/packages/auth0/data_stream/logs/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2021-11-03T03:25:28.923Z",
     "agent": {
-        "ephemeral_id": "3c2232a0-df0e-48e0-8440-96d5500ce25c",
-        "hostname": "docker-fleet-agent",
-        "id": "38ed1ea2-8c9a-4d5a-81ee-826cead96859",
+        "ephemeral_id": "a11436d9-8ad1-4822-86f9-9218bc972cd9",
+        "id": "95de1bcd-72e1-4790-8a3a-0e1890f86f92",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.16.2"
+        "version": "8.4.1"
     },
     "auth0": {
         "logs": {
@@ -87,9 +86,9 @@
         "version": "8.5.0"
     },
     "elastic_agent": {
-        "id": "38ed1ea2-8c9a-4d5a-81ee-826cead96859",
+        "id": "95de1bcd-72e1-4790-8a3a-0e1890f86f92",
         "snapshot": false,
-        "version": "7.16.2"
+        "version": "8.4.1"
     },
     "event": {
         "action": "successful-login",
@@ -100,7 +99,7 @@
         ],
         "dataset": "auth0.logs",
         "id": "90020211103032530111223343147286033102509916061341581378",
-        "ingested": "2022-01-20T05:57:05Z",
+        "ingested": "2022-09-27T04:10:28Z",
         "kind": "event",
         "original": "{\"data\":{\"client_id\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\",\"client_name\":\"Default App\",\"connection\":\"Username-Password-Authentication\",\"connection_id\":\"con_1a5wCUmAs6VOU17n\",\"date\":\"2021-11-03T03:25:28.923Z\",\"details\":{\"completedAt\":1635909928922,\"elapsedTime\":1110091,\"initiatedAt\":1635908818831,\"prompts\":[{\"completedAt\":1635909903693,\"connection\":\"Username-Password-Authentication\",\"connection_id\":\"con_1a5wCUmAs6VOU17n\",\"elapsedTime\":null,\"identity\":\"6182002f34f4dd006b05b5c7\",\"name\":\"prompt-authenticate\",\"stats\":{\"loginsCount\":1},\"strategy\":\"auth0\"},{\"completedAt\":1635909903745,\"elapsedTime\":1084902,\"flow\":\"universal-login\",\"initiatedAt\":1635908818843,\"name\":\"login\",\"timers\":{\"rules\":5},\"user_id\":\"auth0|6182002f34f4dd006b05b5c7\",\"user_name\":\"neo@test.com\"},{\"completedAt\":1635909928352,\"elapsedTime\":23378,\"flow\":\"consent\",\"grantInfo\":{\"audience\":\"https://dev-yoj8axza.au.auth0.com/userinfo\",\"expiration\":null,\"id\":\"618201284369c9b4f9cd6d52\",\"scope\":\"openid profile\"},\"initiatedAt\":1635909904974,\"name\":\"consent\"}],\"session_id\":\"1TAd-7tsPYzxWudzqfHYXN0e6q1D0GSc\",\"stats\":{\"loginsCount\":1}},\"hostname\":\"dev-yoj8axza.au.auth0.com\",\"ip\":\"81.2.69.143\",\"log_id\":\"90020211103032530111223343147286033102509916061341581378\",\"strategy\":\"auth0\",\"strategy_type\":\"database\",\"type\":\"s\",\"user_agent\":\"Mozilla/5.0 (X11;Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0\",\"user_id\":\"auth0|6182002f34f4dd006b05b5c7\",\"user_name\":\"neo@test.com\"},\"log_id\":\"90020211103032530111223343147286033102509916061341581378\"}",
         "outcome": "success",

--- a/packages/auth0/docs/README.md
+++ b/packages/auth0/docs/README.md
@@ -174,12 +174,11 @@ An example event for `logs` looks as following:
 {
     "@timestamp": "2021-11-03T03:25:28.923Z",
     "agent": {
-        "ephemeral_id": "3c2232a0-df0e-48e0-8440-96d5500ce25c",
-        "hostname": "docker-fleet-agent",
-        "id": "38ed1ea2-8c9a-4d5a-81ee-826cead96859",
+        "ephemeral_id": "a11436d9-8ad1-4822-86f9-9218bc972cd9",
+        "id": "95de1bcd-72e1-4790-8a3a-0e1890f86f92",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.16.2"
+        "version": "8.4.1"
     },
     "auth0": {
         "logs": {
@@ -260,9 +259,9 @@ An example event for `logs` looks as following:
         "version": "8.5.0"
     },
     "elastic_agent": {
-        "id": "38ed1ea2-8c9a-4d5a-81ee-826cead96859",
+        "id": "95de1bcd-72e1-4790-8a3a-0e1890f86f92",
         "snapshot": false,
-        "version": "7.16.2"
+        "version": "8.4.1"
     },
     "event": {
         "action": "successful-login",
@@ -273,7 +272,7 @@ An example event for `logs` looks as following:
         ],
         "dataset": "auth0.logs",
         "id": "90020211103032530111223343147286033102509916061341581378",
-        "ingested": "2022-01-20T05:57:05Z",
+        "ingested": "2022-09-27T04:10:28Z",
         "kind": "event",
         "original": "{\"data\":{\"client_id\":\"aI61p8I8aFjmYRliLWgvM9ev97kCCNDB\",\"client_name\":\"Default App\",\"connection\":\"Username-Password-Authentication\",\"connection_id\":\"con_1a5wCUmAs6VOU17n\",\"date\":\"2021-11-03T03:25:28.923Z\",\"details\":{\"completedAt\":1635909928922,\"elapsedTime\":1110091,\"initiatedAt\":1635908818831,\"prompts\":[{\"completedAt\":1635909903693,\"connection\":\"Username-Password-Authentication\",\"connection_id\":\"con_1a5wCUmAs6VOU17n\",\"elapsedTime\":null,\"identity\":\"6182002f34f4dd006b05b5c7\",\"name\":\"prompt-authenticate\",\"stats\":{\"loginsCount\":1},\"strategy\":\"auth0\"},{\"completedAt\":1635909903745,\"elapsedTime\":1084902,\"flow\":\"universal-login\",\"initiatedAt\":1635908818843,\"name\":\"login\",\"timers\":{\"rules\":5},\"user_id\":\"auth0|6182002f34f4dd006b05b5c7\",\"user_name\":\"neo@test.com\"},{\"completedAt\":1635909928352,\"elapsedTime\":23378,\"flow\":\"consent\",\"grantInfo\":{\"audience\":\"https://dev-yoj8axza.au.auth0.com/userinfo\",\"expiration\":null,\"id\":\"618201284369c9b4f9cd6d52\",\"scope\":\"openid profile\"},\"initiatedAt\":1635909904974,\"name\":\"consent\"}],\"session_id\":\"1TAd-7tsPYzxWudzqfHYXN0e6q1D0GSc\",\"stats\":{\"loginsCount\":1}},\"hostname\":\"dev-yoj8axza.au.auth0.com\",\"ip\":\"81.2.69.143\",\"log_id\":\"90020211103032530111223343147286033102509916061341581378\",\"strategy\":\"auth0\",\"strategy_type\":\"database\",\"type\":\"s\",\"user_agent\":\"Mozilla/5.0 (X11;Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0\",\"user_id\":\"auth0|6182002f34f4dd006b05b5c7\",\"user_name\":\"neo@test.com\"},\"log_id\":\"90020211103032530111223343147286033102509916061341581378\"}",
         "outcome": "success",

--- a/packages/auth0/docs/README.md
+++ b/packages/auth0/docs/README.md
@@ -71,7 +71,7 @@ The Auth0 logs dataset provides events from Auth0 log stream. All Auth0 log even
 | auth0.logs.data.location_info.latitude | Global latitude (horizontal) position. | keyword |
 | auth0.logs.data.location_info.longitude | Global longitude (vertical) position. | keyword |
 | auth0.logs.data.location_info.time_zone | Time zone name as found in the [tz database](https://www.iana.org/time-zones). | keyword |
-| auth0.logs.data.log_id | Unique ID of the event. | keyword |
+| auth0.logs.data.log_id | Unique log event identifier | keyword |
 | auth0.logs.data.login.completedAt | Time at which the operation was completed | date |
 | auth0.logs.data.login.elapsedTime | Number of milliseconds the operation took to complete. | long |
 | auth0.logs.data.login.initiatedAt | Time at which the operation was initiated | date |
@@ -257,7 +257,7 @@ An example event for `logs` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.5.0"
     },
     "elastic_agent": {
         "id": "38ed1ea2-8c9a-4d5a-81ee-826cead96859",

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: auth0
 title: "Auth0"
-version: 1.2.1
+version: "1.3.0"
 license: basic
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration


### PR DESCRIPTION
EXPERIMENT DO NOT MERGE

This updates the auth0 integration to ECS 8.5.0.
It was referencing elastic/ecs git@v8.4.0-rc1 and using 8.4.0 in ingest pipelines.

[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@v0.0.0-20220627230044-6efa1ecb3871 -ecs-version=8.5.0 -ecs-git-ref=v8.5.0-rc1 -pr=4285 packages/auth0

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
