### PR TITLE
Add try-catch when trying to download report from google storage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -172,7 +172,12 @@ def gitHubCommentWithBenchmarkReport() {
       // download artifacts for this PR
       def bucketUri = getBenchmarkBucketURI() + "*.xml"
       log(level: 'INFO', text: "googleStorageDownload(bucketUri: ${bucketUri}, localDirectory: ${currentBenchmarkResults}, pathPrefix: ${getBenchmarkPathPrefix()})")
-      googleStorageDownload(bucketUri: bucketUri, credentialsId: "${JOB_GCS_CREDENTIALS}", localDirectory: currentBenchmarkResults, pathPrefix: getBenchmarkPathPrefix())
+      try {
+          googleStorageDownload(bucketUri: bucketUri, credentialsId: "${JOB_GCS_CREDENTIALS}", localDirectory: currentBenchmarkResults, pathPrefix: getBenchmarkPathPrefix())
+      } catch(e) {
+          log(level: 'INFO', text: 'gitHubCommentWithBenchmarkReport: no report available for this build.')
+          return
+      }
 
       // download artifacts from the target branch if any
       if (env.CHANGE_TARGET) {


### PR DESCRIPTION
## What does this PR do?

This PR adds a try-catch block in case there is no package tested and there is no benchmark report generated.


