### PR TITLE
f5,fim,fireeye,fortinet_*: remove duplicate fields

### DIFF
--- a/packages/f5/changelog.yml
+++ b/packages/f5/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4407
 - version: "0.11.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/f5/data_stream/bigipafm/fields/base-fields.yml
+++ b/packages/f5/data_stream/bigipafm/fields/base-fields.yml
@@ -15,9 +15,6 @@
   type: constant_keyword
   description: Event dataset
   value: f5.bigipafm
-- name: '@timestamp'
-  type: date
-  description: Event timestamp.
 - name: container.id
   description: Unique container id.
   ignore_above: 1024
@@ -39,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/f5/data_stream/bigipapm/fields/base-fields.yml
+++ b/packages/f5/data_stream/bigipapm/fields/base-fields.yml
@@ -15,9 +15,6 @@
   type: constant_keyword
   description: Event dataset
   value: f5.bigipapm
-- name: '@timestamp'
-  type: date
-  description: Event timestamp.
 - name: container.id
   description: Unique container id.
   ignore_above: 1024
@@ -39,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/f5/manifest.yml
+++ b/packages/f5/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: f5
 title: F5 Logs
-version: "0.11.1"
+version: "0.11.2"
 description: Collect and parse logs from F5 devices with Elastic Agent.
 categories: ["network", "security"]
 release: experimental

--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4407
 - version: "1.2.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/fim/data_stream/event/fields/agent.yml
+++ b/packages/fim/data_stream/event/fields/agent.yml
@@ -77,11 +77,6 @@
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2
@@ -90,12 +85,6 @@
     ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
   type: group
   fields:
-    - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
     - name: domain
       level: extended
       type: keyword

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: fim
 title: "File Integrity Monitoring"
-version: "1.2.1"
+version: "1.2.2"
 license: basic
 release: ga
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."

--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.6.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4407
 - version: "1.6.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/fireeye/data_stream/nx/fields/agent.yml
+++ b/packages/fireeye/data_stream/nx/fields/agent.yml
@@ -107,10 +107,6 @@
       type: keyword
       ignore_above: 1024
       description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/fireeye/data_stream/nx/fields/ecs.yml
+++ b/packages/fireeye/data_stream/nx/fields/ecs.yml
@@ -63,8 +63,6 @@
 - external: ecs
   name: destination.address
 - external: ecs
-  name: destination.port
-- external: ecs
   name: destination.as.number
 - external: ecs
   name: destination.as.organization.name

--- a/packages/fireeye/manifest.yml
+++ b/packages/fireeye/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: fireeye
 title: "FireEye Network Security"
-version: 1.6.1
+version: 1.6.2
 license: basic
 description: Collect logs from FireEye NX with Elastic Agent.
 type: integration

--- a/packages/fortinet_forticlient/changelog.yml
+++ b/packages/fortinet_forticlient/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.3"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4407
 - version: "1.1.2"
   changes:
     - description: Remove duplicate field.

--- a/packages/fortinet_forticlient/data_stream/log/fields/agent.yml
+++ b/packages/fortinet_forticlient/data_stream/log/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/fortinet_forticlient/data_stream/log/fields/base-fields.yml
+++ b/packages/fortinet_forticlient/data_stream/log/fields/base-fields.yml
@@ -36,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/fortinet_forticlient/manifest.yml
+++ b/packages/fortinet_forticlient/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_forticlient
 title: Fortinet FortiClient Logs
-version: 1.1.2
+version: 1.1.3
 release: ga
 description: Collect logs from Fortinet FortiClient instances with Elastic Agent.
 type: integration

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.4"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4407
 - version: "1.2.3"
   changes:
     - description: Remove duplicate field.

--- a/packages/fortinet_fortigate/data_stream/log/fields/agent.yml
+++ b/packages/fortinet_fortigate/data_stream/log/fields/agent.yml
@@ -58,11 +58,6 @@
   description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: 1.2.3
+version: 1.2.4
 release: ga
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration

--- a/packages/fortinet_fortimail/data_stream/log/fields/agent.yml
+++ b/packages/fortinet_fortimail/data_stream/log/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/fortinet_fortimail/data_stream/log/fields/base-fields.yml
+++ b/packages/fortinet_fortimail/data_stream/log/fields/base-fields.yml
@@ -36,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/fortinet_fortimanager/changelog.yml
+++ b/packages/fortinet_fortimanager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.3"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4407
 - version: "1.1.2"
   changes:
     - description: Remove duplicate field.

--- a/packages/fortinet_fortimanager/data_stream/log/fields/agent.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/fortinet_fortimanager/data_stream/log/fields/base-fields.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/fields/base-fields.yml
@@ -36,8 +36,3 @@
 - name: log.offset
   description: Offset of the entry in the log file.
   type: long
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/fortinet_fortimanager/manifest.yml
+++ b/packages/fortinet_fortimanager/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortimanager
 title: Fortinet FortiManager Logs
-version: 1.1.2
+version: 1.1.3
 release: ga
 description: Collect logs from Fortinet FortiManager instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This removes duplicated fields from f5 and the fortinet packages as part of #4398.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Updates #4398

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
