### PR TITLE
gcp,google_workspace: remove duplicate fields

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.12.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4397
 - version: "2.12.0"
   changes:
     - description: Add GCP Redis

--- a/packages/gcp/data_stream/redis/fields/agent.yml
+++ b/packages/gcp/data_stream/redis/fields/agent.yml
@@ -5,49 +5,11 @@
   footnote: 'Examples: If Metricbeat is running on an GCP Compute VM and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
   type: group
   fields:
-    - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
-    - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
-    - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
     - name: instance.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Instance name of the host machine.
-    - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
-    - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
-    - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.

--- a/packages/gcp/docs/redis.md
+++ b/packages/gcp/docs/redis.md
@@ -70,7 +70,7 @@ An example event for `redis` looks as following:
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |  |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |  |  |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |  |
 | cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
 | cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
 | cloud.instance.name | Instance name of the host machine. | keyword |  |  |

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.12.0"
+version: "2.12.1"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4397
 - version: "1.7.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/google_workspace/data_stream/admin/fields/agent.yml
+++ b/packages/google_workspace/data_stream/admin/fields/agent.yml
@@ -77,11 +77,6 @@
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2

--- a/packages/google_workspace/data_stream/drive/fields/agent.yml
+++ b/packages/google_workspace/data_stream/drive/fields/agent.yml
@@ -77,11 +77,6 @@
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2

--- a/packages/google_workspace/data_stream/groups/fields/agent.yml
+++ b/packages/google_workspace/data_stream/groups/fields/agent.yml
@@ -77,11 +77,6 @@
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2

--- a/packages/google_workspace/data_stream/login/fields/agent.yml
+++ b/packages/google_workspace/data_stream/login/fields/agent.yml
@@ -77,11 +77,6 @@
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2

--- a/packages/google_workspace/data_stream/saml/fields/agent.yml
+++ b/packages/google_workspace/data_stream/saml/fields/agent.yml
@@ -77,11 +77,6 @@
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2

--- a/packages/google_workspace/data_stream/user_accounts/fields/agent.yml
+++ b/packages/google_workspace/data_stream/user_accounts/fields/agent.yml
@@ -77,11 +77,6 @@
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: 1.7.1
+version: 1.7.2
 release: ga
 description: Collect logs from Google Workspace with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes field definition duplications in gcp and google_workspace.

- gcp is a regression
- google_workspace was not discovered in previous rounds of deduplication which depend on `elastic-package check` and are stochastic.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #4338
- Updates #4398

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
