### PR TITLE
Fix adding processors in cloudfront logs

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix adding processors in cloudfront logs.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4308
+      link: https://github.com/elastic/integrations/pull/4395
 - version: "1.24.2"
   changes:
     - description: Fix billing datastream agent template.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.3"
+  changes:
+    - description: Fix adding processors in cloudfront logs.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4308
 - version: "1.24.2"
   changes:
     - description: Fix billing datastream agent template.

--- a/packages/aws/data_stream/cloudfront_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudfront_logs/agent/stream/aws-s3.yml.hbs
@@ -51,5 +51,5 @@ processors:
         regexp:
           message: "^#.*"        
 {{#if processors}}
-{{processors}}
+  - {{processors}}
 {{/if}}

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.24.2
+version: 1.24.3
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix adding processors for `cloudfront` logs in AWS package. With the change, we can see `processors` in agent policy is in the right format now:
```
inputs:
  - id: aws-s3-cloudfront-096288f1-4c9d-4f1b-a6b1-7e73ecc7a849
    name: aws-1
    revision: 1
    type: aws-s3
    use_output: default
    meta:
      package:
        name: aws
        version: 1.24.3
    data_stream:
      namespace: default
    streams:
      - id: aws-s3-aws.cloudfront_logs-096288f1-4c9d-4f1b-a6b1-7e73ecc7a849
        data_stream:
          dataset: aws.cloudfront_logs
          type: logs
        queue_url: 'https://sqs.us-east-1.amazonaws.com/123/test'
        max_number_of_messages: 5
        access_key_id: a
        secret_access_key: b
        session_token: c
        tags:
          - forwarded
          - aws-cloudfront
        publisher_pipeline.disable_host: true
        processors:
          - drop_event:
              when:
                regexp:
                  message: ^#.*
          - drop_event:
              when:
                not:
                  regexp:
                    message: .*text/html.*
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/4394

