### PR TITLE
[aws] Use the base cloudwatch metricset for dynamodb, instead of the lightweight module metricsset

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.4"
+  changes:
+    - description: Do not rely on dynamodb lightweight module metricset.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4395
 - version: "1.24.3"
   changes:
     - description: Fix adding processors in cloudfront logs.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Do not rely on dynamodb lightweight module metricset.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4395
+      link: https://github.com/elastic/integrations/pull/4430
 - version: "1.24.3"
   changes:
     - description: Fix adding processors in cloudfront logs.

--- a/packages/aws/data_stream/dynamodb/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/dynamodb/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["dynamodb"]
+metricsets: ["cloudwatch"]
 period: {{period}}
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}

--- a/packages/aws/data_stream/dynamodb/sample_event.json
+++ b/packages/aws/data_stream/dynamodb/sample_event.json
@@ -33,7 +33,7 @@
     },
     "metricset": {
         "period": 300000,
-        "name": "dynamodb"
+        "name": "cloudwatch"
     },
     "event": {
         "duration": 10586366300,

--- a/packages/aws/docs/dynamodb.md
+++ b/packages/aws/docs/dynamodb.md
@@ -79,7 +79,7 @@ An example event for `dynamodb` looks as following:
     },
     "metricset": {
         "period": 300000,
-        "name": "dynamodb"
+        "name": "cloudwatch"
     },
     "event": {
         "duration": 10586366300,

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.24.3
+version: 1.24.4
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Use the base cloudwatch metricset for dynamodb, instead of the lightweight module metricsset. Lightweight modules are deprecated in beats; the integration should use the cloudwatch metricset.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
