### PR TITLE
carbonblack_edr,checkpoint,cisco_umbrella,gcp,zeek: remove duplicate fields and fix types

### DIFF
--- a/packages/carbonblack_edr/changelog.yml
+++ b/packages/carbonblack_edr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Remove duplicate field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4339
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/carbonblack_edr/data_stream/log/fields/agent.yml
+++ b/packages/carbonblack_edr/data_stream/log/fields/agent.yml
@@ -46,13 +46,6 @@
       type: keyword
       ignore_above: 1024
       description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
     - name: os.family
       level: extended
       type: keyword
@@ -65,17 +58,6 @@
       ignore_above: 1024
       description: Operating system kernel version as a raw string.
       example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
     - name: os.platform
       level: extended
       type: keyword

--- a/packages/carbonblack_edr/manifest.yml
+++ b/packages/carbonblack_edr/manifest.yml
@@ -1,6 +1,6 @@
 name: carbonblack_edr
 title: VMware Carbon Black EDR
-version: "1.5.0"
+version: "1.5.1"
 release: ga
 description: Collect logs from VMware Carbon Black EDR with Elastic Agent.
 type: integration

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.2"
+  changes:
+    - description: Remove duplicate field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/4339
 - version: "1.8.1"
   changes:
     - description: Use ECS geo.location definition.
@@ -33,7 +38,7 @@
   changes:
     - description: Update Checkpoint logo.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/3557
 - version: "1.5.0"
   changes:
     - description: Add TLS and custom options support to TCP input.

--- a/packages/checkpoint/data_stream/firewall/fields/agent.yml
+++ b/packages/checkpoint/data_stream/firewall/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -116,11 +111,6 @@
       type: keyword
       ignore_above: 1024
       description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
     - name: os.family
       level: extended
       type: keyword
@@ -133,29 +123,12 @@
       ignore_above: 1024
       description: Operating system kernel version as a raw string.
       example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
     - name: os.platform
       level: extended
       type: keyword
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
-    - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
     - name: type
       level: core
       type: keyword

--- a/packages/checkpoint/docs/README.md
+++ b/packages/checkpoint/docs/README.md
@@ -597,7 +597,7 @@ An example event for `firewall` looks as following:
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
 | host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
+| host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: checkpoint
 title: Check Point
-version: "1.8.1"
+version: "1.8.2"
 release: ga
 description: Collect logs from Check Point with Elastic Agent.
 type: integration

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.2"
+  changes:
+    - description: Remove duplicate field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4339
 - version: "1.4.1"
   changes:
     - description: Remove hint for cisco managed s3 Bucket List Prefix

--- a/packages/cisco_umbrella/data_stream/log/fields/agent.yml
+++ b/packages/cisco_umbrella/data_stream/log/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -105,13 +100,6 @@
         For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
       example: CONTOSO
       default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
     - name: id
       level: core
       type: keyword
@@ -121,22 +109,6 @@
         As hostname is not always unique, use values that are meaningful in your environment.
 
         Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
-    - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
     - name: os.family
       level: extended
       type: keyword

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_umbrella
 title: Cisco Umbrella
-version: "1.4.1"
+version: "1.4.2"
 license: basic
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.8"
+  changes:
+    - description: Remove duplicate fields and fix types.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4339
 - version: "2.11.7"
   changes:
     - description: Move Dataproc lightweight module config into integration

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.11.8"
   changes:
-    - description: Remove duplicate fields and fix types.
+    - description: Remove duplicate fields.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/4339
 - version: "2.11.7"

--- a/packages/gcp/data_stream/audit/fields/fields.yml
+++ b/packages/gcp/data_stream/audit/fields/fields.yml
@@ -18,7 +18,7 @@
           type: keyword
           description: "String representation of identity of requesting party. Populated for both first and third party identities. Only present for APIs that support third-party identities."
     - name: authorization_info
-      type: group
+      type: array
       description: |
         Authorization information for the operation.
       fields:
@@ -97,7 +97,7 @@
       type: group
       fields:
         - name: current_locations
-          type: keyword
+          type: array
           description: |
             Current locations of the resource.
     - name: service_name

--- a/packages/gcp/data_stream/audit/fields/fields.yml
+++ b/packages/gcp/data_stream/audit/fields/fields.yml
@@ -18,7 +18,7 @@
           type: keyword
           description: "String representation of identity of requesting party. Populated for both first and third party identities. Only present for APIs that support third-party identities."
     - name: authorization_info
-      type: array
+      type: group
       description: |
         Authorization information for the operation.
       fields:
@@ -97,7 +97,7 @@
       type: group
       fields:
         - name: current_locations
-          type: array
+          type: keyword
           description: |
             Current locations of the resource.
     - name: service_name

--- a/packages/gcp/data_stream/billing/fields/agent.yml
+++ b/packages/gcp/data_stream/billing/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/data_stream/compute/fields/agent.yml
+++ b/packages/gcp/data_stream/compute/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an GCP Compute VM and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/data_stream/dataproc/fields/agent.yml
+++ b/packages/gcp/data_stream/dataproc/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an GCP Compute VM and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/data_stream/firestore/fields/agent.yml
+++ b/packages/gcp/data_stream/firestore/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an GCP Compute VM and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/data_stream/firewall/fields/fields.yml
+++ b/packages/gcp/data_stream/firewall/fields/fields.yml
@@ -31,7 +31,7 @@
           description: |
             List of all the target tags that the firewall rule applies to.
         - name: ip_port_info
-          type: array
+          type: keyword
           description: |
             List of ip protocols and applicable port ranges for rules.
         - name: source_service_account

--- a/packages/gcp/data_stream/firewall/fields/fields.yml
+++ b/packages/gcp/data_stream/firewall/fields/fields.yml
@@ -31,7 +31,7 @@
           description: |
             List of all the target tags that the firewall rule applies to.
         - name: ip_port_info
-          type: keyword
+          type: array
           description: |
             List of ip protocols and applicable port ranges for rules.
         - name: source_service_account

--- a/packages/gcp/data_stream/gke/fields/agent.yml
+++ b/packages/gcp/data_stream/gke/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an GCP Compute VM and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/data_stream/loadbalancing_logs/fields/ecs.yml
+++ b/packages/gcp/data_stream/loadbalancing_logs/fields/ecs.yml
@@ -61,19 +61,11 @@
 - external: ecs
   name: user_agent.device.name
 - external: ecs
-  name: user_agent.device.name
-- external: ecs
   name: user_agent.name
-- external: ecs
-  name: user_agent.name
-- external: ecs
-  name: user_agent.original
 - external: ecs
   name: user_agent.original
 - external: ecs
   name: user_agent.os.full
-- external: ecs
-  name: user_agent.os.name
 - external: ecs
   name: user_agent.os.name
 - external: ecs

--- a/packages/gcp/data_stream/loadbalancing_metrics/fields/agent.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an GCP Compute VM and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/data_stream/pubsub/fields/agent.yml
+++ b/packages/gcp/data_stream/pubsub/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an GCP Compute VM and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/data_stream/storage/fields/agent.yml
+++ b/packages/gcp/data_stream/storage/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an GCP Compute VM and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/docs/README.md
+++ b/packages/gcp/docs/README.md
@@ -233,7 +233,7 @@ The `audit` dataset collects audit logs of administrative activities and accesse
 | gcp.audit.request_metadata.caller_ip | The IP address of the caller. | ip |
 | gcp.audit.request_metadata.caller_supplied_user_agent | The user agent of the caller. This information is not authenticated and  should be treated accordingly. | keyword |
 | gcp.audit.request_metadata.raw.caller_ip | The raw IP address of the caller. | keyword |
-| gcp.audit.resource_location.current_locations | Current locations of the resource. | array |
+| gcp.audit.resource_location.current_locations | Current locations of the resource. | keyword |
 | gcp.audit.resource_name | The resource or collection that is the target of the operation.  The name is a scheme-less URI, not including the API service name.  For example, 'shelves/SHELF_ID/books'. | keyword |
 | gcp.audit.response |  | flattened |
 | gcp.audit.service_name | The name of the API service performing the operation.  For example, datastore.googleapis.com. | keyword |
@@ -502,7 +502,7 @@ The `firewall` dataset collects logs from Firewall Rules in your Virtual Private
 | gcp.firewall.rule_details.action | Action that the rule performs on match. | keyword |
 | gcp.firewall.rule_details.destination_range | List of destination ranges that the firewall applies to. | keyword |
 | gcp.firewall.rule_details.direction | Direction of traffic that matches this rule. | keyword |
-| gcp.firewall.rule_details.ip_port_info | List of ip protocols and applicable port ranges for rules. | array |
+| gcp.firewall.rule_details.ip_port_info | List of ip protocols and applicable port ranges for rules. | keyword |
 | gcp.firewall.rule_details.priority | The priority for the firewall rule. | long |
 | gcp.firewall.rule_details.reference | Reference to the firewall rule. | keyword |
 | gcp.firewall.rule_details.source_range | List of source ranges that the firewall rule applies to. | keyword |
@@ -1162,14 +1162,14 @@ The `billing` dataset collects GCP Billing information from Google Cloud BigQuer
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -1260,14 +1260,14 @@ The `compute` dataset is designed to fetch metrics for [Compute Engine](https://
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -1426,7 +1426,7 @@ The `firestore` dataset fetches metrics from [Firestore](https://cloud.google.co
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |

--- a/packages/gcp/docs/README.md
+++ b/packages/gcp/docs/README.md
@@ -233,7 +233,7 @@ The `audit` dataset collects audit logs of administrative activities and accesse
 | gcp.audit.request_metadata.caller_ip | The IP address of the caller. | ip |
 | gcp.audit.request_metadata.caller_supplied_user_agent | The user agent of the caller. This information is not authenticated and  should be treated accordingly. | keyword |
 | gcp.audit.request_metadata.raw.caller_ip | The raw IP address of the caller. | keyword |
-| gcp.audit.resource_location.current_locations | Current locations of the resource. | keyword |
+| gcp.audit.resource_location.current_locations | Current locations of the resource. | array |
 | gcp.audit.resource_name | The resource or collection that is the target of the operation.  The name is a scheme-less URI, not including the API service name.  For example, 'shelves/SHELF_ID/books'. | keyword |
 | gcp.audit.response |  | flattened |
 | gcp.audit.service_name | The name of the API service performing the operation.  For example, datastore.googleapis.com. | keyword |
@@ -502,7 +502,7 @@ The `firewall` dataset collects logs from Firewall Rules in your Virtual Private
 | gcp.firewall.rule_details.action | Action that the rule performs on match. | keyword |
 | gcp.firewall.rule_details.destination_range | List of destination ranges that the firewall applies to. | keyword |
 | gcp.firewall.rule_details.direction | Direction of traffic that matches this rule. | keyword |
-| gcp.firewall.rule_details.ip_port_info | List of ip protocols and applicable port ranges for rules. | keyword |
+| gcp.firewall.rule_details.ip_port_info | List of ip protocols and applicable port ranges for rules. | array |
 | gcp.firewall.rule_details.priority | The priority for the firewall rule. | long |
 | gcp.firewall.rule_details.reference | Reference to the firewall rule. | keyword |
 | gcp.firewall.rule_details.source_range | List of source ranges that the firewall rule applies to. | keyword |

--- a/packages/gcp/docs/audit.md
+++ b/packages/gcp/docs/audit.md
@@ -60,7 +60,7 @@ The `audit` dataset collects audit logs of administrative activities and accesse
 | gcp.audit.request_metadata.caller_ip | The IP address of the caller. | ip |
 | gcp.audit.request_metadata.caller_supplied_user_agent | The user agent of the caller. This information is not authenticated and  should be treated accordingly. | keyword |
 | gcp.audit.request_metadata.raw.caller_ip | The raw IP address of the caller. | keyword |
-| gcp.audit.resource_location.current_locations | Current locations of the resource. | keyword |
+| gcp.audit.resource_location.current_locations | Current locations of the resource. | array |
 | gcp.audit.resource_name | The resource or collection that is the target of the operation.  The name is a scheme-less URI, not including the API service name.  For example, 'shelves/SHELF_ID/books'. | keyword |
 | gcp.audit.response |  | flattened |
 | gcp.audit.service_name | The name of the API service performing the operation.  For example, datastore.googleapis.com. | keyword |

--- a/packages/gcp/docs/audit.md
+++ b/packages/gcp/docs/audit.md
@@ -60,7 +60,7 @@ The `audit` dataset collects audit logs of administrative activities and accesse
 | gcp.audit.request_metadata.caller_ip | The IP address of the caller. | ip |
 | gcp.audit.request_metadata.caller_supplied_user_agent | The user agent of the caller. This information is not authenticated and  should be treated accordingly. | keyword |
 | gcp.audit.request_metadata.raw.caller_ip | The raw IP address of the caller. | keyword |
-| gcp.audit.resource_location.current_locations | Current locations of the resource. | array |
+| gcp.audit.resource_location.current_locations | Current locations of the resource. | keyword |
 | gcp.audit.resource_name | The resource or collection that is the target of the operation.  The name is a scheme-less URI, not including the API service name.  For example, 'shelves/SHELF_ID/books'. | keyword |
 | gcp.audit.response |  | flattened |
 | gcp.audit.service_name | The name of the API service performing the operation.  For example, datastore.googleapis.com. | keyword |

--- a/packages/gcp/docs/billing.md
+++ b/packages/gcp/docs/billing.md
@@ -60,14 +60,14 @@ An example event for `billing` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |

--- a/packages/gcp/docs/compute.md
+++ b/packages/gcp/docs/compute.md
@@ -107,14 +107,14 @@ An example event for `compute` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |

--- a/packages/gcp/docs/dataproc.md
+++ b/packages/gcp/docs/dataproc.md
@@ -81,7 +81,7 @@ An example event for `dataproc` looks as following:
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |

--- a/packages/gcp/docs/firestore.md
+++ b/packages/gcp/docs/firestore.md
@@ -78,7 +78,7 @@ An example event for `firestore` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |

--- a/packages/gcp/docs/firewall.md
+++ b/packages/gcp/docs/firewall.md
@@ -62,7 +62,7 @@ The `firewall` dataset collects logs from Firewall Rules in your Virtual Private
 | gcp.firewall.rule_details.action | Action that the rule performs on match. | keyword |
 | gcp.firewall.rule_details.destination_range | List of destination ranges that the firewall applies to. | keyword |
 | gcp.firewall.rule_details.direction | Direction of traffic that matches this rule. | keyword |
-| gcp.firewall.rule_details.ip_port_info | List of ip protocols and applicable port ranges for rules. | keyword |
+| gcp.firewall.rule_details.ip_port_info | List of ip protocols and applicable port ranges for rules. | array |
 | gcp.firewall.rule_details.priority | The priority for the firewall rule. | long |
 | gcp.firewall.rule_details.reference | Reference to the firewall rule. | keyword |
 | gcp.firewall.rule_details.source_range | List of source ranges that the firewall rule applies to. | keyword |

--- a/packages/gcp/docs/firewall.md
+++ b/packages/gcp/docs/firewall.md
@@ -62,7 +62,7 @@ The `firewall` dataset collects logs from Firewall Rules in your Virtual Private
 | gcp.firewall.rule_details.action | Action that the rule performs on match. | keyword |
 | gcp.firewall.rule_details.destination_range | List of destination ranges that the firewall applies to. | keyword |
 | gcp.firewall.rule_details.direction | Direction of traffic that matches this rule. | keyword |
-| gcp.firewall.rule_details.ip_port_info | List of ip protocols and applicable port ranges for rules. | array |
+| gcp.firewall.rule_details.ip_port_info | List of ip protocols and applicable port ranges for rules. | keyword |
 | gcp.firewall.rule_details.priority | The priority for the firewall rule. | long |
 | gcp.firewall.rule_details.reference | Reference to the firewall rule. | keyword |
 | gcp.firewall.rule_details.source_range | List of source ranges that the firewall rule applies to. | keyword |

--- a/packages/gcp/docs/gke.md
+++ b/packages/gcp/docs/gke.md
@@ -74,14 +74,14 @@ An example event for `gke` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |

--- a/packages/gcp/docs/loadbalancing.md
+++ b/packages/gcp/docs/loadbalancing.md
@@ -322,7 +322,7 @@ An example event for `loadbalancing` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |

--- a/packages/gcp/docs/pubsub.md
+++ b/packages/gcp/docs/pubsub.md
@@ -72,14 +72,14 @@ An example event for `pubsub` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |

--- a/packages/gcp/docs/storage.md
+++ b/packages/gcp/docs/storage.md
@@ -77,14 +77,14 @@ An example event for `storage` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.11.7"
+version: "2.11.8"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.2"
+  changes:
+    - description: Remove duplicate field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4339
 - version: "2.5.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/zeek/data_stream/capture_loss/fields/agent.yml
+++ b/packages/zeek/data_stream/capture_loss/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/connection/fields/agent.yml
+++ b/packages/zeek/data_stream/connection/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/dce_rpc/fields/agent.yml
+++ b/packages/zeek/data_stream/dce_rpc/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/dhcp/fields/agent.yml
+++ b/packages/zeek/data_stream/dhcp/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/dnp3/fields/agent.yml
+++ b/packages/zeek/data_stream/dnp3/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/dns/fields/agent.yml
+++ b/packages/zeek/data_stream/dns/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/dpd/fields/agent.yml
+++ b/packages/zeek/data_stream/dpd/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/files/fields/agent.yml
+++ b/packages/zeek/data_stream/files/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/ftp/fields/agent.yml
+++ b/packages/zeek/data_stream/ftp/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/http/fields/agent.yml
+++ b/packages/zeek/data_stream/http/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/intel/fields/agent.yml
+++ b/packages/zeek/data_stream/intel/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/irc/fields/agent.yml
+++ b/packages/zeek/data_stream/irc/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/kerberos/fields/agent.yml
+++ b/packages/zeek/data_stream/kerberos/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/known_certs/fields/agent.yml
+++ b/packages/zeek/data_stream/known_certs/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/known_hosts/fields/agent.yml
+++ b/packages/zeek/data_stream/known_hosts/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/known_services/fields/agent.yml
+++ b/packages/zeek/data_stream/known_services/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/modbus/fields/agent.yml
+++ b/packages/zeek/data_stream/modbus/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/mysql/fields/agent.yml
+++ b/packages/zeek/data_stream/mysql/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/notice/fields/agent.yml
+++ b/packages/zeek/data_stream/notice/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/ntlm/fields/agent.yml
+++ b/packages/zeek/data_stream/ntlm/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/ntp/fields/agent.yml
+++ b/packages/zeek/data_stream/ntp/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/ocsp/fields/agent.yml
+++ b/packages/zeek/data_stream/ocsp/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/pe/fields/agent.yml
+++ b/packages/zeek/data_stream/pe/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/radius/fields/agent.yml
+++ b/packages/zeek/data_stream/radius/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/rdp/fields/agent.yml
+++ b/packages/zeek/data_stream/rdp/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/rfb/fields/agent.yml
+++ b/packages/zeek/data_stream/rfb/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/signature/fields/agent.yml
+++ b/packages/zeek/data_stream/signature/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/sip/fields/agent.yml
+++ b/packages/zeek/data_stream/sip/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/smb_cmd/fields/agent.yml
+++ b/packages/zeek/data_stream/smb_cmd/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/smb_files/fields/agent.yml
+++ b/packages/zeek/data_stream/smb_files/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/smb_mapping/fields/agent.yml
+++ b/packages/zeek/data_stream/smb_mapping/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/smtp/fields/agent.yml
+++ b/packages/zeek/data_stream/smtp/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/snmp/fields/agent.yml
+++ b/packages/zeek/data_stream/snmp/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/socks/fields/agent.yml
+++ b/packages/zeek/data_stream/socks/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/software/fields/agent.yml
+++ b/packages/zeek/data_stream/software/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/ssh/fields/agent.yml
+++ b/packages/zeek/data_stream/ssh/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/ssl/fields/agent.yml
+++ b/packages/zeek/data_stream/ssl/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/ssl/fields/ecs.yml
+++ b/packages/zeek/data_stream/ssl/fields/ecs.yml
@@ -146,5 +146,3 @@
   name: tls.version
 - external: ecs
   name: tls.version_protocol
-- external: ecs
-  name: tls.version_protocol

--- a/packages/zeek/data_stream/stats/fields/agent.yml
+++ b/packages/zeek/data_stream/stats/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/syslog/fields/agent.yml
+++ b/packages/zeek/data_stream/syslog/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/traceroute/fields/agent.yml
+++ b/packages/zeek/data_stream/traceroute/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/tunnel/fields/agent.yml
+++ b/packages/zeek/data_stream/tunnel/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/weird/fields/agent.yml
+++ b/packages/zeek/data_stream/weird/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/data_stream/x509/fields/agent.yml
+++ b/packages/zeek/data_stream/x509/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword
@@ -107,10 +102,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: 2.5.1
+version: 2.5.2
 release: ga
 description: Collect logs from Zeek with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This is a second tranch of fixing duplicate fields in preparation for the ECS 8.5 update.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #4338

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
