### PR TITLE
Use 'app_insights' metricset for app_state datastream instead of app_state lightweight module metricset

### DIFF
--- a/packages/azure_application_insights/changelog.yml
+++ b/packages/azure_application_insights/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.1.0"
+  changes:
+    - description: Use app_insights metricset instead of app_state lightweight module.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.0.3"
   changes:
     - description: Updated Readme

--- a/packages/azure_application_insights/changelog.yml
+++ b/packages/azure_application_insights/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Use app_insights metricset instead of app_state lightweight module.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/4438
 - version: "1.0.3"
   changes:
     - description: Updated Readme

--- a/packages/azure_application_insights/data_stream/app_insights/agent/stream/stream.yml.hbs
+++ b/packages/azure_application_insights/data_stream/app_insights/agent/stream/stream.yml.hbs
@@ -9,4 +9,3 @@ api_key: {{api_key}}
 {{#if metrics}}
 metrics: {{metrics}}
 {{/if}}
-

--- a/packages/azure_application_insights/data_stream/app_state/agent/stream/stream.yml.hbs
+++ b/packages/azure_application_insights/data_stream/app_state/agent/stream/stream.yml.hbs
@@ -1,4 +1,4 @@
-metricsets: ["app_state"]
+metricsets: ["app_insights"]
 period: {{period}}
 {{#if application_id}}
 application_id: {{application_id}}
@@ -6,3 +6,7 @@ application_id: {{application_id}}
 {{#if api_key}}
 api_key: {{api_key}}
 {{/if}}
+{{#if metrics}}
+metrics: {{metrics}}
+{{/if}}
+  

--- a/packages/azure_application_insights/data_stream/app_state/manifest.yml
+++ b/packages/azure_application_insights/data_stream/app_state/manifest.yml
@@ -14,3 +14,32 @@ streams:
         required: true
         show_user: true
         default: 300s
+      - name: metrics
+        type: yaml
+        title: Metrics
+        multi: false
+        required: true
+        show_user: true
+        default: |
+          - id: ["requests/count", "requests/failed"]
+            segment: ["request/urlHost", "request/name"]
+            aggregation: ["sum"]
+            interval: "P5M"
+          - id: ["users/count", "sessions/count", "users/authenticated"]
+            segment: ["request/urlHost"]
+            aggregation: ["unique"]
+            interval: "P5M"
+          - id: ["browserTimings/networkDuration", "browserTimings/sendDuration", "browserTimings/receiveDuration", "browserTimings/processingDuration", "browserTimings/totalDuration"]
+            segment: ["browserTiming/urlHost", "browserTiming/urlPath"]
+            aggregation: ["avg"]
+            interval: "P5M"
+            top: 5
+          - id: ["exceptions/count", "exceptions/browser", "exceptions/server"]
+            segment: ["exception/type", "cloud/roleName"]
+            aggregation: ["sum"]
+            interval: "P5M"
+          - id: ["performanceCounters/memoryAvailableBytes", "performanceCounters/processCpuPercentageTotal", "performanceCounters/processCpuPercentage", "performanceCounters/processIOBytesPerSecond",
+                 "performanceCounters/processPrivateBytes"]
+            segment: ["cloud/roleName", "cloud/roleInstance"]
+            aggregation: ["avg"]
+            interval: "P5M"

--- a/packages/azure_application_insights/data_stream/app_state/sample_event.json
+++ b/packages/azure_application_insights/data_stream/app_state/sample_event.json
@@ -51,7 +51,7 @@
     },
     "metricset": {
         "period": 300000,
-        "name": "app_state"
+        "name": "app_insights"
     },
     "event": {
         "duration": 815158500,

--- a/packages/azure_application_insights/manifest.yml
+++ b/packages/azure_application_insights/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_application_insights
 title: Azure Application Insights Metrics Overview
-version: 1.0.3
+version: 1.1.0
 release: ga
 description: Collect application insights metrics from Azure Monitor with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Use 'app_insights' metricset for app_state datastream instead of app_state lightweight module metricset

The way the metrics are defined is kinda strange compared to other packages, but this is consistent with the other app insights integration. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
