### PR TITLE
[Stack Monitoring] Remove release field, add preview1 identifier

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.0.0-preview1"
+- version: "1.1.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.0-preview1"
+- version: "3.0.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.0"
+- version: "1.0.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,7 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.0.0
-release: experimental
+version: 1.0.0-preview1
 description: Elasticsearch Integration
 type: integration
 icons:

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.0.0-preview1
+version: 3.0.0-preview1
 description: Elasticsearch Integration
 type: integration
 icons:

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 3.0.0-preview1
+version: 1.1.0-preview1
 description: Elasticsearch Integration
 type: integration
 icons:

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.0-preview1"
+- version: "3.0.0-preview1"
   changes:
     - description: Fix logo
       type: bugfix

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.0"
+- version: "2.0.0-preview1"
   changes:
     - description: Fix logo
       type: bugfix

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.0.0-preview1"
+- version: "2.1.0-preview1"
   changes:
     - description: Fix logo
       type: bugfix

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,7 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.0.0
-release: experimental
+version: 2.0.0-preview1
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.0.0-preview1
+version: 3.0.0-preview1
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 3.0.0-preview1
+version: 2.1.0-preview1
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.0"
+- version: "2.0.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.0-preview1"
+- version: "3.0.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.0.0-preview1"
+- version: "2.1.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets
       type: enhancement

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.0.0-preview1
+version: 3.0.0-preview1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,7 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.0.0
-release: experimental
+version: 2.0.0-preview1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 3.0.0-preview1
+version: 2.1.0-preview1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Remove release field, add preview1 identifier

This is based on recommendations in https://github.com/elastic/kibana/issues/122973 and https://github.com/elastic/package-spec/issues/225

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
#!/usr/bin/env bash

set -euxo pipefail

(cd packages/elasticsearch && elastic-package build)
(cd packages/kibana && elastic-package build)
(cd packages/logstash && elastic-package build)

elastic-package stack up -v -d --version 8.6.0-SNAPSHOT
```

- Verify that elasticsearch, kibana & logstash packages are not immediately visible in integrations search
- Click the "available as an Elastic Agent integration" from a logs/metrics package to see the latest version

Note that the label will show "Beta" until https://github.com/elastic/kibana/issues/122973 is addressed.

## Related issues

Closes https://github.com/elastic/integrations/issues/4107

## Screenshots

Filebeat/metricbeat tutorials on integration search

<img width="1522" alt="Screen Shot 2022-10-06 at 16 21 31" src="https://user-images.githubusercontent.com/690/194242926-9d89221a-e57d-4f73-8ce5-27cbc5df6389.png">

Link on metrics page to agent package

<img width="1522" alt="Screen_Shot_2022-10-06_at_16_21_52" src="https://user-images.githubusercontent.com/690/194243041-a8944313-acc0-4481-bd1d-6ac690020c43.png">

Package with new version

<img width="1522" alt="Screen_Shot_2022-10-06_at_16_22_20" src="https://user-images.githubusercontent.com/690/194243137-07972df4-bbe4-4ec4-937e-b49788a51048.png">


