### PR TITLE
[Stack Monitoring] Remove release field, add preview1 identifier

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.0"
+- version: "1.0.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,7 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.0.0
-release: experimental
+version: 1.0.0-preview1
 description: Elasticsearch Integration
 type: integration
 icons:

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.0"
+- version: "2.0.0-preview1"
   changes:
     - description: Fix logo
       type: bugfix

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,7 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.0.0
-release: experimental
+version: 2.0.0-preview1
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.0"
+- version: "2.0.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,7 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.0.0
-release: experimental
+version: 2.0.0-preview1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Remove release field, add preview1 identifier

This is based on recommendations in https://github.com/elastic/kibana/issues/122973 and https://github.com/elastic/package-spec/issues/225

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Closes https://github.com/elastic/integrations/issues/4107

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
