### PR TITLE
Fix adding multiple processors in cloudfront logs and syslog

### DIFF
--- a/packages/aws/data_stream/cloudfront_logs/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/cloudfront_logs/agent/stream/aws-s3.yml.hbs
@@ -46,10 +46,10 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-  - drop_event:
-      when:
-        regexp:
-          message: "^#.*"        
+- drop_event:
+  when:
+    regexp:
+      message: "^#.*"
 {{#if processors}}
-  - {{processors}}
+{{processors}}
 {{/if}}

--- a/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
+++ b/packages/system/data_stream/syslog/agent/stream/log.yml.hbs
@@ -7,9 +7,9 @@ multiline:
   pattern: "^\\s"
   match: after
 processors:
-  - add_locale: ~
+- add_locale: ~
 {{#if processors.length}}
-  - {{processors}}
+{{processors}}
 {{/if}}
 {{#if tags.length}}
 tags:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix https://github.com/elastic/integrations/pull/4395 and https://github.com/elastic/integrations/pull/4396 by considering adding multiple processors instead of only one...

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Screenshots

wip
