### PR TITLE
cisco_{asa,ftd}: harmonise pipelines

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.0"
+  changes:
+    - description: Harmonise with pipeline with Cisco FTD.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/4380
 - version: "2.7.7"
   changes:
     - description: Remove duplicate fields.

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -105,13 +105,13 @@ processors:
             "append":
               {
                 "field": "error.message",
-                "value": "{{ _ingest.on_failure_message }}",
+                "value": "{{{ _ingest.on_failure_message }}}",
               },
           },
         ]
   - date:
       if: "ctx.event?.timezone != null && ctx._temp_?.raw_date != null"
-      timezone: "{{ event.timezone }}"
+      timezone: "{{{ event.timezone }}}"
       field: "_temp_.raw_date"
       target_field: "@timestamp"
       formats:
@@ -138,7 +138,7 @@ processors:
             "append":
               {
                 "field": "error.message",
-                "value": "{{ _ingest.on_failure_message }}",
+                "value": "{{{ _ingest.on_failure_message }}}",
               },
           },
         ]
@@ -494,7 +494,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338001'"
       field: "server.domain"
       description: "338001"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338002'"
@@ -505,7 +505,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338002'"
       field: "server.domain"
       description: "338002"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338003'"
@@ -526,7 +526,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338005'"
       field: "server.domain"
       description: "338005"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338006'"
@@ -537,7 +537,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338006'"
       field: "server.domain"
       description: "338006"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338007'"
@@ -558,7 +558,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338101'"
       field: "server.domain"
       description: "338101"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338102'"
@@ -569,7 +569,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338102'"
       field: "server.domain"
       description: "338102"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338103'"
@@ -590,7 +590,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338201'"
       field: "server.domain"
       description: "338201"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338202'"
@@ -601,7 +601,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338202'"
       field: "server.domain"
       description: "338202"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338203'"
@@ -612,7 +612,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338203'"
       field: "server.domain"
       description: "338203"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338204'"
@@ -623,7 +623,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338204'"
       field: "server.domain"
       description: "338204"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338301'"
@@ -634,25 +634,25 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "client.address"
       description: "338301"
-      value: "{{destination.address}}"
+      value: "{{{destination.address}}}"
       ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "client.port"
       description: "338301"
-      value: "{{destination.port}}"
+      value: "{{{destination.port}}}"
       ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "server.address"
       description: "338301"
-      value: "{{source.address}}"
+      value: "{{{source.address}}}"
       ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "server.port"
       description: "338301"
-      value: "{{source.port}}"
+      value: "{{{source.port}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '502103'"
@@ -664,8 +664,8 @@ processors:
       field: "event.type"
       description: "502103"
       value:
-      - "group"
-      - "change"
+        - "group"
+        - "change"
   - append:
       if: "ctx._temp_.cisco.message_id == '502103'"
       field: "event.category"
@@ -819,7 +819,7 @@ processors:
       if: '["713905", "713904", "713906", "713902", "713901"].contains(ctx._temp_.cisco.message_id)'
       field: "message"
       patterns:
-      - "^(Group = %{IP}, )?(IP = %{IP:source.address}, )?%{GREEDYDATA:event.reason}$"
+        - "^(Group = %{IP}, )?(IP = %{IP:source.address}, )?%{GREEDYDATA:event.reason}$"
    # Handle ecs action outcome protocol
   - set:
       if: '["434002", "434004"].contains(ctx._temp_.cisco.message_id)'
@@ -1437,7 +1437,7 @@ processors:
   # processor converts it to the right value and populates start and end.
   - set:
       field: "_temp_.duration_hms"
-      value: "{{event.duration}}"
+      value: "{{{event.duration}}}"
       ignore_empty_value: true
 
   #
@@ -1792,7 +1792,7 @@ processors:
   # Fills nat.ip and nat.port even when only the ip or port changed.
   - set:
       field: source.nat.ip
-      value: "{{_temp_.cisco.mapped_source_ip}}"
+      value: "{{{_temp_.cisco.mapped_source_ip}}}"
       if: "ctx?._temp_?.cisco?.mapped_source_ip != ctx?.source?.ip"
       ignore_empty_value: true
   - convert:
@@ -1801,7 +1801,7 @@ processors:
       ignore_missing: true
   - set:
       field: source.nat.port
-      value: "{{_temp_.cisco.mapped_source_port}}"
+      value: "{{{_temp_.cisco.mapped_source_port}}}"
       if: "ctx?._temp_?.cisco?.mapped_source_port != ctx?.source?.port"
       ignore_empty_value: true
   - convert:
@@ -1810,7 +1810,7 @@ processors:
       ignore_missing: true
   - set:
       field: destination.nat.ip
-      value: "{{_temp_.cisco.mapped_destination_ip}}"
+      value: "{{{_temp_.cisco.mapped_destination_ip}}}"
       if: "ctx?._temp_?.cisco.mapped_destination_ip != ctx?.destination?.ip"
       ignore_empty_value: true
   - convert:
@@ -1819,7 +1819,7 @@ processors:
       ignore_missing: true
   - set:
       field: destination.nat.port
-      value: "{{_temp_.cisco.mapped_destination_port}}"
+      value: "{{{_temp_.cisco.mapped_destination_port}}}"
       if: "ctx?._temp_?.cisco?.mapped_destination_port != ctx?.destination?.port"
       ignore_empty_value: true
   - convert:
@@ -1893,7 +1893,7 @@ processors:
 
   - set:
       field: _temp_.url_domain
-      value: "{{url.domain}}"
+      value: "{{{url.domain}}}"
       ignore_failure: true
       if: ctx?.url?.domain != null
 
@@ -1903,7 +1903,7 @@ processors:
       if: ctx?.url?.original != null
   - append:
       field: url.domain
-      value: "{{_temp_.url_domain}}"
+      value: "{{{_temp_.url_domain}}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx?._temp_?.url_domain != null
@@ -2097,17 +2097,27 @@ processors:
           ctx.event.outcome = 'success';
         }
 
+  # Malware event kind is classified as alert when sha_disposition is "Malware", "Custom Detection" not for other cases.
+  - set:
+      if: 'ctx?.event?.code == "430005" && ["Malware", "Custom Detection"].contains(ctx.cisco.asa.security.sha_disposition)'
+      field: event.kind
+      value: alert
+  - append:
+      if: 'ctx?.event?.code == "430005" && !["Malware", "Custom Detection"].contains(ctx.cisco.asa.security.sha_disposition)'
+      field: event.category
+      value: file
+
   - set:
       description: copy destination.user.name to user.name if it is not set
       field: user.name
-      value: "{{destination.user.name}}"
+      value: "{{{destination.user.name}}}"
       ignore_empty_value: true
       if: ctx?.user?.name == null
 
   # Configures observer fields with a copy from cisco and host fields. Later on these might replace host.hostname.
   - set:
       field: observer.hostname
-      value: "{{ host.hostname }}"
+      value: "{{{ host.hostname }}}"
       ignore_empty_value: true
   - set:
       field: observer.vendor
@@ -2123,30 +2133,30 @@ processors:
       ignore_empty_value: true
   - set:
       field: observer.egress.interface.name
-      value: "{{ cisco.asa.destination_interface }}"
+      value: "{{{ cisco.asa.destination_interface }}}"
       ignore_empty_value: true
   - set:
       field: observer.ingress.interface.name
-      value: "{{ cisco.asa.source_interface }}"
+      value: "{{{ cisco.asa.source_interface }}}"
       ignore_empty_value: true
   - append:
       field: related.ip
-      value: "{{source.ip}}"
+      value: "{{{source.ip}}}"
       if: "ctx?.source?.ip != null"
       allow_duplicates: false
   - append:
       field: related.ip
-      value: "{{source.nat.ip}}"
+      value: "{{{source.nat.ip}}}"
       if: "ctx?.source?.nat?.ip != null"
       allow_duplicates: false
   - append:
       field: related.ip
-      value: "{{destination.ip}}"
+      value: "{{{destination.ip}}}"
       if: "ctx?.destination?.ip != null"
       allow_duplicates: false
   - append:
       field: related.ip
-      value: "{{destination.nat.ip}}"
+      value: "{{{destination.nat.ip}}}"
       if: "ctx?.destination?.nat?.ip != null"
       allow_duplicates: false
   - append:
@@ -2156,7 +2166,7 @@ processors:
       allow_duplicates: false
   - append:
       field: related.user
-      value: "{{server.user.name}}"
+      value: "{{{server.user.name}}}"
       if: ctx?.server?.user?.name != null && ctx?.server?.user?.name != ''
       allow_duplicates: false
   - append:
@@ -2171,37 +2181,37 @@ processors:
       allow_duplicates: false
   - append:
       field: related.hash
-      value: "{{file.hash.sha256}}"
+      value: "{{{file.hash.sha256}}}"
       if: "ctx?.file?.hash?.sha256 != null"
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{host.hostname}}"
+      value: "{{{host.hostname}}}"
       if: ctx.host?.hostname != null && ctx.host?.hostname != ''
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{observer.hostname}}"
+      value: "{{{observer.hostname}}}"
       if: ctx.observer?.hostname != null && ctx.observer?.hostname != ''
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       if: ctx.destination?.domain != null && ctx.destination?.domain != ''
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       if: ctx.source?.domain != null && ctx.source?.domain != ''
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{source.user.domain}}"
+      value: "{{{source.user.domain}}}"
       if: ctx.source?.user?.domain != null && ctx.source?.user?.domain != ''
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{destination.user.domain}}"
+      value: "{{{destination.user.domain}}}"
       if: ctx.destination?.user?.domain != null && ctx.destination?.user?.domain != ''
       allow_duplicates: false
   - script:
@@ -2249,4 +2259,4 @@ on_failure:
       ignore_missing: true
   - append:
       field: "error.message"
-      value: "{{ _ingest.on_failure_message }}"
+      value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.7.7"
+version: "2.8.0"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.6"
+  changes:
+    - description: Harmonise with pipeline with Cisco ASA.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/4380
 - version: "2.4.5"
   changes:
     - description: Remove duplicate fields.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -7,7 +7,7 @@
                     "connection_id": "110577675",
                     "destination_interface": "Inside",
                     "source_interface": "Outside",
-                    "source_username": "(LOCAL\\Elastic)",
+                    "source_username": "LOCAL\\Elastic",
                     "termination_user": "zzzzzz"
                 }
             },
@@ -44,6 +44,7 @@
             },
             "network": {
                 "bytes": 148,
+                "community_id": "1:9aBQ+NznvYals1agEGRVJm37dvQ=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -70,12 +71,18 @@
                 "ip": [
                     "10.123.123.123",
                     "10.233.123.123"
+                ],
+                "user": [
+                    "Elastic"
                 ]
             },
             "source": {
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123",
-                "port": 53723
+                "port": 53723,
+                "user": {
+                    "name": "Elastic"
+                }
             },
             "tags": [
                 "preserve_original_event"
@@ -119,6 +126,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:kV/6Jt4iMhVyUT1AW+UO0itOhqU=",
                 "iana_number": "1",
                 "transport": "icmp"
             },
@@ -190,6 +198,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:7nrIUULEgk5A+nhbh4kNmEkwL3o=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -229,7 +238,7 @@
                     "destination_interface": "Outside",
                     "rule_name": "Inside_access_in",
                     "source_interface": "Inside",
-                    "source_username": "(LOCAL\\Elastic)"
+                    "source_username": "LOCAL\\Elastic"
                 }
             },
             "destination": {
@@ -262,6 +271,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:LM0R4Wi8tEf+1pe2ukofXQKxfMc=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -287,12 +297,18 @@
                 ],
                 "ip": [
                     "10.123.123.123"
+                ],
+                "user": [
+                    "Elastic"
                 ]
             },
             "source": {
                 "address": "10.123.123.123",
                 "ip": "10.123.123.123",
-                "port": 57621
+                "port": 57621,
+                "user": {
+                    "name": "Elastic"
+                }
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
@@ -36,6 +36,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:5fapvb2/9FPSvoCspfD2WiW0NdQ=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -118,6 +119,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:XR/BitXv9NInXuXHAcohUF0RzNM=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -203,6 +205,7 @@
             },
             "network": {
                 "bytes": 38110,
+                "community_id": "1:ZfiZ7qrEhwe3W6wpV2g56vRGXjQ=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -287,6 +290,7 @@
             },
             "network": {
                 "bytes": 44010,
+                "community_id": "1:Ph9SZP2LVfI6Vw9XriF6WLudekk=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -371,6 +375,7 @@
             },
             "network": {
                 "bytes": 7652,
+                "community_id": "1:B+sz9IcyuRIohyVsbDs+jlQsd9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -455,6 +460,7 @@
             },
             "network": {
                 "bytes": 7062,
+                "community_id": "1:W1/rT+XybnDF4R4UdZQ0sa4mT24=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -539,6 +545,7 @@
             },
             "network": {
                 "bytes": 5738,
+                "community_id": "1:adfUeTJn0LW2HirexE98QwfZxUI=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -623,6 +630,7 @@
             },
             "network": {
                 "bytes": 4176,
+                "community_id": "1:Z99w+fNZNVOSJdDOifKH0RKIcM4=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -707,6 +715,7 @@
             },
             "network": {
                 "bytes": 1715,
+                "community_id": "1:lRYn5i/a/4JZRny6z1Yo1qYoWcw=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -791,6 +800,7 @@
             },
             "network": {
                 "bytes": 45595,
+                "community_id": "1:kGDbm0eLS+Sdpn3aBJlKAQwx5Ao=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -875,6 +885,7 @@
             },
             "network": {
                 "bytes": 27359,
+                "community_id": "1:kate+q2Q/2OtbOmRRWaHPCmRN4k=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -959,6 +970,7 @@
             },
             "network": {
                 "bytes": 4457,
+                "community_id": "1:5tA8FTtcjt4hjO1ULz6Knv9Jmj4=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1043,6 +1055,7 @@
             },
             "network": {
                 "bytes": 26709,
+                "community_id": "1:n20B5rtOXBeMlQMpwiUola7g/sQ=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1127,6 +1140,7 @@
             },
             "network": {
                 "bytes": 22097,
+                "community_id": "1:WCA/PytrHuEwFVj6H+WVDXWfJrw=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1211,6 +1225,7 @@
             },
             "network": {
                 "bytes": 2209,
+                "community_id": "1:VqC+0XXJtvEuYjrRzaF+ZHrODbI=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1295,6 +1310,7 @@
             },
             "network": {
                 "bytes": 10404,
+                "community_id": "1:k7sMIK9iRX6HqPf7wCq/yoyNvCA=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1379,6 +1395,7 @@
             },
             "network": {
                 "bytes": 123694,
+                "community_id": "1:mduzQAsMTZ4xp6Byvjhcpfcrv70=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1463,6 +1480,7 @@
             },
             "network": {
                 "bytes": 35835,
+                "community_id": "1:pHXsO4UxdxlF36982v16/UPqKMw=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1547,6 +1565,7 @@
             },
             "network": {
                 "bytes": 0,
+                "community_id": "1:/kEOTvw9zHe15tXXUtkoHEC6Yh0=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1624,6 +1643,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:J+wbrbWqx/9CN5sgkzbDl8X6zvw=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -1706,6 +1726,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:EW3nYv2EsVNyWwVZ/8O8io4jVfA=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -1790,6 +1811,7 @@
             },
             "network": {
                 "bytes": 148,
+                "community_id": "1:EW3nYv2EsVNyWwVZ/8O8io4jVfA=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -1872,6 +1894,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:yzjPLy3rBCpHRjR3hWPXoQ0PE3Q=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -1956,6 +1979,7 @@
             },
             "network": {
                 "bytes": 164,
+                "community_id": "1:yzjPLy3rBCpHRjR3hWPXoQ0PE3Q=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -2033,6 +2057,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:q9omdFfLIv04shUHMYUi6dRDUt8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2115,6 +2140,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:e24G90zPRepddiAEq280PJ2Dt34=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2193,6 +2219,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:wY0HQAXYhTOJXTlsqsFfP+gErU4=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2275,6 +2302,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:tMd6McbRs6Utum4Kx01f7l1V0Fw=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2358,6 +2386,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:llluUIIxeTdvNbm7xXS92PkqPxg=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -2441,6 +2470,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:Rg6yigJ2fQgizHALcQtiNKIovzw=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -2525,6 +2555,7 @@
             },
             "network": {
                 "bytes": 111,
+                "community_id": "1:llluUIIxeTdvNbm7xXS92PkqPxg=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -2608,6 +2639,7 @@
             },
             "network": {
                 "bytes": 237,
+                "community_id": "1:Rg6yigJ2fQgizHALcQtiNKIovzw=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -2685,6 +2717,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:B7zSvJiop8ECO4tKGxIcuxL8zZ8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2767,6 +2800,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:h9l2FzDom7t27Qu1B19XofanWsY=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -2845,6 +2879,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:HgRxpVvdN4+DmAuDUBjP8r0O6LE=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -2927,6 +2962,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:wTKGvWrp/DvNNgR83FrR2bt9abI=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -3010,6 +3046,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:B61Cd3PDocUt48KA63DFhI0cIuM=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -3094,6 +3131,7 @@
             },
             "network": {
                 "bytes": 87,
+                "community_id": "1:wTKGvWrp/DvNNgR83FrR2bt9abI=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -3177,6 +3215,7 @@
             },
             "network": {
                 "bytes": 221,
+                "community_id": "1:B61Cd3PDocUt48KA63DFhI0cIuM=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -3254,6 +3293,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:oiUu8EJ76N4sMoBZ4odDbFEvEy8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3336,6 +3376,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:6tiFUxp6Vj5XUa6UFGpeT5yZn3U=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3419,6 +3460,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:EY3fYPMoFpaQxLyDzH9NGCbkJjQ=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -3502,6 +3544,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:/y/o4czeEHU4zp8DrjY9lp97N9c=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -3586,6 +3629,7 @@
             },
             "network": {
                 "bytes": 101,
+                "community_id": "1:EY3fYPMoFpaQxLyDzH9NGCbkJjQ=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -3669,6 +3713,7 @@
             },
             "network": {
                 "bytes": 126,
+                "community_id": "1:/y/o4czeEHU4zp8DrjY9lp97N9c=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -3746,6 +3791,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:2OczMI14cttOG/mH4+zeX4RzQpg=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3828,6 +3874,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:yPnk7rWuiFUvPq5hSZ4LTLCkFZo=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3913,6 +3960,7 @@
             },
             "network": {
                 "bytes": 862,
+                "community_id": "1:yPnk7rWuiFUvPq5hSZ4LTLCkFZo=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3995,6 +4043,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:1JUXuhAmqa122fCgtHPUklrEqoY=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -4079,6 +4128,7 @@
             },
             "network": {
                 "bytes": 104,
+                "community_id": "1:EY3fYPMoFpaQxLyDzH9NGCbkJjQ=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -4162,6 +4212,7 @@
             },
             "network": {
                 "bytes": 176,
+                "community_id": "1:1JUXuhAmqa122fCgtHPUklrEqoY=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -4239,6 +4290,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:DOwEUC6tqp/Du8jX5Vij+76quPA=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -4321,6 +4373,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:qy6jLhkJon1oBc5OcH3f9oz1AjY=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4399,6 +4452,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:S9EaGQG3NJJnIGBkvf3LTCwLEzA=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -4481,6 +4535,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:ktEyVWcVs3OdcrF3mbp6+w0crBM=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4559,6 +4614,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:TZf7oV48+dAAkLZpxs0YmaevxjE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -4641,6 +4697,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:yF8k0SSjYi1QAffgq4/xYM6aQrM=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -4724,6 +4781,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:jANf+Oa1AIWXIAQo9DFHwcPU9j0=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -4808,6 +4866,7 @@
             },
             "network": {
                 "bytes": 104,
+                "community_id": "1:jANf+Oa1AIWXIAQo9DFHwcPU9j0=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -4885,6 +4944,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:lVkswd+hPKCK0FUSQbSuKe9bAuU=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -4967,6 +5027,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:RWUDy04C8kplZW/ImcOEjiivig0=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5045,6 +5106,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:KOyD8euCVIyp02NfhcAKtT4FGn0=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -5127,6 +5189,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:yNYVbJr3eP0LagZWNxVede7nQPk=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5210,6 +5273,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:Sx0NFdCEosBZj1T2uDpMOtjKttY=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -5295,6 +5359,7 @@
             },
             "network": {
                 "bytes": 593,
+                "community_id": "1:RWUDy04C8kplZW/ImcOEjiivig0=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -5372,6 +5437,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:4i56uoUFLyBxwyXCghDMoX5gm/Y=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -5454,6 +5520,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:W/zo/0whfHt19UmGO1Qgxb4HVK8=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5538,6 +5605,7 @@
             },
             "network": {
                 "bytes": 375,
+                "community_id": "1:Sx0NFdCEosBZj1T2uDpMOtjKttY=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -5615,6 +5683,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:3ugfvtrokDp5GOoEGiu82fyfPRE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -5697,6 +5766,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:agxRgF0VQato5ourRhYYU9WynEY=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5742,22 +5812,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8267
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1454 to outside:192.168.98.44/8267 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -5766,8 +5848,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:DOwEUC6tqp/Du8jX5Vij+76quPA=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -5779,7 +5876,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1454
             },
             "tags": [
                 "preserve_original_event"
@@ -5821,6 +5927,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:7y69WhagFHZJlPCQeHiR9Bhhcjo=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -5903,6 +6010,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:gdNXl3B1AxZK+A+wiuiTkNmsedk=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -5948,22 +6056,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8268
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1455 to outside:192.168.98.44/8268 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -5972,8 +6092,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:S9EaGQG3NJJnIGBkvf3LTCwLEzA=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -5985,7 +6120,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1455
             },
             "tags": [
                 "preserve_original_event"
@@ -5994,22 +6138,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8269
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1456 to outside:192.168.98.44/8269 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -6018,8 +6174,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:TZf7oV48+dAAkLZpxs0YmaevxjE=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -6031,7 +6202,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1456
             },
             "tags": [
                 "preserve_original_event"
@@ -6040,22 +6220,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8270
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1457 to outside:192.168.98.44/8270 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -6064,8 +6256,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:lVkswd+hPKCK0FUSQbSuKe9bAuU=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -6077,7 +6284,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1457
             },
             "tags": [
                 "preserve_original_event"
@@ -6086,22 +6302,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8271
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1458 to outside:192.168.98.44/8271 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -6110,8 +6338,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:KOyD8euCVIyp02NfhcAKtT4FGn0=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -6123,7 +6366,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1458
             },
             "tags": [
                 "preserve_original_event"
@@ -6132,22 +6384,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8272
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1459 to outside:192.168.98.44/8272 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -6156,8 +6420,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:4i56uoUFLyBxwyXCghDMoX5gm/Y=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -6169,7 +6448,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1459
             },
             "tags": [
                 "preserve_original_event"
@@ -6178,22 +6466,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8273
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1460 to outside:192.168.98.44/8273 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -6202,8 +6502,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:3ugfvtrokDp5GOoEGiu82fyfPRE=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -6215,7 +6530,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1460
             },
             "tags": [
                 "preserve_original_event"
@@ -6264,6 +6588,7 @@
             },
             "network": {
                 "bytes": 575,
+                "community_id": "1:4Iv419PBNDJdPRXAfFDK73jR3tY=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -6348,6 +6673,7 @@
             },
             "network": {
                 "bytes": 5391,
+                "community_id": "1:gdNXl3B1AxZK+A+wiuiTkNmsedk=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -6425,6 +6751,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:xZAoP7GC/3Cmmd99I/61nA/kFRs=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -6507,6 +6834,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:o6d94KUuLlPtkO8V0idugT9LumA=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -6588,6 +6916,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -6668,6 +6997,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -6748,6 +7078,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -6828,6 +7159,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -6908,6 +7240,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -6988,6 +7321,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7068,6 +7402,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7148,6 +7483,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7228,6 +7564,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7308,6 +7645,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7388,6 +7726,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7468,6 +7807,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7548,6 +7888,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:eDGYCCim2x79ieqSncevN5rke9U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7625,6 +7966,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:PLf8lGhrnxV0bmgAgFTj2TMaRY8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -7707,6 +8049,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:GQgUBPJL/+1zE0GVyJj8zPioJL0=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -7785,6 +8128,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:V/W7M4S1RCEoTYUr0fBQw18o3L0=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -7867,6 +8211,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:tyIOx1b7XE4on6GaliGmcurhU58=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -7951,6 +8296,7 @@
             },
             "network": {
                 "bytes": 373,
+                "community_id": "1:tyIOx1b7XE4on6GaliGmcurhU58=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -8033,6 +8379,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:b1mUakx8YXclh1VopNc+mVisPlc=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -8117,6 +8464,7 @@
             },
             "network": {
                 "bytes": 207,
+                "community_id": "1:b1mUakx8YXclh1VopNc+mVisPlc=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -8194,6 +8542,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:fGD7b2bvtp8HpAhmcMpmtr0TQy4=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -8276,6 +8625,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:mfai1xnh2n3iEGkKcMx1/uOj4rs=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8354,6 +8704,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:J37X5Np5BtSx9vRBrQObVHHdQeo=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -8436,6 +8787,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:L19x38N99okSnqKeqKA/91LIVls=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8521,6 +8873,7 @@
             },
             "network": {
                 "bytes": 12853,
+                "community_id": "1:mfai1xnh2n3iEGkKcMx1/uOj4rs=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -8598,6 +8951,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:vOiksveV9m7pdkJ5lZI3/BKKIBc=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -8680,6 +9034,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:1oKpfnwWzvh0a76lRj+Lf+H9v4I=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -8765,6 +9120,7 @@
             },
             "network": {
                 "bytes": 5291,
+                "community_id": "1:L19x38N99okSnqKeqKA/91LIVls=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -8842,6 +9198,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:JXnNyb+JrnkY0FlCWJ0o6BHyWbs=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -8924,6 +9281,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:t7AyqEa2i/g/pIVig/nVKRIRjN4=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9009,6 +9367,7 @@
             },
             "network": {
                 "bytes": 965,
+                "community_id": "1:1oKpfnwWzvh0a76lRj+Lf+H9v4I=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -9093,6 +9452,7 @@
             },
             "network": {
                 "bytes": 8605,
+                "community_id": "1:t7AyqEa2i/g/pIVig/nVKRIRjN4=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -9170,6 +9530,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:rMPC8dKRJUht5otyIuD8bqae32c=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -9252,6 +9613,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:UmAEn1h+8EOIybW4u5BYI++dVbg=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9337,6 +9699,7 @@
             },
             "network": {
                 "bytes": 3428,
+                "community_id": "1:UmAEn1h+8EOIybW4u5BYI++dVbg=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -9414,6 +9777,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:BQTEjYe/9AyO6AxwcwMlh6tRQvM=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -9496,6 +9860,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:mDdMPTeaLZJ3Ic4XT51l9FyVrcg=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9574,6 +9939,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:Av8ctJrmZ7dNOixGJbbgAp56ZxM=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -9656,6 +10022,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:Mwb5dYXL+wp/DIc02LRWGGkiweU=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9734,6 +10101,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:eutLpSiNzjShq5EM75ucFYpWOuw=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -9816,6 +10184,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:/KL4BE2j6MehSKtvx9BC9KiHmWY=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -9894,6 +10263,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:1i47ggwOBA81TQhZUKuyM4UbKjU=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -9976,6 +10346,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:NQt40Prx+iw1VlHtNOjgB7UHg14=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10061,6 +10432,7 @@
             },
             "network": {
                 "bytes": 2028,
+                "community_id": "1:mDdMPTeaLZJ3Ic4XT51l9FyVrcg=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -10145,6 +10517,7 @@
             },
             "network": {
                 "bytes": 1085,
+                "community_id": "1:Mwb5dYXL+wp/DIc02LRWGGkiweU=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -10229,6 +10602,7 @@
             },
             "network": {
                 "bytes": 868,
+                "community_id": "1:/KL4BE2j6MehSKtvx9BC9KiHmWY=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -10306,6 +10680,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:83edq1aD9JVBtdZlXqW/N8Lh5/I=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -10388,6 +10763,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:JoZ7v/wA/WjxycscO7zww0lh2bU=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10466,6 +10842,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:BTQrlR5AZHHVHnCIfUmRL4tiluc=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -10548,6 +10925,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:FpPxeAj27xAk/nz3WHy4rgxQy7U=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10633,6 +11011,7 @@
             },
             "network": {
                 "bytes": 4439,
+                "community_id": "1:NQt40Prx+iw1VlHtNOjgB7UHg14=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -10710,6 +11089,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:eB6Wc+AYB+cV+ku4nNFOIkD3lek=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -10792,6 +11172,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:eyMVZH5KXp36P9ggTQa4CnFEsX4=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -10877,6 +11258,7 @@
             },
             "network": {
                 "bytes": 914,
+                "community_id": "1:JoZ7v/wA/WjxycscO7zww0lh2bU=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -10961,6 +11343,7 @@
             },
             "network": {
                 "bytes": 871,
+                "community_id": "1:FpPxeAj27xAk/nz3WHy4rgxQy7U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -11043,6 +11426,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:XRkudEQzoOGeR59hYks0NpPRhJQ=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -11121,6 +11505,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:RsyqGXIqmHkfdiNu5GqcRgT4hDc=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -11203,6 +11588,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:vPIZTLf1IkwzWLXl0eovLh3TWYQ=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -11287,6 +11673,7 @@
             },
             "network": {
                 "bytes": 384,
+                "community_id": "1:XRkudEQzoOGeR59hYks0NpPRhJQ=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -11369,6 +11756,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:MA8vNBtTjpzkGaeVEPpL7rYdehs=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -11453,6 +11841,7 @@
             },
             "network": {
                 "bytes": 94,
+                "community_id": "1:MA8vNBtTjpzkGaeVEPpL7rYdehs=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -11530,6 +11919,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:IKXXnd13hV9PZSG5cvPnawhrlwY=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -11612,6 +12002,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:L/FYUvmZyMqAtBXXffQkz21noq8=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -11697,6 +12088,7 @@
             },
             "network": {
                 "bytes": 945,
+                "community_id": "1:vPIZTLf1IkwzWLXl0eovLh3TWYQ=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -11781,6 +12173,7 @@
             },
             "network": {
                 "bytes": 13284,
+                "community_id": "1:eyMVZH5KXp36P9ggTQa4CnFEsX4=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -11863,6 +12256,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:jANf+Oa1AIWXIAQo9DFHwcPU9j0=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -11947,6 +12341,7 @@
             },
             "network": {
                 "bytes": 104,
+                "community_id": "1:jANf+Oa1AIWXIAQo9DFHwcPU9j0=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -12024,6 +12419,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:JCz9NqMAscFrVd6cVJGjYoSTVjc=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -12106,6 +12502,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:Z3+wBM9fC4b2ZRTX2xKrjZXph5M=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -12190,6 +12587,7 @@
             },
             "network": {
                 "bytes": 58512,
+                "community_id": "1:FH5T1GpT06ypD3c2H3GvQa42m+8=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -12234,22 +12632,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8276
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1272 to outside:192.168.98.44/8276 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -12258,8 +12668,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:dm+e2N9F+7psMTLRaZhdNoD+35Y=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -12271,7 +12696,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1272
             },
             "tags": [
                 "preserve_original_event"
@@ -12318,6 +12752,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:tEWu7Iy9Db+cWSJIpWVzT9ICdf8=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -12401,6 +12836,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:hdvcqHxF4FI7ohg6sDxkHbrnr1Q=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -12485,6 +12921,7 @@
             },
             "network": {
                 "bytes": 168,
+                "community_id": "1:tEWu7Iy9Db+cWSJIpWVzT9ICdf8=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -12567,6 +13004,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:tEWu7Iy9Db+cWSJIpWVzT9ICdf8=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -12651,6 +13089,7 @@
             },
             "network": {
                 "bytes": 198,
+                "community_id": "1:hdvcqHxF4FI7ohg6sDxkHbrnr1Q=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -12734,6 +13173,7 @@
             },
             "network": {
                 "bytes": 150,
+                "community_id": "1:tEWu7Iy9Db+cWSJIpWVzT9ICdf8=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -12816,6 +13256,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:KcNbI0fW5xWO1VGttD5KW12vq/c=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -12900,6 +13341,7 @@
             },
             "network": {
                 "bytes": 84,
+                "community_id": "1:KcNbI0fW5xWO1VGttD5KW12vq/c=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -12977,6 +13419,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:Rc52IhrhhWJEiV/Q/KfnDuj22z8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -13059,6 +13502,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:/BcFV9iPotZ+a2hSh1LbxormrRw=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13142,6 +13586,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:daUqtMP3uS/J+e0xU5ZhQqZiOGA=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -13226,6 +13671,7 @@
             },
             "network": {
                 "bytes": 188,
+                "community_id": "1:daUqtMP3uS/J+e0xU5ZhQqZiOGA=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -13303,6 +13749,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:e3HkRsd8rQplyv0zIEVr8q2WAq8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -13385,6 +13832,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:El7CmVRatgpWi/uTSszVlXS7RvM=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13463,6 +13911,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:66o37pw6MYv2lpEz/UGM9D2Ho8I=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -13545,6 +13994,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:MGcr2koPYwvVhGHh16Zoc3Ie0bU=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13623,6 +14073,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:epSGSfgDLViXPSXUiPgPy4mgWOQ=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -13705,6 +14156,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:GnbZNf9te8L/+pbwft3pMkTSXx0=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -13790,6 +14242,7 @@
             },
             "network": {
                 "bytes": 5964,
+                "community_id": "1:MGcr2koPYwvVhGHh16Zoc3Ie0bU=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -13867,6 +14320,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:+mwCB4JYWZbAwFPeKlMV4HSWmzI=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -13949,6 +14403,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:SHKU9BgVTwmk+zMpR25ViNsJwxQ=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14027,6 +14482,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:lLW27FoxFx/lMqTVWx3uBv3lsY8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -14109,6 +14565,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:7o4Hml4sgvG1ub4dQA797um6/Bc=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14194,6 +14651,7 @@
             },
             "network": {
                 "bytes": 6694,
+                "community_id": "1:GnbZNf9te8L/+pbwft3pMkTSXx0=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -14278,6 +14736,7 @@
             },
             "network": {
                 "bytes": 1493,
+                "community_id": "1:SHKU9BgVTwmk+zMpR25ViNsJwxQ=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -14362,6 +14821,7 @@
             },
             "network": {
                 "bytes": 893,
+                "community_id": "1:7o4Hml4sgvG1ub4dQA797um6/Bc=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -14439,6 +14899,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:NHvrP6b5/Mmf0dGA3mQ0ZbakRds=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -14521,6 +14982,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:3ID0XG7Sd965C6Vnvj27BTwK03k=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14599,6 +15061,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:OpKXx3JYrbWDRisSO5qim6H6gHY=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -14681,6 +15144,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:C6rlp8ZtLd3/sbU501v5fkQaS20=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -14764,6 +15228,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:IyKVGq5g9sVanjx5ZasJCZh/zMs=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -14848,6 +15313,7 @@
             },
             "network": {
                 "bytes": 150,
+                "community_id": "1:IyKVGq5g9sVanjx5ZasJCZh/zMs=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -14932,6 +15398,7 @@
             },
             "network": {
                 "bytes": 2750,
+                "community_id": "1:3ID0XG7Sd965C6Vnvj27BTwK03k=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -15009,6 +15476,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:6sa4KKyKp6sQgWfyFRuuEciemwI=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -15091,6 +15559,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:65j0MVw9/9gYDKEr+uLOls+XhDc=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -15169,6 +15638,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:oJFhdOwC0q2/wSkBKCc7a3IE9ss=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -15251,6 +15721,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:kVLZzFOVP5xHyXhfj7vMVdb9fkk=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -15336,6 +15807,7 @@
             },
             "network": {
                 "bytes": 881,
+                "community_id": "1:C6rlp8ZtLd3/sbU501v5fkQaS20=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -15420,6 +15892,7 @@
             },
             "network": {
                 "bytes": 2202,
+                "community_id": "1:kVLZzFOVP5xHyXhfj7vMVdb9fkk=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -15497,6 +15970,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:E1tD2tMTr8HFWTq3wX2/QHew7bA=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -15579,6 +16053,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:npmSfSwKJOc1triiwMja9qhW4wQ=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -15657,6 +16132,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:PepCxrCgLe5kXkyNH8hYn1sUdZ8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -15739,6 +16215,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:du7gmHnIs+0+uXka/I+OLqtyUFA=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -15784,22 +16261,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8280
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1276 to outside:192.168.98.44/8280 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -15808,8 +16297,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:fGD7b2bvtp8HpAhmcMpmtr0TQy4=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -15821,7 +16325,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1276
             },
             "tags": [
                 "preserve_original_event"
@@ -15830,22 +16343,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8281
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1277 to outside:192.168.98.44/8281 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -15854,8 +16379,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:J37X5Np5BtSx9vRBrQObVHHdQeo=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -15867,7 +16407,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1277
             },
             "tags": [
                 "preserve_original_event"
@@ -15876,22 +16425,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8282
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1278 to outside:192.168.98.44/8282 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -15900,8 +16461,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:vOiksveV9m7pdkJ5lZI3/BKKIBc=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -15913,7 +16489,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1278
             },
             "tags": [
                 "preserve_original_event"
@@ -15922,22 +16507,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8283
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1279 to outside:192.168.98.44/8283 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -15946,8 +16543,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:JXnNyb+JrnkY0FlCWJ0o6BHyWbs=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -15959,7 +16571,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1279
             },
             "tags": [
                 "preserve_original_event"
@@ -15968,22 +16589,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8284
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1280 to outside:192.168.98.44/8284 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -15992,8 +16625,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:rMPC8dKRJUht5otyIuD8bqae32c=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16005,7 +16653,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1280
             },
             "tags": [
                 "preserve_original_event"
@@ -16014,22 +16671,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8285
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1281 to outside:192.168.98.44/8285 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16038,8 +16707,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:BQTEjYe/9AyO6AxwcwMlh6tRQvM=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16051,7 +16735,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1281
             },
             "tags": [
                 "preserve_original_event"
@@ -16060,22 +16753,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8286
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1282 to outside:192.168.98.44/8286 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16084,8 +16789,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:Av8ctJrmZ7dNOixGJbbgAp56ZxM=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16097,7 +16817,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1282
             },
             "tags": [
                 "preserve_original_event"
@@ -16106,22 +16835,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8287
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1283 to outside:192.168.98.44/8287 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16130,8 +16871,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:eutLpSiNzjShq5EM75ucFYpWOuw=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16143,7 +16899,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1283
             },
             "tags": [
                 "preserve_original_event"
@@ -16152,22 +16917,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8288
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1284 to outside:192.168.98.44/8288 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16176,8 +16953,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:1i47ggwOBA81TQhZUKuyM4UbKjU=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16189,7 +16981,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1284
             },
             "tags": [
                 "preserve_original_event"
@@ -16198,22 +16999,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8289
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1285 to outside:192.168.98.44/8289 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16222,8 +17035,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:83edq1aD9JVBtdZlXqW/N8Lh5/I=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16235,7 +17063,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1285
             },
             "tags": [
                 "preserve_original_event"
@@ -16244,22 +17081,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8290
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1286 to outside:192.168.98.44/8290 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16268,8 +17117,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:BTQrlR5AZHHVHnCIfUmRL4tiluc=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16281,7 +17145,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1286
             },
             "tags": [
                 "preserve_original_event"
@@ -16290,22 +17163,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8291
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1287 to outside:192.168.98.44/8291 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16314,8 +17199,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:eB6Wc+AYB+cV+ku4nNFOIkD3lek=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16327,7 +17227,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1287
             },
             "tags": [
                 "preserve_original_event"
@@ -16336,22 +17245,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8292
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1288 to outside:192.168.98.44/8292 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16360,8 +17281,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:RsyqGXIqmHkfdiNu5GqcRgT4hDc=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16373,7 +17309,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1288
             },
             "tags": [
                 "preserve_original_event"
@@ -16382,22 +17327,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8297
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1293 to outside:192.168.98.44/8297 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16406,8 +17363,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:66o37pw6MYv2lpEz/UGM9D2Ho8I=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16419,7 +17391,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1293
             },
             "tags": [
                 "preserve_original_event"
@@ -16428,22 +17409,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8298
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1294 to outside:192.168.98.44/8298 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16452,8 +17445,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:epSGSfgDLViXPSXUiPgPy4mgWOQ=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16465,7 +17473,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1294
             },
             "tags": [
                 "preserve_original_event"
@@ -16507,6 +17524,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:ulFKMgEYxrjr2bMa0GSZuw3Hyos=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -16589,6 +17607,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:tk29D/5kgkMIpK+sTf4gQir3w+Y=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -16634,22 +17653,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8299
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1295 to outside:192.168.98.44/8299 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16658,8 +17689,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:+mwCB4JYWZbAwFPeKlMV4HSWmzI=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16671,7 +17717,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1295
             },
             "tags": [
                 "preserve_original_event"
@@ -16680,22 +17735,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8300
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1296 to outside:192.168.98.44/8300 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -16704,8 +17771,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:lLW27FoxFx/lMqTVWx3uBv3lsY8=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -16717,7 +17799,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1296
             },
             "tags": [
                 "preserve_original_event"
@@ -16764,6 +17855,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:hmW08bKKG3rl+h6Z05oPVDZZPAc=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -16847,6 +17939,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:Wp+lE0crv7FOgjCM/KHQS0LAMIE=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -16931,6 +18024,7 @@
             },
             "network": {
                 "bytes": 318,
+                "community_id": "1:hmW08bKKG3rl+h6Z05oPVDZZPAc=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -17014,6 +18108,7 @@
             },
             "network": {
                 "bytes": 104,
+                "community_id": "1:Wp+lE0crv7FOgjCM/KHQS0LAMIE=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -17091,6 +18186,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:M26eKKD4XnmGhuhlxXp/0wWRtDQ=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -17173,6 +18269,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:IWKDs2Dj96xcnQVIL2h0TZzcj4M=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -17218,22 +18315,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8301
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1297 to outside:192.168.98.44/8301 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -17242,8 +18351,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:NHvrP6b5/Mmf0dGA3mQ0ZbakRds=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -17255,7 +18379,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1297
             },
             "tags": [
                 "preserve_original_event"
@@ -17264,22 +18397,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8302
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1298 to outside:192.168.98.44/8302 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -17288,8 +18433,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:OpKXx3JYrbWDRisSO5qim6H6gHY=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -17301,7 +18461,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1298
             },
             "tags": [
                 "preserve_original_event"
@@ -17310,22 +18479,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8303
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1299 to outside:192.168.98.44/8303 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -17334,8 +18515,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:6sa4KKyKp6sQgWfyFRuuEciemwI=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -17347,7 +18543,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1299
             },
             "tags": [
                 "preserve_original_event"
@@ -17356,22 +18561,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8304
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1300 to outside:192.168.98.44/8304 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -17380,8 +18597,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:oJFhdOwC0q2/wSkBKCc7a3IE9ss=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -17393,7 +18625,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1300
             },
             "tags": [
                 "preserve_original_event"
@@ -17402,22 +18643,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8305
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1301 to outside:192.168.98.44/8305 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -17426,8 +18679,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:E1tD2tMTr8HFWTq3wX2/QHew7bA=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -17439,7 +18707,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1301
             },
             "tags": [
                 "preserve_original_event"
@@ -17448,22 +18725,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8306
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1302 to outside:192.168.98.44/8306 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -17472,8 +18761,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:PepCxrCgLe5kXkyNH8hYn1sUdZ8=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -17485,7 +18789,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1302
             },
             "tags": [
                 "preserve_original_event"
@@ -17494,22 +18807,34 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "cisco": {
-                "ftd": {}
+                "ftd": {
+                    "destination_interface": "outside",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "address": "192.168.98.44",
+                "ip": "192.168.98.44",
+                "port": 8307
             },
             "ecs": {
                 "version": "8.4.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "305012",
+                "duration": 30000000000,
+                "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1303 to outside:192.168.98.44/8307 duration 0:00:30",
                 "severity": 6,
+                "start": "2018-10-10T12:34:26.000Z",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -17518,8 +18843,23 @@
             "log": {
                 "level": "informational"
             },
+            "network": {
+                "community_id": "1:Wp7K1SHgAa5oa5G5P38Vnczorss=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
             "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
                 "hostname": "localhost",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
                 "product": "ftd",
                 "type": "idps",
                 "vendor": "Cisco"
@@ -17531,7 +18871,16 @@
             "related": {
                 "hosts": [
                     "localhost"
+                ],
+                "ip": [
+                    "172.31.98.44",
+                    "192.168.98.44"
                 ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "port": 1303
             },
             "tags": [
                 "preserve_original_event"
@@ -17580,6 +18929,7 @@
             },
             "network": {
                 "bytes": 410333,
+                "community_id": "1:IWKDs2Dj96xcnQVIL2h0TZzcj4M=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -17660,6 +19010,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -17740,6 +19091,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -17820,6 +19172,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -17897,6 +19250,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:zxfVKDkdhPKah2behDlCUjybEGM=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -17979,6 +19333,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:sGdA1w84M8JllX94tW4PwnbC98g=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -18060,6 +19415,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18140,6 +19496,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18220,6 +19577,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18300,6 +19658,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18380,6 +19739,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18460,6 +19820,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18540,6 +19901,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18620,6 +19982,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18700,6 +20063,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18780,6 +20144,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18860,6 +20225,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -18940,6 +20306,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19020,6 +20387,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19100,6 +20468,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19180,6 +20549,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19260,6 +20630,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19340,6 +20711,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19420,6 +20792,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19500,6 +20873,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19580,6 +20954,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19660,6 +21035,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19740,6 +21116,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19820,6 +21197,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19900,6 +21278,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -19980,6 +21359,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -20060,6 +21440,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -20140,6 +21521,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -20220,6 +21602,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -20300,6 +21683,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -20380,6 +21764,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -20460,6 +21845,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -20540,6 +21926,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -20620,6 +22007,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ug99RHvEiHN7NT9eT+qTqAscTdE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -95,6 +95,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:KyO7KJquMkQbG2JhHtlE/xANNwA=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -239,6 +240,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:+uUWJ5PKqEMq8F4s0W+i0b/gph8=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -381,6 +383,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:Kf2+k7AyvIg2CiusWtfb6ktO17A=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -525,6 +528,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:ifBN42Zk12nVs0SYoFKVVsSvJQ0=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -668,6 +672,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:msL2v+FL8G2iEtmZzUSXOFUmMqU=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -810,6 +815,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:RqFtHQ/7yk2iMxEfh4RnynhiWjM=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -955,6 +961,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:eOgwnfNZLMNFZVdHRY9Eisa5PhM=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -1097,6 +1104,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:ecIerxjEQw7yKtLrWT8JjELnUJs=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -1240,6 +1248,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:yDWDpzcHJlH1IZW+oYvQUSpvt3w=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -1384,6 +1393,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:sO3JetvTOM9Lt5eomxqyJjYQnxU=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -1526,6 +1536,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:7YlQKXQpw4Ni/+j4wc0hOlfJvTE=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -1662,6 +1673,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:oaDSIEJqyQH86OHbA2jmw/CnWj0=",
                 "iana_number": "6",
                 "protocol": "dns",
                 "transport": "tcp"
@@ -1805,6 +1817,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:XqT/t5LjBxVwExdARl18UHH8ZyA=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -1947,6 +1960,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:R6GrckTqN6itxx1OXywZsW3on+o=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -2090,6 +2104,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:2uIDAY+126r3pPZItAh4E+MRHUI=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -2234,6 +2249,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:eOgwnfNZLMNFZVdHRY9Eisa5PhM=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -2376,6 +2392,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:yDWDpzcHJlH1IZW+oYvQUSpvt3w=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -2518,6 +2535,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:Kf2+k7AyvIg2CiusWtfb6ktO17A=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -2660,6 +2678,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:ecIerxjEQw7yKtLrWT8JjELnUJs=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -2800,6 +2819,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:j0x5eKTJTxDfnjC7UklcOZJRALc=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -2944,6 +2964,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:sO3JetvTOM9Lt5eomxqyJjYQnxU=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
@@ -1,0 +1,2 @@
+<166>Sep 29 2022 15:00:15 hosty : %FTD-6-602303: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xF0079F5A) between 192.168.0.139 and 192.168.0.38 (user= 192.168.0.38) has been created.
+<166>Sep 29 2022 15:00:15 hosty : %FTD-6-602304: IPSEC: An inbound LAN-to-LAN SA (SPI= 0xEAEE970F) between 192.168.0.38 and 192.168.0.139 (user= 192.168.0.38) has been deleted.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -1,0 +1,152 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-09-29T15:00:15.000Z",
+            "cisco": {
+                "ftd": {
+                    "tunnel_type": "LAN-to-LAN"
+                }
+            },
+            "destination": {
+                "address": "192.168.0.38",
+                "ip": "192.168.0.38"
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "created",
+                "code": "602303",
+                "original": "\u003c166\u003eSep 29 2022 15:00:15 hosty : %FTD-6-602303: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xF0079F5A) between 192.168.0.139 and 192.168.0.38 (user= 192.168.0.38) has been created.",
+                "outcome": "success",
+                "severity": 6
+            },
+            "host": {
+                "hostname": "hosty"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 166,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "network": {
+                "direction": "outbound",
+                "type": "ipsec"
+            },
+            "observer": {
+                "hostname": "hosty",
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "hosty"
+                ],
+                "ip": [
+                    "192.168.0.139",
+                    "192.168.0.38"
+                ],
+                "user": [
+                    "192.168.0.38"
+                ]
+            },
+            "source": {
+                "address": "192.168.0.139",
+                "ip": "192.168.0.139"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "192.168.0.38"
+            }
+        },
+        {
+            "@timestamp": "2022-09-29T15:00:15.000Z",
+            "cisco": {
+                "ftd": {
+                    "tunnel_type": "LAN-to-LAN"
+                }
+            },
+            "destination": {
+                "address": "192.168.0.139",
+                "ip": "192.168.0.139"
+            },
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "action": "deleted",
+                "category": [
+                    "network"
+                ],
+                "code": "602304",
+                "kind": "event",
+                "original": "\u003c166\u003eSep 29 2022 15:00:15 hosty : %FTD-6-602304: IPSEC: An inbound LAN-to-LAN SA (SPI= 0xEAEE970F) between 192.168.0.38 and 192.168.0.139 (user= 192.168.0.38) has been deleted.",
+                "outcome": "success",
+                "severity": 6,
+                "type": [
+                    "info",
+                    "deletion",
+                    "user",
+                    "allowed"
+                ]
+            },
+            "host": {
+                "hostname": "hosty"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 166,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "network": {
+                "direction": "inbound",
+                "type": "ipsec"
+            },
+            "observer": {
+                "hostname": "hosty",
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "hosty"
+                ],
+                "ip": [
+                    "192.168.0.38",
+                    "192.168.0.139"
+                ],
+                "user": [
+                    "192.168.0.38"
+                ]
+            },
+            "source": {
+                "address": "192.168.0.38",
+                "ip": "192.168.0.38"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "192.168.0.38"
+            }
+        }
+    ]
+}

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-intrusion.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-intrusion.log-expected.json
@@ -65,6 +65,7 @@
             "message": "SERVER-WEBAPP Ipswitch WhatsUp Small Business directory traversal attempt",
             "network": {
                 "application": "firefox",
+                "community_id": "1:aVBZLbVEijzexcqIhp/89fLm6Fw=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -178,6 +179,7 @@
             "message": "SERVER-WEBAPP Ipswitch WhatsUp Small Business directory traversal attempt",
             "network": {
                 "application": "firefox",
+                "community_id": "1:T2FxxCvrJYccm7bcw2QZ9tWONIo=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -288,6 +290,7 @@
             },
             "message": "APP-DETECT failed FTP login attempt",
             "network": {
+                "community_id": "1:4Ze3PKactlddzol+s7PbEeCTTlk=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -397,6 +400,7 @@
             },
             "message": "APP-DETECT failed FTP login attempt",
             "network": {
+                "community_id": "1:yyUSZl65LfpqAPKtrjT9QRDUlfs=",
                 "iana_number": "6",
                 "transport": "tcp"
             },

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -127,6 +127,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:tTzSWYTCd+HV5W2Q/cSW6AszABM=",
                 "iana_number": "1",
                 "transport": "icmp"
             },
@@ -199,6 +200,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:d9RGgqBro5rzu16MqJQFehDRaKY=",
                 "iana_number": "6",
                 "transport": "tcp"
             },

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -36,6 +36,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:F3oxLROBkJXMp5F9hLkqNR8Uqn8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -105,6 +106,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:F3oxLROBkJXMp5F9hLkqNR8Uqn8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -175,6 +177,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:5bFfEhKly/TggI8dU84rdlvnjiE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -247,6 +250,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:wiURj00rOxBnGPKbG+9cG8pOLvM=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -323,6 +327,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:+MvR510QoAWKA5q9nPhByI0WHrQ=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -393,6 +398,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:J5G+ardU82I3xVPTSKrsg1ndGew=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -467,6 +473,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:5DypvtnEXTrIsteTgGHxM/mzCvw=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -534,6 +541,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:pyhp+QeVMvpVaAT3fNozEnzL6XE=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -608,6 +616,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:LwXurZgpdurWAsE0WysTuQ6avsE=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -679,6 +688,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:ijJFe+Q3p3WX44mP+BgPWi3pu50=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -754,6 +764,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:rtuV+biNXBpzU8tz3p/gHGTTfwE=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -828,6 +839,7 @@
             },
             "network": {
                 "bytes": 140,
+                "community_id": "1:LwXurZgpdurWAsE0WysTuQ6avsE=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -875,7 +887,10 @@
             "destination": {
                 "address": "10.123.1.35",
                 "ip": "10.123.1.35",
-                "port": 52925
+                "port": 52925,
+                "user": {
+                    "name": "user2"
+                }
             },
             "ecs": {
                 "version": "8.4.0"
@@ -902,6 +917,7 @@
             },
             "network": {
                 "bytes": 9999999,
+                "community_id": "1:LwXurZgpdurWAsE0WysTuQ6avsE=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -924,16 +940,26 @@
                 "ip": [
                     "192.168.2.222",
                     "10.123.1.35"
+                ],
+                "user": [
+                    "user2",
+                    "user1"
                 ]
             },
             "source": {
                 "address": "192.168.2.222",
                 "ip": "192.168.2.222",
-                "port": 53
+                "port": 53,
+                "user": {
+                    "name": "user1"
+                }
             },
             "tags": [
                 "preserve_original_event"
-            ]
+            ],
+            "user": {
+                "name": "user2"
+            }
         },
         {
             "@timestamp": "2011-06-04T21:59:52.000Z",
@@ -970,6 +996,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:tTzSWYTCd+HV5W2Q/cSW6AszABM=",
                 "iana_number": "1",
                 "transport": "icmp"
             },
@@ -1029,6 +1056,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:XzGgWCNuyTKRW3qaxWbLXtZv4MI=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1104,6 +1132,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:aejZhwHVuSCnwQgDdoZ/2zCOA28=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -1171,6 +1200,7 @@
                 "level": "critical"
             },
             "network": {
+                "community_id": "1:EA2VznrREgv+x0TbcMCtUOcSiT8=",
                 "direction": "inbound",
                 "iana_number": "17",
                 "protocol": "dns",
@@ -1232,6 +1262,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:vrXgh+DX7gN62EvradQGA7k1t9E=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1301,6 +1332,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:jw58d+NPPTvkuBbii3fHuVQGf3k=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1370,6 +1402,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:ucJC+W2j8SuwOjGpbOun8WWsG34=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1439,6 +1472,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:ZfCIo1TKO8vvAF7yS78Xkaka/l0=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1508,6 +1542,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:GLlxCtnHjErAdCJsW0/rBXMFbM4=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1577,6 +1612,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:1Gatu/nDASJrwA6azGBklfV+JuU=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1646,6 +1682,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:39OuA4jX2uUq79jBczmR7Vpqrrs=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1715,6 +1752,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:mP04rjQjdGkrqMbefqMZ3m3epXg=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1784,6 +1822,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:TUJhCk7pGNvVhgiAnf4YJJaoCpo=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1853,6 +1892,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:I5CP3SodOfjGKI6Za378k19HFx0=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1920,6 +1960,7 @@
                 "level": "critical"
             },
             "network": {
+                "community_id": "1:UlMd5fP3cLr7FnODzgyP54N8DC8=",
                 "direction": "inbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -1981,6 +2022,7 @@
                 "level": "critical"
             },
             "network": {
+                "community_id": "1:nPOw2hmSzlUGBNIZudqPPZAA24o=",
                 "direction": "inbound",
                 "iana_number": "17",
                 "protocol": "dns",
@@ -2042,6 +2084,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:1ImDeNMYSxlbfbLce+uMU4oAt5s=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2111,6 +2154,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:20KTUliRVrf8TApYUu3z7aae10E=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2180,6 +2224,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:K/KVLz6cMAd7ynaOcA3flDM2078=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2249,6 +2294,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:cT5PIBEAe/6SbdGUiAeCxhsuDyY=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2318,6 +2364,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:QKnyKYXc66SVbww5yLMTQOKIlSo=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2387,6 +2434,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ZpFiJzsoqHFLwPcJRRlbX8HsqqI=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2456,6 +2504,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:ZpFiJzsoqHFLwPcJRRlbX8HsqqI=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2525,6 +2574,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:NBzfb0EPuOf4c1ZIXnBAoomPZbU=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2594,6 +2644,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:CvZ+U+QfGONQR89U3YqrSMCLH4U=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2664,6 +2715,7 @@
                 "level": "notification"
             },
             "network": {
+                "community_id": "1:ig4TaYklGXYSgZ7QzME/TwjQNdc=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -2738,6 +2790,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:xQpx+K3UkeF1wQfNjT+9cuVvkHo=",
                 "direction": "outbound",
                 "iana_number": "17",
                 "transport": "udp"
@@ -2815,6 +2868,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:WLNVnzRjdqiei69wYc8qd6+w4us=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -2891,6 +2945,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:WLNVnzRjdqiei69wYc8qd6+w4us=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -3129,6 +3184,7 @@
             },
             "network": {
                 "bytes": 14804,
+                "community_id": "1:jpl9i9YcwfmJL6rzeoC+kNxutF0=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3209,6 +3265,7 @@
             },
             "network": {
                 "bytes": 134781,
+                "community_id": "1:0O2zwShv7d4alKTT/UJuXDWhJtE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3289,6 +3346,7 @@
             },
             "network": {
                 "bytes": 134781,
+                "community_id": "1:0O2zwShv7d4alKTT/UJuXDWhJtE=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3363,6 +3421,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:V4JZiJZoOERbXEFrHA50Pmigs1s=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3432,6 +3491,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:V4JZiJZoOERbXEFrHA50Pmigs1s=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3503,6 +3563,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:jxyRgrUN5AQry8u54siw0ExzTus=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -3581,6 +3642,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:MEjrQ6Y2PIPXcU7c9ILA2aaY05g=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3660,6 +3722,7 @@
                 "level": "informational"
             },
             "network": {
+                "community_id": "1:MEjrQ6Y2PIPXcU7c9ILA2aaY05g=",
                 "direction": "outbound",
                 "iana_number": "6",
                 "transport": "tcp"
@@ -3741,6 +3804,7 @@
             },
             "network": {
                 "bytes": 11420,
+                "community_id": "1:/9gOVG0ZtuA8PJ+qUwTqWsONqNY=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -3817,6 +3881,7 @@
             },
             "network": {
                 "bytes": 1416,
+                "community_id": "1:n1IQHcbrWLb1u8dflqz8hfEElA0=",
                 "iana_number": "17",
                 "transport": "udp"
             },
@@ -4393,6 +4458,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:/FBB+ViYiCpWqWuSowCSy8uGuew=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -4528,6 +4594,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:XKWgpeop6LmXORBjS+D+pjammJ4=",
                 "iana_number": "1",
                 "transport": "icmp"
             },
@@ -4596,6 +4663,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:PCeszW61Rf5HVIhhFCSgJde2rog=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -4685,6 +4753,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:fsjqNPGE2bs9FtxsKfUzPlmoR58=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -4768,6 +4837,7 @@
                 "level": "warning"
             },
             "network": {
+                "community_id": "1:fsjqNPGE2bs9FtxsKfUzPlmoR58=",
                 "iana_number": "6",
                 "transport": "tcp"
             },

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-connection.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-connection.log-expected.json
@@ -68,6 +68,7 @@
             },
             "network": {
                 "application": "icmp client",
+                "community_id": "1:Lc5Ybc+aBSwS/2nqgn+rGxqrgck=",
                 "iana_number": "1",
                 "protocol": "icmp",
                 "transport": "icmp"
@@ -186,6 +187,7 @@
             },
             "network": {
                 "application": "icmp client",
+                "community_id": "1:Lc5Ybc+aBSwS/2nqgn+rGxqrgck=",
                 "iana_number": "1",
                 "protocol": "icmp",
                 "transport": "icmp"
@@ -322,6 +324,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:Efg0qRPWpUqd/Ic35rOzr1m2j2I=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -465,6 +468,7 @@
             },
             "network": {
                 "application": "dns client",
+                "community_id": "1:SoXhZK1CrFzc2miyTD2GGUIZBIc=",
                 "iana_number": "17",
                 "protocol": "dns",
                 "transport": "udp"
@@ -590,6 +594,7 @@
                 "level": "alert"
             },
             "network": {
+                "community_id": "1:e9BEufDTrN3BbL6412GOz3SWm5w=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -735,6 +740,7 @@
                     "advanced packaging tool",
                     "ubuntu"
                 ],
+                "community_id": "1:e9BEufDTrN3BbL6412GOz3SWm5w=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -870,6 +876,7 @@
                 "level": "alert"
             },
             "network": {
+                "community_id": "1:Xumx4bGQqJmLtaW2LNJT/b/cOm8=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
@@ -1011,6 +1018,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:Xumx4bGQqJmLtaW2LNJT/b/cOm8=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -1133,6 +1141,7 @@
                 "level": "alert"
             },
             "network": {
+                "community_id": "1:Lc5Ybc+aBSwS/2nqgn+rGxqrgck=",
                 "iana_number": "1",
                 "transport": "icmp"
             },
@@ -1263,6 +1272,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:EX7LDhHq0D9ez/OeVOOW5FWakkI=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-file-malware.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-file-malware.log-expected.json
@@ -58,6 +58,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:ICpzATq4Q7ls9bAGqEmf+eAOtFc=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -159,6 +160,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:1P/UJpeT0HuAQ0Zj36VUw3NWrms=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -260,6 +262,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:k9jZpiIYklqnW5VrPKZ36zGCfpw=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -361,6 +364,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:1O6Tg+zlE975TFeaA0Qa6QBRfBs=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -470,6 +474,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:9k57JmGIU8Cd4FcndffJHSuGmHg=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -582,6 +587,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:eJqjWMIqoBPiagsWFCmeQAhxZaM=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -698,6 +704,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:EX7LDhHq0D9ez/OeVOOW5FWakkI=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -826,6 +833,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:jk2uwniJ2oCG0t73HeZ9w8gtA8E=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -941,6 +949,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:nOd4Q0QVZ1CGu/nTE/uuQ/52Q3A=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -1067,6 +1076,7 @@
             },
             "network": {
                 "application": "curl",
+                "community_id": "1:XA2hymnhPXBlAcrOGTDeokEUeuk=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"
@@ -1207,6 +1217,7 @@
                     "windows update",
                     "microsoft update"
                 ],
+                "community_id": "1:3J5CRfTwJPSrvAHK5VQbXwWBm4Y=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-malware-site.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-malware-site.log-expected.json
@@ -98,6 +98,7 @@
             },
             "network": {
                 "application": "chrome",
+                "community_id": "1:sHesqNOXlyCHLUQkPcN7vjbck3A=",
                 "iana_number": "6",
                 "protocol": "http",
                 "transport": "tcp"

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -105,13 +105,13 @@ processors:
             "append":
               {
                 "field": "error.message",
-                "value": "{{ _ingest.on_failure_message }}",
+                "value": "{{{ _ingest.on_failure_message }}}",
               },
           },
         ]
   - date:
       if: "ctx.event?.timezone != null && ctx._temp_?.raw_date != null"
-      timezone: "{{ event.timezone }}"
+      timezone: "{{{ event.timezone }}}"
       field: "_temp_.raw_date"
       target_field: "@timestamp"
       formats:
@@ -138,7 +138,7 @@ processors:
             "append":
               {
                 "field": "error.message",
-                "value": "{{ _ingest.on_failure_message }}",
+                "value": "{{{ _ingest.on_failure_message }}}",
               },
           },
         ]
@@ -239,7 +239,7 @@ processors:
       field: "message"
       description: "106015"
       patterns:
-        - "%{NOTSPACE:event.outcome} %{NOTSPACE:network.transport} %{NOTSPACE} %{NOTSPACE} from %{IP:source.address}/%{POSINT:source.port} to %{IP:destination.address}/%{POSINT:destination.port} flags %{DATA} on interface %{NOTSPACE:_temp_.cisco.source_interface}"
+        - "%{NOTSPACE:event.outcome} %{NOTSPACE:network.transport} %{NOTSPACE} %{NOTSPACE} from %{IP:source.address}/%{POSINT:source.port} to %{IPORHOST:destination.address}/%{POSINT:destination.port} flags %{DATA} on interface %{NOTSPACE:_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106016'"
       field: "message"
@@ -275,7 +275,12 @@ processors:
       field: "message"
       description: "106023"
       patterns:
-        - ^%{NOTSPACE:event.outcome} %{NOTSPACE:network.transport} src %{NOTSPACE:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{POSINT:source.port})?\s*(%{GREEDYDATA:_temp_.cisco.source_username} )?dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{POSINT:destination.port})?%{DATA}by access.group "%{NOTSPACE:_temp_.cisco.list_id}"
+        - ^%{NOTSPACE:event.outcome} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{POSINT:source.port})?\s*(\(%{CISCO_USER:_temp_.cisco.source_username}\) )?dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{POSINT:destination.port})?%{DATA}by access-group "%{NOTSPACE:_temp_.cisco.list_id}"
+      pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
+        NOTCOLON: "[^:]*"
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106027'"
       field: "message"
@@ -327,26 +332,78 @@ processors:
       patterns:
         - "User '%{NOTSPACE:server.user.name}', running %{QUOTEDSTRING} from IP %{IP:source.address}, executed %{QUOTEDSTRING:_temp_.cisco.command_line_arguments}"
   - dissect:
+      if: "ctx._temp_.cisco.message_id == '113004'"
+      field: "message"
+      description: "113004"
+      pattern: "AAA user %{_temp_.cisco.aaa_type} Successful: server = %{destination.address} , User = %{source.user.name}"
+  - grok:
+      if: "ctx._temp_.cisco.message_id == '113005'"
+      description: "113005"
+      field: "message"
+      patterns: 
+        - "AAA user authentication Rejected: reason = %{REASON}: server = %{IP:destination.address} : user = ?%{CISCO_USER:source.user.name}: user IP = %{IP:source.address}"
+      pattern_definitions:
+        REASON: (AAA failure|Account has been disabled)
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '113012'"
+      field: "message"
+      description: "113012"
+      pattern: "AAA user authentication Successful: local database: user = %{source.user.name}"
+  - dissect:
       if: "ctx._temp_.cisco.message_id == '113019'"
       field: "message"
       description: "113019"
-      pattern: "Group = %{}, Username = %{source.user.name}, IP = %{destination.address}, Session disconnected. Session Type: %{}, Duration: %{_temp_.duration_hms}, Bytes xmt: %{source.bytes}, Bytes rcv: %{destination.bytes}, Reason: %{message}"
+      pattern: "Group = %{source.user.group.name}, Username = %{source.user.name}, IP = %{destination.address}, Session disconnected. Session Type: %{_temp_.cisco.session_type}, Duration: %{_temp_.duration_hms}, Bytes xmt: %{source.bytes}, Bytes rcv: %{destination.bytes}, Reason: %{event.reason}"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '113021'"
+      field: "message"
+      description: "113021"
+      pattern: "Attempted console login failed. User %{source.user.name} did NOT have appropriate Admin Rights."
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '113040'"
+      field: "message"
+      description: "113040"
+      pattern: "Terminating the VPN connection attempt from %{source.user.group.name}. Reason: This connection is group locked to %{}."
+  - grok:
+      if: '["113029","113030","113031","113032","113033","113034","113035","113036","113038","113039"].contains(ctx._temp_.cisco.message_id)'
+      field: "message"
+      description: "113029, 113030, 113031, 113032, 113033, 113034, 113035, 113036, 113038, 113039"
+      patterns:
+        - "Group <%{NOTSPACE:source.user.group.name}> User <%{CISCO_USER:source.user.name}> IP <%{IP:source.address}>"
+        - "Group %{NOTSPACE:source.user.group.name} User %{CISCO_USER:source.user.name} IP %{IP:source.address}"
+      pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - grok:
       if: '["302013", "302015"].contains(ctx._temp_.cisco.message_id)'
       field: "message"
       description: "302013, 302015"
       patterns:
-        - "Built %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} connection %{NUMBER:_temp_.cisco.connection_id} for %{NOTSPACE:_temp_.cisco.source_interface}:%{IP:source.address}/%{NUMBER:source.port} \\(%{IP:_temp_.natsrcip}/%{NUMBER:_temp_.cisco.mapped_source_port}\\)(\\(%{NOTSPACE:_temp_.cisco.source_username}\\))? to %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{NUMBER:destination.port} \\(%{NOTSPACE:_temp_.natdstip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\\)( \\(%{NOTSPACE:destination.user.name}\\))?%{GREEDYDATA}"
+        - Built %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} connection %{NUMBER:_temp_.cisco.connection_id} for %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port} \(%{IPORHOST:_temp_.natsrcip}/%{NUMBER:_temp_.cisco.mapped_source_port}\)(\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{NUMBER:destination.port} \(%{NOTSPACE:_temp_.natdstip}/%{NUMBER:_temp_.cisco.mapped_destination_port}\)(\(%{CISCO_USER:_temp_.cisco.destination_username}\))?( \(%{CISCO_USER:_temp_.cisco.termination_user}\))?%{GREEDYDATA}
+      pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
+        NOTCOLON: "[^:]*"
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
       if: "ctx._temp_.cisco.message_id == '303002'"
       field: "message"
       description: "303002"
       pattern: "%{network.protocol} connection from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}, user %{client.user.name} %{} file %{file.path}"
-  - dissect:
-      if: "ctx._temp_.cisco.message_id == '302012'"
+  - grok:
+      if: "ctx._temp_.cisco.message_id == '305012'"
       field: "message"
-      description: "302012"
-      pattern: "Teardown %{} %{network.transport} translation from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} duration %{_temp_.duration_hms}"
+      description: "305012"
+      patterns:
+        - Teardown %{DATA} %{NOTSPACE:network.transport} translation from %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port}(\s*\(%{CISCO_USER:_temp_.cisco.source_username}\))? to %{NOTCOLON:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port} duration %{DURATION:_temp_.duration_hms}
+      pattern_definitions:
+        NOTCOLON: "[^:]*"
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
+        DURATION: "%{INT}:%{MINUTE}:%{SECOND}"
   - set:
       if: '["302020"].contains(ctx._temp_.cisco.message_id)'
       field: "event.action"
@@ -357,12 +414,15 @@ processors:
       field: "message"
       description: "302020"
       patterns:
-        - "Built %{NOTSPACE:network.direction} %{NOTSPACE:network.protocol} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\\s*(?:\\(%{NOTSPACE:_temp_.cisco.destination_username}\\) )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\\s*(?:\\(%{NOTSPACE:_temp_.cisco.source_username}\\) )?(type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?"
+        - "Built %{NOTSPACE:network.direction} %{NOTSPACE:network.protocol} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER:_temp_.cisco.destination_username}\\) )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER:_temp_.cisco.source_username}\\) )?(type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?"
       pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         ECSSOURCEIPORHOST: "(?:%{IP:source.address}|%{HOSTNAME:source.domain})"
         ECSDESTIPORHOST: "(?:%{IP:destination.address}|%{HOSTNAME:destination.domain})"
         MAPPEDSRC: "(?:%{DATA:_temp_.natsrcip}|%{HOSTNAME})"
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - dissect:
       if: "ctx._temp_.cisco.message_id == '302022'"
       field: "message"
@@ -378,7 +438,7 @@ processors:
       field: "message"
       description: "304001"
       patterns:
-        - "%{IP:source.address} %{DATA} (%{NOTSPACE}@)?%{IP:destination.address}:%{GREEDYDATA:url.original}"
+        - "(%{NOTSPACE:source.user.name}@)?%{IP:source.address}(\\(%{DATA}\\))? %{DATA} (%{NOTSPACE}@)?%{IPORHOST:destination.address}:%{GREEDYDATA:url.original}"
   - set:
       if: "ctx._temp_.cisco.message_id == '304001'"
       field: "event.outcome"
@@ -394,7 +454,7 @@ processors:
       field: "message"
       description: "305011"
       patterns:
-        - Built %{NOTSPACE} %{NOTSPACE:network.transport} translation from %{NOTSPACE:_temp_.cisco.source_interface}:%{IP:source.address}/%{NUMBER:source.port}(\(%{NOTSPACE:source.user.name}\))? to %{NOTSPACE:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port}
+        - Built %{NOTSPACE} %{NOTSPACE:network.transport} translation from %{NOTSPACE:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port}(\(%{NOTSPACE:source.user.name}\))? to %{NOTSPACE:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port}
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313001'"
       field: "message"
@@ -434,7 +494,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338001'"
       field: "server.domain"
       description: "338001"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338002'"
@@ -445,7 +505,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338002'"
       field: "server.domain"
       description: "338002"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338003'"
@@ -466,7 +526,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338005'"
       field: "server.domain"
       description: "338005"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338006'"
@@ -477,7 +537,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338006'"
       field: "server.domain"
       description: "338006"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338007'"
@@ -498,7 +558,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338101'"
       field: "server.domain"
       description: "338101"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338102'"
@@ -509,7 +569,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338102'"
       field: "server.domain"
       description: "338102"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338103'"
@@ -530,7 +590,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338201'"
       field: "server.domain"
       description: "338201"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338202'"
@@ -541,7 +601,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338202'"
       field: "server.domain"
       description: "338202"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338203'"
@@ -552,7 +612,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338203'"
       field: "server.domain"
       description: "338203"
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338204'"
@@ -563,7 +623,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338204'"
       field: "server.domain"
       description: "338204"
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338301'"
@@ -574,25 +634,25 @@ processors:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "client.address"
       description: "338301"
-      value: "{{destination.address}}"
+      value: "{{{destination.address}}}"
       ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "client.port"
       description: "338301"
-      value: "{{destination.port}}"
+      value: "{{{destination.port}}}"
       ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "server.address"
       description: "338301"
-      value: "{{source.address}}"
+      value: "{{{source.address}}}"
       ignore_empty_value: true
   - set:
       if: "ctx._temp_.cisco.message_id == '338301'"
       field: "server.port"
       description: "338301"
-      value: "{{source.port}}"
+      value: "{{{source.port}}}"
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '502103'"
@@ -627,6 +687,22 @@ processors:
       description: "609001"
       pattern: "Built local-host %{_temp_.cisco.source_interface}:%{source.address}"
   - dissect:
+      if: "ctx._temp_.cisco.message_id == '607001'"
+      field: "message"
+      description: "607001"
+      pattern: "Pre-allocate SIP %{_temp_.cisco.connection_type} secondary channel for %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} to %{_temp_.cisco.source_interface}:%{source.address} from %{_temp_.cisco.message} message"
+  - grok:
+      if: "ctx._temp_.cisco.message_id == '607001'"
+      description: "607001"
+      field: "_temp_.cisco.connection_type"
+      patterns:
+        - "%{CONNECTION}"
+      pattern_definitions:
+        TRANSPORTS: "(?:UDP|TCP)"
+        PROTOCOLS: "(?:RTP|RTCP)"
+        CONNECTION: "(?:%{TRANSPORTS:network.transport}|%{PROTOCOLS:network.protocol})"
+      ignore_failure: true
+  - dissect:
       if: "ctx._temp_.cisco.message_id == '609002'"
       field: "message"
       description: "609002"
@@ -635,7 +711,7 @@ processors:
       if: '["611102", "611101"].contains(ctx._temp_.cisco.message_id)'
       field: "message"
       description: "611102, 611101"
-      pattern: "User authentication %{event.outcome}: IP address: %{source.address}, Uname: %{server.user.name}"
+      pattern: 'User authentication %{event.outcome}: IP address: %{source.address}, Uname: %{server.user.name}'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '710003'"
       field: "message"
@@ -651,6 +727,13 @@ processors:
       field: "message"
       description: "713049"
       pattern: "Group = %{}, IP = %{source.address}, Security negotiation complete for LAN-to-LAN Group (%{}) %{}, Inbound SPI = %{}, Outbound SPI = %{}"
+      ignore_failure: true
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '713049'"
+      field: "message"
+      description: "713049"
+      pattern: "Group = %{}, Username = %{user.name}, IP = %{source.address}, Security negotiation complete for User (%{}) %{}, Inbound SPI = %{}, Outbound SPI = %{}"
+      ignore_failure: true
   - grok:
       if: "ctx._temp_.cisco.message_id == '716002'"
       field: "message"
@@ -665,11 +748,12 @@ processors:
       patterns:
         - "Group <%{NOTSPACE:_temp_.cisco.webvpn.group_name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> IPv4 Address <%{IP:_temp_.cisco.assigned_ip}> %{GREEDYDATA}"
         - "Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} IPv4 Address %{IP:_temp_.cisco.assigned_ip} %{GREEDYDATA}"
-  - dissect:
+  - grok:
       if: "ctx._temp_.cisco.message_id == '733100'"
       field: "message"
       description: "733100"
-      pattern: "[%{_temp_.cisco.burst.object}] drop %{_temp_.cisco.burst.id} exceeded. Current burst rate is %{_temp_.cisco.burst.current_rate} per second, max configured rate is %{_temp_.cisco.burst.configured_rate}; Current average rate is %{_temp_.cisco.burst.avg_rate} per second, max configured rate is %{_temp_.cisco.burst.configured_avg_rate}; Cumulative total count is %{_temp_.cisco.burst.cumulative_count}"
+      patterns:
+        - \[(%{SPACE})?%{DATA:_temp_.cisco.burst.object}\] drop %{NOTSPACE:_temp_.cisco.burst.id} exceeded. Current burst rate is %{INT:_temp_.cisco.burst.current_rate} per second, max configured rate is %{INT:_temp_.cisco.burst.configured_rate}; Current average rate is %{INT:_temp_.cisco.burst.avg_rate} per second, max configured rate is %{INT:_temp_.cisco.burst.configured_avg_rate}; Cumulative total count is %{INT:_temp_.cisco.burst.cumulative_count}
   - dissect:
       if: "ctx._temp_.cisco.message_id == '734001'"
       field: "message"
@@ -679,7 +763,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '805001'"
       field: "message"
       description: "805001"
-      pattern: "Offloaded %{network.transport} for connection %{_temp_.cisco.connection_id} from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})"
+      pattern: "Offloaded %{network.transport} Flow for connection %{_temp_.cisco.connection_id} from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '805002'"
       field: "message"
@@ -708,7 +792,7 @@ processors:
   - dissect:
       if: '["602303", "602304"].contains(ctx._temp_.cisco.message_id)'
       field: "message"
-      pattern: "%{network.type}: An %{network.direction} %{network.inner} SA (SPI= %{}) between %{source.address} and %{destination.address} (user= %{user.name}) has been %{event.action}."
+      pattern: "%{network.type}: An %{network.direction} %{_temp_.cisco.tunnel_type} SA (SPI= %{}) between %{source.address} and %{destination.address} (user= %{user.name}) has been %{event.action}."
   - dissect:
       if: "ctx._temp_.cisco.message_id == '750002'"
       field: "message"
@@ -721,6 +805,12 @@ processors:
       if: "ctx._temp_.cisco.message_id == '713202'"
       field: "message"
       pattern: "IP = %{source.address}, %{event.reason}. %{} packet."
+  - grok:
+      if: "ctx._temp_.cisco.message_id == '716039'"
+      field: "message"
+      patterns:
+        - "Authentication: rejected, group = %{NOTSPACE:source.user.group.name} user = %{USER:source.user.name} , Session Type: %{NOTSPACE:_temp_.cisco.session_type}"
+        - "Group <%{NOTSPACE:source.user.group.name}> User <%{USER:source.user.name}> IP <%{IP:source.address}> Authentication: rejected, Session Type: %{NOTSPACE:_temp_.cisco.session_type}\\."
   - dissect:
       if: "ctx._temp_.cisco.message_id == '750003'"
       field: "message"
@@ -730,7 +820,7 @@ processors:
       field: "message"
       patterns:
         - "^(Group = %{IP}, )?(IP = %{IP:source.address}, )?%{GREEDYDATA:event.reason}$"
-    # Handle ecs action outcome protocol
+   # Handle ecs action outcome protocol
   - set:
       if: '["434002", "434004"].contains(ctx._temp_.cisco.message_id)'
       field: "event.outcome"
@@ -748,13 +838,49 @@ processors:
       field: "event.outcome"
       value: "success"
   - set:
-      if: '["602303", "602304"].contains(ctx._temp_.cisco.message_id)'
+      if: '["113004", "113012"].contains(ctx._temp_.cisco.message_id)'
       field: "event.outcome"
       value: "success"
   - set:
-      if: '["713905", "713904", "713906", "713902", "713901", "710005"].contains(ctx._temp_.cisco.message_id)'
+      if: '["113002", "113005", "113021"].contains(ctx._temp_.cisco.message_id)'
       field: "event.outcome"
       value: "failure"
+  - set:
+      if: '["602303", "602304", "611101"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.outcome"
+      value: "success"
+  - set:
+      if: '["605004", "611102"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.outcome"
+      value: "failure"
+  - set:
+      if: '["734001"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.outcome"
+      value: "success"
+  - set:
+      if: '["716039"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.outcome"
+      value: "failure"
+  - set:
+      if: '["710005"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.outcome"
+      value: "failure"
+  - set:
+      if: '["713901", "713902", "713903", "713904", "713905"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.outcome"
+      value: "failure"
+  - set:
+      if: '["113039"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.action"
+      value: "client-vpn-connected"
+  - set:
+      if: '["113029","113030","113031","113032","113033","113034","113035","113036","113037","113038"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.action"
+      value: "client-vpn-error"
+  - set:
+      if: '["113040"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.action"
+      value: "client-vpn-disconnected"
   - set:
       if: '["750002", "750003"].contains(ctx._temp_.cisco.message_id)'
       field: "event.action"
@@ -763,6 +889,14 @@ processors:
       if: '["750003", "713905", "713904", "713906", "713902", "713901"].contains(ctx._temp_.cisco.message_id)'
       field: "event.action"
       value: "error"
+  - set:
+      if: '["113005", "113021", "605004", "611102", "716039"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.action"
+      value: "logon-failed"
+  - set:
+      if: '["113004", "113012", "611101", "734001"].contains(ctx._temp_.cisco.message_id)'
+      field: "event.action"
+      value: "logged-in"
   - append:
       if: '["750003", "713905", "713904", "713906", "713902", "713901"].contains(ctx._temp_.cisco.message_id)'
       field: "event.type"
@@ -772,27 +906,31 @@ processors:
   # Handle 302xxx messages (Flow expiration a.k.a "Teardown")
   #
   - set:
-      if: '["302012", "302014", "302016", "302018", "302021", "302036", "302304", "302306", "609001", "609002"].contains(ctx._temp_.cisco.message_id)'
+      if: '["305012", "302014", "302016", "302018", "302021", "302036", "302304", "302306", "609001", "609002"].contains(ctx._temp_.cisco.message_id)'
       field: "event.action"
       value: "flow-expiration"
-      description: "302012, 302014, 302016, 302018, 302021, 302036, 302304, 302306, 609001, 609002"
+      description: "305012, 302014, 302016, 302018, 302021, 302036, 302304, 302306, 609001, 609002"
   - grok:
       field: "message"
       if: '["302014", "302016", "302018", "302021", "302036", "302304", "302306"].contains(ctx._temp_.cisco.message_id)'
       description: "302014, 302016, 302018, 302021, 302036, 302304, 302306"
       patterns:
-        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.source_username} )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.destination_username} )?duration (?:%{TIME:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) %{NOTCOLON:event.reason} from %{NOTCOLON:_temp_.cisco.termination_initiator} \(%{NOTSPACE:_temp_.cisco.termination_user}\)
-        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.source_username} )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.destination_username} )?duration (?:%{TIME:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) %{NOTCOLON:event.reason} from %{NOTCOLON:_temp_.cisco.termination_initiator}
-        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.source_username} )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.destination_username} )?duration (?:%{TIME:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) %{NOTCOLON:event.reason} \(%{NOTSPACE:_temp_.cisco.termination_user}\)
-        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.source_username} )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.destination_username} )?duration (?:%{TIME:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) \(%{NOTSPACE:_temp_.cisco.termination_user}\)
-        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.source_username} )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.destination_username} )?duration (?:%{TIME:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) %{NOTCOLON:event.reason}
-        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.source_username} )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:%{NOTSPACE:_temp_.cisco.destination_username} )?duration (?:%{TIME:_temp_.duration_hms} bytes %{NUMBER:network.bytes})
-        - ^Teardown %{NOTSPACE:network.transport} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\s*(?:\(%{NOTSPACE:_temp_.cisco.destination_username}\) )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\s*(?:\(%{NOTSPACE:_temp_.cisco.source_username}\))?(\s*type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?
+        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.source_username}\)? )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?duration (?:%{DURATION:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) %{NOTCOLON:event.reason} from %{NOTCOLON:_temp_.cisco.termination_initiator} \(%{CISCO_USER:_temp_.cisco.termination_user}\)
+        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.source_username}\)? )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?duration (?:%{DURATION:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) %{NOTCOLON:event.reason} from %{NOTCOLON:_temp_.cisco.termination_initiator}
+        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.source_username}\)? )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?duration (?:%{DURATION:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) %{NOTCOLON:event.reason} \(%{CISCO_USER:_temp_.cisco.termination_user}\)
+        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.source_username}\)? )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?duration (?:%{DURATION:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) \(%{CISCO_USER:_temp_.cisco.termination_user}\)
+        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.source_username}\)? )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?duration (?:%{DURATION:_temp_.duration_hms} bytes %{NUMBER:network.bytes}) %{NOTCOLON:event.reason}
+        - ^Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{DATA:source.address}/%{NUMBER:source.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.source_username}\)? )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{DATA:destination.address}/%{NUMBER:destination.port:int}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?duration (?:%{DURATION:_temp_.duration_hms} bytes %{NUMBER:network.bytes})
+        - ^Teardown %{NOTSPACE:network.transport} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\s*(?:\(?%{CISCO_USER:_temp_.cisco.destination_username}\)? )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\s*(?:\(%{CISCO_USER:_temp_.cisco.source_username}\))?(\s*type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?
       pattern_definitions:
+        HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-_]{0,62}))*(\\.?|\\b)"
+        IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         NOTCOLON: "[^:]*"
         ECSSOURCEIPORHOST: "(?:%{IP:source.address}|%{HOSTNAME:source.domain})"
         ECSDESTIPORHOST: "(?:%{IP:destination.address}|%{HOSTNAME:destination.domain})"
-        MAPPEDSRC: "(?:%{DATA:_temp_.natsrcip}|%{HOSTNAME})"
+        MAPPEDSRC: "(?:%{IPORHOST:_temp_.natsrcip}|%{HOSTNAME})"
+        DURATION: "%{INT}:%{MINUTE}:%{SECOND}"
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
 
   #
   # Decode FTD's Security Event Syslog Messages
@@ -1299,7 +1437,7 @@ processors:
   # processor converts it to the right value and populates start and end.
   - set:
       field: "_temp_.duration_hms"
-      value: "{{event.duration}}"
+      value: "{{{event.duration}}}"
       ignore_empty_value: true
 
   #
@@ -1318,7 +1456,7 @@ processors:
                 } else if (c == (char)':') {
                     total = (total + cur) * 60;
                     cur = 0;
-                } else {
+                } else if (c != (char)'h' && c == (char)'m' && c == (char)'s') {
                     return 0;
                 }
             }
@@ -1334,6 +1472,66 @@ processors:
         ctx.event['start'] = ZonedDateTime.ofInstant(
             Instant.parse(end).minusNanos(nanos),
             ZoneOffset.UTC);
+  #
+  # Parse Source/Dest Username/Domain
+  #
+  - grok:
+      field: "_temp_.cisco.source_username"
+      if: 'ctx?._temp_?.cisco?.source_username != null'
+      ignore_failure: true
+      patterns:
+        - '%{CISCO_DOMAIN_USER:_temp_.cisco.source_username}%{CISCO_SGT}'
+      pattern_definitions:
+        CISCO_DOMAIN_USER: (%{CISCO_DOMAIN})?%{CISCO_USER}
+        CISCO_SGT: (, *%{NUMBER:_temp_.cisco.source_user_security_group_tag})?
+        CISCO_USER: "%{USERNAME}(@%{HOSTNAME})?"
+        CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME}\\)?
+  - convert:
+      field: _temp_.cisco.source_user_security_group_tag
+      type: long
+      ignore_missing: true
+  - grok:
+      field: "_temp_.cisco.destination_username"
+      if: 'ctx?._temp_?.cisco?.destination_username != null'
+      ignore_failure: true
+      patterns:
+        - '%{CISCO_DOMAIN_USER:_temp_.cisco.destination_username}%{CISCO_SGT}'
+      pattern_definitions:
+        CISCO_DOMAIN_USER: (%{CISCO_DOMAIN})?%{CISCO_USER}
+        CISCO_SGT: (, *%{NUMBER:_temp_.cisco.destination_user_security_group_tag})?
+        CISCO_USER: "%{USERNAME}(@%{HOSTNAME})?"
+        CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME}\\)?
+  - convert:
+      field: _temp_.cisco.destination_user_security_group_tag
+      type: long
+      ignore_missing: true
+  - set:
+      field: source.user.name
+      value: "{{{ _temp_.cisco.source_username }}}"
+      if: 'ctx?.source?.user?.name == null && ctx?._temp_?.cisco?.source_username != null'
+  - set:
+      field: destination.user.name
+      value: "{{{ _temp_.cisco.destination_username }}}"
+      if: 'ctx?.destination?.user?.name == null && ctx?._temp_?.cisco?.destination_username != null'
+  - grok:
+      field: "source.user.name"
+      if: 'ctx?.source?.user?.name != null'
+      ignore_failure: true
+      patterns:
+        - (%{CISCO_DOMAIN})?%{CISCO_USER}
+      pattern_definitions:
+        CISCO_USER: "%{USERNAME:source.user.name}(@%{HOSTNAME:source.user.domain})?"
+        CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME:source.user.domain}\\)?
+  - grok:
+      field: "destination.user.name"
+      if: 'ctx?.destination?.user?.name != null'
+      ignore_failure: true
+      patterns:
+        - (%{CISCO_DOMAIN})?%{CISCO_USER}
+      pattern_definitions:
+        CISCO_USER: "%{USERNAME:destination.user.name}(@%{HOSTNAME:destination.user.domain})?"
+        CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME:destination.user.domain}\\)?
+
   #
   # Normalize protocol names
   #
@@ -1443,46 +1641,57 @@ processors:
       field: source.port
       type: integer
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: destination.port
       type: integer
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: source.bytes
       type: long
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: destination.bytes
       type: long
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: network.bytes
       type: long
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: source.packets
       type: integer
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: destination.packets
       type: integer
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: _temp_.cisco.mapped_source_port
       type: integer
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: _temp_.cisco.mapped_destination_port
       type: integer
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: _temp_.cisco.icmp_code
       type: integer
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: _temp_.cisco.icmp_type
       type: integer
       ignore_failure: true
+      ignore_missing: true
   - convert:
       field: http.response.status_code
       type: integer
@@ -1494,6 +1703,11 @@ processors:
   - convert:
       field: network.iana_number
       type: string
+      ignore_failure: true
+      ignore_missing: true
+  - convert:
+      field: sip.to.uri.port
+      type: integer
       ignore_failure: true
   #
   # Assign ECS .ip fields from .address is a valid IP address is found,
@@ -1586,7 +1800,7 @@ processors:
   # Fills nat.ip and nat.port even when only the ip or port changed.
   - set:
       field: source.nat.ip
-      value: "{{_temp_.cisco.mapped_source_ip}}"
+      value: "{{{_temp_.cisco.mapped_source_ip}}}"
       if: "ctx?._temp_?.cisco?.mapped_source_ip != ctx?.source?.ip"
       ignore_empty_value: true
   - convert:
@@ -1595,7 +1809,7 @@ processors:
       ignore_missing: true
   - set:
       field: source.nat.port
-      value: "{{_temp_.cisco.mapped_source_port}}"
+      value: "{{{_temp_.cisco.mapped_source_port}}}"
       if: "ctx?._temp_?.cisco?.mapped_source_port != ctx?.source?.port"
       ignore_empty_value: true
   - convert:
@@ -1604,7 +1818,7 @@ processors:
       ignore_missing: true
   - set:
       field: destination.nat.ip
-      value: "{{_temp_.cisco.mapped_destination_ip}}"
+      value: "{{{_temp_.cisco.mapped_destination_ip}}}"
       if: "ctx?._temp_?.cisco.mapped_destination_ip != ctx?.destination?.ip"
       ignore_empty_value: true
   - convert:
@@ -1613,7 +1827,7 @@ processors:
       ignore_missing: true
   - set:
       field: destination.nat.port
-      value: "{{_temp_.cisco.mapped_destination_port}}"
+      value: "{{{_temp_.cisco.mapped_destination_port}}}"
       if: "ctx?._temp_?.cisco?.mapped_destination_port != ctx?.destination?.port"
       ignore_empty_value: true
   - convert:
@@ -1687,7 +1901,7 @@ processors:
 
   - set:
       field: _temp_.url_domain
-      value: "{{url.domain}}"
+      value: "{{{url.domain}}}"
       ignore_failure: true
       if: ctx?.url?.domain != null
 
@@ -1697,7 +1911,7 @@ processors:
       if: ctx?.url?.original != null
   - append:
       field: url.domain
-      value: "{{_temp_.url_domain}}"
+      value: "{{{_temp_.url_domain}}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx?._temp_?.url_domain != null
@@ -1861,14 +2075,14 @@ processors:
   - set:
       description: copy destination.user.name to user.name if it is not set
       field: user.name
-      value: "{{destination.user.name}}"
+      value: "{{{destination.user.name}}}"
       ignore_empty_value: true
       if: ctx?.user?.name == null
 
   # Configures observer fields with a copy from cisco and host fields. Later on these might replace host.hostname.
   - set:
       field: observer.hostname
-      value: "{{ host.hostname }}"
+      value: "{{{ host.hostname }}}"
       ignore_empty_value: true
   - set:
       field: observer.vendor
@@ -1884,76 +2098,86 @@ processors:
       ignore_empty_value: true
   - set:
       field: observer.egress.interface.name
-      value: "{{ cisco.ftd.destination_interface }}"
+      value: "{{{ cisco.ftd.destination_interface }}}"
       ignore_empty_value: true
   - set:
       field: observer.ingress.interface.name
-      value: "{{ cisco.ftd.source_interface }}"
+      value: "{{{ cisco.ftd.source_interface }}}"
       ignore_empty_value: true
   - append:
       field: related.ip
-      value: "{{source.ip}}"
+      value: "{{{source.ip}}}"
       if: "ctx?.source?.ip != null"
       allow_duplicates: false
   - append:
       field: related.ip
-      value: "{{source.nat.ip}}"
+      value: "{{{source.nat.ip}}}"
       if: "ctx?.source?.nat?.ip != null"
       allow_duplicates: false
   - append:
       field: related.ip
-      value: "{{destination.ip}}"
+      value: "{{{destination.ip}}}"
       if: "ctx?.destination?.ip != null"
       allow_duplicates: false
   - append:
       field: related.ip
-      value: "{{destination.nat.ip}}"
+      value: "{{{destination.nat.ip}}}"
       if: "ctx?.destination?.nat?.ip != null"
       allow_duplicates: false
   - append:
       field: related.user
-      value: "{{user.name}}"
+      value: "{{{user.name}}}"
       if: ctx?.user?.name != null && ctx?.user?.name != ''
       allow_duplicates: false
   - append:
       field: related.user
-      value: "{{server.user.name}}"
+      value: "{{{server.user.name}}}"
       if: ctx?.server?.user?.name != null && ctx?.server?.user?.name != ''
       allow_duplicates: false
   - append:
       field: related.user
-      value: "{{source.user.name}}"
+      value: "{{{source.user.name}}}"
       if: ctx?.source?.user?.name != null && ctx?.source?.user?.name != ''
       allow_duplicates: false
   - append:
       field: related.user
-      value: "{{destination.user.name}}"
+      value: "{{{destination.user.name}}}"
       if: ctx?.destination?.user?.name != null && ctx?.destination?.user?.name != ''
       allow_duplicates: false
   - append:
       field: related.hash
-      value: "{{file.hash.sha256}}"
+      value: "{{{file.hash.sha256}}}"
       if: "ctx?.file?.hash?.sha256 != null"
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{host.hostname}}"
+      value: "{{{host.hostname}}}"
       if: ctx.host?.hostname != null && ctx.host?.hostname != ''
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{observer.hostname}}"
+      value: "{{{observer.hostname}}}"
       if: ctx.observer?.hostname != null && ctx.observer?.hostname != ''
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{destination.domain}}"
+      value: "{{{destination.domain}}}"
       if: ctx.destination?.domain != null && ctx.destination?.domain != ''
       allow_duplicates: false
   - append:
       field: related.hosts
-      value: "{{source.domain}}"
+      value: "{{{source.domain}}}"
       if: ctx.source?.domain != null && ctx.source?.domain != ''
+      allow_duplicates: false
+  - append:
+      field: related.hosts
+      value: "{{{source.user.domain}}}"
+      if: ctx.source?.user?.domain != null && ctx.source?.user?.domain != ''
+      allow_duplicates: false
+  - append:
+      field: related.hosts
+      value: "{{{destination.user.domain}}}"
+      if: ctx.destination?.user?.domain != null && ctx.destination?.user?.domain != ''
       allow_duplicates: false
   - script:
       lang: painless
@@ -1979,6 +2203,9 @@ processors:
           }
         }
         handleMap(ctx);
+  - community_id:
+      ignore_missing: true
+      ignore_failure: true
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
@@ -1997,4 +2224,4 @@ on_failure:
       ignore_missing: true
   - append:
       field: "error.message"
-      value: "{{ _ingest.on_failure_message }}"
+      value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/cisco_ftd/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_ftd/data_stream/log/fields/ecs.yml
@@ -111,6 +111,8 @@
 - external: ecs
   name: network.bytes
 - external: ecs
+  name: network.community_id
+- external: ecs
   name: network.direction
 - external: ecs
   name: network.iana_number

--- a/packages/cisco_ftd/data_stream/log/fields/fields.yml
+++ b/packages/cisco_ftd/data_stream/log/fields/fields.yml
@@ -142,6 +142,11 @@
       default_field: false
       description: |
         The WebVPN group name the user belongs to
+    - name: tunnel_type
+      type: keyword
+      default_field: false
+      description: >
+        SA type (remote access or L2L)
     - name: termination_user
       default_field: false
       type: keyword

--- a/packages/cisco_ftd/data_stream/log/sample_event.json
+++ b/packages/cisco_ftd/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2019-08-16T09:39:03.000Z",
     "agent": {
-        "ephemeral_id": "173348ff-0df7-4c59-b0b0-f4aad4a82751",
-        "id": "b9045ecb-c8cf-4d1a-8b37-757e202e9ea1",
+        "ephemeral_id": "cf085b8c-2652-446c-93ab-0426f7cb54d1",
+        "id": "c46e592b-7ede-4f31-9714-c3e0bc5c3213",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.0"
+        "version": "8.4.1"
     },
     "cisco": {
         "ftd": {
@@ -60,12 +60,12 @@
         "port": 80
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "b9045ecb-c8cf-4d1a-8b37-757e202e9ea1",
+        "id": "c46e592b-7ede-4f31-9714-c3e0bc5c3213",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.4.1"
     },
     "event": {
         "action": "malware-detected",
@@ -76,8 +76,8 @@
         ],
         "code": "430005",
         "dataset": "cisco_ftd.log",
-        "ingested": "2022-06-22T01:38:18Z",
-        "kind": "event",
+        "ingested": "2022-10-05T00:03:15Z",
+        "kind": "alert",
         "original": "2019-08-16T09:39:03Z firepower  %FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 81.2.69.144, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip",
         "severity": 1,
         "start": "2019-08-16T09:39:02Z",
@@ -102,11 +102,12 @@
     "log": {
         "level": "alert",
         "source": {
-            "address": "172.31.0.6:55524"
+            "address": "192.168.240.4:50316"
         }
     },
     "network": {
         "application": "curl",
+        "community_id": "1:jk2uwniJ2oCG0t73HeZ9w8gtA8E=",
         "iana_number": "6",
         "protocol": "http",
         "transport": "tcp"

--- a/packages/cisco_ftd/docs/README.md
+++ b/packages/cisco_ftd/docs/README.md
@@ -22,11 +22,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2019-08-16T09:39:03.000Z",
     "agent": {
-        "ephemeral_id": "173348ff-0df7-4c59-b0b0-f4aad4a82751",
-        "id": "b9045ecb-c8cf-4d1a-8b37-757e202e9ea1",
+        "ephemeral_id": "cf085b8c-2652-446c-93ab-0426f7cb54d1",
+        "id": "c46e592b-7ede-4f31-9714-c3e0bc5c3213",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.0"
+        "version": "8.4.1"
     },
     "cisco": {
         "ftd": {
@@ -81,12 +81,12 @@ An example event for `log` looks as following:
         "port": 80
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "b9045ecb-c8cf-4d1a-8b37-757e202e9ea1",
+        "id": "c46e592b-7ede-4f31-9714-c3e0bc5c3213",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.4.1"
     },
     "event": {
         "action": "malware-detected",
@@ -97,8 +97,8 @@ An example event for `log` looks as following:
         ],
         "code": "430005",
         "dataset": "cisco_ftd.log",
-        "ingested": "2022-06-22T01:38:18Z",
-        "kind": "event",
+        "ingested": "2022-10-05T00:03:15Z",
+        "kind": "alert",
         "original": "2019-08-16T09:39:03Z firepower  %FTD-1-430005: SrcIP: 10.0.1.20, DstIP: 81.2.69.144, SrcPort: 46004, DstPort: 80, Protocol: tcp, FileDirection: Download, FileAction: Malware Cloud Lookup, FileSHA256: 2546dcffc5ad854d4ddc64fbf056871cd5a00f2471cb7a5bfd4ac23b6e9eedad, SHA_Disposition: Unavailable, SperoDisposition: Spero detection not performed on file, ThreatName: Win.Ransomware.Eicar::95.sbx.tg, FileName: eicar_com.zip, FileType: ZIP, FileSize: 184, ApplicationProtocol: HTTP, Client: cURL, User: No Authentication Required, FirstPacketSecond: 2019-08-16T09:39:02Z, FilePolicy: malware-and-file-policy, FileStorageStatus: Not Stored (Disposition Was Pending), FileSandboxStatus: File Size Is Too Small, URI: http://www.eicar.org/download/eicar_com.zip",
         "severity": 1,
         "start": "2019-08-16T09:39:02Z",
@@ -123,11 +123,12 @@ An example event for `log` looks as following:
     "log": {
         "level": "alert",
         "source": {
-            "address": "172.31.0.6:55524"
+            "address": "192.168.240.4:50316"
         }
     },
     "network": {
         "application": "curl",
+        "community_id": "1:jk2uwniJ2oCG0t73HeZ9w8gtA8E=",
         "iana_number": "6",
         "protocol": "http",
         "transport": "tcp"
@@ -215,6 +216,7 @@ An example event for `log` looks as following:
 | cisco.ftd.termination_user | AAA name of user requesting termination | keyword |
 | cisco.ftd.threat_category | Category for the malware / botnet traffic. For example: virus, botnet, trojan, etc. | keyword |
 | cisco.ftd.threat_level | Threat level for malware / botnet traffic. One of very-low, low, moderate, high or very-high. | keyword |
+| cisco.ftd.tunnel_type | SA type (remote access or L2L) | keyword |
 | cisco.ftd.username |  | keyword |
 | cisco.ftd.webvpn.group_name | The WebVPN group name the user belongs to | keyword |
 | client.address | Some event client addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
@@ -318,6 +320,7 @@ An example event for `log` looks as following:
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | network.application | When a specific application or service is identified from network connection details (source/dest IPs, ports, certificates, or wire format), this field captures the application's or service's name. For example, the original event identifies the network connection being from a specific web service in a `https` network connection, like `facebook` or `twitter`. The field value must be normalized to lowercase for querying. | keyword |
 | network.bytes | Total bytes transferred in both directions. If `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum. | long |
+| network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | network.direction | Direction of the network traffic. When mapping events from a host-based monitoring context, populate this field from the host's point of view, using the values "ingress" or "egress". When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of the network perimeter, using the values "inbound", "outbound", "internal" or "external". Note that "internal" is not crossing perimeter boundaries, and is meant to describe communication between two hosts within the perimeter. Note also that "external" is meant to describe traffic between two hosts that are external to the perimeter. This could for example be useful for ISPs or VPN service providers. | keyword |
 | network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which use the IANA Protocol Number. | keyword |
 | network.inner | Network.inner fields are added in addition to network.vlan fields to describe the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include vlan.id and vlan.name. Inner vlan fields are typically used when sending traffic with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.) | object |

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ftd
 title: Cisco FTD
-version: "2.4.5"
+version: "2.4.6"
 license: basic
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This brings the cisco_asa and cisco_ftd ingest pipelines more into agreement though parts dealing with ECS categorisation remain distinct.

The changes in cisco_asa do not affect test outcomes and are for the most part cosmetic to reduce diff noise in future changes. It does add the malware event kind classification that exists in cisco_ftd.

The changes in cisco_ftd fix incorrect handling of:
- network.inner/cisco.ftd.tunnel_type fields
- 305012 events.

And add the network.community_id field to events.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Close #2116

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
