### PR TITLE
IIS - Update ingest pipeline to process event.duration

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Updated the ingest pipeline to process the event.duration value.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4481
 - version: "1.2.0"
   changes:
     - description: Updated the condition check for ignore_older flag.

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-8.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-8.log-expected.json
@@ -16,6 +16,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2019-08-14 00:09:32 W3SVC1 SE119654 ::1 GET /help/default.aspx area= 80 - ::1 HTTP/1.1 Mozilla/5.0+(compatible;+MSIE+9.0;+Windows+NT+6.1;+Trident/5.0) - - localhost 403 4 5 5279 160 15",
                 "outcome": "failure",
@@ -96,6 +97,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2019-08-14 00:09:32 W3SVC1 SE119654 ::1 GET /help/default.aspx area= 80 - ::1 HTTP/1.1 Mozilla/5.0+(compatible;+MSIE+9.0;+Windows+NT+6.1;+Trident/5.0) - - localhost 403 4 5 5279 136 0",
                 "outcome": "failure",
@@ -176,6 +178,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2019-08-14 00:09:32 W3SVC1 SE119654 ::1 GET /help/default.aspx area= 80 - ::1 HTTP/1.1 Mozilla/5.0+(compatible;+MSIE+9.0;+Windows+NT+6.1;+Trident/5.0) - - localhost 403 4 5 5279 136 0",
                 "outcome": "failure",
@@ -255,6 +258,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2019-08-14 00:12:02 W3SVC1 SE119654 10.60.79.142 GET /default.aspx - 80 - 10.60.74.238 HTTP/1.0 - - - - 403 4 5 1372 18 0",
                 "outcome": "failure",
@@ -320,6 +324,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2019-08-14 00:13:10 W3SVC1 SE119654 10.60.79.142 GET /default.aspx - 80 - 10.60.74.238 HTTP/1.1 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - - se119654.saifg.rbc.com 403 4 5 1353 313 15",
                 "outcome": "failure",
@@ -399,6 +404,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2019-08-14 00:13:10 W3SVC1 SE119654 10.60.79.142 GET /default.aspx - 80 - 10.60.74.238 HTTP/1.1 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - - se119654.saifg.rbc.com 200 4 5 1353 313 15",
                 "outcome": "success",

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-72.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-72.log-expected.json
@@ -15,6 +15,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2018-12-31 12:02:53 10.44.0.136 GET /pbserver/..À¯..À¯..À¯..À¯..À¯../winnt/system32/cmd.exe /c+dir+c:\\+/OG 8080 - 10.50.6.188 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 404 0 64 0",
                 "outcome": "failure",
@@ -84,6 +85,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 46000000,
                 "kind": "event",
                 "original": "2018-12-31 12:02:53 10.44.0.136 GET /pbserver/..ÁÁ..ÁÁ..ÁÁ..ÁÁ..ÁÁ../winnt/system32/cmd.exe /c+dir+c:\\+/OG 8080 - 10.50.6.188 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 404 0 2 46",
                 "outcome": "failure",
@@ -153,6 +155,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2018-12-31 12:02:53 10.44.0.136 GET /Director - 443 - 10.50.6.188 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 401 0 0 0",
                 "outcome": "failure",
@@ -220,6 +223,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2018-12-31 12:02:53 10.44.0.136 GET / - 443 - 10.50.6.188 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 401 0 0 0",
                 "outcome": "failure",
@@ -287,6 +291,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2018-12-31 12:02:53 10.44.0.136 GET /pbserver/..Áœ..Áœ..Áœ..Áœ..Áœ../winnt/system32/cmd.exe /c+dir+c:\\+/OG 8080 - 10.50.6.188 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 404 0 64 15",
                 "outcome": "failure",
@@ -356,6 +361,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 12000000,
                 "kind": "event",
                 "original": "2022-03-13 02:04:11 10.44.0.136 GET /pbserver/..Áœ..Áœ..Áœ..Áœ..Áœ../winnt/system32/cmd.exe /c+dir+c:\\+/OG 8080 - 10.44.0.136 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 200 0 0 12 216.160.83.61,81.2.69.193",
                 "outcome": "success",
@@ -428,6 +434,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 12000000,
                 "kind": "event",
                 "original": "2022-03-13 02:04:11 10.44.0.136 GET /pbserver/..Áœ..Áœ..Áœ..Áœ..Áœ../winnt/system32/cmd.exe /c+dir+c:\\+/OG 8080 - 10.44.0.136 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 200 0 0 12 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
                 "outcome": "success",
@@ -500,6 +507,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 12000000,
                 "kind": "event",
                 "original": "2022-03-13 02:04:11 fe81::63ae:94c0:196e:8adf%3 GET /pbserver/..Áœ..Áœ..Áœ..Áœ..Áœ../winnt/system32/cmd.exe /c+dir+c:+/OG 8080 - fe81::64ae:95c0:196e:8adf%3 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 200 0 0 12 81.2.69.144",
                 "outcome": "success",
@@ -572,6 +580,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 12000000,
                 "kind": "event",
                 "original": "2022-03-13 02:04:11 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6 GET /pbserver/..Áœ..Áœ..Áœ..Áœ..Áœ../winnt/system32/cmd.exe /c+dir+c:+/OG 8080 - fe81::64ae:95c0:196e:8adf%3 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 200 0 0 12 81.2.69.143,81.2.69.144",
                 "outcome": "success",
@@ -644,6 +653,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 12000000,
                 "kind": "event",
                 "original": "2022-03-13 02:04:11 fe81::63ae:94c0:196e:8adf%3 GET /pbserver/..Áœ..Áœ..Áœ..Áœ..Áœ../winnt/system32/cmd.exe /c+dir+c:+/OG 8080 - fe81::64ae:95c0:196e:8adf%3 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 200 0 0 12 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
                 "outcome": "success",
@@ -716,6 +726,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 12000000,
                 "kind": "event",
                 "original": "2022-03-13 02:04:11 fe81::63ae:94c0:196e:8adf%3 GET /pbserver/..Áœ..Áœ..Áœ..Áœ..Áœ../winnt/system32/cmd.exe /c+dir+c:\\+/OG 8080 - fe81::64ae:95c0:196e:8adf%3 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 200 0 0 12",
                 "outcome": "success",

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-75.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-75.log-expected.json
@@ -15,6 +15,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 792000000,
                 "kind": "event",
                 "original": "2018-08-28 18:24:25 [10.100.220.70](http://10.100.220.70) GET / - 80 - [10.100.118.31](http://10.100.118.31) Mozilla/4.0+(compatible;+MSIE+7.0;+Windows+NT+6.3;+WOW64;+Trident/7.0;+.NET4.0E;+.NET4.0C;+.NET+CLR+3.5.30729;+.NET+CLR[+2.0.50727](tel:+2050727);+.NET+CLR+3.0.30729) 404 4 2 792",
                 "outcome": "failure",
@@ -82,6 +83,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2019-03-06 18:43:17 10.0.140.107 GET /health-monitoring - 80 - 10.0.140.2 - 200 0 0 15",
                 "outcome": "success",
@@ -136,6 +138,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2019-03-06 18:43:17 10.0.140.107 GET /health-monitoring - 80 - 10.0.140.2 - 200 0 0 15",
                 "outcome": "success",
@@ -190,6 +193,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2019-03-06 18:43:17 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6 GET /health-monitoring - 80 - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6 - 200 0 0 15",
                 "outcome": "success",

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access.log-expected.json
@@ -15,6 +15,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 123000000,
                 "kind": "event",
                 "original": "2018-01-01 08:09:10 127.0.0.1 GET / q=100 80 - 67.43.156.13 Mozilla/5.0+(Windows+NT+6.1;+Win64;+x64;+rv:57.0)+Gecko/20100101+Firefox/57.0 - 200 0 0 123",
                 "outcome": "success",
@@ -93,6 +94,7 @@
                 "category": [
                     "web"
                 ],
+                "duration": 789000000,
                 "kind": "event",
                 "original": "2018-01-01 09:10:11 W3SVC1 GET / - 80 - 127.0.0.1 Mozilla/5.0+(Windows+NT+6.1;+Win64;+x64;+rv:57.0)+Gecko/20100101+Firefox/57.0 - - example.com 200 0 0 123 456 789",
                 "outcome": "success"
@@ -165,6 +167,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 789000000,
                 "kind": "event",
                 "original": "2018-01-01 10:11:12 W3SVC1 MACHINE-NAME 127.0.0.1 GET / - 80 - 67.43.156.13 HTTP/1.1 Mozilla/5.0+(Macintosh;+Intel+Mac+OS+X+10_14_0)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/70.0.3538.102+Safari/537.36 - - example.com 200 0 0 123 456 789",
                 "outcome": "success",
@@ -254,6 +257,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2018-12-31 12:52:33 10.44.0.136 GET / redirect:${%23req%3d%23context.get('com.opensymphony.xwork2.dispatcher.HttpServletRequest'),%23webroot%3d%23req.getSession().getServletContext().getRealPath('/'),%23resp.println(%23webroot),%23resp.flush(),%23resp.close()} 443 - 10.50.6.188 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 401 0 0 0",
                 "outcome": "failure",
@@ -322,6 +326,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2018-12-31 12:52:33 10.44.0.136 GET /${#context['xwork.MethodAccessor.denyMethodExecution']=!(#_memberAccess['allowStaticMethodAccess']=true),(@java.lang.Runtime@getRuntime()).exec('ipconfig').waitFor()}.action - 443 - 10.50.6.188 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) - 404 0 2 0",
                 "outcome": "failure",
@@ -388,6 +393,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 46000000,
                 "kind": "event",
                 "original": "2021-11-28 00:00:04 W3SVC1 10.44.0.136 GET /cdgo SERVER-STATUS=200 443 - 67.43.156.13 HTTP/1.1 Chrome/2.12.1 - example.com 200 0 0 34018 303 46",
                 "outcome": "success",

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis10-access.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis10-access.log-expected.json
@@ -15,6 +15,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 26000000,
                 "kind": "event",
                 "original": "2022-05-09 17:10:04 10.119.32.8 POST /civault/Cryptology/Cryptology.svc - 443 - 10.119.0.62 Mozilla/4.0+(compatible;+MSIE+7.0;+Windows+NT+10.0;+Win64;+x64;+Trident/7.0;+.NET4.0C;+.NET4.0E;+.NET+CLR+2.0.50727;+.NET+CLR+3.0.30729;+.NET+CLR+3.5.30729) - [apcvwp00049.corp.acxiom.net](https://apcvwp00049.corp.acxiom.net/) 200 0 0 26",
                 "outcome": "success",
@@ -84,6 +85,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 232000000,
                 "kind": "event",
                 "original": "2022-05-08 01:26:01 10.119.32.8 POST /NamingServiceANSWS/ANSWS.svc - 443 - 10.119.38.250 - - itwebcert.acxiom.com 200 0 0 232",
                 "outcome": "success",
@@ -140,6 +142,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 23000000,
                 "kind": "event",
                 "original": "2021-06-10 23:26:57 10.44.0.136 GET / - 80 - 10.46.208.5 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+5.1;+Trident/4.0) BIGipServerYAkgvoMHHYQAGkWEWadfsadfnyAqAere=27246369425.20480.0000 itweb.acx.co 200 0 0 23",
                 "outcome": "success",

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-ipv6zone.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-ipv6zone.log-expected.json
@@ -16,6 +16,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 789000000,
                 "kind": "event",
                 "original": "2018-01-01 10:11:12 W3SVC1 MACHINE-NAME ::1%0 GET / - 80 - ::1%0 HTTP/1.1 Mozilla/5.0+(Macintosh;+Intel+Mac+OS+X+10_14_0)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/70.0.3538.102+Safari/537.36 - - example.com 200 0 0 123 456 789",
                 "outcome": "success",

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-x-forward-for-extended.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-x-forward-for-extended.log-expected.json
@@ -16,6 +16,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2020-10-04 22:00:34 W3SVC2 freca1 10.24.129.162 GET /favicon.ico - 80 - 10.24.136.240 HTTP/1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:81.0)+Gecko/20100101+Firefox/81.0 - https://images.hogeschoolrotterdam.nl/Blob/adeec119008c48758c1a6be53aeeb2ac/34ff475072d54117bcb46ea7f023bd87.jpg?width=1200\u0026height=630\u0026mode=crop images.hogeschoolrotterdam.nl 404 0 2 1437 534 0 67.43.156.14",
                 "outcome": "failure",
@@ -99,6 +100,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2020-10-05 21:40:30 W3SVC2 freca1 10.24.129.162 GET /robots.txt - 80 - 10.24.136.240 HTTP/1.1 Twitterbot/1.0 - - images.hogeschoolrotterdam.nl 200 0 0 346 306 0 67.43.156.14",
                 "outcome": "success",
@@ -176,6 +178,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2020-10-05 21:48:33 W3SVC2 freca1 10.24.129.162 GET /app_data/cache/9/e/1/c/3/7/9e1c37a203a2a306e8f5d4df1bddb1109dd42e57.jpg width=35\u0026height=38\u0026mode=crop 80 - 10.24.136.240 HTTP/1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/70.0.3538.102+Safari/537.36+Edge/18.18362 BIGipServerYAkgvoMsadfHHYQAGkWEWnyAqAads=27246369425.20480.0000 https://www.rotterdamuas.com/ images.hogeschoolrotterdam.nl 200 0 0 2007 581 15 67.43.156.14",
                 "outcome": "success",
@@ -261,6 +264,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2020-10-05 21:48:33 W3SVC2 freca1 10.24.129.162 GET /app_data/cache/f/b/7/1/2/7/fb71277260ae26a108c3608ce1a62474a55b2556.jpg width=75\u0026height=40\u0026mode=crop 80 - 10.24.136.240 HTTP/1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/70.0.3538.102+Safari/537.36+Edge/18.18362 BIGipServerYAkgvoMHHYQAGkWEWadfsadfnyAqAere=27246369425.20480.0000 https://www.rotterdamuas.com/ images.hogeschoolrotterdam.nl 200 0 0 2926 581 0 67.43.156.14",
                 "outcome": "success",
@@ -346,6 +350,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 15000000,
                 "kind": "event",
                 "original": "2020-10-08 22:00:22 W3SVC2 freca1 10.24.129.162 GET /Blob/a9e2fe596ac14a4ab07beb6b6e2c6545/15a3917cacf44de59af9cc899e90a9d4.png width=60\u0026height=20\u0026mode=crop 80 - 10.24.136.240 HTTP/1.1 Mozilla/5.0+(iPhone;+CPU+iPhone+OS+13_7+like+Mac+OS+X)+AppleWebKit/605.1.15+(KHTML,+like+Gecko)+Version/13.1.2+Mobile/15E148+Safari/604.1 imagedpi=1;+imagequality=30;+_ga=GA1.2.14440223724.16021494379;+_gid=GA1.2.12504478161.16021944379;+_gat_UA-155746052-5=1;+BIGipServerYAkgvoMHHYQAGkWsadfsdfEWnyAqA=!vbipVwbt0UWJ4QSsPvjjVxViTXMqdXWYaferu1dRyQoUTVVBGLZPB39PoNX5Tw66+GT0ChJCfnp/xfhM8lI=;+_gcl_au=1.1.1297303538.1602194379 https://www.hogeschoolrotterdam.nl/opleidingen/bachelor/elektrotechniek/voltijd/ images.hogeschoolrotterdam.nl 304 0 0 388 979 15 67.43.156.14",
                 "outcome": "success",
@@ -431,6 +436,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 0,
                 "kind": "event",
                 "original": "2020-10-08 22:00:22 W3SVC2 freca1 10.24.129.162 GET /Blob/ff64cd9efcf4424dbf06b3b8133eeea2/f2e0b2998b1f43cb98e5b31c7faa91f4.jpg width=60\u0026height=20\u0026mode=crop 80 - 10.24.136.240 HTTP/1.1 Mozilla/5.0+(iPhone;+CPU+iPhone+OS+13_7+like+Mac+OS+X)+AppleWebKit/605.1.15+(KHTML,+like+Gecko)+Version/13.1.2+Mobile/15E148+Safari/604.1 imagedpi=1;+imagequality=30;+_ga=GA1.2.14440223724.16021494379;+_gid=GA1.2.12504748161.16021944379;+_gat_UA-155764052-5=1;+BIGipServerYAkgvoMHHYQAGkWEsadfsdfsWnyAqA=!vbipVwbt0UWJ4QSsPvjjVxViTXMqdXWYu1dRyQoUTVerwerVBGLZPB39PoNX5Tw66+GT0ChJCfnp/xfhM8lI=;+_gcl_au=1.1.1297303538.1602194379 https://www.hogeschoolrotterdam.nl/opleidingen/bachelor/elektrotechniek/voltijd/ images.hogeschoolrotterdam.nl 304 0 0 388 979 0 67.43.156.14",
                 "outcome": "success",

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-x-forward-for.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-x-forward-for.log-expected.json
@@ -15,6 +15,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 26000000,
                 "kind": "event",
                 "original": "2020-10-07 23:00:17 192.168.16.11 POST /Production-UI/api/finance/legacy/GeneralLedger/LoadBatchTotals - 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 26 192.168.198.23",
                 "outcome": "success",
@@ -86,6 +87,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 32000000,
                 "kind": "event",
                 "original": "2020-10-07 23:00:17 192.168.16.11 POST /Production-UI/api/finance/legacy/GeneralLedger/LoadBatchTotals - 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 32 192.168.198.23",
                 "outcome": "success",
@@ -157,6 +159,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 46000000,
                 "kind": "event",
                 "original": "2020-10-07 23:00:17 192.168.16.11 POST /Production-UI/api/finance/legacy/GeneralLedger/LoadJETotals - 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 46 192.168.198.23",
                 "outcome": "success",
@@ -228,6 +231,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 32000000,
                 "kind": "event",
                 "original": "2020-10-07 23:00:17 192.168.16.11 GET /Production-UI/data/finance/legacy/GLAPAprvMaster $filter=BatchId%20eq%20%27FY21HSNG0820%27\u0026$orderby=Subsys,Ref\u0026$skip=0\u0026$top=20 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 32 192.168.198.23",
                 "outcome": "success",
@@ -300,6 +304,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 166000000,
                 "kind": "event",
                 "original": "2020-10-07 23:00:17 192.168.16.11 GET /Production-UI/data/finance/legacy/GLATrnsDetail $filter=Subsys%20eq%20%27JE%27%20and%20Ref%20eq%20%27HSNG08-MR%27%20and%20BatchId%20eq%20%27FY21HSNG0820%27\u0026$orderby=RecNo\u0026$skip=0\u0026$top=20 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 166 192.168.198.23",
                 "outcome": "success",
@@ -372,6 +377,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 60000000,
                 "kind": "event",
                 "original": "2020-10-07 23:06:42 192.168.16.11 GET /Production-UI/api/finance/legacy/documents/PendingAttachments/GLJEUB - 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 60 192.168.198.23",
                 "outcome": "success",
@@ -443,6 +449,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 72000000,
                 "kind": "event",
                 "original": "2020-10-07 23:06:42 192.168.16.11 POST /Production-UI/api/finance/legacy/documents/GLATrnsDetail/attachments/ - 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 72 192.168.198.23",
                 "outcome": "success",
@@ -514,6 +521,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 88000000,
                 "kind": "event",
                 "original": "2020-10-07 23:06:42 192.168.16.11 POST /Production-UI/api/finance/legacy/documents/GLAPAprvMaster/attachments/ - 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 88 192.168.198.23",
                 "outcome": "success",
@@ -585,6 +593,7 @@
                     "web",
                     "network"
                 ],
+                "duration": 286000000,
                 "kind": "event",
                 "original": "2020-10-07 23:07:02 192.168.16.11 POST /Production-UI/api/finance/legacy/documents/attachDoc - 443 - 192.168.7.63 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/67.43.156.13+Safari/537.36 https://onesolfarm.ggcity.org/Production-UI/ui/uiscreens/generalledger/GLJEUB 200 0 0 286 192.168.198.23",
                 "outcome": "success",

--- a/packages/iis/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/iis/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -77,10 +77,6 @@ processors:
       field: url.domain
       value: "{{destination.domain}}"
       if: ctx.url?.domain == null && ctx.destination?.domain != null
-  - remove:
-      field:
-        - _temp_
-      ignore_missing: true
   - rename:
       field: '@timestamp'
       target_field: event.created
@@ -97,9 +93,10 @@ processors:
       source: ctx.event.duration = Math.round(ctx._temp_.duration * params.scale)
       params:
           scale: 1000000
-      if: ctx.temp?.duration != null
+      if: ctx._temp_?.duration != null
   - remove:
-      field: _temp_.duration
+      field:
+        - _temp_
       ignore_missing: true
   - urldecode:
       field: user_agent.original

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 1.2.0
+version: 1.2.1
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
- Bug


## What does this PR do?
This PR updates the field name in the ingest pipeline processor. Which will ingest the event.duration field to Elasticsearch. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


## How to test this PR locally
Run pipeline tests
Verify the event.duration field is captured in the Expected json file.
Run the integration and verify the data is getting ingested into Elasticsearch.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #4475 
