### PR TITLE
[microsoft_dhcp] Fix broken hyperlink in docs

### DIFF
--- a/packages/microsoft_dhcp/_dev/build/docs/README.md
+++ b/packages/microsoft_dhcp/_dev/build/docs/README.md
@@ -14,7 +14,7 @@ Ingest logs from Microsoft DHCP Server, by default logged with the filename form
 Logs may also be ingested from Microsoft DHCPv6 Server, by default logged with the filename format:
 `%windir%\System32\DHCP\DhcpV6SrvLog-*.log`
 
-Relevant documentation for Microsoft DHCP can be found on [this]https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd183591(v=ws.10) location.
+Relevant documentation for Microsoft DHCP can be found on [this](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd183591(v=ws.10)) location.
 
 {{event "log"}}
 

--- a/packages/microsoft_dhcp/changelog.yml
+++ b/packages/microsoft_dhcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Fix a bug in documenation with hyperlink to Microsoft website
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4393
 - version: "1.7.0"
   changes:
     - description: Change host.domain to host.name to reflect the event data and then extract host.domain from the host.name

--- a/packages/microsoft_dhcp/docs/README.md
+++ b/packages/microsoft_dhcp/docs/README.md
@@ -14,7 +14,7 @@ Ingest logs from Microsoft DHCP Server, by default logged with the filename form
 Logs may also be ingested from Microsoft DHCPv6 Server, by default logged with the filename format:
 `%windir%\System32\DHCP\DhcpV6SrvLog-*.log`
 
-Relevant documentation for Microsoft DHCP can be found on [this]https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd183591(v=ws.10) location.
+Relevant documentation for Microsoft DHCP can be found on [this](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd183591(v=ws.10)) location.
 
 An example event for `log` looks as following:
 

--- a/packages/microsoft_dhcp/docs/README.md
+++ b/packages/microsoft_dhcp/docs/README.md
@@ -143,3 +143,4 @@ An example event for `log` looks as following:
 | tags | List of keywords used to tag each event. | keyword |
 | user.name | Short name or login of the user. | keyword |
 | user.name.text | Multi-field of `user.name`. | match_only_text |
+

--- a/packages/microsoft_dhcp/manifest.yml
+++ b/packages/microsoft_dhcp/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_dhcp
 title: Microsoft DHCP
-version: "1.7.0"
+version: "1.7.1"
 license: basic
 description: Collect logs from Microsoft DHCP with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug

## What does this PR do?
This fixes an issue in the documentation and does not impact the integration itself.

The hyperlink is broken and displays incorrectly here on GitHub and in Kibana. Also, the last parenthesis ")" is not properly parsed either so the link doesn't work at all in Kibana, (you will get a 404 not found).

## Screenshots

![image](https://user-images.githubusercontent.com/5582679/194126558-219ca833-076f-41fc-b4ef-cd562f0fb8d2.png)

![image](https://user-images.githubusercontent.com/5582679/194126661-0fdf0e42-95b0-4d9b-8667-847e940bbc45.png)
