### PR TITLE
[Synthetics] Change state.duration_ms to long from date

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,7 @@
 # newer versions go on top
+- version: "0.11.1"
+  changes:
+    - description: Change incorrectly typed `states.duration` field from `date` to long
 - version: "0.11.0"
   changes:
     - description: Add support for new data used in future synthetics UI

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -2,6 +2,8 @@
 - version: "0.11.1"
   changes:
     - description: Change incorrectly typed `states.duration` field from `date` to long
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4477
 - version: "0.11.0"
   changes:
     - description: Add support for new data used in future synthetics UI

--- a/packages/synthetics/data_stream/browser/fields/common.yml
+++ b/packages/synthetics/data_stream/browser/fields/common.yml
@@ -105,7 +105,7 @@
         First time state with this ID was seen
 
     - name: duration_ms
-      type: date
+      type: long
       description: >
         Length of time this state has existed in millis
 

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -13,6 +13,7 @@ elasticsearch:
         sort.field:
           - "url.full.keyword"
           - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -15,6 +15,7 @@ elasticsearch:
           - "http.request.url.keyword"
           - "http.response.headers.etag"
           - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetics monitors network information

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -12,6 +12,7 @@ elasticsearch:
         codec: best_compression
         sort.field:
           - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetics monitors screenshot information

--- a/packages/synthetics/data_stream/http/fields/common.yml
+++ b/packages/synthetics/data_stream/http/fields/common.yml
@@ -105,7 +105,7 @@
         First time state with this ID was seen
 
     - name: duration_ms
-      type: date
+      type: long
       description: >
         Length of time this state has existed in millis
 

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -13,6 +13,7 @@ elasticsearch:
         sort.field:
           - "monitor.id"
           - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/http
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/icmp/fields/common.yml
+++ b/packages/synthetics/data_stream/icmp/fields/common.yml
@@ -105,7 +105,7 @@
         First time state with this ID was seen
 
     - name: duration_ms
-      type: date
+      type: long
       description: >
         Length of time this state has existed in millis
 

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -13,6 +13,7 @@ elasticsearch:
         sort.field:
           - "monitor.id"
           - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/icmp
     title: Synthetic monitor check

--- a/packages/synthetics/data_stream/tcp/fields/common.yml
+++ b/packages/synthetics/data_stream/tcp/fields/common.yml
@@ -105,7 +105,7 @@
         First time state with this ID was seen
 
     - name: duration_ms
-      type: date
+      type: long
       description: >
         Length of time this state has existed in millis
 

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -13,6 +13,7 @@ elasticsearch:
         sort.field:
           - "monitor.id"
           - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/tcp
     title: Synthetic monitor check

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.11.0
+version: 0.11.1
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
This fixes the type of this numeric field to correctly be a long, thus matching heartbeat.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
