### PR TITLE
Fix kubernetes typo in cluster overview dash

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Fix typo in cluster overview dashboard
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4363
 - version: "1.27.0"
   changes:
     - description: New cluster overview dashboard

--- a/packages/kubernetes/data_stream/apiserver/manifest.yml
+++ b/packages/kubernetes/data_stream/apiserver/manifest.yml
@@ -48,5 +48,6 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes API Server metrics
     description: Collect Kubernetes API Server metrics

--- a/packages/kubernetes/data_stream/audit_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/audit_logs/manifest.yml
@@ -24,5 +24,5 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: >
+        description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -66,5 +66,6 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Container metrics
     description: Collect Kubernetes Container metrics

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -58,5 +58,5 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: >
+        description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/kubernetes/data_stream/controllermanager/manifest.yml
+++ b/packages/kubernetes/data_stream/controllermanager/manifest.yml
@@ -55,5 +55,6 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: Kubernetes Controller Manager metrics
     description: Collect Kubernetes Controller Manager metrics

--- a/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
@@ -78,7 +78,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 10,
-                            "markdown": "This dashboard requires [`kube-state metrics`](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment) to be installed in your Kubenretes cluster to properly function. \nFor more information please check **Section: state_\\* and event** of [Kubernetes Integration](https://docs.elastic.co/en/integrations/kubernetes)",
+                            "markdown": "This dashboard requires [`kube-state metrics`](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment) to be installed in your Kubernetes cluster to properly function. \nFor more information please check **Section: state_\\* and event** of [Kubernetes integration](https://docs.elastic.co/en/integrations/kubernetes)",
                             "openLinksInNewTab": false
                         },
                         "title": "",

--- a/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
@@ -78,7 +78,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 10,
-                            "markdown": "This dashboard requires [`kube-state metrics`](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment) to be installed in your Kubernetes cluster to properly function. \nFor more information please check **Section: state_\\* and event** of [Kubernetes integration](https://docs.elastic.co/en/integrations/kubernetes)",
+                            "markdown": "This dashboard requires having [`kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment) deployed to your Kubernetes cluster to function properly. \nCheck the **Section: state_\\* and event** of the [Elastic Kubernetes integration](https://docs.elastic.co/en/integrations/kubernetes).",
                             "openLinksInNewTab": false
                         },
                         "title": "",

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.27.0
+version: 1.27.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
Fixes a typo in cluster overview ootb kubernetes dashboard.


<img width="528" alt="Screen Shot 2022-11-02 at 6 34 05 PM" src="https://user-images.githubusercontent.com/26270880/199667521-338a746a-3079-4866-977e-4914e898fad4.png">
 
Kubenretes---> Kubernetes
Integration---> integration


<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
