### PR TITLE
[microsoft_sqlserver] Establish Named instance connection by Instance Name

### DIFF
--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -11,8 +11,7 @@ See: [SQL Server Audit page](https://docs.microsoft.com/en-us/sql/relational-dat
 
 ## Named Instance
 
-Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Edit the instance port and provide the named instance port to connect to the named instance and collect metrics.
-See: [Instruction on how to configure server to listen Named Instance port](https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-a-server-to-listen-on-a-specific-tcp-port?view=sql-server-ver15)
+Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Establish named instance connection by using the instance name along with the host name (Ex: `host/instance_name` or `host:named_instance_port`) to collect metrics.
 
 ## Compatibility
 

--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -18,7 +18,7 @@ Microsoft SQL Server has a feature that allows running multiple databases on the
 As of now the integration supports collecting metrics from single host. For multi host, each host needs to run a new integration.
 
 User has to provide the user name, password and the host name,
-Syntax for the host based on default and named instance is listed below,
+The host configuration also contains both named instance or port details, as per the syntax below,
 
 ### Connecting to Default Instance (host)
 

--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -11,22 +11,22 @@ See: [SQL Server Audit page](https://docs.microsoft.com/en-us/sql/relational-dat
 
 ## Named Instance
 
-Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Establish named instance connection by using the instance name along with the host name (Ex: `host/instance_name` or `host:named_instance_port`) to collect metrics.
+Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Establish named instance connection by using the instance name along with the host name (Ex: `host/instance_name` or `host:named_instance_port`) to collect metrics. Details of the host configuration is provided below.
 
 ## Host Configuration
 
-As of now the integration supports collecting metrics from single host. For multi host, each host needs to run a new integration.
+Integration supports collecting metrics from single host. For multi host metrics, each host can be run as a new integration.
 
-User has to provide the user name, password and the host name. The host configuration also contains both named instance or port details, as per the syntax below,
+As part of the input configuration, need to provide the user name, password and the host details. The host configuration supports both named instance or default(no-name) instance, as per the syntax below.
 
 ### Connecting to Default Instance (host)
 
-* `host`    ex: `localhost` (Instance name is not needed when connecting to default instance)
+* `host`    ex: `localhost` (Instance name is not needed when connecting to default instance) or
 * `host:port ` ex: `localhost:1433`
 
 ### Connecting to Named Instance (host)
 
-* `host/instance_name`  ex: `localhost/namedinstance_01`
+* `host/instance_name`  ex: `localhost/namedinstance_01` or
 * `host:named_instance_port`  ex: `localhost:60873`
 
 ## Compatibility

--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -17,8 +17,7 @@ Microsoft SQL Server has a feature that allows running multiple databases on the
 
 As of now the integration supports collecting metrics from single host. For multi host, each host needs to run a new integration.
 
-User has to provide the user name, password and the host name,
-The host configuration also contains both named instance or port details, as per the syntax below,
+User has to provide the user name, password and the host name. The host configuration also contains both named instance or port details, as per the syntax below,
 
 ### Connecting to Default Instance (host)
 

--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -13,6 +13,23 @@ See: [SQL Server Audit page](https://docs.microsoft.com/en-us/sql/relational-dat
 
 Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Establish named instance connection by using the instance name along with the host name (Ex: `host/instance_name` or `host:named_instance_port`) to collect metrics.
 
+## Host Configuration
+
+As of now the integration supports collecting metrics from single host. For multi host, each host needs to run a new integration.
+
+User has to provide the user name, password and the host name,
+Syntax for the host based on default and named instance is listed below,
+
+### Connecting to Default Instance (host)
+
+* `host`    ex: `localhost` (Instance name is not needed when connecting to default instance)
+* `host:port ` ex: `localhost:1433`
+
+### Connecting to Named Instance (host)
+
+* `host/instance_name`  ex: `localhost/namedinstance_01`
+* `host:named_instance_port`  ex: `localhost:60873`
+
 ## Compatibility
 
 The package collects `performance` and `transaction_log` metrics, and `audit` events from the event log. Other log sources such as file are not supported.

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Adding support for Named Instance connection using instance name or by port number.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4501
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/microsoft_sqlserver/data_stream/performance/agent/stream/stream.yml.hbs
+++ b/packages/microsoft_sqlserver/data_stream/performance/agent/stream/stream.yml.hbs
@@ -1,7 +1,7 @@
 metricsets: ["query"]
 # Specify hosts in the below format. TODO: hosts need to be updated to support multiple entries.
 hosts: 
-  - sqlserver://{{username}}:{{password}}@{{hosts}}:{{port}}   
+  - sqlserver://{{username}}:{{password}}@{{hosts}}
 period: {{period}}
 raw_data.enabled: true
 # Below dynamic_counter_name handles the dynamic counter name passing it to SQL query

--- a/packages/microsoft_sqlserver/data_stream/transaction_log/agent/stream/stream.yml.hbs
+++ b/packages/microsoft_sqlserver/data_stream/transaction_log/agent/stream/stream.yml.hbs
@@ -1,7 +1,7 @@
 metricsets: ["query"]
 # Specify hosts in the below format. TODO:hosts need to be updated to support multiple entries.
 hosts:
-    - sqlserver://{{username}}:{{password}}@{{hosts}}:{{port}}
+    - sqlserver://{{username}}:{{password}}@{{hosts}}
 period: {{period}}
 driver: mssql
 raw_data.enabled: true

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -11,8 +11,7 @@ See: [SQL Server Audit page](https://docs.microsoft.com/en-us/sql/relational-dat
 
 ## Named Instance
 
-Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Edit the instance port and provide the named instance port to connect to the named instance and collect metrics.
-See: [Instruction on how to configure server to listen Named Instance port](https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-a-server-to-listen-on-a-specific-tcp-port?view=sql-server-ver15)
+Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Establish named instance connection by using the instance name along with the host name (Ex: `host/instance_name` or `host:named_instance_port`) to collect metrics.
 
 ## Compatibility
 

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -18,7 +18,7 @@ Microsoft SQL Server has a feature that allows running multiple databases on the
 As of now the integration supports collecting metrics from single host. For multi host, each host needs to run a new integration.
 
 User has to provide the user name, password and the host name,
-Syntax for the host based on default and named instance is listed below,
+The host configuration also contains both named instance or port details, as per the syntax below,
 
 ### Connecting to Default Instance (host)
 

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -17,8 +17,7 @@ Microsoft SQL Server has a feature that allows running multiple databases on the
 
 As of now the integration supports collecting metrics from single host. For multi host, each host needs to run a new integration.
 
-User has to provide the user name, password and the host name,
-The host configuration also contains both named instance or port details, as per the syntax below,
+User has to provide the user name, password and the host name. The host configuration also contains both named instance or port details, as per the syntax below,
 
 ### Connecting to Default Instance (host)
 

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -11,22 +11,22 @@ See: [SQL Server Audit page](https://docs.microsoft.com/en-us/sql/relational-dat
 
 ## Named Instance
 
-Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Establish named instance connection by using the instance name along with the host name (Ex: `host/instance_name` or `host:named_instance_port`) to collect metrics.
+Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Establish named instance connection by using the instance name along with the host name (Ex: `host/instance_name` or `host:named_instance_port`) to collect metrics. Details of the host configuration is provided below.
 
 ## Host Configuration
 
-As of now the integration supports collecting metrics from single host. For multi host, each host needs to run a new integration.
+Integration supports collecting metrics from single host. For multi host metrics, each host can be run as a new integration.
 
-User has to provide the user name, password and the host name. The host configuration also contains both named instance or port details, as per the syntax below,
+As part of the input configuration, need to provide the user name, password and the host details. The host configuration supports both named instance or default(no-name) instance, as per the syntax below.
 
 ### Connecting to Default Instance (host)
 
-* `host`    ex: `localhost` (Instance name is not needed when connecting to default instance)
+* `host`    ex: `localhost` (Instance name is not needed when connecting to default instance) or
 * `host:port ` ex: `localhost:1433`
 
 ### Connecting to Named Instance (host)
 
-* `host/instance_name`  ex: `localhost/namedinstance_01`
+* `host/instance_name`  ex: `localhost/namedinstance_01` or
 * `host:named_instance_port`  ex: `localhost:60873`
 
 ## Compatibility
@@ -534,3 +534,4 @@ An example event for `transaction_log` looks as following:
 | mssql.metrics.used_log_space_pct | A percentage of the occupied size of the log as a percent of the total log size. | float | percent | gauge |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |  |
+

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -13,6 +13,23 @@ See: [SQL Server Audit page](https://docs.microsoft.com/en-us/sql/relational-dat
 
 Microsoft SQL Server has a feature that allows running multiple databases on the same host (or clustered hosts) with separate settings. Establish named instance connection by using the instance name along with the host name (Ex: `host/instance_name` or `host:named_instance_port`) to collect metrics.
 
+## Host Configuration
+
+As of now the integration supports collecting metrics from single host. For multi host, each host needs to run a new integration.
+
+User has to provide the user name, password and the host name,
+Syntax for the host based on default and named instance is listed below,
+
+### Connecting to Default Instance (host)
+
+* `host`    ex: `localhost` (Instance name is not needed when connecting to default instance)
+* `host:port ` ex: `localhost:1433`
+
+### Connecting to Named Instance (host)
+
+* `host/instance_name`  ex: `localhost/namedinstance_01`
+* `host:named_instance_port`  ex: `localhost:60873`
+
 ## Compatibility
 
 The package collects `performance` and `transaction_log` metrics, and `audit` events from the event log. Other log sources such as file are not supported.

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "1.4.0"
+version: "1.5.0"
 license: basic
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration
@@ -48,12 +48,13 @@ policy_templates:
         vars:
           - name: hosts
             type: text
-            title: Hosts
-            multi: true
+            title: Host
+            multi: false
             required: true
             show_user: true
             default:
               - localhost
+            description: Host Name Ex - (DefaultInstance - host or host:port) (Named Instance - host/instanceName or host:NamedInstancePort)
           - name: password
             type: password
             title: Password
@@ -68,13 +69,6 @@ policy_templates:
             required: true
             show_user: true
             default: domain\username
-          - name: port
-            type: integer
-            title: Instance Port
-            multi: false
-            required: true
-            show_user: true
-            default: 1433
         title: Collect Microsoft SQL Server performance and transaction_log metrics
         description: Collecting performance and transaction_log metrics from Microsoft SQL Server instances
 owner:


### PR DESCRIPTION
- Enhancement


## What does this PR do?

Connection is established with and without port number and also with the Instance Name.

> Default Instance - `username:password@host`, `username:password@host:port` 
> Named Instance - `username:password@host:port`, `username:password@host/InstanceName`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

- Enable mssql integrations
- Connect to mssql named instance to collect data. (Test by instance name and by port number)
- Connect to mssql default instance using default connection string and by port number.