### PR TITLE
akamai,auditd,barracuda,bluecoat,box_events,carbon_black_cloud,cef: remove duplicated fields

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4399
 - version: "2.1.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/akamai/data_stream/siem/fields/ecs.yml
+++ b/packages/akamai/data_stream/siem/fields/ecs.yml
@@ -12,8 +12,6 @@
   external: ecs
 - name: client.geo.continent_name
   external: ecs
-- name: client.geo.country_iso_code
-  external: ecs
 - name: client.geo.region_iso_code
   external: ecs
 - name: client.geo.location

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.1.1"
+version: "2.1.2"
 release: ga
 description: Collect logs from Akamai with Elastic Agent.
 type: integration

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.3.4"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4399
 - version: "3.3.3"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/auditd/data_stream/log/fields/agent.yml
+++ b/packages/auditd/data_stream/log/fields/agent.yml
@@ -77,11 +77,6 @@
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2
@@ -90,12 +85,6 @@
     ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
   type: group
   fields:
-    - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
     - name: domain
       level: extended
       type: keyword

--- a/packages/auditd/data_stream/log/fields/fields.yml
+++ b/packages/auditd/data_stream/log/fields/fields.yml
@@ -36,9 +36,6 @@
       type: keyword
       description: |
         The first argument to the system call.
-    - name: a0
-      description: The first argument to the system call.
-      type: keyword
     - name: addr
       type: ip
     - name: rport

--- a/packages/auditd/data_stream/log/fields/package-fields.yml
+++ b/packages/auditd/data_stream/log/fields/package-fields.yml
@@ -24,25 +24,6 @@
           type: keyword
           description: |
             Name of the group.
-    - name: effective
-      type: group
-      fields:
-        - name: id
-          type: keyword
-          description: |
-            One or multiple unique identifiers of the user.
-        - name: name
-          type: keyword
-          description: |
-            Short name or login of the user.
-        - name: group.id
-          type: keyword
-          description: |
-            Unique identifier for the group on the system/platform.
-        - name: group.name
-          type: keyword
-          description: |
-            Name of the group.
     - name: filesystem
       type: group
       fields:

--- a/packages/auditd/docs/README.md
+++ b/packages/auditd/docs/README.md
@@ -250,7 +250,7 @@ An example event for `log` looks as following:
 | user.audit.name | Short name or login of the user. | keyword |
 | user.effective.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.effective.group.name | Name of the group. | keyword |
-| user.effective.id | One or multiple unique identifiers of the user. | keyword |
+| user.effective.id | Unique identifier of the user. | keyword |
 | user.effective.name | Short name or login of the user. | keyword |
 | user.effective.name.text | Multi-field of `user.effective.name`. | match_only_text |
 | user.filesystem.group.id | Unique identifier for the group on the system/platform. | keyword |

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd Logs
-version: "3.3.3"
+version: "3.3.4"
 release: ga
 description: Collect logs from Linux audit daemon with Elastic Agent.
 type: integration

--- a/packages/barracuda/changelog.yml
+++ b/packages/barracuda/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4399
 - version: "0.11.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/barracuda/data_stream/spamfirewall/fields/base-fields.yml
+++ b/packages/barracuda/data_stream/spamfirewall/fields/base-fields.yml
@@ -15,9 +15,6 @@
   type: constant_keyword
   description: Event dataset
   value: barracuda.spamfirewall
-- name: '@timestamp'
-  type: date
-  description: Event timestamp.
 - name: container.id
   description: Unique container id.
   ignore_above: 1024
@@ -39,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/barracuda/data_stream/waf/fields/base-fields.yml
+++ b/packages/barracuda/data_stream/waf/fields/base-fields.yml
@@ -15,9 +15,6 @@
   type: constant_keyword
   description: Event dataset
   value: barracuda.waf
-- name: '@timestamp'
-  type: date
-  description: Event timestamp.
 - name: container.id
   description: Unique container id.
   ignore_above: 1024
@@ -39,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/barracuda/manifest.yml
+++ b/packages/barracuda/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: barracuda
 title: Barracuda Logs
-version: "0.11.1"
+version: "0.11.2"
 description: Collect spam and web application firewall logs from Barracuda devices with Elastic Agent.
 categories: ["network", "security"]
 release: experimental

--- a/packages/bluecoat/changelog.yml
+++ b/packages/bluecoat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4399
 - version: "0.10.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/bluecoat/data_stream/director/fields/base-fields.yml
+++ b/packages/bluecoat/data_stream/director/fields/base-fields.yml
@@ -15,9 +15,6 @@
   type: constant_keyword
   description: Event dataset
   value: bluecoat.director
-- name: '@timestamp'
-  type: date
-  description: Event timestamp.
 - name: container.id
   description: Unique container id.
   ignore_above: 1024
@@ -39,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/bluecoat/manifest.yml
+++ b/packages/bluecoat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: bluecoat
 title: Blue Coat Director Logs
-version: "0.10.1"
+version: "0.10.2"
 description: Collect director logs from Blue Coat devices with Elastic Agent.
 categories: ["network", "security"]
 release: experimental

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4399
 - version: "0.1.0"
   changes:
     - description: Initial beta version of the package

--- a/packages/box_events/data_stream/events/fields/fields.yml
+++ b/packages/box_events/data_stream/events/fields/fields.yml
@@ -149,6 +149,3 @@
         - name: trashed_at
           description: The time at which this file was put in the trash
           type: boolean
-        - name: id
-          description: The unique identifier that represent a folder
-          type: keyword

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: box_events
 title: Box Events
-version: 0.1.0
+version: 0.1.1
 release: beta
 license: basic
 description: "Collect logs from Box with Elastic Agent."

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4399
 - version: "1.3.0"
   changes:
     - description: Add Support of SQS input type.

--- a/packages/carbon_black_cloud/data_stream/alert/fields/agent.yml
+++ b/packages/carbon_black_cloud/data_stream/alert/fields/agent.yml
@@ -105,38 +105,11 @@
         For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
       example: CONTOSO
       default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword
       ignore_above: 1024
       description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
     - name: os.family
       level: extended
       type: keyword
@@ -166,12 +139,6 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
-    - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
     - name: type
       level: core
       type: keyword

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/fields/agent.yml
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/fields/agent.yml
@@ -105,38 +105,11 @@
         For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
       example: CONTOSO
       default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword
       ignore_above: 1024
       description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
     - name: os.family
       level: extended
       type: keyword
@@ -149,29 +122,12 @@
       ignore_above: 1024
       description: Operating system kernel version as a raw string.
       example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
     - name: os.platform
       level: extended
       type: keyword
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
-    - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
     - name: type
       level: core
       type: keyword

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/fields/agent.yml
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/fields/agent.yml
@@ -105,6 +105,10 @@
         For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
       example: CONTOSO
       default_field: false
+    - name: ip
+      level: core
+      type: ip
+      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/fields/agent.yml
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/fields/agent.yml
@@ -105,61 +105,17 @@
         For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
       example: CONTOSO
       default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword
       ignore_above: 1024
       description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
-    - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
     - name: os.kernel
       level: extended
       type: keyword
       ignore_above: 1024
       description: Operating system kernel version as a raw string.
       example: 4.4.0-112-generic
-    - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
     - name: os.platform
       level: extended
       type: keyword

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/fields/agent.yml
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/fields/agent.yml
@@ -105,38 +105,11 @@
         For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
       example: CONTOSO
       default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword
       ignore_above: 1024
       description: Host mac addresses.
-    - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
     - name: os.family
       level: extended
       type: keyword

--- a/packages/carbon_black_cloud/docs/README.md
+++ b/packages/carbon_black_cloud/docs/README.md
@@ -1041,6 +1041,7 @@ An example event for `asset_vulnerability_summary` looks as following:
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
+| host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |

--- a/packages/carbon_black_cloud/docs/README.md
+++ b/packages/carbon_black_cloud/docs/README.md
@@ -651,7 +651,7 @@ An example event for `endpoint_event` looks as following:
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
 | host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
+| host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
@@ -1041,7 +1041,6 @@ An example event for `asset_vulnerability_summary` looks as following:
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
 | host.mac | Host mac addresses. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | host.os.build | OS build information. | keyword |
@@ -1049,7 +1048,7 @@ An example event for `asset_vulnerability_summary` looks as following:
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
 | host.os.kernel | Operating system kernel version as a raw string. | keyword |
 | host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
+| host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. If the OS you're dealing with is not listed as an expected value, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "1.3.0"
+version: "1.3.1"
 license: basic
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.4"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4399
 - version: "2.3.3"
   changes:
     - description: Remove duplicate field.

--- a/packages/cef/data_stream/log/fields/fields.yml
+++ b/packages/cef/data_stream/log/fields/fields.yml
@@ -339,18 +339,6 @@
     - name: deviceCustomDate2Label
       type: keyword
       description: All custom fields have a corresponding label field. Each of these fields is a string and describes the purpose of the custom field.
-    - name: deviceCustomIPv6Address2
-      type: ip
-      description: One of four IPv6 address fields available to map fields that do not apply to any other in this dictionary.
-    - name: deviceCustomIPv6Address2Label
-      type: keyword
-      description: All custom fields have a corresponding label field. Each of these fields is a string and describes the purpose of the custom field.
-    - name: deviceCustomIPv6Address3
-      type: ip
-      description: One of four IPv6 address fields available to map fields that do not apply to any other in this dictionary.
-    - name: deviceCustomIPv6Address3Label
-      type: keyword
-      description: All custom fields have a corresponding label field. Each of these fields is a string and describes the purpose of the custom field.
     - name: deviceCustomNumber1
       type: long
       description: One of three number fields available to map fields that do not apply to any other in this dictionary. Use sparingly and seek a more specific, dictionary supplied field when possible.

--- a/packages/cef/manifest.yml
+++ b/packages/cef/manifest.yml
@@ -1,6 +1,6 @@
 name: cef
 title: Common Event Format (CEF)
-version: 2.3.3
+version: 2.3.4
 release: ga
 description: Collect logs from CEF Logs with Elastic Agent.
 type: integration

--- a/packages/lastpass/changelog.yml
+++ b/packages/lastpass/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: Initial Release.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4399


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This removes duplicated field definitions in a some of the SEI packages identified in #4398.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Updates #4398

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
