### PR TITLE
moving cloud security posture to GA

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Cloud Security Posture integration is now GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4359
 - version: "0.0.33"
   changes:
     - description: Remove unconfigurable default fields from hbs files

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Cloud Security Posture integration is now GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4359
+      link: https://github.com/elastic/integrations/pull/4362
 - version: "0.0.33"
   changes:
     - description: Remove unconfigurable default fields from hbs files

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,8 +1,8 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Kubernetes Security Posture Management"
-version: 0.0.33
-release: beta
+version: 1.0.0
+release: ga
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
 type: integration


### PR DESCRIPTION
## What does this PR do?

Cloud Security Posture integration is now GA.

___ 

- Closes: https://github.com/elastic/security-team/issues/5108