### PR TITLE
[netflow] Amend 2.2.5 changelog entry with correct link

### DIFF
--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix invalid Kibana search indexRefName reference.
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/2572
+      link: https://github.com/elastic/integrations/pull/4379
 - version: "2.2.4"
   changes:
     - description: Remove duplicate field.


### PR DESCRIPTION
## What does this PR do?

Amend 2.2.5 changelog entry with correct link.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
