### PR TITLE
[system] fix adding additional processors in syslog data stream

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Fix adding processors in syslog data stream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4396
 - version: "1.20.0"
   changes:
     - description: Improve system overview and host overview dashboards

--- a/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
+++ b/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
@@ -7,9 +7,9 @@ multiline:
   pattern: "^\\s"
   match: after
 processors:
-- add_locale: ~
+  - add_locale: ~
 {{#if processors.length}}
-{{processors}}
+  - {{processors}}
 {{/if}}
 {{#if tags.length}}
 tags:

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.20.0
+version: 1.20.1
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Similar to https://github.com/elastic/integrations/pull/4395, this PR is to fix adding processors for `syslog` in system package. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
