### PR TITLE
winlog: allow users to configure providers list

### DIFF
--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Allow users to configure providers list.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4553
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/winlog/data_stream/winlog/agent/stream/winlog.yml.hbs
+++ b/packages/winlog/data_stream/winlog/agent/stream/winlog.yml.hbs
@@ -5,6 +5,12 @@ name: {{channel}}
 {{#if preserve_original_event}}
 include_xml: true
 {{/if}}
+{{#if providers}}
+provider:
+{{#each providers as |p|}}
+  - {{p}}
+{{/each}}
+{{/if}}
 {{#if event_id}}
 event_id: {{event_id}}
 {{/if}}

--- a/packages/winlog/data_stream/winlog/manifest.yml
+++ b/packages/winlog/data_stream/winlog/manifest.yml
@@ -30,6 +30,13 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: providers
+        type: text
+        title: Providers
+        description: A list of providers (source names) to include.
+        required: false
+        multi: true
+        show_user: false
       - name: event_id
         type: text
         title: Event ID

--- a/packages/winlog/manifest.yml
+++ b/packages/winlog/manifest.yml
@@ -3,7 +3,7 @@ name: winlog
 title: Custom Windows Event Logs
 description: Collect and parse logs from any Windows event log channel with Elastic Agent.
 type: integration
-version: "1.8.0"
+version: "1.9.0"
 release: ga
 conditions:
   kibana.version: '^7.16.0 || ^8.0.0'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This adds the capacity for users to configure the providers list [available in Winlogbeat](https://www.elastic.co/guide/en/beats/winlogbeat/current/configuration-winlogbeat-options.html#_event_logs_provider).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4547 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
<img width="742" alt="Screen Shot 2022-11-04 at 12 28 20" src="https://user-images.githubusercontent.com/90160302/199869214-30c94e92-c103-4edd-9673-538c762f58a1.png">
