### PR TITLE
Add processors setting for k8s data_streams

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.0"
+  changes:
+    - description: Add `processors` configuration option for Kubernetes data_streams
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.25.0"
   changes:
     - description: Add `condition` configuration option to container logs data stream

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `processors` configuration option for Kubernetes data_streams
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/4363
 - version: "1.25.0"
   changes:
     - description: Add `condition` configuration option to container logs data stream

--- a/packages/kubernetes/data_stream/apiserver/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/apiserver/agent/stream/stream.yml.hbs
@@ -16,3 +16,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/apiserver/manifest.yml
+++ b/packages/kubernetes/data_stream/apiserver/manifest.yml
@@ -40,5 +40,14 @@ streams:
         show_user: true
         default:
           - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes API Server metrics
     description: Collect Kubernetes API Server metrics

--- a/packages/kubernetes/data_stream/apiserver/manifest.yml
+++ b/packages/kubernetes/data_stream/apiserver/manifest.yml
@@ -49,6 +49,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes API Server metrics
     description: Collect Kubernetes API Server metrics

--- a/packages/kubernetes/data_stream/apiserver/manifest.yml
+++ b/packages/kubernetes/data_stream/apiserver/manifest.yml
@@ -48,13 +48,5 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes API Server metrics
     description: Collect Kubernetes API Server metrics

--- a/packages/kubernetes/data_stream/apiserver/manifest.yml
+++ b/packages/kubernetes/data_stream/apiserver/manifest.yml
@@ -49,5 +49,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes API Server metrics
     description: Collect Kubernetes API Server metrics

--- a/packages/kubernetes/data_stream/audit_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/audit_logs/agent/stream/stream.yml.hbs
@@ -38,3 +38,6 @@ processors:
             throw "expected kubernetes.audit.annotations.authorization_k8s_io/decision === allow";
         }
       }
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/audit_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/audit_logs/manifest.yml
@@ -27,3 +27,4 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"

--- a/packages/kubernetes/data_stream/audit_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/audit_logs/manifest.yml
@@ -18,3 +18,12 @@ streams:
         multi: true
         default:
           - /var/log/kubernetes/kube-apiserver-audit.log
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/kubernetes/data_stream/audit_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/audit_logs/manifest.yml
@@ -27,4 +27,10 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra

--- a/packages/kubernetes/data_stream/audit_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/audit_logs/manifest.yml
@@ -26,11 +26,3 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra

--- a/packages/kubernetes/data_stream/container/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container/agent/stream/stream.yml.hbs
@@ -18,3 +18,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -66,13 +66,5 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -4,11 +4,13 @@ paths:
   - {{this}}
 {{/each}}
 prospector.scanner.symlinks: {{ symlinks }}
-{{#if condition}}
-condition: {{ condition }}
-{{/if}}
 parsers:
 - container:
     stream: {{ containerParserStream }}
     format: {{ containerParserFormat }}
 {{ additionalParsersConfig }}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -61,3 +61,4 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -61,4 +61,10 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -52,3 +52,12 @@ streams:
           #     pattern: '^\['
           #     negate: true
           #     match: after
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -60,11 +60,3 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra

--- a/packages/kubernetes/data_stream/controllermanager/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/controllermanager/agent/stream/stream.yml.hbs
@@ -12,3 +12,8 @@ ssl.verification_mode: {{ssl.verification_mode}}
 {{/if}}
 
 condition: ${kubernetes.labels.{{~controller_manager_label_key~}} } == '{{controller_manager_label_value}}'
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/controllermanager/manifest.yml
+++ b/packages/kubernetes/data_stream/controllermanager/manifest.yml
@@ -47,5 +47,14 @@ streams:
         required: true
         show_user: false
         default: kube-controller-manager
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Controller Manager metrics
     description: Collect Kubernetes Controller Manager metrics

--- a/packages/kubernetes/data_stream/controllermanager/manifest.yml
+++ b/packages/kubernetes/data_stream/controllermanager/manifest.yml
@@ -55,13 +55,5 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Controller Manager metrics
     description: Collect Kubernetes Controller Manager metrics

--- a/packages/kubernetes/data_stream/controllermanager/manifest.yml
+++ b/packages/kubernetes/data_stream/controllermanager/manifest.yml
@@ -56,6 +56,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Controller Manager metrics
     description: Collect Kubernetes Controller Manager metrics

--- a/packages/kubernetes/data_stream/controllermanager/manifest.yml
+++ b/packages/kubernetes/data_stream/controllermanager/manifest.yml
@@ -56,5 +56,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Controller Manager metrics
     description: Collect Kubernetes Controller Manager metrics

--- a/packages/kubernetes/data_stream/event/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/event/agent/stream/stream.yml.hbs
@@ -5,3 +5,8 @@ skip_older: {{skip_older}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/event/manifest.yml
+++ b/packages/kubernetes/data_stream/event/manifest.yml
@@ -31,5 +31,14 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Event metrics
     description: Collect Kubernetes Event metrics

--- a/packages/kubernetes/data_stream/event/manifest.yml
+++ b/packages/kubernetes/data_stream/event/manifest.yml
@@ -40,12 +40,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Event metrics
     description: Collect Kubernetes Event metrics

--- a/packages/kubernetes/data_stream/event/manifest.yml
+++ b/packages/kubernetes/data_stream/event/manifest.yml
@@ -40,6 +40,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Event metrics
     description: Collect Kubernetes Event metrics

--- a/packages/kubernetes/data_stream/event/manifest.yml
+++ b/packages/kubernetes/data_stream/event/manifest.yml
@@ -40,5 +40,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Event metrics
     description: Collect Kubernetes Event metrics

--- a/packages/kubernetes/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/node/agent/stream/stream.yml.hbs
@@ -15,3 +15,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/node/manifest.yml
+++ b/packages/kubernetes/data_stream/node/manifest.yml
@@ -45,5 +45,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics

--- a/packages/kubernetes/data_stream/node/manifest.yml
+++ b/packages/kubernetes/data_stream/node/manifest.yml
@@ -54,5 +54,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics

--- a/packages/kubernetes/data_stream/node/manifest.yml
+++ b/packages/kubernetes/data_stream/node/manifest.yml
@@ -54,12 +54,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics

--- a/packages/kubernetes/data_stream/node/manifest.yml
+++ b/packages/kubernetes/data_stream/node/manifest.yml
@@ -54,6 +54,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics

--- a/packages/kubernetes/data_stream/pod/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/pod/agent/stream/stream.yml.hbs
@@ -18,3 +18,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -58,5 +58,14 @@ streams:
           #     include_labels: ["nodelabel2"]
           #     include_annotations: ["nodeannotation1"]
           #   deployment: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics

--- a/packages/kubernetes/data_stream/proxy/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/proxy/agent/stream/stream.yml.hbs
@@ -4,3 +4,8 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/proxy/manifest.yml
+++ b/packages/kubernetes/data_stream/proxy/manifest.yml
@@ -27,12 +27,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Proxy metrics
     description: Collect Kubernetes Proxy metrics

--- a/packages/kubernetes/data_stream/proxy/manifest.yml
+++ b/packages/kubernetes/data_stream/proxy/manifest.yml
@@ -18,5 +18,15 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Proxy metrics
     description: Collect Kubernetes Proxy metrics

--- a/packages/kubernetes/data_stream/proxy/manifest.yml
+++ b/packages/kubernetes/data_stream/proxy/manifest.yml
@@ -27,6 +27,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Proxy metrics
     description: Collect Kubernetes Proxy metrics

--- a/packages/kubernetes/data_stream/scheduler/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/scheduler/agent/stream/stream.yml.hbs
@@ -10,3 +10,8 @@ bearer_token_file: {{bearer_token_file}}
 ssl.verification_mode: {{ssl.verification_mode}}
 {{/if}}
 condition: ${kubernetes.labels.{{~scheduler_label_key~}} } == '{{scheduler_label_value}}'
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/scheduler/manifest.yml
+++ b/packages/kubernetes/data_stream/scheduler/manifest.yml
@@ -47,5 +47,14 @@ streams:
         required: true
         show_user: false
         default: kube-scheduler
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Scheduler metrics
     description: Collect Kubernetes Scheduler metrics

--- a/packages/kubernetes/data_stream/scheduler/manifest.yml
+++ b/packages/kubernetes/data_stream/scheduler/manifest.yml
@@ -56,6 +56,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Scheduler metrics
     description: Collect Kubernetes Scheduler metrics

--- a/packages/kubernetes/data_stream/scheduler/manifest.yml
+++ b/packages/kubernetes/data_stream/scheduler/manifest.yml
@@ -56,5 +56,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Scheduler metrics
     description: Collect Kubernetes Scheduler metrics

--- a/packages/kubernetes/data_stream/scheduler/manifest.yml
+++ b/packages/kubernetes/data_stream/scheduler/manifest.yml
@@ -56,12 +56,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Scheduler metrics
     description: Collect Kubernetes Scheduler metrics

--- a/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
@@ -26,3 +26,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -71,5 +71,14 @@ streams:
           #     include_labels: ["nodelabel2"]
           #     include_annotations: ["nodeannotation1"]
           #   deployment: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -80,5 +80,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -80,12 +80,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -80,6 +80,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_cronjob/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_cronjob/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Cronjob metrics
     description: Collect Kubernetes Cronjob metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Cronjob metrics
     description: Collect Kubernetes Cronjob metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Cronjob metrics
     description: Collect Kubernetes Cronjob metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Cronjob metrics
     description: Collect Kubernetes Cronjob metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_daemonset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_daemonset/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -59,5 +59,14 @@ streams:
         required: false
         show_user: false
         default: # /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Deamonset metrics
     description: Collect Kubernetes Deamonset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -68,5 +68,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Deamonset metrics
     description: Collect Kubernetes Deamonset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -68,6 +68,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Deamonset metrics
     description: Collect Kubernetes Deamonset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -68,12 +68,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Deamonset metrics
     description: Collect Kubernetes Deamonset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_deployment/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_deployment/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Deployment metrics
     description: Collect Kubernetes Deployment metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Deployment metrics
     description: Collect Kubernetes Deployment metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Deployment metrics
     description: Collect Kubernetes Deployment metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Deployment metrics
     description: Collect Kubernetes Deployment metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Job metrics
     description: Collect Kubernetes Job metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Job metrics
     description: Collect Kubernetes Job metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Job metrics
     description: Collect Kubernetes Job metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Job metrics
     description: Collect Kubernetes Job metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_node/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_node/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Node metrics
     description: Collect Kubernetes Node metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolume/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_persistentvolume/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes PersistentVolume metrics
     description: Collect Kubernetes PersistentVolume metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes PersistentVolume metrics
     description: Collect Kubernetes PersistentVolume metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes PersistentVolume metrics
     description: Collect Kubernetes PersistentVolume metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes PersistentVolume metrics
     description: Collect Kubernetes PersistentVolume metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes PersistentVolumeClaim metrics
     description: Collect Kubernetes PersistentVolumeClaim metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes PersistentVolumeClaim metrics
     description: Collect Kubernetes PersistentVolumeClaim metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes PersistentVolumeClaim metrics
     description: Collect Kubernetes PersistentVolumeClaim metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes PersistentVolumeClaim metrics
     description: Collect Kubernetes PersistentVolumeClaim metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
@@ -26,3 +26,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -71,5 +71,14 @@ streams:
           #     include_labels: ["nodelabel2"]
           #     include_annotations: ["nodeannotation1"]
           #   deployment: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -80,5 +80,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -80,12 +80,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -80,6 +80,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Pod metrics
     description: Collect Kubernetes Pod metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_replicaset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_replicaset/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Replicaset metrics
     description: Collect Kubernetes Replicaset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Replicaset metrics
     description: Collect Kubernetes Replicaset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Replicaset metrics
     description: Collect Kubernetes Replicaset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Replicaset metrics
     description: Collect Kubernetes Replicaset metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_resourcequota/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_resourcequota/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes ResourceQuota metrics
     description: Collect Kubernetes ResourceQuota metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes ResourceQuota metrics
     description: Collect Kubernetes ResourceQuota metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes ResourceQuota metrics
     description: Collect Kubernetes ResourceQuota metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes ResourceQuota metrics
     description: Collect Kubernetes ResourceQuota metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_service/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_service/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Service metrics
     description: Collect Kubernetes Service metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Service metrics
     description: Collect Kubernetes Service metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Service metrics
     description: Collect Kubernetes Service metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Service metrics
     description: Collect Kubernetes Service metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_statefulset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_statefulset/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes StatefulSet metrics
     description: Collect Kubernetes StatefulSet metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes StatefulSet metrics
     description: Collect Kubernetes StatefulSet metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes StatefulSet metrics
     description: Collect Kubernetes StatefulSet metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes StatefulSet metrics
     description: Collect Kubernetes StatefulSet metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_storageclass/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_storageclass/agent/stream/stream.yml.hbs
@@ -23,3 +23,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -58,5 +58,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes StorageClass metrics
     description: Collect Kubernetes StorageClass metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -67,12 +67,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes StorageClass metrics
     description: Collect Kubernetes StorageClass metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -67,5 +67,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes StorageClass metrics
     description: Collect Kubernetes StorageClass metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -67,6 +67,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes StorageClass metrics
     description: Collect Kubernetes StorageClass metrics from kube_state_metrics

--- a/packages/kubernetes/data_stream/system/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/system/agent/stream/stream.yml.hbs
@@ -15,3 +15,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/system/manifest.yml
+++ b/packages/kubernetes/data_stream/system/manifest.yml
@@ -45,5 +45,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes System metrics
     description: Collect Kubernetes system metrics

--- a/packages/kubernetes/data_stream/system/manifest.yml
+++ b/packages/kubernetes/data_stream/system/manifest.yml
@@ -54,5 +54,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes System metrics
     description: Collect Kubernetes system metrics

--- a/packages/kubernetes/data_stream/system/manifest.yml
+++ b/packages/kubernetes/data_stream/system/manifest.yml
@@ -54,6 +54,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes System metrics
     description: Collect Kubernetes system metrics

--- a/packages/kubernetes/data_stream/system/manifest.yml
+++ b/packages/kubernetes/data_stream/system/manifest.yml
@@ -54,12 +54,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes System metrics
     description: Collect Kubernetes system metrics

--- a/packages/kubernetes/data_stream/volume/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/volume/agent/stream/stream.yml.hbs
@@ -15,3 +15,8 @@ ssl.certificate_authorities:
   - {{this}}
 {{/each}}
 {{/if}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/kubernetes/data_stream/volume/manifest.yml
+++ b/packages/kubernetes/data_stream/volume/manifest.yml
@@ -45,5 +45,14 @@ streams:
         multi: true
         required: false
         show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Volume metrics
     description: Collect Kubernetes Volume metrics

--- a/packages/kubernetes/data_stream/volume/manifest.yml
+++ b/packages/kubernetes/data_stream/volume/manifest.yml
@@ -54,5 +54,6 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
     title: Kubernetes Volume metrics
     description: Collect Kubernetes Volume metrics

--- a/packages/kubernetes/data_stream/volume/manifest.yml
+++ b/packages/kubernetes/data_stream/volume/manifest.yml
@@ -54,12 +54,5 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: |
-          # Example, uncomment this if you want to manually set the orchestrator fields 
-          #- add_fields:
-          #    target: orchestrator.cluster
-          #    fields:
-          #      name: my-cluster
-          #      url: internal.k8s.infra
     title: Kubernetes Volume metrics
     description: Collect Kubernetes Volume metrics

--- a/packages/kubernetes/data_stream/volume/manifest.yml
+++ b/packages/kubernetes/data_stream/volume/manifest.yml
@@ -54,6 +54,12 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
-        default: "# Example, uncomment this if you want to manually set the orchestrator fields \n# - add_fields:\n#     target: orchestrator.cluster\n#     fields:\n#       name: my-cluster\n#       url: internal.k8s.infra\n"
+        default: |
+          # Example, uncomment this if you want to manually set the orchestrator fields 
+          #- add_fields:
+          #    target: orchestrator.cluster
+          #    fields:
+          #      name: my-cluster
+          #      url: internal.k8s.infra
     title: Kubernetes Volume metrics
     description: Collect Kubernetes Volume metrics

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.25.0
+version: 1.26.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds `processors` fields for all the Kubernetes data_streams.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes https://github.com/elastic/integrations/issues/4288


## Screenshots

TBA
