### PR TITLE
ti_{cif3,recordedfuture}: map threat.indicator.geo.location as geo_point

### DIFF
--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Use ECS definition for `threat.indicator.geo.location`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4552
 - version: "0.3.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/ti_cif3/data_stream/feed/fields/ecs.yml
+++ b/packages/ti_cif3/data_stream/feed/fields/ecs.yml
@@ -95,9 +95,7 @@
 - external: ecs
   name: threat.indicator.geo.country_iso_code
 - external: ecs
-  name: threat.indicator.geo.location.lat
-- external: ecs
-  name: threat.indicator.geo.location.lon
+  name: threat.indicator.geo.location
 - external: ecs
   name: threat.indicator.geo.region_name
 - external: ecs

--- a/packages/ti_cif3/docs/README.md
+++ b/packages/ti_cif3/docs/README.md
@@ -93,8 +93,6 @@ CIFv3 `confidence` field values (0..10) are converted to ECS confidence (None, L
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.geo.country_iso_code | Country ISO code. | keyword |
 | threat.indicator.geo.location | Longitude and latitude. | geo_point |
-| threat.indicator.geo.location.lat | Longitude and latitude. | geo_point |
-| threat.indicator.geo.location.lon | Longitude and latitude. | geo_point |
 | threat.indicator.geo.region_name | Region name. | keyword |
 | threat.indicator.geo.timezone | The time zone of the location, such as IANA time zone name. | keyword |
 | threat.indicator.ip | Identifies a threat indicator as an IP address (irrespective of direction). | ip |

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: "0.3.0"
+version: "0.3.1"
 release: beta
 license: basic
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."

--- a/packages/ti_recordedfuture/changelog.yml
+++ b/packages/ti_recordedfuture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Use ECS definition for `threat.indicator.geo.location`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4552
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/ti_recordedfuture/data_stream/threat/fields/ecs.yml
+++ b/packages/ti_recordedfuture/data_stream/threat/fields/ecs.yml
@@ -65,8 +65,6 @@
 - external: ecs
   name: threat.indicator.as.organization.name
 - external: ecs
-  name: threat.indicator.geo.location.lat
-- external: ecs
-  name: threat.indicator.geo.location.lon
+  name: threat.indicator.geo.location
 - external: ecs
   name: threat.indicator.geo.country_iso_code

--- a/packages/ti_recordedfuture/docs/README.md
+++ b/packages/ti_recordedfuture/docs/README.md
@@ -197,8 +197,7 @@ An example event for `threat` looks as following:
 | threat.indicator.file.hash.sha512 | SHA512 hash. | keyword |
 | threat.indicator.first_seen | The date and time when intelligence source first reported sighting this indicator. | date |
 | threat.indicator.geo.country_iso_code | Country ISO code. | keyword |
-| threat.indicator.geo.location.lat | Longitude and latitude. | geo_point |
-| threat.indicator.geo.location.lon | Longitude and latitude. | geo_point |
+| threat.indicator.geo.location | Longitude and latitude. | geo_point |
 | threat.indicator.ip | Identifies a threat indicator as an IP address (irrespective of direction). | ip |
 | threat.indicator.last_seen | The date and time when intelligence source last reported sighting this indicator. | date |
 | threat.indicator.marking.tlp | Traffic Light Protocol sharing markings. | keyword |

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "1.4.0"
+version: "1.4.1"
 release: ga
 description: Ingest threat intelligence indicators from Recorded Future risk lists with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This uses the ECS definition of `threat.indicator.geo.location` to ensure that it is mapped as `geo_point`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4542

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
