### PR TITLE
[GCP] Fix kubernetes.io service prefix indendation

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.9"
+  changes:
+    - description: Fix GKE kubernetes.io indentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4355
 - version: "2.11.8"
   changes:
     - description: Remove duplicate fields.

--- a/packages/gcp/data_stream/gke/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/gke/agent/stream/stream.yml.hbs
@@ -16,8 +16,8 @@ zone: {{zone}}
 exclude_labels: {{exclude_labels}}
 metrics:
   - service: gke
-      service_metric_prefix: kubernetes.io/
-      metric_types:
+    service_metric_prefix: kubernetes.io/
+    metric_types:
       - "container/cpu/core_usage_time"
       - "container/cpu/limit_cores"
       - "container/cpu/limit_utilization"

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.11.8"
+version: "2.11.9"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fixes `kubernetes.io` service prefix indentation.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
