### PR TITLE
docs: fix doc build error

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Documentation bugfix
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4504
 - version: "1.0.4"
   changes:
     - description: Updated mapping to include orchastrator.cluster.name.

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,9 +1,14 @@
 # newer versions go on top
+- version: "1.0.5"
+  changes:
+    - description: Documentation bugfix
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.0.4"
   changes:
-  - description: Updated mapping to include orchastrator.cluster.name.
-    type: enhancement
-    link: https://github.com/elastic/integrations/pull/4454
+    - description: Updated mapping to include orchastrator.cluster.name.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4454
 - version: "1.0.3"
   changes:
     - description: Updated the readme to remove the broken internal link

--- a/packages/cloud_security_posture/docs/README.md
+++ b/packages/cloud_security_posture/docs/README.md
@@ -161,6 +161,7 @@ make sure to grant the following permissions:
 
 JSON object of an IAM Policy with the permissions above: 
 
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -191,7 +192,7 @@ JSON object of an IAM Policy with the permissions above:
         }
     ]
 }
-
+```
 
 ## Leader election
 

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Kubernetes Security Posture Management"
-version: 1.0.4
+version: 1.0.5
 release: ga
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."


### PR DESCRIPTION
### Summary

This PR fixes a documentation build error for docs.elastic.co. All code blocks must be formatted in markdown code blocks.

* For https://github.com/elastic/wordlake/pull/50.