### PR TITLE
Simplified system tests for Containerd 

### DIFF
--- a/packages/containerd/_dev/deploy/docker/docker-compose.yml
+++ b/packages/containerd/_dev/deploy/docker/docker-compose.yml
@@ -1,27 +1,20 @@
 version: '2.3'
 services:
-  kubernetes_is_ready:
+  containerd_is_ready:
     image: tianon/true
     depends_on:
-      kubernetes:
+      containerd:
         condition: service_healthy
-  kubernetes:
+  containerd:
     image: nginx:alpine
     ports:
       - 1338
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
-    depends_on:
-      - containerd
+      - ./containerdv1.5.2.txt:/www/data/v1/metrics
     healthcheck:
       interval: 1s
       retries: 120
       timeout: 120s
       test: |-
-        curl -f -s http://localhost:1338/v1/metrics -o /dev/null
-  containerd:
-    image: chanjarster/prometheus-mock-data:latest
-    ports:
-      - 8080
-    volumes:
-      - ./containerdv1.5.2.txt:/home/java-app/etc/scrape-data.txt
+        curl -f -s http://localhost:1338/v1/ -o /dev/null

--- a/packages/containerd/_dev/deploy/docker/nginx.conf
+++ b/packages/containerd/_dev/deploy/docker/nginx.conf
@@ -8,10 +8,11 @@ http {
 
     server {
         listen 1338;
-        location /v1/metrics {
-            proxy_pass         http://containerd:8080/metrics;
-            proxy_redirect     off;
+
+        root /www/data;
+
+        location /v1 {
+            autoindex on;
         }
     }
-
 }

--- a/packages/containerd/data_stream/blkio/_dev/test/system/test-default-config.yml
+++ b/packages/containerd/data_stream/blkio/_dev/test/system/test-default-config.yml
@@ -1,4 +1,4 @@
-service: kubernetes
+service: containerd
 data_stream:
   vars:
     period: 5s

--- a/packages/containerd/data_stream/cpu/_dev/test/system/test-default-config.yml
+++ b/packages/containerd/data_stream/cpu/_dev/test/system/test-default-config.yml
@@ -1,4 +1,4 @@
-service: kubernetes
+service: containerd
 data_stream:
   vars:
     period: 5s

--- a/packages/containerd/data_stream/memory/_dev/test/system/test-default-config.yml
+++ b/packages/containerd/data_stream/memory/_dev/test/system/test-default-config.yml
@@ -1,4 +1,4 @@
-service: kubernetes
+service: containerd
 data_stream:
   vars:
     period: 5s


### PR DESCRIPTION
## What does this PR do?

It makes possible to run containerd system tests on ARM64 laptops.

It achieve this by removing the need for the docker image chanjarster/prometheus-mock-data that was built for AMD64 and it couldn't run on ARM64. It solves this [issue](https://github.com/elastic/integrations/issues/4456) for the containerd integration by not using anymore the docker image .

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

System tests are run by jenkins as part of the usual pipeline.

## Related issues

- Relates https://github.com/elastic/integrations/issues/4456