### PR TITLE
[azure_application_insights] change app_state metricset and add pipeline

### DIFF
--- a/packages/azure_application_insights/changelog.yml
+++ b/packages/azure_application_insights/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.4"
+  changes:
+    - description: Change app_state metricset to app_insights and add pipeline.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4536
 - version: "1.0.3"
   changes:
     - description: Updated Readme

--- a/packages/azure_application_insights/data_stream/app_state/_dev/test/pipeline/test-azure-application-insights-app-state.json
+++ b/packages/azure_application_insights/data_stream/app_state/_dev/test/pipeline/test-azure-application-insights-app-state.json
@@ -1,0 +1,82 @@
+{
+    "events": [
+        {
+            "cloud": {
+                "provider": "azure"
+            },
+            "agent": {
+                "name": "docker-fleet-agent",
+                "id": "8c6e9ddc-da28-4d05-b041-62c63f028ede",
+                "ephemeral_id": "fd20db17-bd2f-4a20-a685-c36c1fa8e3ab",
+                "type": "metricbeat",
+                "version": "8.4.1"
+            },
+            "@timestamp": "2022-11-02T10:12:23.319Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "service": {
+                "type": "azure"
+            },
+            "data_stream": {
+                "namespace": "default",
+                "type": "metrics",
+                "dataset": "azure.app_state"
+            },
+            "host": {
+                "hostname": "docker-fleet-agent",
+                "os": {
+                    "kernel": "5.15.49-linuxkit",
+                    "codename": "focal",
+                    "name": "Ubuntu",
+                    "type": "linux",
+                    "family": "debian",
+                    "version": "20.04.4 LTS (Focal Fossa)",
+                    "platform": "ubuntu"
+                },
+                "containerized": false,
+                "ip": [
+                    "172.19.0.7"
+                ],
+                "name": "docker-fleet-agent",
+                "id": "51511c1493f34922b559a964798246ec",
+                "mac": [
+                    "02:42:ac:13:00:07"
+                ],
+                "architecture": "x86_64"
+            },
+            "elastic_agent": {
+                "id": "8c6e9ddc-da28-4d05-b041-62c63f028ede",
+                "version": "8.4.1",
+                "snapshot": false
+            },
+            "metricset": {
+                "period": 300000,
+                "name": "app_insights"
+            },
+            "event": {
+                "duration": 1454465509,
+                "agent_id_status": "verified",
+                "ingested": "2022-11-02T10:12:25Z",
+                "module": "azure",
+                "dataset": "azure.app_state"
+            },
+            "azure": {
+                "metrics": {
+                    "performance_counters_memory_available_bytes": {
+                        "avg": 73509546.67
+                    }
+                },
+                "app_insights": {
+                    "end_date": "2022-11-02T10:12:23.319Z",
+                    "start_date": "2022-11-02T10:07:23.319Z"
+                },
+                "application_id": "baa4546f-434e-4466-a32e-9032fb886d3e",
+                "dimensions": {
+                    "cloud_role_instance": "Maurizios-MacBook-Pro.local",
+                    "cloud_role_name": "Web"
+                }
+            }
+        }
+    ]
+}

--- a/packages/azure_application_insights/data_stream/app_state/_dev/test/pipeline/test-azure-application-insights-app-state.json-expected.json
+++ b/packages/azure_application_insights/data_stream/app_state/_dev/test/pipeline/test-azure-application-insights-app-state.json-expected.json
@@ -1,0 +1,80 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-11-02T10:12:23.319Z",
+            "agent": {
+                "ephemeral_id": "fd20db17-bd2f-4a20-a685-c36c1fa8e3ab",
+                "id": "8c6e9ddc-da28-4d05-b041-62c63f028ede",
+                "name": "docker-fleet-agent",
+                "type": "metricbeat",
+                "version": "8.4.1"
+            },
+            "azure": {
+                "app_state": {
+                    "end_date": "2022-11-02T10:12:23.319Z",
+                    "performance_counters_memory_available_bytes": {
+                        "avg": 7.350954667E7
+                    },
+                    "start_date": "2022-11-02T10:07:23.319Z"
+                },
+                "application_id": "baa4546f-434e-4466-a32e-9032fb886d3e",
+                "dimensions": {
+                    "cloud_role_instance": "Maurizios-MacBook-Pro.local",
+                    "cloud_role_name": "Web"
+                }
+            },
+            "cloud": {
+                "provider": "azure"
+            },
+            "data_stream": {
+                "dataset": "azure.app_state",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "elastic_agent": {
+                "id": "8c6e9ddc-da28-4d05-b041-62c63f028ede",
+                "snapshot": false,
+                "version": "8.4.1"
+            },
+            "event": {
+                "agent_id_status": "verified",
+                "dataset": "azure.app_state",
+                "duration": 1454465509,
+                "ingested": "2022-11-02T10:12:25Z",
+                "module": "azure"
+            },
+            "host": {
+                "architecture": "x86_64",
+                "containerized": false,
+                "hostname": "docker-fleet-agent",
+                "id": "51511c1493f34922b559a964798246ec",
+                "ip": [
+                    "172.19.0.7"
+                ],
+                "mac": [
+                    "02:42:ac:13:00:07"
+                ],
+                "name": "docker-fleet-agent",
+                "os": {
+                    "codename": "focal",
+                    "family": "debian",
+                    "kernel": "5.15.49-linuxkit",
+                    "name": "Ubuntu",
+                    "platform": "ubuntu",
+                    "type": "linux",
+                    "version": "20.04.4 LTS (Focal Fossa)"
+                }
+            },
+            "metricset": {
+                "name": "app_insights",
+                "period": 300000
+            },
+            "service": {
+                "type": "azure"
+            }
+        }
+    ]
+}

--- a/packages/azure_application_insights/data_stream/app_state/agent/stream/stream.yml.hbs
+++ b/packages/azure_application_insights/data_stream/app_state/agent/stream/stream.yml.hbs
@@ -1,8 +1,11 @@
-metricsets: ["app_state"]
+metricsets: ["app_insights"]
 period: {{period}}
 {{#if application_id}}
 application_id: {{application_id}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}
+{{/if}}
+{{#if metrics}}
+metrics: {{metrics}}
 {{/if}}

--- a/packages/azure_application_insights/data_stream/app_state/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure_application_insights/data_stream/app_state/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,25 @@
+---
+description: Pipeline for parsing Azure App State metrics.
+processors:
+  - rename:
+      field: azure.metrics
+      target_field: azure.app_state
+      ignore_missing: true
+  - rename:
+      field: azure.app_insights.end_date
+      target_field: azure.app_state.end_date
+      ignore_missing: true
+  - rename:
+      field: azure.app_insights.start_date
+      target_field: azure.app_state.start_date
+      ignore_missing: true
+  - remove:
+      ignore_missing: true
+      field:
+        - azure.metrics
+        - azure.app_insights
+    
+on_failure:
+  - set:
+      field: error.message
+      value: '{{ _ingest.on_failure_message }}'

--- a/packages/azure_application_insights/data_stream/app_state/manifest.yml
+++ b/packages/azure_application_insights/data_stream/app_state/manifest.yml
@@ -14,3 +14,31 @@ streams:
         required: true
         show_user: true
         default: 300s
+      - name: metrics
+        type: yaml
+        title: Metrics
+        multi: false
+        required: true
+        show_user: true
+        default: |
+          - id: ["requests/count", "requests/failed"]
+            segment: ["request/urlHost", "request/name"]
+            aggregation: ["sum"]
+            interval: "P5M"
+          - id: ["users/count", "sessions/count", "users/authenticated"]
+            segment: ["request/urlHost"]
+            aggregation: ["unique"]
+            interval: "P5M"
+          - id: ["browserTimings/networkDuration", "browserTimings/sendDuration", "browserTimings/receiveDuration", "browserTimings/processingDuration", "browserTimings/totalDuration"]
+            segment: ["browserTiming/urlHost", "browserTiming/urlPath"]
+            aggregation: ["avg"]
+            interval: "P5M"
+            top: 5
+          - id: ["exceptions/count", "exceptions/browser", "exceptions/server"]
+            segment: ["exception/type", "cloud/roleName"]
+            aggregation: ["sum"]
+            interval: "P5M"
+          - id: ["performanceCounters/memoryAvailableBytes", "performanceCounters/processCpuPercentageTotal", "performanceCounters/processCpuPercentage", "performanceCounters/processIOBytesPerSecond", "performanceCounters/processPrivateBytes"]
+            segment: ["cloud/roleName", "cloud/roleInstance"]
+            aggregation: ["avg"]
+            interval: "P5M"

--- a/packages/azure_application_insights/data_stream/app_state/sample_event.json
+++ b/packages/azure_application_insights/data_stream/app_state/sample_event.json
@@ -51,7 +51,7 @@
     },
     "metricset": {
         "period": 300000,
-        "name": "app_state"
+        "name": "app_insights"
     },
     "event": {
         "duration": 815158500,

--- a/packages/azure_application_insights/manifest.yml
+++ b/packages/azure_application_insights/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_application_insights
 title: Azure Application Insights Metrics Overview
-version: 1.0.3
+version: 1.0.4
 release: ga
 description: Collect application insights metrics from Azure Monitor with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Use `app_insights` metricset for `app_state` data stream and add pipeline with tests.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4446 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
