### PR TITLE
cisco_*: remove duplicate fields

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.7"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4400
 - version: "2.7.6"
   changes:
     - description: Remove duplicate field.

--- a/packages/cisco_asa/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_asa/data_stream/log/fields/ecs.yml
@@ -49,8 +49,6 @@
 - external: ecs
   name: event.created
 - external: ecs
-  name: event.created
-- external: ecs
   name: event.duration
 - external: ecs
   name: event.end
@@ -136,8 +134,6 @@
   name: related.ip
 - external: ecs
   name: related.user
-- external: ecs
-  name: server.domain
 - external: ecs
   name: source.address
 - external: ecs

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.7.6"
+version: "2.7.7"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.5"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4400
 - version: "2.4.4"
   changes:
     - description: Remove duplicate field.

--- a/packages/cisco_ftd/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_ftd/data_stream/log/fields/ecs.yml
@@ -57,8 +57,6 @@
 - external: ecs
   name: event.created
 - external: ecs
-  name: event.created
-- external: ecs
   name: event.duration
 - external: ecs
   name: event.end
@@ -162,8 +160,6 @@
   name: related.ip
 - external: ecs
   name: related.user
-- external: ecs
-  name: server.domain
 - external: ecs
   name: service.id
 - external: ecs

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ftd
 title: Cisco FTD
-version: "2.4.4"
+version: "2.4.5"
 license: basic
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.3"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4400
 - version: "1.9.2"
   changes:
     - description: Remove duplicate field.

--- a/packages/cisco_ios/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_ios/data_stream/log/fields/ecs.yml
@@ -35,8 +35,6 @@
 - external: ecs
   name: event.created
 - external: ecs
-  name: event.created
-- external: ecs
   name: event.duration
 - external: ecs
   name: event.end

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ios
 title: Cisco IOS
-version: "1.9.2"
+version: "1.9.3"
 license: basic
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration

--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4400
 - version: "1.1.0"
   changes:
     - description: Allow non-numeric task ID fields to be ingested

--- a/packages/cisco_ise/data_stream/log/fields/agent.yml
+++ b/packages/cisco_ise/data_stream/log/fields/agent.yml
@@ -97,20 +97,11 @@
       description: 'Name of the domain of which the host is a member. For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
       example: CONTOSO
       default_field: false
-    - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host. It normally contains what the `hostname` command returns on the host machine.'
     - name: id
       level: core
       type: keyword
       ignore_above: 1024
       description: 'Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/cisco_ise/data_stream/log/fields/fields.yml
+++ b/packages/cisco_ise/data_stream/log/fields/fields.yml
@@ -739,8 +739,6 @@
       type: keyword
     - name: step_latency
       type: keyword
-    - name: state
-      type: keyword
     - name: status
       type: keyword
     - name: sysstats

--- a/packages/cisco_ise/manifest.yml
+++ b/packages/cisco_ise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ise
 title: Cisco ISE
-version: "1.1.0"
+version: "1.1.1"
 license: basic
 description: Collect logs from Cisco ISE with Elastic Agent.
 type: integration

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4400
 - version: "1.2.1"
   changes:
     - description: Remove duplicate field.

--- a/packages/cisco_meraki/data_stream/events/fields/agent.yml
+++ b/packages/cisco_meraki/data_stream/events/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/cisco_meraki/data_stream/events/fields/ecs.yml
+++ b/packages/cisco_meraki/data_stream/events/fields/ecs.yml
@@ -277,10 +277,6 @@
 - external: ecs
   name: threat.indicator.file.hash.sha256
 - external: ecs
-  name: network.direction
-- external: ecs
-  name: network.protocol
-- external: ecs
   name: client.geo.city_name
 - external: ecs
   name: client.geo.continent_name

--- a/packages/cisco_meraki/data_stream/log/fields/agent.yml
+++ b/packages/cisco_meraki/data_stream/log/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/cisco_meraki/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_meraki/data_stream/log/fields/ecs.yml
@@ -275,10 +275,6 @@
 - external: ecs
   name: threat.indicator.file.hash.sha256
 - external: ecs
-  name: network.direction
-- external: ecs
-  name: network.protocol
-- external: ecs
   name: client.geo.city_name
 - external: ecs
   name: client.geo.continent_name

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_meraki
 title: Cisco Meraki
-version: 1.2.1
+version: 1.2.2
 license: basic
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration

--- a/packages/cisco_nexus/changelog.yml
+++ b/packages/cisco_nexus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.3"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4400
 - version: "0.7.2"
   changes:
     - description: Remove duplicate field.

--- a/packages/cisco_nexus/data_stream/log/fields/agent.yml
+++ b/packages/cisco_nexus/data_stream/log/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/cisco_nexus/data_stream/log/fields/base-fields.yml
+++ b/packages/cisco_nexus/data_stream/log/fields/base-fields.yml
@@ -36,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/cisco_nexus/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_nexus/data_stream/log/fields/ecs.yml
@@ -203,8 +203,6 @@
 - external: ecs
   name: source.top_level_domain
 - external: ecs
-  name: tags
-- external: ecs
   name: url.domain
 - external: ecs
   name: url.original

--- a/packages/cisco_nexus/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_nexus/data_stream/log/fields/ecs.yml
@@ -203,6 +203,8 @@
 - external: ecs
   name: source.top_level_domain
 - external: ecs
+  name: tags
+- external: ecs
   name: url.domain
 - external: ecs
   name: url.original

--- a/packages/cisco_nexus/manifest.yml
+++ b/packages/cisco_nexus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_nexus
 title: Cisco Nexus
-version: "0.7.2"
+version: "0.7.3"
 license: basic
 description: Collect logs from Cisco Nexus with Elastic Agent.
 type: integration

--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4400
 - version: "1.0.0"
   changes:
     - description: Make GA

--- a/packages/cisco_secure_email_gateway/data_stream/log/fields/agent.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/fields/agent.yml
@@ -178,9 +178,6 @@
       description: >
         OS codename, if any.
 
-- name: input.type
-  type: keyword
-  description: Input type
 - name: log.offset
   type: long
   description: Log offset

--- a/packages/cisco_secure_email_gateway/manifest.yml
+++ b/packages/cisco_secure_email_gateway/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_secure_email_gateway
 title: Cisco Secure Email Gateway
-version: "1.0.0"
+version: "1.0.1"
 license: basic
 description: Collect logs from Cisco Secure Email Gateway with Elastic Agent.
 type: integration

--- a/packages/cisco_secure_endpoint/changelog.yml
+++ b/packages/cisco_secure_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4400
 - version: "2.6.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/cisco_secure_endpoint/data_stream/event/fields/agent.yml
+++ b/packages/cisco_secure_endpoint/data_stream/event/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/cisco_secure_endpoint/data_stream/event/fields/ecs.yml
+++ b/packages/cisco_secure_endpoint/data_stream/event/fields/ecs.yml
@@ -25,8 +25,6 @@
 - external: ecs
   name: event.id
 - external: ecs
-  name: event.code
-- external: ecs
   name: event.timezone
 - name: related.ip
   external: ecs

--- a/packages/cisco_secure_endpoint/manifest.yml
+++ b/packages/cisco_secure_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_secure_endpoint
 title: Cisco Secure Endpoint
-version: 2.6.1
+version: 2.6.2
 license: basic
 description: Collect logs from Cisco Secure Endpoint (AMP) with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This removes duplicate field definitions from the non-deperecated cisco packages.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Updates #4398

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
