### PR TITLE
panw: fix handling of event.outcome

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.1.2"
+  changes:
+    - description: Fix handling of event.outcome.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4506
 - version: "3.1.1"
   changes:
     - description: fix adding processors to tcp and udp configs

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
@@ -32,7 +32,7 @@
                 "created": "2021-11-11T15:42:44.000-08:00",
                 "kind": "event",
                 "original": "\u003c14\u003eNov 30 16:09:33 PA-220 1,2021/11/11 15:42:44,007051000184334,DECRYPTION,0,2561,2021/11/11 15:42:44,81.2.69.145,81.2.69.144,81.2.69.145,81.2.69.144,intrazone-default,,,incomplete,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,,2021/11/11 15:42:44,33288,1,49908,443,49908,20077,0x1400000,tcp,allow,N/A,,,,,731a6a1a-9a62-4a92-a49a-0876025a9436,Server_Hello,Client_Hello,TLS1.2,ECDHE,AES_256_GCM,SHA384,,,Certificate,trusted,Trusted,GlobalProtect,ba67e84495b59512,a6a13e87221733b712ddbd0978da1ffdd69503dfd1f0a86f73d86bf90b743b85,2021/11/11 15:21:28,2022/11/11 15:21:28,V3,2048,9,9,0,0,:::::RSA,com.example.com,com.example.com,,,Received fatal alert CertificateUnknown from client,,,,,,,,2021-11-11T15:42:44.845-08:00,,,,,,,,,,,,,,,,,7028724914890736000,0x0,0,0,0,0,,PA-VM,1,unknown,unknown,unknown,1,,,incomplete,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "timezone": "-08:00",
                 "type": [
                     "allowed"

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-gtp-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-gtp-sample.log-expected.json
@@ -32,7 +32,6 @@
                 "end": "2021-10-26T18:22:21.000+07:00",
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2019/10/09 10:20:15,001234567890002,GTP,0,2304,2019/10/09 10:20:15,81.2.69.142,81.2.69.144,,,rule-name,,,app,v-system,s-zone,d-zone,inbound-int,outbound-int,log-action,,1212121,,9550,9551,,,,tcp,action,gtp-event,msisdn,apn,rat,gtp-msg-type,81.2.69.142,TE-Ide-1,TE-Ide-2,GTP-interface,GTP-cause,4,mcc,mnc,1010,100,GTP-event-code,,,src-loc,dst-loc,,,,,,,,imsi,imei,,,,,,,,,,,,,,,,,2021/10/26 15:35:42,9999,TI-Rule,81.2.69.142,remote-user-id,uuid,pcap-id,1970-01-01T01:00:00.000+01:00,ASST,ASD,app-sub-cat,app-cat,app-tech,4,app-char,app-container,no,no",
-                "outcome": "success",
                 "start": "2021-10-26T15:35:42.000+07:00",
                 "timezone": "+07:00"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-hipmatch-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-hipmatch-sample.log-expected.json
@@ -12,7 +12,6 @@
                 "created": "2021-03-02T10:06:31.000-06:00",
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2021/03/02 10:06:31,12345678999,HIPMATCH,0,2305,2021/03/02 10:06:25,domain\\mustermanm,vsys1,PC12345,,10.20.30.40,GlobalProtect 5.1.1,1,object,0,0,6894571641485024543,0x8000000000000000,267,24,19,0,,de-firewall,1,0.0.0.0,d275bcbe-3a07-4e69-85c5-3ad9192c212e,F0S48Y2,,1970-01-01T01:00:00.000+01:00",
-                "outcome": "success",
                 "timezone": "-06:00"
             },
             "host": {
@@ -84,7 +83,6 @@
                 "created": "2019-10-09T10:20:15.000-06:00",
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2019/10/09 10:20:15,001234567890002,HIPMATCH,0,2304,2019/10/09 10:20:15,ira,vsys1,oh-C02ABCDEFGH4,Mac,89.160.20.112,GP-HIP-PROFILE,1,profile,0,0,0123456789,0x0,0,0,0,0,,SumoRedfw01a,1,0.0.0.0,gh:85:90:99:5a:40,C02ABCDEFGH",
-                "outcome": "success",
                 "timezone": "-06:00"
             },
             "host": {

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
@@ -109,7 +109,7 @@
                 "created": "2013-03-25T23:59:02.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,CONFIG,0,0,2012/02/25 00:53:40,192.168.0.2,,commit,admin,Web,Submitted,,0,0x0",
-                "outcome": "success",
+                "outcome": "unknown",
                 "timezone": "+05:45"
             },
             "host": {
@@ -156,7 +156,6 @@
                 "created": "2013-03-25T23:59:02.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,routing,0,2012/02/25 00:53:53,,routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -197,7 +196,6 @@
                 "created": "2013-03-25T23:59:02.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,vpn,0,2012/02/25 00:53:56,,ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -238,7 +236,6 @@
                 "created": "2013-03-25T23:59:02.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,routing,0,2012/02/25 00:54:16,,routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -279,7 +276,6 @@
                 "created": "2013-03-25T23:59:02.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,ras,0,2012/02/25 00:54:16,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -368,7 +364,7 @@
                 "created": "2013-03-25T23:59:02.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,CONFIG,0,0,2012/02/25 00:57:36,192.168.0.2,,commit,badguy,Web,Submitted,,0,0x0",
-                "outcome": "success",
+                "outcome": "unknown",
                 "timezone": "+05:45"
             },
             "host": {
@@ -415,7 +411,6 @@
                 "created": "2013-03-25T23:59:02.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,routing,0,2012/02/25 00:57:49,,routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -456,7 +451,6 @@
                 "created": "2013-03-25T23:59:02.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:02 1,2013/03/25 23:59:02,1606001116,SYSTEM,vpn,0,2012/02/25 00:57:52,,ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -497,7 +491,6 @@
                 "created": "2013-03-25T23:59:07.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,routing,0,2012/02/25 00:58:12,,routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -538,7 +531,6 @@
                 "created": "2013-03-25T23:59:07.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,vpn,0,2012/02/25 00:58:12,,ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -579,7 +571,6 @@
                 "created": "2013-03-25T23:59:07.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,ras,0,2012/02/25 00:58:12,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -620,7 +611,6 @@
                 "created": "2013-03-25T23:59:07.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,general,1,2012/02/25 00:58:14,,unknown,,0,0,general,informational,Config installed,909,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -661,7 +651,6 @@
                 "created": "2013-03-25T23:59:07.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,1606001116,SYSTEM,general,0,2012/02/25 00:59:36,,general,,0,0,general,informational,Log type config cleared by user badguy ,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -702,7 +691,6 @@
                 "created": "2013-03-25T23:59:22.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,general,1,2012/04/10 03:11:57,,unknown,,0,0,general,informational,Config installed,884,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -743,7 +731,6 @@
                 "created": "2013-03-25T23:59:22.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,ras,0,2012/04/10 03:11:56,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -784,7 +771,6 @@
                 "created": "2013-03-25T23:59:22.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,vpn,0,2012/04/10 03:11:56,,ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -825,7 +811,6 @@
                 "created": "2013-03-25T23:59:22.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,routing,0,2012/04/10 03:11:56,,routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -866,7 +851,6 @@
                 "created": "2013-03-25T23:59:22.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,SYSTEM,ras,0,2012/04/10 03:06:11,,rasmgr-config-p1-success,,0,0,general,informational,RASMGR daemon configuration load phase-1 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -907,7 +891,6 @@
                 "created": "2013-03-25T23:59:27.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,routing,0,2012/04/10 03:06:00,,routed-config-p1-success,,0,0,general,informational,Route daemon configuration load phase-1 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -948,7 +931,6 @@
                 "created": "2013-03-25T23:59:27.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,general,1,2012/04/09 09:02:53,,unknown,,0,0,general,informational,Config installed,840,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -989,7 +971,6 @@
                 "created": "2013-03-25T23:59:27.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,ras,0,2012/04/09 09:02:52,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -1030,7 +1011,6 @@
                 "created": "2013-03-25T23:59:27.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,vpn,0,2012/04/09 09:02:52,,ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -1071,7 +1051,6 @@
                 "created": "2013-03-25T23:59:27.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,routing,0,2012/04/09 09:02:52,,routed-config-p2-success,,0,0,general,informational,Route daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -1112,7 +1091,6 @@
                 "created": "2013-03-25T23:59:27.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,ras,0,2012/04/09 09:00:55,,rasmgr-config-p1-success,,0,0,general,informational,RASMGR daemon configuration load phase-1 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -1153,7 +1131,6 @@
                 "created": "2013-03-25T23:59:27.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:27 1,2013/03/25 23:59:27,01606001116,SYSTEM,vpn,0,2012/04/09 09:00:52,,ike-config-p1-success,,0,0,general,informational,IKE daemon configuration load phase-1 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -1194,7 +1171,7 @@
                 "created": "2013-03-25T23:59:32.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:32 1,2013/03/25 23:59:32,01606001116,CONFIG,0,0,2012/04/09 09:00:35,192.168.0.2,,commit,admin,Web,Submitted,,0,0x0",
-                "outcome": "success",
+                "outcome": "unknown",
                 "timezone": "+05:45"
             },
             "host": {
@@ -1289,7 +1266,6 @@
                 "created": "2013-03-25T23:59:47.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,SYSTEM,general,1,2012/04/09 03:21:53,,unknown,,0,0,general,informational,Config installed,821,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -1330,7 +1306,6 @@
                 "created": "2013-03-25T23:59:47.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,SYSTEM,ras,0,2012/04/09 03:21:53,,rasmgr-config-p2-success,,0,0,general,informational,RASMGR daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },
@@ -1371,7 +1346,6 @@
                 "created": "2013-03-25T23:59:47.000+05:45",
                 "kind": "event",
                 "original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,SYSTEM,vpn,0,2012/04/09 03:21:53,,ike-config-p2-success,,0,0,general,informational,IKE daemon configuration load phase-2 succeeded.,0,0x0",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "+05:45"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
@@ -2125,7 +2125,7 @@
                 "created": "2012-10-30T09:46:22.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:46:22 1,2012/10/30 09:46:22,01606001116,THREAT,url,1,2012/04/10 04:39:54,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:55,25713,1,59300,80,0,0,0x200000,tcp,block-url,\"infodist1.com/in.cgi?11\u0026parameter=404\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -2606,7 +2606,7 @@
                 "created": "2012-10-30T09:46:27.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:46:27 1,2012/10/30 09:46:27,01606001116,THREAT,url,1,2012/04/10 04:39:52,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:53,26927,1,59296,80,0,0,0x200000,tcp,block-url,\"findmorepill.com/klik/search.php?q=xxx\",(9999),online-gambling,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Germany,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -5341,7 +5341,7 @@
                 "created": "2012-10-30T09:46:47.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:46:47 1,2012/10/30 09:46:47,01606001116,THREAT,url,1,2012/04/10 04:39:43,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:44,4086,1,59261,80,0,0,0x200000,tcp,block-url,\"wantfinest.com/tds/in.cgi?default\",(9999),unknown,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -5500,7 +5500,7 @@
                 "created": "2012-10-30T09:47:02.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:47:02 1,2012/10/30 09:47:02,01606001116,THREAT,url,1,2012/04/10 04:39:38,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:39,26534,1,59248,80,0,0,0x200000,tcp,block-url,\"sameshitasiteverwas.com/traf/tds/in.cgi?2\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Korea Republic Of,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -5659,7 +5659,7 @@
                 "created": "2012-10-30T09:47:02.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:47:02 1,2012/10/30 09:47:02,01606001116,THREAT,url,1,2012/04/10 04:39:39,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:40,26965,1,59251,80,0,0,0x200000,tcp,block-url,\"svarkon.ru/update.exe\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -5818,7 +5818,7 @@
                 "created": "2012-10-30T09:47:12.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:47:12 1,2012/10/30 09:47:12,01606001116,THREAT,url,1,2012/04/10 04:39:36,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:37,26076,1,59244,80,0,0,0x200000,tcp,block-url,\"onlinescanxpp.com/land/eurl/1.php?code=\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -5977,7 +5977,7 @@
                 "created": "2012-10-30T09:47:17.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:47:17 1,2012/10/30 09:47:17,01606001116,THREAT,url,1,2012/04/10 04:39:34,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:35,26198,1,59237,80,0,0,0x200000,tcp,block-url,\"nolagtime.com/conn/?JKV_1RWbUUdIfRUWUaITfdIfbREdYEYdfTTRI-6XBB_1WQR-6GF5_1AU-6LC6_1Y-gW-gEUQQ-gE-tsDF6K5D_rpX51_rR-t-66FC_1Q_fQ_fQ_fQ_fQ_fQ_fQ_fQ-62BG_1Q-672V_1YOR-6N8J_1Q-6252_1WQRR-69LV_1-65GZ_1W-6\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -6136,7 +6136,7 @@
                 "created": "2012-10-30T09:47:17.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:47:17 1,2012/10/30 09:47:17,01606001116,THREAT,url,1,2012/04/10 04:39:35,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:36,26056,1,59238,80,0,0,0x200000,tcp,block-url,\"nolagtime.com/gwc.txt\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -6295,7 +6295,7 @@
                 "created": "2012-10-30T09:51:03.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:51:03 1,2012/10/30 09:51:03,01606001116,THREAT,url,1,2012/04/10 04:38:19,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:38:20,25465,1,59010,80,0,0,0x200000,tcp,block-url,\"karavan.us/bon/index.php\",(9999),unknown,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -6454,7 +6454,7 @@
                 "created": "2012-10-30T09:51:23.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:51:23 1,2012/10/30 09:51:23,01606001116,THREAT,url,1,2012/04/10 04:38:14,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:38:15,24316,1,58969,80,0,0,0x200000,tcp,block-url,\"findnolimits.com/go.php?sid=1\",(9999),dead-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -6613,7 +6613,7 @@
                 "created": "2012-10-30T09:51:33.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:51:33 1,2012/10/30 09:51:33,01606001116,THREAT,url,1,2012/04/10 04:38:12,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:38:13,17258,1,58941,80,0,0,0x200000,tcp,block-url,\"bizoplata.ru/moun.html\",(9999),parked-domains,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -6772,7 +6772,7 @@
                 "created": "2012-10-30T09:51:33.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:51:33 1,2012/10/30 09:51:33,01606001116,THREAT,url,1,2012/04/10 04:38:12,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:38:13,24735,1,58942,80,0,0,0x200000,tcp,block-url,\"bizoplata.ru/palast.html\",(9999),parked-domains,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -6924,7 +6924,7 @@
                 "created": "2012-10-30T09:53:33.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:53:33 1,2012/10/30 09:53:33,01606001116,THREAT,spyware,1,2012/04/10 04:37:28,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:33,23497,1,80,58849,0,0,0x200000,tcp,drop-all-packets,\"controller.php\",Bredolab.Gen Command and Control Traffic(13024),any,critical,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 1,
                 "timezone": "+10:00"
             },
@@ -7087,7 +7087,7 @@
                 "created": "2012-10-30T09:53:38.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:53:38 1,2012/10/30 09:53:38,01606001116,THREAT,url,1,2012/04/10 04:37:32,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:32,23711,1,58856,80,0,0,0x200000,tcp,block-url,\"www.15min.it/\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Canada,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -7246,7 +7246,7 @@
                 "created": "2012-10-30T09:53:48.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:53:48 1,2012/10/30 09:53:48,01606001116,THREAT,url,1,2012/04/10 04:37:27,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:27,23659,1,58847,80,0,0,0x200000,tcp,block-url,\"tubemov.com/\",(9999),adult-and-pornography,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -7405,7 +7405,7 @@
                 "created": "2012-10-30T09:53:58.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:53:58 1,2012/10/30 09:53:58,01606001116,THREAT,url,1,2012/04/10 04:37:25,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:25,23782,1,58841,80,0,0,0x200000,tcp,block-url,\"pagesinxt.com/?dn=teenstube.us\u0026flrdr=yes\u0026nxte=js\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Virgin Islands British,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -7564,7 +7564,7 @@
                 "created": "2012-10-30T09:55:23.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:55:23 1,2012/10/30 09:55:23,01606001116,THREAT,url,1,2012/04/10 04:37:05,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:37:06,23239,1,58795,80,0,0,0x200000,tcp,block-url,\"movfree.com/\",(9999),spyware-and-adware,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -7723,7 +7723,7 @@
                 "created": "2012-10-30T09:56:23.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:56:23 1,2012/10/30 09:56:23,01606001116,THREAT,url,1,2012/04/10 04:36:51,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:52,22479,1,58753,80,0,0,0x200000,tcp,block-url,\"gometascan.com/\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -7882,7 +7882,7 @@
                 "created": "2012-10-30T09:57:33.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:57:33 1,2012/10/30 09:57:33,01606001116,THREAT,url,1,2012/04/10 04:36:39,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:40,21458,1,58708,80,0,0,0x200000,tcp,block-url,\"antivirus-powerful-scannerv2.com/download/Install_11-1.exe\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -8041,7 +8041,7 @@
                 "created": "2012-10-30T09:57:38.000+10:00",
                 "kind": "alert",
                 "original": "Oct 30 09:57:38 1,2012/10/30 09:57:38,01606001116,THREAT,url,1,2012/04/10 04:36:38,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:39,21577,1,58707,80,0,0,0x200000,tcp,block-url,\"antivirus-powerful-scannerv2.com/1/?id=11-1\u0026back==TQzyDTyMUQNMI=N\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -8200,7 +8200,7 @@
                 "created": "2013-03-25T23:58:52.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:58:52 1,2013/03/25 23:58:52,1606001116,THREAT,url,1,2012/04/10 04:36:27,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:28,21487,1,58603,80,0,0,0x200000,tcp,block-url,\"basdzsdas.com/poker/config.bin\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -8359,7 +8359,7 @@
                 "created": "2013-03-25T23:58:52.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:58:52 1,2013/03/25 23:58:52,1606001116,THREAT,url,1,2012/04/10 04:36:27,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:28,21487,1,58603,80,0,0,0x200000,tcp,block-url,\"basdzsdas.com/poker/config.bin\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -8511,7 +8511,7 @@
                 "created": "2013-03-25T23:58:57.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:58:57 1,2013/03/25 23:58:57,1606001116,THREAT,file,1,2012/04/10 04:19:59,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:20:05,64856,1,80,54431,0,0,0x200000,tcp,deny,\"uLLGRaXP.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "+10:00",
                 "type": [
@@ -8677,7 +8677,7 @@
                 "created": "2013-03-25T23:58:57.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:58:57 1,2013/03/25 23:58:57,1606001116,THREAT,url,1,2012/04/10 04:36:27,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:36:28,21487,1,58603,80,0,0,0x200000,tcp,block-url,\"basdzsdas.com/poker/config.bin\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -8829,7 +8829,7 @@
                 "created": "2013-03-25T23:59:07.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,01606001116,THREAT,file,1,2012/04/10 04:51:29,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:51:34,37983,1,80,61220,0,0,0x200000,tcp,deny,\"FunkyEmoticons_setup.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,European Union,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "+10:00",
                 "type": [
@@ -8988,7 +8988,7 @@
                 "created": "2013-03-25T23:59:07.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,01606001116,THREAT,file,1,2012/04/10 04:54:33,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:54:38,41989,1,80,61726,0,0,0x200000,tcp,deny,\"52hxw.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,China,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "+10:00",
                 "type": [
@@ -9154,7 +9154,7 @@
                 "created": "2013-03-25T23:59:07.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:07 1,2013/03/25 23:59:07,01606001116,THREAT,url,1,2012/04/10 05:01:00,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 05:01:00,49238,1,63007,80,0,0,0x200000,tcp,block-url,\"softsellfast.com/test/config.bin\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -9306,7 +9306,7 @@
                 "created": "2013-03-25T23:59:12.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:12 1,2013/03/25 23:59:12,01606001116,THREAT,file,1,2012/04/10 04:45:17,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:45:23,21592,1,80,60212,0,0,0x200000,tcp,deny,\"setup.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,Netherlands,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "+10:00",
                 "type": [
@@ -9465,7 +9465,7 @@
                 "created": "2013-03-25T23:59:12.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:12 1,2013/03/25 23:59:12,01606001116,THREAT,file,1,2012/04/10 04:46:16,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:46:22,33760,1,80,60392,0,0,0x200000,tcp,deny,\"Live-Player_setup.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,European Union,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "+10:00",
                 "type": [
@@ -9631,7 +9631,7 @@
                 "created": "2013-03-25T23:59:12.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:12 1,2013/03/25 23:59:12,01606001116,THREAT,url,1,2012/04/10 04:42:39,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:42:39,28723,1,59709,80,0,0,0x200000,tcp,block-url,\"boialex.narod.ru/config.txt\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -9790,7 +9790,7 @@
                 "created": "2013-03-25T23:59:12.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:12 1,2013/03/25 23:59:12,01606001116,THREAT,url,1,2012/04/10 04:42:42,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:42:42,28932,1,59721,80,0,0,0x200000,tcp,block-url,\"edw-melon.narod.ru/config.txt\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -9949,7 +9949,7 @@
                 "created": "2013-03-25T23:59:12.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:12 1,2013/03/25 23:59:12,01606001116,THREAT,url,1,2012/04/10 04:42:51,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:42:51,28953,1,59752,80,0,0,0x200000,tcp,block-url,\"maximtushin.narod.ru/config.txt\",(9999),malware-sites,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,Russian Federation,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -10101,7 +10101,7 @@
                 "created": "2013-03-25T23:59:17.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:17 1,2013/03/25 23:59:17,01606001116,THREAT,file,1,2012/04/10 04:19:59,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,crusher,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:20:05,64856,1,80,54431,0,0,0x200000,tcp,deny,\"uLLGRaXP.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "+10:00",
                 "type": [
@@ -10267,7 +10267,7 @@
                 "created": "2013-03-25T23:59:22.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:22 1,2013/03/25 23:59:22,01606001116,THREAT,url,1,2012/04/10 04:09:01,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:09:01,55402,1,63183,80,0,0,0x200000,tcp,block-url,\"marketingsoluchion.biz/fkn/config.bin\",(9999),unknown,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -11373,7 +11373,7 @@
                 "created": "2013-03-25T23:59:32.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:32 1,2013/03/25 23:59:32,01606001116,THREAT,data,1,2012/04/09 08:58:18,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:58:22,29312,1,80,57876,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -11532,7 +11532,7 @@
                 "created": "2013-03-25T23:59:32.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:32 1,2013/03/25 23:59:32,01606001116,THREAT,file,1,2012/04/09 08:22:27,175.16.199.1,192.168.0.6,0.0.0.0,0.0.0.0,rule1,,jordy,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:22:31,26747,1,80,1082,0,0,0x200000,tcp,deny,\"about.exe\",Windows Executable (EXE)(52020),any,low,server-to-client,0,0x0,Ukraine,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "+10:00",
                 "type": [
@@ -11691,7 +11691,7 @@
                 "created": "2013-03-25T23:59:37.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:37 1,2013/03/25 23:59:37,01606001116,THREAT,data,1,2012/04/09 07:11:43,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:11:48,19205,1,80,50986,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -11850,7 +11850,7 @@
                 "created": "2013-03-25T23:59:37.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:37 1,2013/03/25 23:59:37,01606001116,THREAT,data,1,2012/04/09 07:14:02,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:14:07,19360,1,80,51716,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -12009,7 +12009,7 @@
                 "created": "2013-03-25T23:59:37.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:37 1,2013/03/25 23:59:37,01606001116,THREAT,data,1,2012/04/09 07:14:39,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:14:44,19696,1,80,52119,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -12168,7 +12168,7 @@
                 "created": "2013-03-25T23:59:37.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:37 1,2013/03/25 23:59:37,01606001116,THREAT,data,1,2012/04/09 07:16:03,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:16:08,19679,1,80,52411,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -12486,7 +12486,7 @@
                 "created": "2013-03-25T23:59:37.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:37 1,2013/03/25 23:59:37,01606001116,THREAT,data,1,2012/04/09 07:25:04,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 07:25:09,20422,1,80,53026,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -13122,7 +13122,7 @@
                 "created": "2013-03-25T23:59:37.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:37 1,2013/03/25 23:59:37,01606001116,THREAT,data,1,2012/04/09 08:16:57,175.16.199.1,192.168.0.6,0.0.0.0,0.0.0.0,rule1,,jordy,web-browsing,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 08:17:01,25874,1,80,1046,0,0,0x200000,tcp,reset-both,\"8fe44cb728c0f40750c64ee906eb72.css\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -13281,7 +13281,7 @@
                 "created": "2013-03-25T23:59:42.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:42 1,2013/03/25 23:59:42,01606001116,THREAT,data,1,2012/04/09 04:06:41,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 04:06:46,2175,1,80,61734,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -13440,7 +13440,7 @@
                 "created": "2013-03-25T23:59:42.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:42 1,2013/03/25 23:59:42,01606001116,THREAT,data,1,2012/04/09 04:12:52,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 04:12:57,3046,1,80,62292,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -13758,7 +13758,7 @@
                 "created": "2013-03-25T23:59:42.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:42 1,2013/03/25 23:59:42,01606001116,THREAT,data,1,2012/04/09 06:48:44,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:48:48,16852,1,80,65265,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -14235,7 +14235,7 @@
                 "created": "2013-03-25T23:59:42.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:42 1,2013/03/25 23:59:42,01606001116,THREAT,data,1,2012/04/09 06:51:34,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:51:39,15878,1,80,49722,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -14553,7 +14553,7 @@
                 "created": "2013-03-25T23:59:42.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:42 1,2013/03/25 23:59:42,01606001116,THREAT,data,1,2012/04/09 06:54:35,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:54:41,17433,1,80,50108,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -14712,7 +14712,7 @@
                 "created": "2013-03-25T23:59:42.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:42 1,2013/03/25 23:59:42,01606001116,THREAT,data,1,2012/04/09 06:54:55,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,picard,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 06:55:00,17104,1,80,50387,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -15030,7 +15030,7 @@
                 "created": "2013-03-25T23:59:47.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,THREAT,data,1,2012/04/09 03:45:45,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:45:50,65257,1,80,60005,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -15189,7 +15189,7 @@
                 "created": "2013-03-25T23:59:47.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,THREAT,data,1,2012/04/09 03:49:17,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:49:22,537,1,80,60443,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -15348,7 +15348,7 @@
                 "created": "2013-03-25T23:59:47.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,THREAT,data,1,2012/04/09 03:53:41,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:53:45,914,1,80,60822,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -15507,7 +15507,7 @@
                 "created": "2013-03-25T23:59:47.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,THREAT,data,1,2012/04/09 03:55:23,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 03:55:28,1475,1,80,61105,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [
@@ -15825,7 +15825,7 @@
                 "created": "2013-03-25T23:59:47.000+10:00",
                 "kind": "alert",
                 "original": "Mar 25 23:59:47 1,2013/03/25 23:59:47,01606001116,THREAT,data,1,2012/04/09 04:03:55,175.16.199.1,192.168.0.2,0.0.0.0,0.0.0.0,rule1,,jordy,google-maps,vsys1,untrust,trust,ethernet1/2,ethernet1/1,forwardAll,2012/04/09 04:04:00,1965,1,80,61470,0,0,0x200000,tcp,reset-both,\"js\",PII(60000),any,informational,server-to-client,0,0x0,United States,192.168.0.0-192.168.255.255,0,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+10:00",
                 "type": [

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-ip-tag-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-ip-tag-sample.log-expected.json
@@ -13,7 +13,6 @@
                 "created": "2019-11-23T00:44:44.000+01:00",
                 "kind": "event",
                 "original": "1,2019/11/23 00:44:44,01234567890,IPTAG,login,2561,2019/11/23 00:44:44,vsys,81.2.69.142,tag-name,1000,1000,100,Data Source Name, Data Source Type,Data Source Subtype,1000,0x0,0,0,0,0,vsys-name,d-name,vsys-id,1970-01-01T01:00:00.000+01:00",
-                "outcome": "success",
                 "timezone": "+01:00"
             },
             "message": "vsys,81.2.69.142,tag-name,1000,1000,100,Data Source Name, Data Source Type,Data Source Subtype,1000,0x0,0,0,0,0,vsys-name,d-name,vsys-id,1970-01-01T01:00:00.000+01:00",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-sctp-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-sctp-sample.log-expected.json
@@ -29,7 +29,6 @@
                 "created": "2019-10-09T10:20:15.000+05:30",
                 "kind": "event",
                 "original": "Nov 30 16:09:08 1,2019/10/09 10:20:15,001234567890002,SCTP,0,2304,2019/10/09 10:20:15,81.2.69.142,81.2.69.144,,,rule-name,,,,vsys,src-zone,dst-zone,inbound-int,outbound-int,log-action,,1000,1000,9550,9551,,,,,tcp,action,0,0,0,0,vsys-name,device-name,1000,,2000,payload-protocol-id,4,chunk-type,,tag-1,tag-2,100,dia-app-id,dia-cmd-code,dia-avp-code,sctp-stream-id,end-reason,100,SSN,SGT,filter,1,2,3,11,12,13,3000,1970-01-01T01:00:00.000+01:00",
-                "outcome": "success",
                 "timezone": "+05:30"
             },
             "log": {

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-system-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-system-sample.log-expected.json
@@ -13,7 +13,6 @@
                 "created": "2021-10-26T15:05:03.000Z",
                 "kind": "event",
                 "original": "1,2021/10/26 15:05:03,,SYSTEM,general,2561,2021/10/26 15:05:03,,general,,0,0,general,informational,\"Connection to Update server closed: updates.paloaltonetworks.com, source: 81.2.69.193\",1234567890,0x0,0,0,0,0,,PA-VM,0,0,2021-10-26T15:05:03.440-07:00",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC"
             },
@@ -64,7 +63,6 @@
                 "created": "2021-10-26T14:49:02.000Z",
                 "kind": "event",
                 "original": "1,2021/10/26 14:49:02,,SYSTEM,general,2561,2021/10/26 14:49:02,,general,,0,0,general,informational,\"Connection to Update server closed: updates.paloaltonetworks.com, source: 81.2.69.193\",1234567890,0x0,0,0,0,0,,PA-VM,0,0,2021-10-26T14:49:03.776-07:00",
-                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-threat-sample.log-expected.json
@@ -36,7 +36,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28191,1,52984,443,37679,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7726,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -193,7 +193,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28219,1,52983,443,28249,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7727,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -350,7 +350,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,27723,1,52986,443,63898,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7728,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -507,7 +507,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28172,1,52985,443,7515,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7729,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -664,7 +664,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28151,1,52987,443,3225,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7730,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -821,7 +821,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28076,1,52988,443,60449,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7731,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -978,7 +978,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28173,1,52990,443,60559,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7732,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -1135,7 +1135,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28186,1,52989,443,47414,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7733,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -1292,7 +1292,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28192,1,52992,443,37673,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7734,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -1449,7 +1449,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:36 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,27011,1,52991,443,8232,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7735,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -1606,7 +1606,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28240,1,52994,443,32982,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7736,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -1763,7 +1763,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28143,1,52993,443,10473,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7737,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -1920,7 +1920,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28272,1,52995,443,20446,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7738,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -2077,7 +2077,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28146,1,52996,443,34699,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7739,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -2234,7 +2234,7 @@
                 "created": "2018-11-30T16:44:36.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:36,012801096514,THREAT,url,2049,2018/11/30 16:44:36,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:36,28278,1,52997,443,22820,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7740,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -2391,7 +2391,7 @@
                 "created": "2018-11-30T16:44:37.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:37,012801096514,THREAT,url,2049,2018/11/30 16:44:37,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:37,28185,1,52998,443,41060,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7741,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -2548,7 +2548,7 @@
                 "created": "2018-11-30T16:44:37.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:37,012801096514,THREAT,url,2049,2018/11/30 16:44:37,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:37,28201,1,52999,443,9058,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7742,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -2705,7 +2705,7 @@
                 "created": "2018-11-30T16:44:37.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:37,012801096514,THREAT,url,2049,2018/11/30 16:44:37,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:37,28148,1,53001,443,54846,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7743,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -2862,7 +2862,7 @@
                 "created": "2018-11-30T16:44:37.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:37 PA-220 1,2018/11/30 16:44:37,012801096514,THREAT,url,2049,2018/11/30 16:44:37,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:37,28121,1,53002,443,52731,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7744,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -3019,7 +3019,7 @@
                 "created": "2018-11-30T16:44:38.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:38 PA-220 1,2018/11/30 16:44:38,012801096514,THREAT,url,2049,2018/11/30 16:44:38,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:38,28228,1,53003,443,15165,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7745,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -3176,7 +3176,7 @@
                 "created": "2018-11-30T16:44:38.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:38 PA-220 1,2018/11/30 16:44:38,012801096514,THREAT,url,2049,2018/11/30 16:44:38,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:38,28196,1,53004,443,53918,443,0x403000,tcp,block-url,\"b.scorecardresearch.com/\",(9999),business-and-economy,informational,client-to-server,7746,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -3333,7 +3333,7 @@
                 "created": "2018-11-30T16:44:38.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:38 PA-220 1,2018/11/30 16:44:38,012801096514,THREAT,url,2049,2018/11/30 16:44:38,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:38,28007,1,53000,443,40792,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7747,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -3490,7 +3490,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:46 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28117,1,53006,443,54044,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7748,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -3647,7 +3647,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:46 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28109,1,53007,443,19544,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7749,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -3804,7 +3804,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:46 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28260,1,53008,443,13462,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7750,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -3961,7 +3961,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:46 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28275,1,53010,443,44892,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7752,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -4118,7 +4118,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:46 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28266,1,53011,443,16487,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7753,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -4275,7 +4275,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:46 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28294,1,53012,443,23952,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7754,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -4432,7 +4432,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:46 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28248,1,53013,443,2810,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7755,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -4589,7 +4589,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:46 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28274,1,53014,443,13272,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7756,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -4746,7 +4746,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:47 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28285,1,53022,443,8663,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7762,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -4903,7 +4903,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:47 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28306,1,53023,443,55738,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7763,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -5060,7 +5060,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:47 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28116,1,53024,443,10650,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7764,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -5217,7 +5217,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:47 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28214,1,53025,443,44087,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7765,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -5374,7 +5374,7 @@
                 "created": "2018-11-30T16:44:46.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:47 PA-220 1,2018/11/30 16:44:46,012801096514,THREAT,url,2049,2018/11/30 16:44:46,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:46,28080,1,53026,443,15915,443,0x403000,tcp,block-url,\"consent.cmp.oath.com/\",(9999),business-and-economy,informational,client-to-server,7766,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -5531,7 +5531,7 @@
                 "created": "2018-11-30T16:44:53.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:53 PA-220 1,2018/11/30 16:44:53,012801096514,THREAT,url,2049,2018/11/30 16:44:53,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:53,28318,1,53041,443,41165,443,0x403000,tcp,block-url,\"cdn.taboola.com/\",(9999),business-and-economy,informational,client-to-server,7768,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -5688,7 +5688,7 @@
                 "created": "2018-11-30T16:44:54.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:54 PA-220 1,2018/11/30 16:44:54,012801096514,THREAT,url,2049,2018/11/30 16:44:54,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:54,28300,1,53040,443,54133,443,0x403000,tcp,block-url,\"rules.quantcount.com/\",(9999),business-and-economy,informational,client-to-server,7769,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -5845,7 +5845,7 @@
                 "created": "2018-11-30T16:44:58.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:59 PA-220 1,2018/11/30 16:44:58,012801096514,THREAT,url,2049,2018/11/30 16:44:58,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:58,28339,1,53093,443,8485,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7770,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -6002,7 +6002,7 @@
                 "created": "2018-11-30T16:44:58.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:59 PA-220 1,2018/11/30 16:44:58,012801096514,THREAT,url,2049,2018/11/30 16:44:58,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:58,28299,1,53094,443,12496,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7771,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -6159,7 +6159,7 @@
                 "created": "2018-11-30T16:44:58.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:59 PA-220 1,2018/11/30 16:44:58,012801096514,THREAT,url,2049,2018/11/30 16:44:58,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:58,28303,1,53095,443,17029,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7772,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -6316,7 +6316,7 @@
                 "created": "2018-11-30T16:44:58.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:44:59 PA-220 1,2018/11/30 16:44:58,012801096514,THREAT,url,2049,2018/11/30 16:44:58,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:58,28390,1,53096,443,23696,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7773,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -6473,7 +6473,7 @@
                 "created": "2018-11-30T16:44:59.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:00 PA-220 1,2018/11/30 16:44:59,012801096514,THREAT,url,2049,2018/11/30 16:44:59,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:59,28433,1,53097,443,34769,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7774,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -6630,7 +6630,7 @@
                 "created": "2018-11-30T16:44:59.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:00 PA-220 1,2018/11/30 16:44:59,012801096514,THREAT,url,2049,2018/11/30 16:44:59,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:59,28380,1,53099,443,22486,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7775,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -6787,7 +6787,7 @@
                 "created": "2018-11-30T16:44:59.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:00 PA-220 1,2018/11/30 16:44:59,012801096514,THREAT,url,2049,2018/11/30 16:44:59,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:44:59,28363,1,53100,443,12894,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7776,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -6944,7 +6944,7 @@
                 "created": "2018-11-30T16:45:00.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:00 PA-220 1,2018/11/30 16:45:00,012801096514,THREAT,url,2049,2018/11/30 16:45:00,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28349,1,53101,443,62348,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7777,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -7101,7 +7101,7 @@
                 "created": "2018-11-30T16:45:00.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:00 PA-220 1,2018/11/30 16:45:00,012801096514,THREAT,url,2049,2018/11/30 16:45:00,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28411,1,53104,443,6224,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7778,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -7258,7 +7258,7 @@
                 "created": "2018-11-30T16:45:00.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:00 PA-220 1,2018/11/30 16:45:00,012801096514,THREAT,url,2049,2018/11/30 16:45:00,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28397,1,53107,443,44120,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7779,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -7415,7 +7415,7 @@
                 "created": "2018-11-30T16:45:00.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:00 PA-220 1,2018/11/30 16:45:00,012801096514,THREAT,url,2049,2018/11/30 16:45:00,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28347,1,53108,443,44228,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7780,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -7572,7 +7572,7 @@
                 "created": "2018-11-30T16:45:00.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:00 PA-220 1,2018/11/30 16:45:00,012801096514,THREAT,url,2049,2018/11/30 16:45:00,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:00,28443,1,53109,443,31322,443,0x403000,tcp,block-url,\"srv-2018-11-30-22.config.parsely.com/\",(9999),business-and-economy,informational,client-to-server,7781,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -7729,7 +7729,7 @@
                 "created": "2018-11-30T16:45:13.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:14 PA-220 1,2018/11/30 16:45:13,012801096514,THREAT,url,2049,2018/11/30 16:45:13,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:13,28439,1,53118,443,1672,443,0x403000,tcp,block-url,\"www.googleadservices.com/\",(9999),business-and-economy,informational,client-to-server,7782,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -7886,7 +7886,7 @@
                 "created": "2018-11-30T16:45:15.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:15,012801096514,THREAT,url,2049,2018/11/30 16:45:15,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:15,25958,1,53126,443,20801,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7783,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -8043,7 +8043,7 @@
                 "created": "2018-11-30T16:45:15.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:15,012801096514,THREAT,url,2049,2018/11/30 16:45:15,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:15,28429,1,53127,443,24533,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7784,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -8200,7 +8200,7 @@
                 "created": "2018-11-30T16:45:15.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:15,012801096514,THREAT,url,2049,2018/11/30 16:45:15,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:15,28465,1,53128,443,30150,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7785,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -8357,7 +8357,7 @@
                 "created": "2018-11-30T16:45:15.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:15,012801096514,THREAT,url,2049,2018/11/30 16:45:15,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:15,28504,1,53129,443,36305,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7786,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -8514,7 +8514,7 @@
                 "created": "2018-11-30T16:45:16.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:16,012801096514,THREAT,url,2049,2018/11/30 16:45:16,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28458,1,53130,443,42682,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7787,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -8671,7 +8671,7 @@
                 "created": "2018-11-30T16:45:16.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:16,012801096514,THREAT,url,2049,2018/11/30 16:45:16,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28491,1,53131,443,22530,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7788,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -8828,7 +8828,7 @@
                 "created": "2018-11-30T16:45:16.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:16,012801096514,THREAT,url,2049,2018/11/30 16:45:16,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28520,1,53132,443,43713,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7789,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -8985,7 +8985,7 @@
                 "created": "2018-11-30T16:45:16.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:16,012801096514,THREAT,url,2049,2018/11/30 16:45:16,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28335,1,53133,443,60608,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7790,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -9142,7 +9142,7 @@
                 "created": "2018-11-30T16:45:16.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:16 PA-220 1,2018/11/30 16:45:16,012801096514,THREAT,url,2049,2018/11/30 16:45:16,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28414,1,53134,443,9302,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7791,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -9299,7 +9299,7 @@
                 "created": "2018-11-30T16:45:16.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:17 PA-220 1,2018/11/30 16:45:16,012801096514,THREAT,url,2049,2018/11/30 16:45:16,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:16,28488,1,53135,443,11634,443,0x403000,tcp,block-url,\"service.maxymiser.net/\",(9999),business-and-economy,informational,client-to-server,7792,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -9456,7 +9456,7 @@
                 "created": "2018-11-30T16:45:26.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:26,012801096514,THREAT,url,2049,2018/11/30 16:45:26,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28469,1,53152,443,30818,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7793,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -9613,7 +9613,7 @@
                 "created": "2018-11-30T16:45:26.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:26,012801096514,THREAT,url,2049,2018/11/30 16:45:26,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28556,1,53155,443,64260,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7794,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -9770,7 +9770,7 @@
                 "created": "2018-11-30T16:45:26.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:26,012801096514,THREAT,url,2049,2018/11/30 16:45:26,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28558,1,53158,443,7071,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7795,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -9927,7 +9927,7 @@
                 "created": "2018-11-30T16:45:26.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:26,012801096514,THREAT,url,2049,2018/11/30 16:45:26,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28531,1,53160,443,4512,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7796,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -10084,7 +10084,7 @@
                 "created": "2018-11-30T16:45:26.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:26,012801096514,THREAT,url,2049,2018/11/30 16:45:26,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:26,28580,1,53161,443,3422,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7797,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -10241,7 +10241,7 @@
                 "created": "2018-11-30T16:45:27.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:27,012801096514,THREAT,url,2049,2018/11/30 16:45:27,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28477,1,53162,443,4651,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7798,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -10398,7 +10398,7 @@
                 "created": "2018-11-30T16:45:27.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:27,012801096514,THREAT,url,2049,2018/11/30 16:45:27,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28484,1,53163,443,19068,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7799,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -10555,7 +10555,7 @@
                 "created": "2018-11-30T16:45:27.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:27,012801096514,THREAT,url,2049,2018/11/30 16:45:27,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28609,1,53164,443,5831,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7800,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -10712,7 +10712,7 @@
                 "created": "2018-11-30T16:45:27.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:27,012801096514,THREAT,url,2049,2018/11/30 16:45:27,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28564,1,53165,443,7084,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7801,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -10869,7 +10869,7 @@
                 "created": "2018-11-30T16:45:27.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:27 PA-220 1,2018/11/30 16:45:27,012801096514,THREAT,url,2049,2018/11/30 16:45:27,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28542,1,53166,443,18633,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7802,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -11026,7 +11026,7 @@
                 "created": "2018-11-30T16:45:27.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:28 PA-220 1,2018/11/30 16:45:27,012801096514,THREAT,url,2049,2018/11/30 16:45:27,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28590,1,53167,443,25557,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7803,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -11183,7 +11183,7 @@
                 "created": "2018-11-30T16:45:27.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:28 PA-220 1,2018/11/30 16:45:27,012801096514,THREAT,url,2049,2018/11/30 16:45:27,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:27,28455,1,53150,443,20661,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7804,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -11340,7 +11340,7 @@
                 "created": "2018-11-30T16:45:28.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:29 PA-220 1,2018/11/30 16:45:28,012801096514,THREAT,url,2049,2018/11/30 16:45:28,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:28,28585,1,53185,443,65438,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7805,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -11497,7 +11497,7 @@
                 "created": "2018-11-30T16:45:28.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:29 PA-220 1,2018/11/30 16:45:28,012801096514,THREAT,url,2049,2018/11/30 16:45:28,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:28,28462,1,53187,443,53101,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7806,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -11654,7 +11654,7 @@
                 "created": "2018-11-30T16:45:28.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:29 PA-220 1,2018/11/30 16:45:28,012801096514,THREAT,url,2049,2018/11/30 16:45:28,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:28,28839,1,53188,443,35463,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7807,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -11811,7 +11811,7 @@
                 "created": "2018-11-30T16:45:29.000+09:30",
                 "kind": "alert",
                 "original": "Nov 30 16:45:30 PA-220 1,2018/11/30 16:45:29,012801096514,THREAT,url,2049,2018/11/30 16:45:29,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:45:29,28400,1,53178,443,45769,443,0x403000,tcp,block-url,\"segment-data.zqtk.net/\",(9999),business-and-economy,informational,client-to-server,7808,0x2000000000000000,192.168.0.0-192.168.255.255,United States,0,,0,,,0,,,,,,,,0,0,0,0,0,,PA-220,,,,,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "+09:30",
                 "type": [
@@ -11968,7 +11968,7 @@
                 "created": "2021-11-16T16:24:30.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:24:30,007051000184334,THREAT,virus,2561,2021/11/16 16:24:30,89.160.20.156,67.43.156.12,81.2.69.193,67.43.156.12,LAn-TO-WAn,,,web-browsing,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:24:30,1450,2,51360,36524,37704,36524,0x502000,tcp,reset-both,\"browser\",Virus/Linux.example(419149938),medium-risk,medium,server-to-client,7031297127854637094,0x0,United States,China,,,0,,,1,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,elf,Antivirus-3901-4412,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:24:30.762-08:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -12156,7 +12156,7 @@
                 "created": "2021-11-16T16:24:05.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:24:05,007051000184334,THREAT,virus,2561,2021/11/16 16:24:05,89.160.20.156,67.43.156.12,81.2.69.193,67.43.156.12,LAn-TO-WAn,,,web-browsing,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:24:05,1451,1,51361,36524,24986,36524,0x502000,tcp,reset-both,\"browser\",Virus/Linux.example(419149938),medium-risk,medium,server-to-client,7031297127854637092,0x0,United States,China,,,0,,,1,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,elf,Antivirus-3901-4412,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:24:05.837-08:00,,,,internet-utility,general-internet,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,web-browsing,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -12344,7 +12344,7 @@
                 "created": "2021-11-16T16:23:55.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:23:55,007051000184334,THREAT,spyware,2561,2021/11/16 16:23:55,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:23:55,1448,1,59738,53,4993,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637090,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:23:55.782-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -12531,7 +12531,7 @@
                 "created": "2021-11-16T16:19:45.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:19:45,007051000184334,THREAT,spyware,2561,2021/11/16 16:19:45,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:19:45,1401,1,59189,53,53300,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637088,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:19:45.724-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -12715,7 +12715,7 @@
                 "created": "2021-11-16T16:13:19.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:13:19,007051000184334,THREAT,spyware,2561,2021/11/16 16:13:19,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:13:19,1290,1,59141,53,11524,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637082,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:13:19.974-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -12902,7 +12902,7 @@
                 "created": "2021-11-16T16:12:04.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:12:04,007051000184334,THREAT,spyware,2561,2021/11/16 16:12:04,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:12:04,1275,1,59707,53,8970,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637081,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:12:05.774-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -13089,7 +13089,7 @@
                 "created": "2021-11-16T16:11:24.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:11:24,007051000184334,THREAT,spyware,2561,2021/11/16 16:11:24,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:11:24,1263,1,57732,53,4137,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637080,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:11:25.659-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -13276,7 +13276,7 @@
                 "created": "2021-11-16T16:11:04.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:11:04,007051000184334,THREAT,spyware,2561,2021/11/16 16:11:04,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:11:04,1257,1,58456,53,3450,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637079,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:11:05.657-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -13463,7 +13463,7 @@
                 "created": "2021-11-16T16:10:44.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 16:10:44,007051000184334,THREAT,spyware,2561,2021/11/16 16:10:44,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 16:10:44,1245,1,57998,53,16281,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637078,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T16:10:45.653-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -13647,7 +13647,7 @@
                 "created": "2021-11-16T15:40:32.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 15:40:32,007051000184334,THREAT,spyware,2561,2021/11/16 15:40:32,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:40:32,972,1,59108,53,8224,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637069,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:40:32.221-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -13831,7 +13831,7 @@
                 "created": "2021-11-16T15:30:17.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 15:30:17,007051000184334,THREAT,spyware,2561,2021/11/16 15:30:17,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:30:17,881,1,59495,53,8571,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637066,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:30:17.132-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -14015,7 +14015,7 @@
                 "created": "2021-11-16T15:25:06.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 15:25:06,007051000184334,THREAT,spyware,2561,2021/11/16 15:25:06,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:25:06,827,1,59091,53,43821,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637063,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:25:07.057-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -14202,7 +14202,7 @@
                 "created": "2021-11-16T15:23:56.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 15:23:56,007051000184334,THREAT,spyware,2561,2021/11/16 15:23:56,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:23:56,810,1,59200,53,50584,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637058,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:23:57.037-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -14389,7 +14389,7 @@
                 "created": "2021-11-16T15:23:11.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 15:23:11,007051000184334,THREAT,spyware,2561,2021/11/16 15:23:11,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:23:11,799,1,58689,53,16219,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637057,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:23:12.026-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -14576,7 +14576,7 @@
                 "created": "2021-11-16T15:22:56.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 15:22:56,007051000184334,THREAT,spyware,2561,2021/11/16 15:22:56,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 15:22:56,789,1,59276,53,32921,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7031297127854637056,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T15:22:57.024-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -14765,7 +14765,7 @@
                 "created": "2021-11-16T11:29:34.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:29:34,007051000184334,THREAT,spyware,2561,2021/11/16 11:29:34,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:29:34,49252,1,58941,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735140,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:29:34.357-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -14941,7 +14941,7 @@
                 "created": "2021-11-16T11:29:34.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:29:34,007051000184334,THREAT,spyware,2561,2021/11/16 11:29:34,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:29:34,49251,1,58941,53,39925,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735139,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:29:34.356-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -15133,7 +15133,7 @@
                 "created": "2021-11-16T11:29:29.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:29:29,007051000184334,THREAT,spyware,2561,2021/11/16 11:29:29,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:29:29,49250,1,59424,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735138,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:29:29.356-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -15309,7 +15309,7 @@
                 "created": "2021-11-16T11:29:24.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:29:24,007051000184334,THREAT,spyware,2561,2021/11/16 11:29:24,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:29:24,49248,1,59424,53,47554,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735137,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:29:24.620-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -15498,7 +15498,7 @@
                 "created": "2021-11-16T11:17:58.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:17:58,007051000184334,THREAT,spyware,2561,2021/11/16 11:17:58,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:17:58,48952,1,57439,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735054,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:58.973-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -15674,7 +15674,7 @@
                 "created": "2021-11-16T11:17:53.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:17:53,007051000184334,THREAT,spyware,2561,2021/11/16 11:17:53,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:17:53,48947,1,57439,53,16531,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735053,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:53.974-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -15866,7 +15866,7 @@
                 "created": "2021-11-16T11:17:43.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:17:43,007051000184334,THREAT,spyware,2561,2021/11/16 11:17:43,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:17:43,48919,2,58744,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735044,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:43.973-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -16042,7 +16042,7 @@
                 "created": "2021-11-16T11:17:38.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:17:38,007051000184334,THREAT,spyware,2561,2021/11/16 11:17:38,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:17:38,48918,2,58744,53,24963,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735038,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:38.972-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -16234,7 +16234,7 @@
                 "created": "2021-11-16T11:17:38.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:17:38,007051000184334,THREAT,spyware,2561,2021/11/16 11:17:38,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:17:38,48917,1,57421,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735031,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:38.971-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -16410,7 +16410,7 @@
                 "created": "2021-11-16T11:17:33.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:17:33,007051000184334,THREAT,spyware,2561,2021/11/16 11:17:33,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:17:33,48916,1,57421,53,62251,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104735030,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:17:34.473-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -16602,7 +16602,7 @@
                 "created": "2021-11-16T11:15:08.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:15:08,007051000184334,THREAT,spyware,2561,2021/11/16 11:15:08,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:15:08,48826,1,57689,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734979,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:15:08.911-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -16778,7 +16778,7 @@
                 "created": "2021-11-16T11:15:08.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:15:08,007051000184334,THREAT,spyware,2561,2021/11/16 11:15:08,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:15:08,48823,1,57689,53,49041,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734977,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:15:08.910-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -16970,7 +16970,7 @@
                 "created": "2021-11-16T11:14:58.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:14:58,007051000184334,THREAT,spyware,2561,2021/11/16 11:14:58,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:14:58,48816,2,59499,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734973,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:58.908-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -17146,7 +17146,7 @@
                 "created": "2021-11-16T11:14:53.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:14:53,007051000184334,THREAT,spyware,2561,2021/11/16 11:14:53,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:14:53,48808,2,59499,53,8453,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734970,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:53.909-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -17338,7 +17338,7 @@
                 "created": "2021-11-16T11:14:48.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:14:48,007051000184334,THREAT,spyware,2561,2021/11/16 11:14:48,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:14:48,48804,1,58167,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734965,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:49.372-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -17519,7 +17519,7 @@
                 "created": "2021-11-16T11:14:13.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:14:13,007051000184334,THREAT,spyware,2561,2021/11/16 11:14:13,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:14:13,48794,1,57362,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734964,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:13.900-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -17695,7 +17695,7 @@
                 "created": "2021-11-16T11:14:08.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:14:08,007051000184334,THREAT,spyware,2561,2021/11/16 11:14:08,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:14:08,48793,1,57362,53,8723,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734963,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:08.899-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -17887,7 +17887,7 @@
                 "created": "2021-11-16T11:14:03.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:14:03,007051000184334,THREAT,spyware,2561,2021/11/16 11:14:03,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:14:03,48792,1,59250,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734962,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:04.367-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -18063,7 +18063,7 @@
                 "created": "2021-11-16T11:14:03.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:14:03,007051000184334,THREAT,spyware,2561,2021/11/16 11:14:03,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:14:03,48789,1,59250,53,61084,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734961,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:14:04.366-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -18255,7 +18255,7 @@
                 "created": "2021-11-16T11:13:48.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:13:48,007051000184334,THREAT,spyware,2561,2021/11/16 11:13:48,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:13:48,48786,1,58572,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734960,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:13:48.897-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -18431,7 +18431,7 @@
                 "created": "2021-11-16T11:13:43.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:13:43,007051000184334,THREAT,spyware,2561,2021/11/16 11:13:43,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:13:43,48776,1,58572,53,38616,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734959,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:13:43.900-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -18623,7 +18623,7 @@
                 "created": "2021-11-16T11:13:43.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:13:43,007051000184334,THREAT,spyware,2561,2021/11/16 11:13:43,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:13:43,48775,1,57763,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734954,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:13:43.900-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -18799,7 +18799,7 @@
                 "created": "2021-11-16T11:13:38.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:13:38,007051000184334,THREAT,spyware,2561,2021/11/16 11:13:38,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:13:38,48773,1,57763,53,39403,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734953,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:13:39.364-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -18988,7 +18988,7 @@
                 "created": "2021-11-16T11:08:38.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:08:38,007051000184334,THREAT,spyware,2561,2021/11/16 11:08:38,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:08:38,48682,1,59303,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734926,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:08:38.865-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -19164,7 +19164,7 @@
                 "created": "2021-11-16T11:08:33.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:08:33,007051000184334,THREAT,spyware,2561,2021/11/16 11:08:33,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:08:33,48681,1,59303,53,38104,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734925,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:08:33.864-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -19356,7 +19356,7 @@
                 "created": "2021-11-16T11:08:28.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:08:28,007051000184334,THREAT,spyware,2561,2021/11/16 11:08:28,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:08:28,48680,1,59271,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734924,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:08:28.863-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -19532,7 +19532,7 @@
                 "created": "2021-11-16T11:08:23.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:08:23,007051000184334,THREAT,spyware,2561,2021/11/16 11:08:23,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:08:23,48679,1,59271,53,51838,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734923,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:08:24.296-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -19724,7 +19724,7 @@
                 "created": "2021-11-16T11:07:23.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:07:23,007051000184334,THREAT,spyware,2561,2021/11/16 11:07:23,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:07:23,48657,1,58570,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734917,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:07:23.829-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -19900,7 +19900,7 @@
                 "created": "2021-11-16T11:07:23.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:07:23,007051000184334,THREAT,spyware,2561,2021/11/16 11:07:23,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:07:23,48656,1,58570,53,9367,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734916,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:07:23.829-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -20092,7 +20092,7 @@
                 "created": "2021-11-16T11:07:18.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:07:18,007051000184334,THREAT,spyware,2561,2021/11/16 11:07:18,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:07:18,48655,1,59762,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734915,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:07:18.829-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -20268,7 +20268,7 @@
                 "created": "2021-11-16T11:07:13.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:07:13,007051000184334,THREAT,spyware,2561,2021/11/16 11:07:13,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:07:13,48651,1,59762,53,26416,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734914,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:07:14.287-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -20455,7 +20455,7 @@
                 "created": "2021-11-16T11:06:48.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:48,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:48,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:48,48636,1,58503,53,62409,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734908,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:48.825-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -20647,7 +20647,7 @@
                 "created": "2021-11-16T11:06:43.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:43,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:43,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:43,48634,2,58503,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734906,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:43.825-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -20828,7 +20828,7 @@
                 "created": "2021-11-16T11:06:38.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:38,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:38,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:38,48630,2,58477,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734903,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:38.824-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -21004,7 +21004,7 @@
                 "created": "2021-11-16T11:06:33.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:33,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:33,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:33,48629,2,58477,53,39559,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734902,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:33.823-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -21196,7 +21196,7 @@
                 "created": "2021-11-16T11:06:28.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:28,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:28,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:28,48627,1,57709,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734901,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:28.823-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -21372,7 +21372,7 @@
                 "created": "2021-11-16T11:06:23.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:23,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:23,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:23,48626,1,57709,53,2447,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734899,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:23.822-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -21564,7 +21564,7 @@
                 "created": "2021-11-16T11:06:13.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:13,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:13,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:13,48617,2,58762,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734898,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:13.823-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -21740,7 +21740,7 @@
                 "created": "2021-11-16T11:06:13.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:13,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:13,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:13,48612,2,58762,53,3404,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734897,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:13.821-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -21932,7 +21932,7 @@
                 "created": "2021-11-16T11:06:08.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:08,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:08,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 11:06:08,48608,1,58258,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734896,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:09.281-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -22108,7 +22108,7 @@
                 "created": "2021-11-16T11:06:08.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 11:06:08,007051000184334,THREAT,spyware,2561,2021/11/16 11:06:08,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 11:06:08,48598,1,58258,53,36779,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104734893,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T11:06:09.279-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -22297,7 +22297,7 @@
                 "created": "2021-11-16T10:46:50.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:46:50,007051000184334,THREAT,spyware,2561,2021/11/16 10:46:50,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:46:50,32207,2,58714,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104719000,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:50.451-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -22473,7 +22473,7 @@
                 "created": "2021-11-16T10:46:45.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:46:45,007051000184334,THREAT,spyware,2561,2021/11/16 10:46:45,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:46:45,32203,2,58714,53,44895,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718999,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:45.424-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -22660,7 +22660,7 @@
                 "created": "2021-11-16T10:46:30.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:46:30,007051000184334,THREAT,spyware,2561,2021/11/16 10:46:30,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:46:30,32192,2,59157,53,43210,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718998,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:31.371-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -22852,7 +22852,7 @@
                 "created": "2021-11-16T10:46:30.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:46:30,007051000184334,THREAT,spyware,2561,2021/11/16 10:46:30,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:46:30,32191,3,58392,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718997,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:31.370-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -23033,7 +23033,7 @@
                 "created": "2021-11-16T10:46:20.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:46:20,007051000184334,THREAT,spyware,2561,2021/11/16 10:46:20,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:46:20,32187,1,58839,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718996,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:20.318-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -23209,7 +23209,7 @@
                 "created": "2021-11-16T10:46:20.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:46:20,007051000184334,THREAT,spyware,2561,2021/11/16 10:46:20,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:46:20,32184,2,58839,53,49708,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718995,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:46:20.317-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -23401,7 +23401,7 @@
                 "created": "2021-11-16T10:45:55.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:55,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:55,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:55,32175,1,57493,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718994,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:55.090-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -23577,7 +23577,7 @@
                 "created": "2021-11-16T10:45:55.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:55,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:55,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:55,32174,1,57493,53,23766,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718993,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:55.089-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -23764,7 +23764,7 @@
                 "created": "2021-11-16T10:45:45.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:45,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:45,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:45,32170,2,57937,53,33499,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718992,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:45.088-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -23956,7 +23956,7 @@
                 "created": "2021-11-16T10:45:45.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:45,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:45,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:45,32169,2,57937,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718991,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:45.088-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -24137,7 +24137,7 @@
                 "created": "2021-11-16T10:45:35.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:35,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:35,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:35,32165,2,58434,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718990,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:35.028-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -24313,7 +24313,7 @@
                 "created": "2021-11-16T10:45:30.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:30,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:30,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:30,32164,2,58434,53,7540,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718989,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:30.028-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -24505,7 +24505,7 @@
                 "created": "2021-11-16T10:45:25.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:25,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:25,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:25,32158,2,57951,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718988,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:25.027-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -24686,7 +24686,7 @@
                 "created": "2021-11-16T10:45:20.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:20,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:20,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:20,32157,1,58516,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718987,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:20.048-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -24862,7 +24862,7 @@
                 "created": "2021-11-16T10:45:20.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:20,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:20,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:20,32156,2,57951,53,26691,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718986,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:20.048-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -25049,7 +25049,7 @@
                 "created": "2021-11-16T10:45:20.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:20,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:20,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:20,32155,1,58516,53,38731,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718985,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:20.047-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -25241,7 +25241,7 @@
                 "created": "2021-11-16T10:45:15.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:15,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:15,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:15,32152,1,59591,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718984,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:15.022-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -25422,7 +25422,7 @@
                 "created": "2021-11-16T10:45:15.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:15,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:15,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:45:15,32150,1,58733,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718983,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:15.021-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -25598,7 +25598,7 @@
                 "created": "2021-11-16T10:45:15.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:15,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:15,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:15,32141,1,59591,53,59026,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718982,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:15.021-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -25782,7 +25782,7 @@
                 "created": "2021-11-16T10:45:10.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:45:10,007051000184334,THREAT,spyware,2561,2021/11/16 10:45:10,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:45:10,32137,1,58733,53,24928,53,0x403000,udp,drop-packet,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718981,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:45:10.136-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -25971,7 +25971,7 @@
                 "created": "2021-11-16T10:41:24.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:41:24,007051000184334,THREAT,spyware,2561,2021/11/16 10:41:24,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:41:24,32055,1,59535,53,0,0,0x3000,udp,drop,\"www.xiaz.xyz\",generic:www.xiaz.xyz(421497696),any,medium,client-to-server,7029847907104718980,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:41:24.982-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -26147,7 +26147,7 @@
                 "created": "2021-11-16T10:41:19.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:41:19,007051000184334,THREAT,spyware,2561,2021/11/16 10:41:19,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:41:19,32053,1,59535,53,16245,53,0x403000,udp,drop,\"www.xiaz.xyz\",generic:www.xiaz.xyz(421497696),any,medium,client-to-server,7029847907104718979,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:41:19.983-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -26339,7 +26339,7 @@
                 "created": "2021-11-16T10:41:19.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:41:19,007051000184334,THREAT,spyware,2561,2021/11/16 10:41:19,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:41:19,32052,1,57359,53,0,0,0x3000,udp,drop,\"www.xiaz.xyz\",generic:www.xiaz.xyz(421497696),any,medium,client-to-server,7029847907104718978,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:41:19.982-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -26515,7 +26515,7 @@
                 "created": "2021-11-16T10:41:14.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:41:14,007051000184334,THREAT,spyware,2561,2021/11/16 10:41:14,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:41:14,32045,1,57359,53,28021,53,0x403000,udp,drop-packet,\"www.xiaz.xyz\",generic:www.xiaz.xyz(421497696),any,medium,client-to-server,7029847907104718977,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:41:14.992-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -26699,7 +26699,7 @@
                 "created": "2021-11-16T10:28:44.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:28:44,007051000184334,THREAT,spyware,2561,2021/11/16 10:28:44,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:28:44,31811,1,58771,53,48581,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718976,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:44.802-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -26891,7 +26891,7 @@
                 "created": "2021-11-16T10:28:39.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:28:39,007051000184334,THREAT,spyware,2561,2021/11/16 10:28:39,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:28:39,31804,1,58771,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718975,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:39.801-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -27072,7 +27072,7 @@
                 "created": "2021-11-16T10:28:34.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:28:34,007051000184334,THREAT,spyware,2561,2021/11/16 10:28:34,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:28:34,31801,2,57508,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718974,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:34.801-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -27248,7 +27248,7 @@
                 "created": "2021-11-16T10:28:29.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:28:29,007051000184334,THREAT,spyware,2561,2021/11/16 10:28:29,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:28:29,31800,2,57508,53,43363,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718973,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:29.800-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -27440,7 +27440,7 @@
                 "created": "2021-11-16T10:28:24.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:28:24,007051000184334,THREAT,spyware,2561,2021/11/16 10:28:24,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:28:24,31799,1,59397,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718972,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:25.768-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -27616,7 +27616,7 @@
                 "created": "2021-11-16T10:28:24.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:28:24,007051000184334,THREAT,spyware,2561,2021/11/16 10:28:24,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:28:24,31798,1,59397,53,34018,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718971,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:28:25.767-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -27808,7 +27808,7 @@
                 "created": "2021-11-16T10:27:49.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:49,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:49,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:49,31787,1,59777,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718970,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:49.795-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -27984,7 +27984,7 @@
                 "created": "2021-11-16T10:27:44.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:44,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:44,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:44,31781,2,59148,53,41708,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718969,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:45.763-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -28176,7 +28176,7 @@
                 "created": "2021-11-16T10:27:44.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:44,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:44,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:44,31779,1,59148,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718968,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:45.762-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -28352,7 +28352,7 @@
                 "created": "2021-11-16T10:27:34.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:34,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:34,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:34,31777,1,58514,53,34803,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718967,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:34.757-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -28544,7 +28544,7 @@
                 "created": "2021-11-16T10:27:29.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:29,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:29,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:29,31775,2,58993,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718966,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:29.758-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -28720,7 +28720,7 @@
                 "created": "2021-11-16T10:27:24.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:24,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:24,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:24,31774,1,58993,53,14335,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718965,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:24.756-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -28912,7 +28912,7 @@
                 "created": "2021-11-16T10:27:19.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:19,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:19,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:19,31770,2,59215,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718964,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:19.756-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -29088,7 +29088,7 @@
                 "created": "2021-11-16T10:27:14.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:14,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:14,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:14,31766,2,59215,53,58034,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718963,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:14.755-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -29275,7 +29275,7 @@
                 "created": "2021-11-16T10:27:04.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:04,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:04,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:27:04,31762,1,57615,53,65092,53,0x403000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718962,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:04.776-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -29467,7 +29467,7 @@
                 "created": "2021-11-16T10:27:04.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:27:04,007051000184334,THREAT,spyware,2561,2021/11/16 10:27:04,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:27:04,31761,2,58004,53,0,0,0x3000,udp,drop,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718961,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:27:04.776-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -29643,7 +29643,7 @@
                 "created": "2021-11-16T10:26:59.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:26:59,007051000184334,THREAT,spyware,2561,2021/11/16 10:26:59,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:26:59,31760,1,58004,53,50075,53,0x403000,udp,drop-packet,\"sabaint.me\",generic:sabaint.me(418218978),any,medium,client-to-server,7029847907104718960,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:26:59.749-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },
@@ -29832,7 +29832,7 @@
                 "created": "2021-11-16T10:12:09.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:12:09,007051000184334,THREAT,spyware,2561,2021/11/16 10:12:09,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:12:09,31425,2,58480,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718955,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:12:09.249-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -30008,7 +30008,7 @@
                 "created": "2021-11-16T10:12:04.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:12:04,007051000184334,THREAT,spyware,2561,2021/11/16 10:12:04,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:12:04,31424,2,58480,53,28628,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718954,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:12:04.291-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -30195,7 +30195,7 @@
                 "created": "2021-11-16T10:11:34.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:11:34,007051000184334,THREAT,spyware,2561,2021/11/16 10:11:34,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:11:34,31415,1,59487,53,17390,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718953,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:34.244-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -30387,7 +30387,7 @@
                 "created": "2021-11-16T10:11:29.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:11:29,007051000184334,THREAT,spyware,2561,2021/11/16 10:11:29,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:11:29,31412,2,58329,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718952,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:29.243-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -30563,7 +30563,7 @@
                 "created": "2021-11-16T10:11:24.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:11:24,007051000184334,THREAT,spyware,2561,2021/11/16 10:11:24,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:11:24,31411,1,58329,53,39886,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718951,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:24.243-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -30755,7 +30755,7 @@
                 "created": "2021-11-16T10:11:14.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:11:14,007051000184334,THREAT,spyware,2561,2021/11/16 10:11:14,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:11:14,31409,1,57978,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718950,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:14.242-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -30931,7 +30931,7 @@
                 "created": "2021-11-16T10:11:09.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:11:09,007051000184334,THREAT,spyware,2561,2021/11/16 10:11:09,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:11:09,31402,3,59191,53,1563,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718949,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:09.241-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -31123,7 +31123,7 @@
                 "created": "2021-11-16T10:11:04.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:11:04,007051000184334,THREAT,spyware,2561,2021/11/16 10:11:04,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:11:04,31401,2,59191,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718948,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:11:04.241-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -31304,7 +31304,7 @@
                 "created": "2021-11-16T10:10:54.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:10:54,007051000184334,THREAT,spyware,2561,2021/11/16 10:10:54,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:10:54,31397,2,59725,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718947,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:54.240-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -31480,7 +31480,7 @@
                 "created": "2021-11-16T10:10:54.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:10:54,007051000184334,THREAT,spyware,2561,2021/11/16 10:10:54,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:10:54,31390,2,59725,53,30685,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718946,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:54.239-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -31672,7 +31672,7 @@
                 "created": "2021-11-16T10:10:44.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:10:44,007051000184334,THREAT,spyware,2561,2021/11/16 10:10:44,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:10:44,31381,2,57339,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718945,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:44.233-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -31848,7 +31848,7 @@
                 "created": "2021-11-16T10:10:39.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:10:39,007051000184334,THREAT,spyware,2561,2021/11/16 10:10:39,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:10:39,31380,2,57339,53,64069,53,0x403000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718944,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:39.233-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -32040,7 +32040,7 @@
                 "created": "2021-11-16T10:10:39.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:10:39,007051000184334,THREAT,spyware,2561,2021/11/16 10:10:39,89.160.20.156,89.160.20.112,,,intrazone-default,,,dns,vsys1,LAN,LAN,ethernet1/2,ethernet1/2,LFPpan,2021/11/16 10:10:39,31379,1,58903,53,0,0,0x3000,udp,drop,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718943,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,731c6b1a-9a62-4a92-a49c-0876025f9436,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:39.233-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30",
                 "type": [
@@ -32216,7 +32216,7 @@
                 "created": "2021-11-16T10:10:34.000+09:30",
                 "kind": "alert",
                 "original": "1,2021/11/16 10:10:34,007051000184334,THREAT,spyware,2561,2021/11/16 10:10:34,89.160.20.156,67.43.156.13,81.2.69.193,67.43.156.13,LAn-TO-WAn,,,dns,vsys1,LAN,WAN,ethernet1/2,ethernet1/1,LFPpan,2021/11/16 10:10:34,31373,1,58903,53,26180,53,0x403000,udp,drop-packet,\"www.virussign.com\",generic:www.virussign.com(327891564),any,medium,client-to-server,7029847907104718942,0x0,United States,United States,,,0,,,0,,,,,,,,0,0,0,0,0,,PA-VM,,,,,0,,0,,N/A,dns-malware,AppThreat-0-0,0x0,0,4294967295,,,5aa3aaa9-610a-433a-8aaa-729378021aaa,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-11-16T10:10:35.294-08:00,,,,infrastructure,networking,network-protocol,3,\"used-by-malware,has-known-vulnerability,pervasive-use\",,dns,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 3,
                 "timezone": "+09:30"
             },

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-traffic-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-traffic-sample.log-expected.json
@@ -14526,7 +14526,7 @@
                 "end": "2018-11-30T16:09:16.000Z",
                 "kind": "event",
                 "original": "Nov 30 16:09:49 PA-220 1,2018/11/30 16:09:49,012801096514,TRAFFIC,end,2049,2018/11/30 16:09:49,192.168.15.196,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24258,1,54659,53,19658,53,0x400019,udp,drop ICMP,340,148,192,4,2018/11/30 16:09:16,0,any,0,32091189,0x0,192.168.0.0-192.168.255.255,United States,0,2,2,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
-                "outcome": "success",
+                "outcome": "failure",
                 "start": "2018-11-30T16:09:16.000Z",
                 "timezone": "UTC",
                 "type": [
@@ -14714,7 +14714,7 @@
                 "end": "2018-11-30T16:09:16.000Z",
                 "kind": "event",
                 "original": "Nov 30 16:09:49 PA-220 1,2018/11/30 16:09:49,012801096514,TRAFFIC,end,2049,2018/11/30 16:09:49,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24155,1,57446,53,64352,53,0x400019,udp,reset client,291,83,208,2,2018/11/30 16:09:16,0,any,0,32091190,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
-                "outcome": "success",
+                "outcome": "failure",
                 "start": "2018-11-30T16:09:16.000Z",
                 "timezone": "UTC",
                 "type": [
@@ -14902,7 +14902,7 @@
                 "end": "2018-11-30T16:09:16.000Z",
                 "kind": "event",
                 "original": "Nov 30 16:09:49 PA-220 1,2018/11/30 16:09:49,012801096514,TRAFFIC,end,2049,2018/11/30 16:09:49,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,dns,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24232,1,22655,53,60126,53,0x400019,udp,reset server,184,84,100,2,2018/11/30 16:09:16,0,any,0,32091191,0x0,192.168.0.0-192.168.255.255,United States,0,1,1,aged-out,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
-                "outcome": "success",
+                "outcome": "failure",
                 "start": "2018-11-30T16:09:16.000Z",
                 "timezone": "UTC",
                 "type": [
@@ -15090,7 +15090,7 @@
                 "end": "2018-11-30T16:09:31.000Z",
                 "kind": "event",
                 "original": "Nov 30 16:09:49 PA-220 1,2018/11/30 16:09:49,012801096514,TRAFFIC,end,2049,2018/11/30 16:09:49,192.168.15.224,175.16.199.1,192.168.1.63,175.16.199.1,new_outbound_from_trust,,,ssl,vsys1,trust,untrust,ethernet1/2,ethernet1/1,send_to_mac,2018/11/30 16:09:49,24330,1,52509,443,59771,443,0x40001a,tcp,reset both,9290,2053,7237,24,2018/11/30 16:09:21,10,business-and-economy,0,32091192,0x0,192.168.0.0-192.168.255.255,United States,0,13,11,tcp-rst-from-client,0,0,0,0,,PA-220,from-policy,,,0,,0,,N/A,0,0,0,0",
-                "outcome": "success",
+                "outcome": "failure",
                 "start": "2018-11-30T16:09:21.000Z",
                 "timezone": "UTC",
                 "type": [

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-tunnel-inspection-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-tunnel-inspection-sample.log-expected.json
@@ -41,7 +41,7 @@
                 "end": "2061-01-06T08:16:14.930Z",
                 "kind": "event",
                 "original": "1,2021/11/23 00:44:44,1234567890,START,start,2561,2021/11/23 00:44:44,10.0.0.10,175.16.199.1,10.0.0.20,10.0.0.30,rule,,d-user,app,vsys,s-zone,d-zone,inbound,outbound,log,,id,100,9000,9550,9200,9300,0,tcp,action,4,1000,user,src-loc,dst-loc,0,0,0,0,vsys-name,d-name,imsi,imei,1000,1000,1000,10,10,10,10,10,10,20,200,75,50,1000,1000,end,action,2021-11-23T00:44:44.930-08:00,1234567890,rule1,81.2.69.192,100,100,pcap,dug,100,100,2021-11-23T00:44:44.930-08:00,asd,ast,100,app-sc,cat,tech,4,char,con,no,no",
-                "outcome": "success",
+                "outcome": "failure",
                 "start": "2021-11-23T08:44:44.930Z",
                 "type": [
                     "start",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-userid-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-userid-sample.log-expected.json
@@ -16,8 +16,7 @@
                 "code": "0",
                 "created": "2021-03-24T11:00:49.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/03/24 11:00:49,013101001305,USERID,login,2305,2021/03/24 11:00:49,vsys1,81.2.69.193,domain\\name,,0,1,10800,0,0,\u003cdata-source-collected\u003e,\u003cdata-source-type\u003e,1252774,0x0,0,0,0,0,,FW01,1,,2021/03/24 11:00:49,1,0x80000000,name",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/03/24 11:00:49,013101001305,USERID,login,2305,2021/03/24 11:00:49,vsys1,81.2.69.193,domain\\name,,0,1,10800,0,0,\u003cdata-source-collected\u003e,\u003cdata-source-type\u003e,1252774,0x0,0,0,0,0,,FW01,1,,2021/03/24 11:00:49,1,0x80000000,name"
             },
             "message": "vsys1,81.2.69.193,domain\\name,,0,1,10800,0,0,\u003cdata-source-collected\u003e,\u003cdata-source-type\u003e,1252774,0x0,0,0,0,0,,FW01,1,,2021/03/24 11:00:49,1,0x80000000,name",
             "network": {
@@ -121,8 +120,7 @@
                 "code": "0",
                 "created": "2021-03-24T10:59:45.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/03/24 10:59:45,013101001305,USERID,logout,2305,2021/03/24 10:59:45,vsys1,10.55.18.7,domain\\name,,0,1,0,0,0,\u003cdata-source-collected\u003e,\u003cdata-source-type\u003e,1252765,0x0,0,0,0,0,,FW01,1,,2021/03/24 10:59:45,1,0x80000000,name",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/03/24 10:59:45,013101001305,USERID,logout,2305,2021/03/24 10:59:45,vsys1,10.55.18.7,domain\\name,,0,1,0,0,0,\u003cdata-source-collected\u003e,\u003cdata-source-type\u003e,1252765,0x0,0,0,0,0,,FW01,1,,2021/03/24 10:59:45,1,0x80000000,name"
             },
             "message": "vsys1,10.55.18.7,domain\\name,,0,1,0,0,0,\u003cdata-source-collected\u003e,\u003cdata-source-type\u003e,1252765,0x0,0,0,0,0,,FW01,1,,2021/03/24 10:59:45,1,0x80000000,name",
             "network": {
@@ -214,8 +212,7 @@
                 "code": "0",
                 "created": "2013-03-28T12:53:05.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,1,0x0",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,1,0x0"
             },
             "message": "vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,1,0x0",
             "network": {
@@ -294,8 +291,7 @@
                 "code": "0",
                 "created": "2013-03-28T12:53:05.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,2,0x0",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,2,0x0"
             },
             "message": "vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,2,0x0",
             "network": {
@@ -374,8 +370,7 @@
                 "code": "0",
                 "created": "2013-03-28T12:53:05.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,3,0x0",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,3,0x0"
             },
             "message": "vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,3,0x0",
             "network": {
@@ -454,8 +449,7 @@
                 "code": "0",
                 "created": "2013-03-28T12:53:05.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,4,0x0",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2013/03/28 12:53:05,001701000225,USERID,login,12,2013/03/28 12:53:05,vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,4,0x0"
             },
             "message": "vsys1,172.17.128.92,plano2008r2\\administrator,test,0,1,2700,0,0,active-directory,unknown,4,0x0",
             "network": {
@@ -534,8 +528,7 @@
                 "code": "0",
                 "created": "2021-04-05T14:52:16.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/04/05 14:52:16,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:52:16,vsys1,10.68.2.9,domain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277996,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:16,1,0x80000000,admin",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/04/05 14:52:16,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:52:16,vsys1,10.68.2.9,domain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277996,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:16,1,0x80000000,admin"
             },
             "message": "vsys1,10.68.2.9,domain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277996,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:16,1,0x80000000,admin",
             "network": {
@@ -627,8 +620,7 @@
                 "code": "0",
                 "created": "2021-04-05T14:52:33.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/04/05 14:52:33,\u003cserial-number\u003e,USERID,logout,2305,2021/04/05 14:52:33,vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1277997,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:34,1,0x80000000,admin",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/04/05 14:52:33,\u003cserial-number\u003e,USERID,logout,2305,2021/04/05 14:52:33,vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1277997,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:34,1,0x80000000,admin"
             },
             "message": "vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1277997,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:52:34,1,0x80000000,admin",
             "network": {
@@ -720,8 +712,7 @@
                 "code": "0",
                 "created": "2021-04-05T14:53:10.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:10,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:53:10,vsys1,10.68.2.9,subdomain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277998,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:11,1,0x80000000,admin",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:10,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:53:10,vsys1,10.68.2.9,subdomain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277998,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:11,1,0x80000000,admin"
             },
             "message": "vsys1,10.68.2.9,subdomain\\admin,,0,1,10800,0,0,vpn-client,globalprotect,1277998,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:11,1,0x80000000,admin",
             "network": {
@@ -813,8 +804,7 @@
                 "code": "0",
                 "created": "2021-04-05T14:53:31.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:31,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:53:31,vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1277999,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,admin",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:31,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:53:31,vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1277999,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,admin"
             },
             "message": "vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1277999,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,admin",
             "network": {
@@ -905,8 +895,7 @@
                 "code": "0",
                 "created": "2021-04-05T14:53:31.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:31,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:53:31,vsys1,10.68.2.9,user,,0,1,10800,0,0,vpn-client,globalprotect,1278000,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,user",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:31,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:53:31,vsys1,10.68.2.9,user,,0,1,10800,0,0,vpn-client,globalprotect,1278000,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,user"
             },
             "message": "vsys1,10.68.2.9,user,,0,1,10800,0,0,vpn-client,globalprotect,1278000,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:31,1,0x80000000,user",
             "network": {
@@ -997,8 +986,7 @@
                 "code": "0",
                 "created": "2021-04-05T14:53:49.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:49,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:53:49,vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1278001,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:49,1,0x80000000,admin",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:49,\u003cserial-number\u003e,USERID,login,2305,2021/04/05 14:53:49,vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1278001,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:49,1,0x80000000,admin"
             },
             "message": "vsys1,10.68.2.9,admin,,0,1,10800,0,0,vpn-client,globalprotect,1278001,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:49,1,0x80000000,admin",
             "network": {
@@ -1089,8 +1077,7 @@
                 "code": "0",
                 "created": "2021-04-05T14:53:52.000Z",
                 "kind": "event",
-                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:52,\u003cserial-number\u003e,USERID,logout,2305,2021/04/05 14:53:52,vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1278002,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:52,1,0x80000000,admin",
-                "outcome": "success"
+                "original": "Nov 30 16:09:08 1,2021/04/05 14:53:52,\u003cserial-number\u003e,USERID,logout,2305,2021/04/05 14:53:52,vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1278002,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:52,1,0x80000000,admin"
             },
             "message": "vsys1,10.68.2.9,domain\\admin,,0,1,0,0,0,vpn-client,globalprotect,1278002,0x0,0,0,0,0,,CORE-FW,1,,2021/04/05 14:53:52,1,0x80000000,admin",
             "network": {

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/authentication.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/authentication.yml
@@ -68,6 +68,11 @@ processors:
       value:
         - authentication
 
+# Set event.outcome
+  - set:
+      field: event.outcome
+      value: success
+
 # Set custom fields to ECS fields
   - set:
       field: observer.hostname

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/config.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/config.yml
@@ -77,6 +77,20 @@ processors:
       copy_from: panw.panos.device_name
       ignore_failure: true
 
+# Set event.outcome from panw.panos.result: documented allowed values are Submitted, Succeeded, Failed, and Unauthorized
+  - set:
+      if: ctx.panw?.panos?.result == "Succeeded"
+      field: event.outcome
+      value: success
+  - set:
+      if: ctx.panw?.panos?.result == "Failed"
+      field: event.outcome
+      value: failure
+  - set:
+      if: ctx.event?.outcome == null || ctx.event.outcome == ""
+      field: event.outcome
+      value: unknown
+
 on_failure:
   - append:
       field: error.message

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/correlated_event.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/correlated_event.yml
@@ -31,6 +31,11 @@ processors:
       value:
         - network
 
+# Set event.outcome
+  - set:
+      field: event.outcome
+      value: success
+
 # Set custom fields to ECS fields
   - set:
       field: log.level

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/decryption.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/decryption.yml
@@ -155,6 +155,16 @@ processors:
       value:
         - network
 
+# Set event.outcome from panw.panos.error_message: a non-empty error would indicate a failure.
+  - set:
+      if: ctx.panw?.panos?.error_message == null || ctx.panw.panos.error_message == ""
+      field: event.outcome
+      value: success
+  - set:
+      if: ctx.panw?.panos?.error_message != ""
+      field: event.outcome
+      value: failure
+
 # Set custom fields to ECS fields
   - set:
       field: panw.panos.hash

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -1043,9 +1043,6 @@ processors:
       field: event.type
       value: denied
       if: "ctx.panw?.panos?.action != null && ['deny', 'drop', 'reset-client', 'reset-server', 'reset-both', 'block-url', 'block-ip', 'random-drop', 'sinkhole', 'block'].contains(ctx.panw.panos.action)"
-  - set:
-      field: event.outcome
-      value: success
 
 # event.action for traffic, gtp and tunnel inspection logs.
   - set:

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/threat.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/threat.yml
@@ -150,6 +150,19 @@ processors:
         - threat
         - network
 
+# Set event.outcome from panw.panos.action: allowable values:
+#  alert, allow, deny, drop, reset-client, reset-server, reset-both, block-url,
+#  block-ip, random-drop, sinkhole, syncookie-sent, block-continue, continue,
+#  block-override, override-lockout, override and block
+  - set:
+      if: ctx.panw?.panos?.action != null && ["alert", "allow", "continue"].contains(ctx.panw.panos.action)
+      field: event.outcome
+      value: success
+  - set:
+      if: ctx.event?.outcome == null || ctx.event.outcome == ""
+      field: event.outcome
+      value: failure
+
 # Set network.forwarded_ip field
   - convert:
       field: _temp_.forwarded_ip

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
@@ -128,6 +128,17 @@ processors:
       value:
         - network
 
+# Set event.outcome from panw.panos.action: allowable values:
+#  allow, deny, drop, drop ICMP, reset both, reset client, and reset server
+  - set:
+      if: ctx.panw?.panos?.action == "allow"
+      field: event.outcome
+      value: success
+  - set:
+      if: ctx.event?.outcome == null || ctx.event.outcome == ""
+      field: event.outcome
+      value: failure
+
 # Set custom fields to ECS fields
   - set:
       field: destination.bytes

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/tunnel_inspection.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/tunnel_inspection.yml
@@ -92,6 +92,17 @@ processors:
       value:
         - network
 
+# Set event.outcome from panw.panos.action: allowable values:
+#  allow, deny, drop, drop ICMP, reset both, reset client, and reset server
+  - set:
+      if: ctx.panw?.panos?.action == "allow"
+      field: event.outcome
+      value: success
+  - set:
+      if: ctx.event?.outcome == null || ctx.event.outcome == ""
+      field: event.outcome
+      value: failure
+
 # Set custom fields to ECS fields
   - set:
       field: destination.bytes

--- a/packages/panw/data_stream/panos/sample_event.json
+++ b/packages/panw/data_stream/panos/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2012-04-10T04:39:56.000Z",
     "agent": {
-        "ephemeral_id": "7020cf01-7612-4194-9da0-390244968573",
-        "id": "9cfce01d-2b4b-49d1-8777-572f0a4da3bc",
+        "ephemeral_id": "c6ec5509-7ac3-414d-93ac-638efeaf799f",
+        "id": "19fc4a39-4777-4ea9-8980-3fd25ad3216f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.1"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "panw.panos",
@@ -30,12 +30,12 @@
         "port": 80
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "9cfce01d-2b4b-49d1-8777-572f0a4da3bc",
+        "id": "19fc4a39-4777-4ea9-8980-3fd25ad3216f",
         "snapshot": false,
-        "version": "8.2.1"
+        "version": "8.4.1"
     },
     "event": {
         "action": "url_filtering",
@@ -47,8 +47,9 @@
         ],
         "created": "2012-10-30T09:46:12.000Z",
         "dataset": "panw.panos",
-        "ingested": "2022-07-11T14:27:45Z",
+        "ingested": "2022-10-27T05:10:33Z",
         "kind": "alert",
+        "original": "\u003c14\u003eNov 30 16:09:08 PA-220 1,2012/10/30 09:46:12,01606001116,THREAT,url,1,2012/04/10 04:39:56,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
         "outcome": "success",
         "severity": 5,
         "timezone": "+00:00",
@@ -57,7 +58,7 @@
         ]
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "labels": {
         "captive_portal": true,
@@ -66,7 +67,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.208.7:36957"
+            "address": "192.168.128.4:36614"
         },
         "syslog": {
             "facility": {
@@ -154,6 +155,7 @@
         }
     },
     "tags": [
+        "preserve_original_event",
         "panw-panos",
         "forwarded"
     ],

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -32,11 +32,11 @@ An example event for `panos` looks as following:
 {
     "@timestamp": "2012-04-10T04:39:56.000Z",
     "agent": {
-        "ephemeral_id": "7020cf01-7612-4194-9da0-390244968573",
-        "id": "9cfce01d-2b4b-49d1-8777-572f0a4da3bc",
+        "ephemeral_id": "c6ec5509-7ac3-414d-93ac-638efeaf799f",
+        "id": "19fc4a39-4777-4ea9-8980-3fd25ad3216f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.1"
+        "version": "8.4.1"
     },
     "data_stream": {
         "dataset": "panw.panos",
@@ -61,12 +61,12 @@ An example event for `panos` looks as following:
         "port": 80
     },
     "ecs": {
-        "version": "8.3.0"
+        "version": "8.4.0"
     },
     "elastic_agent": {
-        "id": "9cfce01d-2b4b-49d1-8777-572f0a4da3bc",
+        "id": "19fc4a39-4777-4ea9-8980-3fd25ad3216f",
         "snapshot": false,
-        "version": "8.2.1"
+        "version": "8.4.1"
     },
     "event": {
         "action": "url_filtering",
@@ -78,8 +78,9 @@ An example event for `panos` looks as following:
         ],
         "created": "2012-10-30T09:46:12.000Z",
         "dataset": "panw.panos",
-        "ingested": "2022-07-11T14:27:45Z",
+        "ingested": "2022-10-27T05:10:33Z",
         "kind": "alert",
+        "original": "\u003c14\u003eNov 30 16:09:08 PA-220 1,2012/10/30 09:46:12,01606001116,THREAT,url,1,2012/04/10 04:39:56,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
         "outcome": "success",
         "severity": 5,
         "timezone": "+00:00",
@@ -88,7 +89,7 @@ An example event for `panos` looks as following:
         ]
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "labels": {
         "captive_portal": true,
@@ -97,7 +98,7 @@ An example event for `panos` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.208.7:36957"
+            "address": "192.168.128.4:36614"
         },
         "syslog": {
             "facility": {
@@ -185,6 +186,7 @@ An example event for `panos` looks as following:
         }
     },
     "tags": [
+        "preserve_original_event",
         "panw-panos",
         "forwarded"
     ],

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: 3.1.1
+version: 3.1.2
 release: ga
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This makes `event.outcome` dependent on event actions and results where appropriate. In some cases `event.outcome` is left empty as the original event does not have a success/failure state.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4495

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
