### PR TITLE
[MongoDB]Adding username and password to handlebar file

### DIFF
--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.3"
+  changes:
+    - description: Add username and password for the template file
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/2916
 - version: "1.3.2"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add username and password for the template file
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/2916
+      link: https://github.com/elastic/integrations/pull/4381
 - version: "1.3.2"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/mongodb/data_stream/metrics/agent/stream/stream.yml.hbs
+++ b/packages/mongodb/data_stream/metrics/agent/stream/stream.yml.hbs
@@ -3,4 +3,10 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+{{#if password}}
+password: {{password}}
+{{/if}}
 period: {{period}}
+{{#if username}}
+username: {{username}}
+{{/if}}

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: 1.3.2
+version: 1.3.3
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Bug

## What does this PR do?

Updated the username and password variable in the template file for metrics data stream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.


## How to test this PR locally

- Clone the PR.
- Run the elastic-package stack up command.
- Add the mongoDb integration.
- In Integration UI provide all host related details.
- Enrol the elastic agent.
- MongoDB Metrics should be flowing to the Elastic-search.

## Related issues


- Closes #4345

