### PR TITLE
gcp: fix type of dns.answers.ttl

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.11"
+  changes:
+    - description: Fix type of dns.answers.ttl.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4371
 - version: "2.11.10"
   changes:
     - description: Add ingest pipeline for dataproc.

--- a/packages/gcp/data_stream/dns/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/gcp/data_stream/dns/_dev/test/pipeline/test-dns.log-expected.json
@@ -20,7 +20,7 @@
                         "class": "IN",
                         "data": "127.0.0.1",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "A"
                     }
                 ],
@@ -111,7 +111,7 @@
                         "class": "IN",
                         "data": "0:0:0:0:0:0:0:1",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "AAAA"
                     }
                 ],
@@ -202,35 +202,35 @@
                         "class": "IN",
                         "data": "1 aspmx.l.google.com",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "MX"
                     },
                     {
                         "class": "IN",
                         "data": "10 alt3.aspmx.l.google.com",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "MX"
                     },
                     {
                         "class": "IN",
                         "data": "10 alt4.aspmx.l.google.com",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "MX"
                     },
                     {
                         "class": "IN",
                         "data": "5 alt1.aspmx.l.google.com",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "MX"
                     },
                     {
                         "class": "IN",
                         "data": "5 alt2.aspmx.l.google.com",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "MX"
                     }
                 ],
@@ -322,28 +322,28 @@
                         "class": "IN",
                         "data": "ns-1168.awsdns-18.org",
                         "name": "elastic.co",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "NS"
                     },
                     {
                         "class": "IN",
                         "data": "ns-1737.awsdns-25.co.uk",
                         "name": "elastic.co",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "NS"
                     },
                     {
                         "class": "IN",
                         "data": "ns-339.awsdns-42.com",
                         "name": "elastic.co",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "NS"
                     },
                     {
                         "class": "IN",
                         "data": "ns-785.awsdns-34.net",
                         "name": "elastic.co",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "NS"
                     }
                 ],
@@ -430,14 +430,14 @@
                         "class": "IN",
                         "data": "\"adobe-idp-site-verification=f0ae487a2bd7cc4eb1fc64162e1a85c5b39002bc5fe0d7d7373ece0fdb3fd494\"",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "TXT"
                     },
                     {
                         "class": "IN",
                         "data": "\"atlassian-domain-verification=eFQHgCgWimOfFj3Ol7kfJg9RGDmaS8X6V2M6YZRgnEY6/iKi0SUYWRlOvBOmgV7H\"",
                         "name": "elastic.co",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "TXT"
                     }
                 ],
@@ -523,7 +523,7 @@
                         "class": "IN",
                         "data": "67.43.156.13",
                         "name": "asdf.gcp.example.com.",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "A"
                     }
                 ],
@@ -672,7 +672,7 @@
                         "class": "IN",
                         "data": "67.43.156.13",
                         "name": "asdf.gcp.example.com.",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "A"
                     }
                 ],
@@ -889,28 +889,28 @@
                         "class": "IN",
                         "data": "ns-cloud-a2.googledomains.com",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "NS"
                     },
                     {
                         "class": "IN",
                         "data": "ns-cloud-a3.googledomains.com",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "NS"
                     },
                     {
                         "class": "IN",
                         "data": "ns-cloud-a4.googledomains.com",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "NS"
                     },
                     {
                         "class": "IN",
                         "data": "ns-cloud-a1.googledomains.com",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "NS"
                     }
                 ],
@@ -987,7 +987,7 @@
                         "class": "IN",
                         "data": "ns-cloud-a1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "SOA"
                     }
                 ],
@@ -1064,7 +1064,7 @@
                         "class": "IN",
                         "data": "ns-cloud-a1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "SOA"
                     }
                 ],
@@ -1141,7 +1141,7 @@
                         "class": "IN",
                         "data": "ns-cloud-a1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "SOA"
                     }
                 ],
@@ -1218,7 +1218,7 @@
                         "class": "IN",
                         "data": "ns-cloud-a1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "SOA"
                     }
                 ],
@@ -1295,7 +1295,7 @@
                         "class": "IN",
                         "data": "ns-cloud-a1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300",
                         "name": "gcp.example.com.",
-                        "ttl": "21600",
+                        "ttl": 21600,
                         "type": "SOA"
                     }
                 ],
@@ -1508,14 +1508,14 @@
                         "class": "IN",
                         "data": "asdf.gcp.example.com",
                         "name": "cname.gcp.example.com.",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "CNAME"
                     },
                     {
                         "class": "IN",
                         "data": "67.43.156.13",
                         "name": "asdf.gcp.example.com.",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "A"
                     }
                 ],
@@ -1597,7 +1597,7 @@
                         "class": "IN",
                         "data": "67.43.156.13",
                         "name": "asdf.gcp.example.com.",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "A"
                     }
                 ],
@@ -1678,7 +1678,7 @@
                         "class": "IN",
                         "data": "67.43.156.13",
                         "name": "asdf.gcp.example.com.",
-                        "ttl": "300",
+                        "ttl": 300,
                         "type": "A"
                     }
                 ],

--- a/packages/gcp/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -147,7 +147,7 @@ processors:
 
             // Assign answer parts.
             def name = answer_parts[0];
-            def ttl = answer_parts[1];
+            def ttl = Long.parseLong(answer_parts[1]);
             def cls = answer_parts[2];
             def type = answer_parts[3];
             def data = answer_parts[4];
@@ -190,7 +190,7 @@ processors:
             new_answer.put("type", answer.type);
           }
           if(answer.ttl != null) {
-            new_answer.put("ttl", answer.ttl);
+            new_answer.put("ttl", Long.parseLong(answer.ttl));
           }
           if(answer.rvalue != null) {
             new_answer.put("data", answer.rvalue);

--- a/packages/gcp/data_stream/dns/sample_event.json
+++ b/packages/gcp/data_stream/dns/sample_event.json
@@ -1,96 +1,102 @@
 {
-    "@timestamp": "2022-01-23T09:16:05.341Z",
+    "@timestamp": "2021-12-12T15:59:40.446Z",
     "agent": {
-        "ephemeral_id": "0b86920e-9dac-4b22-91c8-e594b22a00b4",
-        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
+        "ephemeral_id": "87190725-9632-41a5-ba26-ebffca397d74",
+        "id": "0168f0f0-b64d-4a7a-ba00-c309f9e7f0ca",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.3"
+        "version": "8.4.1"
     },
     "cloud": {
-        "availability_zone": "europe-west2-a",
-        "instance": {
-            "id": "8340998530665147",
-            "name": "instance"
-        },
         "project": {
-            "id": "project"
+            "id": "key-reference-123456"
         },
         "provider": "gcp",
-        "region": "europe-west2"
+        "region": "global"
     },
     "data_stream": {
         "dataset": "gcp.dns",
         "namespace": "ep",
         "type": "logs"
     },
+    "destination": {
+        "address": "216.239.32.106",
+        "ip": "216.239.32.106"
+    },
     "dns": {
         "answers": [
             {
                 "class": "IN",
-                "data": "127.0.0.1",
-                "name": "elastic.co",
-                "ttl": "300",
+                "data": "67.43.156.13",
+                "name": "asdf.gcp.example.com.",
+                "ttl": 300,
                 "type": "A"
             }
         ],
         "question": {
-            "name": "elastic.co",
-            "registered_domain": "elastic.co",
-            "top_level_domain": "co",
+            "name": "asdf.gcp.example.com",
+            "registered_domain": "example.com",
+            "subdomain": "asdf.gcp",
+            "top_level_domain": "com",
             "type": "A"
         },
         "resolved_ip": [
-            "127.0.0.1"
+            "67.43.156.13"
         ],
         "response_code": "NOERROR"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
+        "id": "0168f0f0-b64d-4a7a-ba00-c309f9e7f0ca",
         "snapshot": false,
-        "version": "8.2.3"
+        "version": "8.4.1"
     },
     "event": {
+        "action": "dns-query",
         "agent_id_status": "verified",
-        "created": "2022-06-28T02:46:41.230Z",
+        "category": "network",
+        "created": "2022-10-03T22:33:56.157Z",
         "dataset": "gcp.dns",
-        "id": "vwroyze8pg7y",
-        "ingested": "2022-06-28T02:46:42Z",
+        "id": "zir4wud11tm",
+        "ingested": "2022-10-03T22:33:57Z",
         "kind": "event",
         "outcome": "success"
     },
     "gcp": {
         "dns": {
             "auth_answer": true,
+            "destination_ip": "216.239.32.106",
             "protocol": "UDP",
-            "query_name": "elastic.co.",
+            "query_name": "asdf.gcp.example.com.",
             "query_type": "A",
-            "rdata": "elastic.co.\t300\tIN\ta\t127.0.0.1",
             "response_code": "NOERROR",
-            "server_latency": 14,
-            "source_ip": "10.154.0.3",
-            "source_network": "default",
-            "vm_instance_id": "8340998530665147",
-            "vm_instance_name": "694119234537.instance",
-            "vm_project_id": "project",
-            "vm_zone_name": "europe-west2-a"
+            "server_latency": 0,
+            "source_type": "internet",
+            "target_type": "public-zone"
         }
     },
     "input": {
         "type": "gcp-pubsub"
     },
     "log": {
-        "logger": "projects/project/logs/dns.googleapis.com%2Fdns_queries"
+        "level": "INFO",
+        "logger": "projects/key-reference-123456/logs/dns.googleapis.com%2Fdns_queries"
     },
     "network": {
+        "iana_number": "17",
+        "protocol": "dns",
         "transport": "udp"
     },
-    "source": {
-        "address": "10.154.0.3",
-        "ip": "10.154.0.3"
+    "related": {
+        "hosts": [
+            "asdf.gcp.example.com"
+        ],
+        "ip": [
+            "67.43.156.13",
+            "216.239.32.106"
+        ]
     },
     "tags": [
         "forwarded",

--- a/packages/gcp/docs/README.md
+++ b/packages/gcp/docs/README.md
@@ -1048,98 +1048,104 @@ An example event for `dns` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-01-23T09:16:05.341Z",
+    "@timestamp": "2021-12-12T15:59:40.446Z",
     "agent": {
-        "ephemeral_id": "0b86920e-9dac-4b22-91c8-e594b22a00b4",
-        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
+        "ephemeral_id": "87190725-9632-41a5-ba26-ebffca397d74",
+        "id": "0168f0f0-b64d-4a7a-ba00-c309f9e7f0ca",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.3"
+        "version": "8.4.1"
     },
     "cloud": {
-        "availability_zone": "europe-west2-a",
-        "instance": {
-            "id": "8340998530665147",
-            "name": "instance"
-        },
         "project": {
-            "id": "project"
+            "id": "key-reference-123456"
         },
         "provider": "gcp",
-        "region": "europe-west2"
+        "region": "global"
     },
     "data_stream": {
         "dataset": "gcp.dns",
         "namespace": "ep",
         "type": "logs"
     },
+    "destination": {
+        "address": "216.239.32.106",
+        "ip": "216.239.32.106"
+    },
     "dns": {
         "answers": [
             {
                 "class": "IN",
-                "data": "127.0.0.1",
-                "name": "elastic.co",
-                "ttl": "300",
+                "data": "67.43.156.13",
+                "name": "asdf.gcp.example.com.",
+                "ttl": 300,
                 "type": "A"
             }
         ],
         "question": {
-            "name": "elastic.co",
-            "registered_domain": "elastic.co",
-            "top_level_domain": "co",
+            "name": "asdf.gcp.example.com",
+            "registered_domain": "example.com",
+            "subdomain": "asdf.gcp",
+            "top_level_domain": "com",
             "type": "A"
         },
         "resolved_ip": [
-            "127.0.0.1"
+            "67.43.156.13"
         ],
         "response_code": "NOERROR"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
+        "id": "0168f0f0-b64d-4a7a-ba00-c309f9e7f0ca",
         "snapshot": false,
-        "version": "8.2.3"
+        "version": "8.4.1"
     },
     "event": {
+        "action": "dns-query",
         "agent_id_status": "verified",
-        "created": "2022-06-28T02:46:41.230Z",
+        "category": "network",
+        "created": "2022-10-03T22:33:56.157Z",
         "dataset": "gcp.dns",
-        "id": "vwroyze8pg7y",
-        "ingested": "2022-06-28T02:46:42Z",
+        "id": "zir4wud11tm",
+        "ingested": "2022-10-03T22:33:57Z",
         "kind": "event",
         "outcome": "success"
     },
     "gcp": {
         "dns": {
             "auth_answer": true,
+            "destination_ip": "216.239.32.106",
             "protocol": "UDP",
-            "query_name": "elastic.co.",
+            "query_name": "asdf.gcp.example.com.",
             "query_type": "A",
-            "rdata": "elastic.co.\t300\tIN\ta\t127.0.0.1",
             "response_code": "NOERROR",
-            "server_latency": 14,
-            "source_ip": "10.154.0.3",
-            "source_network": "default",
-            "vm_instance_id": "8340998530665147",
-            "vm_instance_name": "694119234537.instance",
-            "vm_project_id": "project",
-            "vm_zone_name": "europe-west2-a"
+            "server_latency": 0,
+            "source_type": "internet",
+            "target_type": "public-zone"
         }
     },
     "input": {
         "type": "gcp-pubsub"
     },
     "log": {
-        "logger": "projects/project/logs/dns.googleapis.com%2Fdns_queries"
+        "level": "INFO",
+        "logger": "projects/key-reference-123456/logs/dns.googleapis.com%2Fdns_queries"
     },
     "network": {
+        "iana_number": "17",
+        "protocol": "dns",
         "transport": "udp"
     },
-    "source": {
-        "address": "10.154.0.3",
-        "ip": "10.154.0.3"
+    "related": {
+        "hosts": [
+            "asdf.gcp.example.com"
+        ],
+        "ip": [
+            "67.43.156.13",
+            "216.239.32.106"
+        ]
     },
     "tags": [
         "forwarded",

--- a/packages/gcp/docs/dns.md
+++ b/packages/gcp/docs/dns.md
@@ -101,98 +101,104 @@ An example event for `dns` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-01-23T09:16:05.341Z",
+    "@timestamp": "2021-12-12T15:59:40.446Z",
     "agent": {
-        "ephemeral_id": "0b86920e-9dac-4b22-91c8-e594b22a00b4",
-        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
+        "ephemeral_id": "87190725-9632-41a5-ba26-ebffca397d74",
+        "id": "0168f0f0-b64d-4a7a-ba00-c309f9e7f0ca",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.3"
+        "version": "8.4.1"
     },
     "cloud": {
-        "availability_zone": "europe-west2-a",
-        "instance": {
-            "id": "8340998530665147",
-            "name": "instance"
-        },
         "project": {
-            "id": "project"
+            "id": "key-reference-123456"
         },
         "provider": "gcp",
-        "region": "europe-west2"
+        "region": "global"
     },
     "data_stream": {
         "dataset": "gcp.dns",
         "namespace": "ep",
         "type": "logs"
     },
+    "destination": {
+        "address": "216.239.32.106",
+        "ip": "216.239.32.106"
+    },
     "dns": {
         "answers": [
             {
                 "class": "IN",
-                "data": "127.0.0.1",
-                "name": "elastic.co",
-                "ttl": "300",
+                "data": "67.43.156.13",
+                "name": "asdf.gcp.example.com.",
+                "ttl": 300,
                 "type": "A"
             }
         ],
         "question": {
-            "name": "elastic.co",
-            "registered_domain": "elastic.co",
-            "top_level_domain": "co",
+            "name": "asdf.gcp.example.com",
+            "registered_domain": "example.com",
+            "subdomain": "asdf.gcp",
+            "top_level_domain": "com",
             "type": "A"
         },
         "resolved_ip": [
-            "127.0.0.1"
+            "67.43.156.13"
         ],
         "response_code": "NOERROR"
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "08bce509-f1bf-4b71-8b6b-b8965e7a733b",
+        "id": "0168f0f0-b64d-4a7a-ba00-c309f9e7f0ca",
         "snapshot": false,
-        "version": "8.2.3"
+        "version": "8.4.1"
     },
     "event": {
+        "action": "dns-query",
         "agent_id_status": "verified",
-        "created": "2022-06-28T02:46:41.230Z",
+        "category": "network",
+        "created": "2022-10-03T22:33:56.157Z",
         "dataset": "gcp.dns",
-        "id": "vwroyze8pg7y",
-        "ingested": "2022-06-28T02:46:42Z",
+        "id": "zir4wud11tm",
+        "ingested": "2022-10-03T22:33:57Z",
         "kind": "event",
         "outcome": "success"
     },
     "gcp": {
         "dns": {
             "auth_answer": true,
+            "destination_ip": "216.239.32.106",
             "protocol": "UDP",
-            "query_name": "elastic.co.",
+            "query_name": "asdf.gcp.example.com.",
             "query_type": "A",
-            "rdata": "elastic.co.\t300\tIN\ta\t127.0.0.1",
             "response_code": "NOERROR",
-            "server_latency": 14,
-            "source_ip": "10.154.0.3",
-            "source_network": "default",
-            "vm_instance_id": "8340998530665147",
-            "vm_instance_name": "694119234537.instance",
-            "vm_project_id": "project",
-            "vm_zone_name": "europe-west2-a"
+            "server_latency": 0,
+            "source_type": "internet",
+            "target_type": "public-zone"
         }
     },
     "input": {
         "type": "gcp-pubsub"
     },
     "log": {
-        "logger": "projects/project/logs/dns.googleapis.com%2Fdns_queries"
+        "level": "INFO",
+        "logger": "projects/key-reference-123456/logs/dns.googleapis.com%2Fdns_queries"
     },
     "network": {
+        "iana_number": "17",
+        "protocol": "dns",
         "transport": "udp"
     },
-    "source": {
-        "address": "10.154.0.3",
-        "ip": "10.154.0.3"
+    "related": {
+        "hosts": [
+            "asdf.gcp.example.com"
+        ],
+        "ip": [
+            "67.43.156.13",
+            "216.239.32.106"
+        ]
     },
     "tags": [
         "forwarded",

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.11.10"
+version: "2.11.11"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This converts `dns.answers.ttl` to long during document parsing to conform to ECS spec for this field.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4361

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
