### PR TITLE
cisco_duo: drop messages that hold no events

### DIFF
--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.2"
+  changes:
+    - description: Fix handling of empty event lists.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/4514
 - version: "1.5.1"
   changes:
     - description: Use ECS geo.location definition.

--- a/packages/cisco_duo/data_stream/admin/_dev/test/pipeline/test-empty.log
+++ b/packages/cisco_duo/data_stream/admin/_dev/test/pipeline/test-empty.log
@@ -1,0 +1,1 @@
+{"response":[],"stat":"OK"}

--- a/packages/cisco_duo/data_stream/admin/_dev/test/pipeline/test-empty.log-expected.json
+++ b/packages/cisco_duo/data_stream/admin/_dev/test/pipeline/test-empty.log-expected.json
@@ -1,0 +1,17 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "kind": "event",
+                "original": "{\"response\":[],\"stat\":\"OK\"}",
+                "outcome": "success"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_duo/data_stream/admin/_dev/test/pipeline/test-empty.log-expected.json
+++ b/packages/cisco_duo/data_stream/admin/_dev/test/pipeline/test-empty.log-expected.json
@@ -1,17 +1,5 @@
 {
     "expected": [
-        {
-            "ecs": {
-                "version": "8.4.0"
-            },
-            "event": {
-                "kind": "event",
-                "original": "{\"response\":[],\"stat\":\"OK\"}",
-                "outcome": "success"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        }
+        null
     ]
 }

--- a/packages/cisco_duo/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -15,6 +15,7 @@ request.transforms:
       value: '[[sprintf "Basic %s" (base64Encode (sprintf "%s:%s" "{{integration_key}}" (hmac "sha1" "{{secret_key}}" (formatDate (now) "Mon, 02 Jan 2006 15:04:05 -0700") "\n" "GET" "\n" .url.Host "\n" "/admin/v1/logs/administrator" "\n" .url.RawQuery)))]]'
 response.split:
   target: body.response
+  ignore_empty_value: true
 cursor:
   last_published:
     value: '[[toInt .last_event.timestamp]]'

--- a/packages/cisco_duo/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,8 @@ processors:
       field: event.original
       target_field: json
       ignore_failure: true
+  - drop:
+      if: ctx.json?.response instanceof List && ctx.json.response.length == 0
   - fingerprint:
       fields:
         - json.timestamp

--- a/packages/cisco_duo/data_stream/auth/_dev/test/pipeline/test-empty.log
+++ b/packages/cisco_duo/data_stream/auth/_dev/test/pipeline/test-empty.log
@@ -1,0 +1,1 @@
+{"response":{"authlogs":[]},"stat":"OK"}

--- a/packages/cisco_duo/data_stream/auth/_dev/test/pipeline/test-empty.log-expected.json
+++ b/packages/cisco_duo/data_stream/auth/_dev/test/pipeline/test-empty.log-expected.json
@@ -1,0 +1,30 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "error": {
+                "message": [
+                    "field [access_device] not present as part of path [json.access_device.ip]"
+                ]
+            },
+            "event": {
+                "category": "authentication",
+                "kind": "event",
+                "original": "{\"response\":{\"authlogs\":[]},\"stat\":\"OK\"}",
+                "outcome": "failure",
+                "type": "info"
+            },
+            "json": {
+                "response": {
+                    "authlogs": []
+                },
+                "stat": "OK"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_duo/data_stream/auth/_dev/test/pipeline/test-empty.log-expected.json
+++ b/packages/cisco_duo/data_stream/auth/_dev/test/pipeline/test-empty.log-expected.json
@@ -1,30 +1,5 @@
 {
     "expected": [
-        {
-            "ecs": {
-                "version": "8.4.0"
-            },
-            "error": {
-                "message": [
-                    "field [access_device] not present as part of path [json.access_device.ip]"
-                ]
-            },
-            "event": {
-                "category": "authentication",
-                "kind": "event",
-                "original": "{\"response\":{\"authlogs\":[]},\"stat\":\"OK\"}",
-                "outcome": "failure",
-                "type": "info"
-            },
-            "json": {
-                "response": {
-                    "authlogs": []
-                },
-                "stat": "OK"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        }
+        null
     ]
 }

--- a/packages/cisco_duo/data_stream/auth/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/auth/agent/stream/httpjson.yml.hbs
@@ -24,6 +24,7 @@ request.transforms:
       value: '[[sprintf "Basic %s" (base64Encode (sprintf "%s:%s" "{{integration_key}}" (hmac "sha1" "{{secret_key}}" (formatDate (now) "Mon, 02 Jan 2006 15:04:05 -0700") "\n" "GET" "\n" .url.Host "\n" "/admin/v2/logs/authentication" "\n" .url.RawQuery)))]]'
 response.split:
   target: body.response.authlogs
+  ignore_empty_value: true
 cursor:
   last_published:
     value: '[[mul (toInt .last_event.timestamp) 1000]]'

--- a/packages/cisco_duo/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,8 @@ processors:
       field: event.original
       target_field: json
       ignore_failure: true
+  - drop:
+      if: ctx.json?.response?.authlogs instanceof List && ctx.json.response.authlogs.length == 0
   - fingerprint:
       fields:
         - json.timestamp

--- a/packages/cisco_duo/data_stream/offline_enrollment/_dev/test/pipeline/test-empty.log
+++ b/packages/cisco_duo/data_stream/offline_enrollment/_dev/test/pipeline/test-empty.log
@@ -1,0 +1,1 @@
+{"response": [], "stat": "OK"}

--- a/packages/cisco_duo/data_stream/offline_enrollment/_dev/test/pipeline/test-empty.log-expected.json
+++ b/packages/cisco_duo/data_stream/offline_enrollment/_dev/test/pipeline/test-empty.log-expected.json
@@ -1,0 +1,15 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "original": "{\"response\": [], \"stat\": \"OK\"}"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_duo/data_stream/offline_enrollment/_dev/test/pipeline/test-empty.log-expected.json
+++ b/packages/cisco_duo/data_stream/offline_enrollment/_dev/test/pipeline/test-empty.log-expected.json
@@ -1,15 +1,5 @@
 {
     "expected": [
-        {
-            "ecs": {
-                "version": "8.4.0"
-            },
-            "event": {
-                "original": "{\"response\": [], \"stat\": \"OK\"}"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        }
+        null
     ]
 }

--- a/packages/cisco_duo/data_stream/offline_enrollment/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/offline_enrollment/agent/stream/httpjson.yml.hbs
@@ -15,6 +15,7 @@ request.transforms:
       value: '[[sprintf "Basic %s" (base64Encode (sprintf "%s:%s" "{{integration_key}}" (hmac "sha1" "{{secret_key}}" (formatDate (now) "Mon, 02 Jan 2006 15:04:05 -0700") "\n" "GET" "\n" .url.Host "\n" "/admin/v1/logs/offline_enrollment" "\n" .url.RawQuery)))]]'
 response.split:
   target: body.response
+  ignore_empty_value: true
 cursor:
   last_published:
     value: '[[toInt .last_event.timestamp]]'

--- a/packages/cisco_duo/data_stream/offline_enrollment/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/offline_enrollment/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,8 @@ processors:
       field: event.original
       target_field: json
       ignore_failure: true
+  - drop:
+      if: ctx.json?.response instanceof List && ctx.json.response.length == 0
   - fingerprint:
       fields:
         - json.timestamp

--- a/packages/cisco_duo/data_stream/summary/_dev/test/pipeline/test-summary.log-expected.json
+++ b/packages/cisco_duo/data_stream/summary/_dev/test/pipeline/test-summary.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2022-07-27T02:23:04.309812405Z",
+            "@timestamp": "2022-10-27T21:43:27.362576949Z",
             "cisco_duo": {
                 "summary": {
                     "admin_count": 6,
@@ -21,7 +21,7 @@
             ]
         },
         {
-            "@timestamp": "2022-07-27T02:23:04.309819920Z",
+            "@timestamp": "2022-10-27T21:43:27.362601509Z",
             "cisco_duo": {
                 "summary": {
                     "admin_count": 3,

--- a/packages/cisco_duo/data_stream/telephony/_dev/test/pipeline/test-empty.log
+++ b/packages/cisco_duo/data_stream/telephony/_dev/test/pipeline/test-empty.log
@@ -1,0 +1,1 @@
+{"response": [], "stat": "OK"}

--- a/packages/cisco_duo/data_stream/telephony/_dev/test/pipeline/test-empty.log-expected.json
+++ b/packages/cisco_duo/data_stream/telephony/_dev/test/pipeline/test-empty.log-expected.json
@@ -1,0 +1,16 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.4.0"
+            },
+            "event": {
+                "kind": "event",
+                "original": "{\"response\": [], \"stat\": \"OK\"}"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_duo/data_stream/telephony/_dev/test/pipeline/test-empty.log-expected.json
+++ b/packages/cisco_duo/data_stream/telephony/_dev/test/pipeline/test-empty.log-expected.json
@@ -1,16 +1,5 @@
 {
     "expected": [
-        {
-            "ecs": {
-                "version": "8.4.0"
-            },
-            "event": {
-                "kind": "event",
-                "original": "{\"response\": [], \"stat\": \"OK\"}"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        }
+        null
     ]
 }

--- a/packages/cisco_duo/data_stream/telephony/agent/stream/httpjson.yml.hbs
+++ b/packages/cisco_duo/data_stream/telephony/agent/stream/httpjson.yml.hbs
@@ -15,6 +15,7 @@ request.transforms:
       value: '[[sprintf "Basic %s" (base64Encode (sprintf "%s:%s" "{{integration_key}}" (hmac "sha1" "{{secret_key}}" (formatDate (now) "Mon, 02 Jan 2006 15:04:05 -0700") "\n" "GET" "\n" .url.Host "\n" "/admin/v1/logs/telephony" "\n" .url.RawQuery)))]]'
 response.split:
   target: body.response
+  ignore_empty_value: true
 cursor:
   last_published:
     value: '[[toInt .last_event.timestamp]]'

--- a/packages/cisco_duo/data_stream/telephony/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_duo/data_stream/telephony/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,8 @@ processors:
       field: event.original
       target_field: json
       ignore_failure: true
+  - drop:
+      if: ctx.json?.response instanceof List && ctx.json.response.length == 0
   - fingerprint:
       fields:
         - json.timestamp

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_duo
 title: Cisco Duo
-version: "1.5.1"
+version: "1.5.2"
 license: basic
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This works around the behaviour of the httpjson input that results in a root object being sent to ingest when a split would result in zero children.

**Note** Looking further into the httpjson behaviour the `ignore_empty_value` option on the split processor (not originally intended to handle this) does do the right thing in this case. However is is not testable either in the integration test framework because we cannot test for zero events, nor in the httpjson package input tests for the same reason.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4502

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
