### PR TITLE
[docs] Escape left angle bracket (`<`)

### DIFF
--- a/packages/infoblox_bloxone_ddi/_dev/build/docs/README.md
+++ b/packages/infoblox_bloxone_ddi/_dev/build/docs/README.md
@@ -1,7 +1,5 @@
 # Infoblox BloxOne DDI
 
-## Overview
-
 The [Infoblox BloxOne DDI](https://www.infoblox.com/products/bloxone-ddi/) integration allows you to monitor DNS, DHCP and IP address management activity. DDI is the foundation of core network services that enables all communications over an IP-based network.
 
 Use the Infoblox BloxOne DDI integration to collects and parses data from the REST APIs and then visualize that data in Kibana.
@@ -27,7 +25,7 @@ This module has been tested against `Infoblox BloxOne DDI API (v1)`.
 ### To collect data from Infoblox BloxOne DDI APIs, the user must have API Key. To create an API key follow the below steps:
 
 1. Log on to the Cloud Services Portal.
-2. Go to **<User_Name> -> User Profile**.
+2. Go to **\<User_Name> -> User Profile**.
 3. Go to **User API Keys** page.
 4. Click **Create** to create a new API key. Specify the following:
     - **Name**: Specify the name of the key.

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix documentation build error.
       type: enhancement
-      link: TBD
+      link: https://github.com/elastic/integrations/pull/4369
 - version: '0.1.0'
   changes:
     - description: Initial Release.

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -2,7 +2,7 @@
 - version: '0.1.1'
   changes:
     - description: Fix documentation build error.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/4369
 - version: '0.1.0'
   changes:

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.1.1'
+  changes:
+    - description: Fix documentation build error.
+      type: enhancement
+      link: TBD
 - version: '0.1.0'
   changes:
     - description: Initial Release.

--- a/packages/infoblox_bloxone_ddi/docs/README.md
+++ b/packages/infoblox_bloxone_ddi/docs/README.md
@@ -1,7 +1,5 @@
 # Infoblox BloxOne DDI
 
-## Overview
-
 The [Infoblox BloxOne DDI](https://www.infoblox.com/products/bloxone-ddi/) integration allows you to monitor DNS, DHCP and IP address management activity. DDI is the foundation of core network services that enables all communications over an IP-based network.
 
 Use the Infoblox BloxOne DDI integration to collects and parses data from the REST APIs and then visualize that data in Kibana.
@@ -27,7 +25,7 @@ This module has been tested against `Infoblox BloxOne DDI API (v1)`.
 ### To collect data from Infoblox BloxOne DDI APIs, the user must have API Key. To create an API key follow the below steps:
 
 1. Log on to the Cloud Services Portal.
-2. Go to **<User_Name> -> User Profile**.
+2. Go to **\<User_Name> -> User Profile**.
 3. Go to **User API Keys** page.
 4. Click **Create** to create a new API key. Specify the following:
     - **Name**: Specify the name of the key.

--- a/packages/infoblox_bloxone_ddi/manifest.yml
+++ b/packages/infoblox_bloxone_ddi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: infoblox_bloxone_ddi
 title: Infoblox BloxOne DDI
-version: '0.1.0'
+version: '0.1.1'
 license: basic
 description: Collect logs from Infoblox BloxOne DDI with Elastic Agent.
 type: integration


### PR DESCRIPTION
Related: https://github.com/elastic/integrations/pull/4295

## What does this PR do?

Escapes the left angle bracket (`<`) used in the new Infoblox BloxOne DDI doc. 

The [Integration docs](https://docs.elastic.co/integrations) use MDX (not plain Markdown). From the [MDX documentation](https://mdxjs.com/docs/what-is-mdx/#markdown):

>Unescaped left angle bracket / less than (`<`) and left curly brace (`{`) have to be escaped: `\<` or `\{` (or use expressions: `{'<'}`, `{'{'}`)

I used `\<` because it also renders correctly in plain Markdown (see **Screenshots** below).

Note: This PR also removes the "Overview" heading, which will be added when the file is processed from a Markdown file to an MDX file. Though including the "Overview" heading here doesn't break the build, it does result in two "Overview" headings on the page for this integration on [docs.elastic.co](https://docs.elastic.co/integrations).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Screenshots

<img width="324" alt="Screen Shot 2022-10-03 at 4 39 49 PM" src="https://user-images.githubusercontent.com/10479155/193690534-3b1aa713-4015-49b2-bddf-117594fb2900.png">
