### PR TITLE
Add "security" category to featured security integrations

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Add security category to package metadata.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4392
 - version: "1.0.0"
   changes:
     - description: Cloud Security Posture integration is now GA.

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -9,6 +9,7 @@ type: integration
 categories:
   - containers
   - kubernetes
+  - security
 conditions:
   kibana.version: "^8.5.0"
 screenshots:

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Kubernetes Security Posture Management"
-version: 1.0.0
+version: 1.0.1
 release: ga
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Add security category to package metadata.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4392
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -7,6 +7,7 @@ description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
 categories:
   - web
+  - security
 release: ga
 conditions:
   kibana.version: ^8.4.0

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.6.0"
+version: "1.6.1"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

As part of https://github.com/elastic/kibana/issues/141823, we want to have featured integrations for certain categories. The network_traffic and cloud_security_posture integrations will be featured in the security category so they need the security category in the manifest.