### PR TITLE
[google_workspace] Change fingerprint processor to avoid skipping events.

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.3"
+  changes:
+    - description: Change fingerprint processor to avoid skipping events.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.7.2"
   changes:
     - description: Remove duplicate fields.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Change fingerprint processor to avoid skipping events.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/4500
 - version: "1.7.2"
   changes:
     - description: Remove duplicate fields.

--- a/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -32,6 +32,7 @@ processors:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
         - json.id
+        - json.events
       target_field: _id
       ignore_missing: true
       ignore_failure: true

--- a/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
@@ -32,6 +32,7 @@ processors:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
         - json.id
+        - json.events
       target_field: _id
       ignore_missing: true
       ignore_failure: true

--- a/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
@@ -35,6 +35,7 @@ processors:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
         - json.id
+        - json.events
       target_field: _id
       ignore_missing: true
       ignore_failure: true

--- a/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
@@ -32,6 +32,7 @@ processors:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
         - json.id
+        - json.events
       target_field: _id
       ignore_missing: true
       ignore_failure: true

--- a/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
@@ -38,6 +38,7 @@ processors:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
         - json.id
+        - json.events
       target_field: _id
       ignore_missing: true
       ignore_failure: true

--- a/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
@@ -38,6 +38,7 @@ processors:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
         - json.id
+        - json.events
       target_field: _id
       ignore_missing: true
       ignore_failure: true

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: 1.7.2
+version: 1.7.3
 release: ga
 description: Collect logs from Google Workspace with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Fingerprints the whole event object in addition to the ID one. Some items from the API return multiple events, which share the same id object. This causes that only the first one would get stored and the rest would be dropped because of the duplicated id.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
