### PR TITLE
[tcp/udp] Fix indentation of syslog processor in agent handlebars file

### DIFF
--- a/packages/tcp/changelog.yml
+++ b/packages/tcp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.1"
+  changes:
+    - description: Fix indentation of syslog processor in agent handlebars file.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9999 # FIXME: Change PR number
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/tcp/changelog.yml
+++ b/packages/tcp/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix indentation of syslog processor in agent handlebars file.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9999 # FIXME: Change PR number
+      link: https://github.com/elastic/integrations/pull/4528
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/tcp/data_stream/generic/agent/stream/tcp.yml.hbs
+++ b/packages/tcp/data_stream/generic/agent/stream/tcp.yml.hbs
@@ -38,12 +38,12 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{#if syslog}}
-  - syslog:
-      {{syslog_options}}
+- syslog:
+    {{syslog_options}}
 {{/if}}
 {{processors}}
 {{else if syslog}}
 processors:
-  - syslog:
-      {{syslog_options}}
+- syslog:
+    {{syslog_options}}
 {{/if}}

--- a/packages/tcp/manifest.yml
+++ b/packages/tcp/manifest.yml
@@ -3,7 +3,7 @@ name: tcp
 title: Custom TCP Logs
 description: Collect raw TCP data from listening TCP port with Elastic Agent.
 type: integration
-version: "1.4.0"
+version: "1.4.1"
 release: ga
 conditions:
   kibana.version: "^8.2.1"

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.1"
+  changes:
+    - description: Fix indentation of syslog processor in agent handlebars file.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9999 # FIXME: Change PR number
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix indentation of syslog processor in agent handlebars file.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9999 # FIXME: Change PR number
+      link: https://github.com/elastic/integrations/pull/4528
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.4.0

--- a/packages/udp/data_stream/generic/agent/stream/udp.yml.hbs
+++ b/packages/udp/data_stream/generic/agent/stream/udp.yml.hbs
@@ -28,12 +28,12 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{#if syslog}}
-  - syslog:
-      {{syslog_options}}
+- syslog:
+    {{syslog_options}}
 {{/if}}
 {{processors}}
 {{else if syslog}}
 processors:
-  - syslog:
-      {{syslog_options}}
+- syslog:
+    {{syslog_options}}
 {{/if}}

--- a/packages/udp/manifest.yml
+++ b/packages/udp/manifest.yml
@@ -3,7 +3,7 @@ name: udp
 title: Custom UDP Logs
 description: Collect raw UDP data from listening UDP port with Elastic Agent.
 type: integration
-version: "1.4.0"
+version: "1.4.1"
 release: ga
 conditions:
   kibana.version: "^8.2.1"


### PR DESCRIPTION
## What does this PR do?

Fixes the indentation of the syslog processor in the agent handlebars file.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #4525 
