### PR TITLE
[Synthetics] Add processors to all data streams

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add processor config option to all data streams
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4023
+      link: https://github.com/elastic/integrations/pull/4425
 - version: "0.11.0"
   changes:
     - description: Add support for new data used in future synthetics UI

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.0"
+  changes:
+    - description: Add processor config option to all data streams
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4023
 - version: "0.11.0"
   changes:
     - description: Add support for new data used in future synthetics UI

--- a/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
+++ b/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
@@ -78,22 +78,25 @@ source.zip_url.ssl.supported_protocols: {{source.zip_url.ssl.supported_protocols
 source.zip_url.proxy_url: {{source.zip_url.proxy_url}}
 {{/if}}
 processors:
-  - add_observer_metadata:
-      geo:
-        name: {{location_name}}
-  - add_fields:
-      target: ''
-      fields:
-        monitor.fleet_managed: true
-        {{#if config_id}}
-        config_id: {{config_id}}
-        {{/if}}
-        {{#if run_once}}
-        run_once: {{run_once}}
-        {{/if}}
-        {{#if monitor.project.name}}
-        monitor.project.name: {{monitor.project.name}}
-        {{/if}}
-        {{#if monitor.project.id}}
-        monitor.project.id: {{monitor.project.id}}
-        {{/if}}
+- add_observer_metadata:
+    geo:
+      name: {{location_name}}
+- add_fields:
+    target: ''
+    fields:
+      monitor.fleet_managed: true
+      {{#if config_id}}
+      config_id: {{config_id}}
+      {{/if}}
+      {{#if run_once}}
+      run_once: {{run_once}}
+      {{/if}}
+      {{#if monitor.project.name}}
+      monitor.project.name: {{monitor.project.name}}
+      {{/if}}
+      {{#if monitor.project.id}}
+      monitor.project.id: {{monitor.project.id}}
+      {{/if}}
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -241,3 +241,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/synthetics/data_stream/browser_network/agent/stream/browser.network.yml.hbs
+++ b/packages/synthetics/data_stream/browser_network/agent/stream/browser.network.yml.hbs
@@ -1,8 +1,11 @@
 processors:
-  - add_observer_metadata:
-      geo: 
-        name: Fleet managed
-  - add_fields:
-      target: ''
-      fields:
-        monitor.fleet_managed: true
+- add_observer_metadata:
+    geo: 
+      name: Fleet managed
+- add_fields:
+    target: ''
+    fields:
+      monitor.fleet_managed: true   
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -21,3 +21,13 @@ streams:
     description: Store network information for synthetic monitors
     template_path: browser.network.yml.hbs
     enabled: true
+    vars:
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/synthetics/data_stream/browser_screenshot/agent/stream/browser.screenshot.yml.hbs
+++ b/packages/synthetics/data_stream/browser_screenshot/agent/stream/browser.screenshot.yml.hbs
@@ -1,8 +1,11 @@
 processors:
-  - add_observer_metadata:
-      geo: 
-        name: Fleet managed
-  - add_fields:
-      target: ''
-      fields:
-        monitor.fleet_managed: true
+- add_observer_metadata:
+    geo: 
+      name: Fleet managed
+- add_fields:
+    target: ''
+    fields:
+      monitor.fleet_managed: true
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -18,3 +18,13 @@ streams:
     description: Store screenshots for synthetic monitors
     template_path: browser.screenshot.yml.hbs
     enabled: true
+    vars:
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -67,22 +67,25 @@ ssl.verification_mode: {{ssl.verification_mode}}
 ssl.supported_protocols: {{ssl.supported_protocols}}
 {{/if}}
 processors:
-  - add_observer_metadata:
-      geo: 
-        name: {{location_name}}
-  - add_fields:
-      target: ''
-      fields:
-        monitor.fleet_managed: true
-        {{#if config_id}}
-        config_id: {{config_id}}
-        {{/if}}
-        {{#if run_once}}
-        run_once: {{run_once}}
-        {{/if}}
-        {{#if monitor.project.name}}
-        monitor.project.name: {{monitor.project.name}}
-        {{/if}}
-        {{#if monitor.project.id}}
-        monitor.project.id: {{monitor.project.id}}
-        {{/if}}
+- add_observer_metadata:
+    geo: 
+      name: {{location_name}}
+- add_fields:
+    target: ''
+    fields:
+      monitor.fleet_managed: true
+      {{#if config_id}}
+      config_id: {{config_id}}
+      {{/if}}
+      {{#if run_once}}
+      run_once: {{run_once}}
+      {{/if}}
+      {{#if monitor.project.name}}
+      monitor.project.name: {{monitor.project.name}}
+      {{/if}}
+      {{#if monitor.project.id}}
+      monitor.project.id: {{monitor.project.id}}
+      {{/if}}
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -236,3 +236,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -19,22 +19,25 @@ timeout: {{timeout}}
 tags: {{tags}}
 {{/if}}
 processors:
-  - add_observer_metadata:
-      geo: 
-        name: {{location_name}}
-  - add_fields:
-      target: ''
-      fields:
-        monitor.fleet_managed: true
-        {{#if config_id}}
-        config_id: {{config_id}}
-        {{/if}}
-        {{#if run_once}}
-        run_once: {{run_once}}
-        {{/if}}
-        {{#if monitor.project.name}}
-        monitor.project.name: {{monitor.project.name}}
-        {{/if}}
-        {{#if monitor.project.id}}
-        monitor.project.id: {{monitor.project.id}}
-        {{/if}}
+- add_observer_metadata:
+    geo: 
+      name: {{location_name}}
+- add_fields:
+    target: ''
+    fields:
+      monitor.fleet_managed: true
+      {{#if config_id}}
+      config_id: {{config_id}}
+      {{/if}}
+      {{#if run_once}}
+      run_once: {{run_once}}
+      {{/if}}
+      {{#if monitor.project.name}}
+      monitor.project.name: {{monitor.project.name}}
+      {{/if}}
+      {{#if monitor.project.id}}
+      monitor.project.id: {{monitor.project.id}}
+      {{/if}}
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -129,3 +129,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -46,22 +46,25 @@ ssl.verification_mode: {{ssl.verification_mode}}
 ssl.supported_protocols: {{ssl.supported_protocols}}
 {{/if}}
 processors:
-  - add_observer_metadata:
-      geo: 
-        name: {{location_name}}
-  - add_fields:
-      target: ''
-      fields:
-        monitor.fleet_managed: true
-        {{#if config_id}}
-        config_id: {{config_id}}
-        {{/if}}
-        {{#if run_once}}
-        run_once: {{run_once}}
-        {{/if}}
-        {{#if monitor.project.name}}
-        monitor.project.name: {{monitor.project.name}}
-        {{/if}}
-        {{#if monitor.project.id}}
-        monitor.project.id: {{monitor.project.id}}
-        {{/if}}
+- add_observer_metadata:
+    geo: 
+      name: {{location_name}}
+- add_fields:
+    target: ''
+    fields:
+      monitor.fleet_managed: true
+      {{#if config_id}}
+      config_id: {{config_id}}
+      {{/if}}
+      {{#if run_once}}
+      run_once: {{run_once}}
+      {{/if}}
+      {{#if monitor.project.name}}
+      monitor.project.name: {{monitor.project.name}}
+      {{/if}}
+      {{#if monitor.project.id}}
+      monitor.project.id: {{monitor.project.id}}
+      {{/if}}
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -183,3 +183,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.11.0
+version: 0.12.0
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Add config option for additional processors to all data streams

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4420

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
