### PR TITLE
Add custom processors and logs to log integration

### DIFF
--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Add custom logs and processors
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2538
 - version: "1.0.0"
   changes:
     - description: Release Custom Logs as GA

--- a/packages/log/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/log/data_stream/log/agent/stream/stream.yml.hbs
@@ -5,5 +5,15 @@ paths:
 
 data_stream:
   dataset: {{data_stream.dataset}}
+{{#if processors.length}}
+processors:
+{{processors}}
+{{/if}}
+{{#if tags.length}}
+tags:
+{{#each tags as |tag i|}}
+- {{tag}}
+{{/each}}
+{{/if}}
 
 {{custom}}

--- a/packages/log/data_stream/log/manifest.yml
+++ b/packages/log/data_stream/log/manifest.yml
@@ -21,6 +21,7 @@ streams:
       - name: tags
         type: text
         title: Tags
+        description: Tags to include in the published event
         multi: true
         show_user: false
       - name: processors

--- a/packages/log/data_stream/log/manifest.yml
+++ b/packages/log/data_stream/log/manifest.yml
@@ -17,8 +17,20 @@ streams:
         title: Dataset name
         description: >
           Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
         type: text
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
       - name: custom
         title: Custom configurations
         description: >

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -4,7 +4,7 @@ title: Custom Logs
 description: >-
   Collect custom logs with Elastic Agent.
 type: integration
-version: 1.0.0
+version: 1.1.0
 release: ga
 license: basic
 categories:


### PR DESCRIPTION
Closes https://github.com/elastic/integrations/issues/3432

## What does this PR do?

This adds a field for custom tags and processors in the `logs` integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
