### PR TITLE
[Synthetics] project fields for lightweight monitors

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adds project fields for lightweight monitors
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/3998
+      link: https://github.com/elastic/integrations/pull/4326
 - version: "0.10.2"
   changes:
     - description: Adjusts ids for project monitors and add playwright_options

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.3"
+  changes:
+    - description: Adds project fields for lightweight monitors
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3998
 - version: "0.10.2"
   changes:
     - description: Adjusts ids for project monitors and add playwright_options

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -80,3 +80,9 @@ processors:
         {{#if run_once}}
         run_once: {{run_once}}
         {{/if}}
+        {{#if monitor.project.name}}
+        monitor.project.name: {{monitor.project.name}}
+        {{/if}}
+        {{#if monitor.project.id}}
+        monitor.project.id: {{monitor.project.id}}
+        {{/if}}

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -224,3 +224,15 @@ streams:
         multi: false
         required: false
         show_user: false
+      - name: monitor.project.id
+        type: text
+        title: Project id
+        multi: false
+        required: false
+        show_user: true
+      - name: monitor.project.name
+        type: text
+        title: Project id
+        multi: false
+        required: false
+        show_user: true

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -32,3 +32,9 @@ processors:
         {{#if run_once}}
         run_once: {{run_once}}
         {{/if}}
+        {{#if monitor.project.name}}
+        monitor.project.name: {{monitor.project.name}}
+        {{/if}}
+        {{#if monitor.project.id}}
+        monitor.project.id: {{monitor.project.id}}
+        {{/if}}

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -117,3 +117,15 @@ streams:
         multi: false
         required: false
         show_user: false
+      - name: monitor.project.id
+        type: text
+        title: Project id
+        multi: false
+        required: false
+        show_user: true
+      - name: monitor.project.name
+        type: text
+        title: Project id
+        multi: false
+        required: false
+        show_user: true

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -59,3 +59,9 @@ processors:
         {{#if run_once}}
         run_once: {{run_once}}
         {{/if}}
+        {{#if monitor.project.name}}
+        monitor.project.name: {{monitor.project.name}}
+        {{/if}}
+        {{#if monitor.project.id}}
+        monitor.project.id: {{monitor.project.id}}
+        {{/if}}

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -171,3 +171,15 @@ streams:
         multi: false
         required: false
         show_user: false
+      - name: monitor.project.id
+        type: text
+        title: Project id
+        multi: false
+        required: false
+        show_user: true
+      - name: monitor.project.name
+        type: text
+        title: Project id
+        multi: false
+        required: false
+        show_user: true

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.10.2
+version: 0.10.3
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration
@@ -25,7 +25,7 @@ policy_templates:
         title: Browser
         description: Perform an Browser check
 conditions:
-  kibana.version: "^8.4.0"
+  kibana.version: "^8.5.0"
 icons:
   - src: /img/uptime-logo-color-64px.svg
     size: 16x16


### PR DESCRIPTION
Adds project fields to lightweight project monitors via processors.

<img width="566" alt="Screen Shot 2022-09-29 at 1 23 35 PM" src="https://user-images.githubusercontent.com/11356435/193102231-06753f85-24df-4c6b-8d7b-d852927bd33d.png">

### Testing
1. Pull down this PR
2. `cd packages/synthetics`
3. `elastic-package clean`
4. `elastic-package build`
5. `elastic-package stack up --version 8.5.0-SNAPSHOT -v`
6. Navigate to Uptime. Create a private location with the elastic-package agent policy
7. In your terminal, run `npx @elastic/synthetics init` to init a new synthetics testing directory, or update an existing testing directory to by updating `synthetics.config.ts` to use `https://localhost:5601` and update private locations to include your new private location. 
8. In your `journeys` directory within your synthetics tests, add the following lightweight monitors in a `heartbeat.yml` file
```
heartbeat.monitors:
- type: icmp
  id: stuff
  name: Cloudflare DNS
  hosts: ["1.1.1.1"]
  tags: ["service:dns", "org:cloudflare"]
- type: http
  name: A name
  id: http-monitor-with-host
  urls: ["http://www.doordash.com"] 
  tags: ["service:dns", "org:cloudflare"]
- type: tcp
  id: gmail-smtp
  name: GMail SMTP
  hosts: ["smtp.gmail.com:587"]
  tags: ["service:smtp", "org:google"]
```
10. Run `eval "$(elastic-package stack shellinit)" && export NODE_EXTRA_CA_CERTS=${ELASTIC_PACKAGE_CA_CERT}` within the synthetics directory
11. Navigate to Uptime Monitor Management. Generate an api key
12. In the synthetics directory, run `SYNTHETICS_API_KEY={THEAPIKEY} npm run push`
13. In Uptime, confirm that the project fields exist on the resulting documents, either in discover or dev tools