### PR TITLE
micsosoft_sqlserver: allow text encoding configuration

### DIFF
--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Allow text encoding configuration.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4554
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/microsoft_sqlserver/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/microsoft_sqlserver/data_stream/log/agent/stream/log.yml.hbs
@@ -17,6 +17,9 @@ multiline:
   pattern: '^\d{4}-\d{2}-\d{2}'
   negate: true
   match: after
+{{#if encoding}}
+encoding: {{encoding}}
+{{/if}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/microsoft_sqlserver/data_stream/log/manifest.yml
+++ b/packages/microsoft_sqlserver/data_stream/log/manifest.yml
@@ -13,6 +13,13 @@ streams:
         show_user: true
         default:
           - /var/opt/mssql/log/error*
+      - name: encoding
+        description: The file encoding to use for reading data that contains international characters. Valid encoding names are listed [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-log.html#_encoding_3).
+        type: text
+        title: Encoding
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "1.6.0"
+version: "1.7.0"
 license: basic
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This adds an advanced configuration option to allow users to specify the text encoding to be used.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4538

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
<img width="742" alt="Screen Shot 2022-11-04 at 14 14 57" src="https://user-images.githubusercontent.com/90160302/199881062-f7a70fa2-05fb-41ef-84f0-46e88f1ad1bf.png">
