### PR TITLE
cisco_{asa,ftd}: add configuration for internal and external zones

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.0"
+  changes:
+    - description: Allow configuration of internal/external zones
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4579
 - version: "2.9.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cisco_asa/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/stream.yml.hbs
@@ -18,3 +18,21 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if internal_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      internal_zones:
+        {{#each internal_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}
+{{#if external_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      external_zones:
+        {{#each external_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}

--- a/packages/cisco_asa/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/tcp.yml.hbs
@@ -17,6 +17,24 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if internal_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      internal_zones:
+        {{#each internal_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}
+{{#if external_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      external_zones:
+        {{#each external_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}
 {{#if tcp_options}}
 {{tcp_options}}
 {{/if}}

--- a/packages/cisco_asa/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/udp.yml.hbs
@@ -14,3 +14,21 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if internal_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      internal_zones:
+        {{#each internal_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}
+{{#if external_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      external_zones:
+        {{#each external_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}

--- a/packages/cisco_asa/data_stream/log/manifest.yml
+++ b/packages/cisco_asa/data_stream/log/manifest.yml
@@ -31,6 +31,18 @@ streams:
         required: true
         show_user: true
         default: 9001
+      - name: internal_zones
+        type: text
+        title: Internal Zones
+        multi: true
+        required: false
+        show_user: false
+      - name: external_zones
+        type: text
+        title: External Zones
+        multi: true
+        required: false
+        show_user: false
       - name: preserve_original_event
         required: true
         show_user: true
@@ -78,6 +90,18 @@ streams:
         required: true
         show_user: true
         default: 9001
+      - name: internal_zones
+        type: text
+        title: Internal Zones
+        multi: true
+        required: false
+        show_user: false
+      - name: external_zones
+        type: text
+        title: External Zones
+        multi: true
+        required: false
+        show_user: false
       - name: preserve_original_event
         required: true
         show_user: true
@@ -129,6 +153,22 @@ streams:
         show_user: true
         default:
           - /var/log/cisco-asa.log
+      - name: internal_zones
+        type: text
+        title: Internal Zones
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - trust
+      - name: external_zones
+        type: text
+        title: External Zones
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - untrust
       - name: tags
         type: text
         title: Tags

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.9.0"
+version: "2.10.0"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,5 +1,9 @@
 # newer versions go on top
-
+- version: "2.6.0"
+  changes:
+    - description: Allow configuration of internal/external zones
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4579
 - version: "2.5.1"
   changes:
     - description: Enhancement of network direction

--- a/packages/cisco_ftd/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/cisco_ftd/data_stream/log/agent/stream/stream.yml.hbs
@@ -18,3 +18,21 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if internal_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      internal_zones:
+        {{#each internal_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}
+{{#if external_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      external_zones:
+        {{#each external_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}

--- a/packages/cisco_ftd/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/cisco_ftd/data_stream/log/agent/stream/tcp.yml.hbs
@@ -17,6 +17,24 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if internal_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      internal_zones:
+        {{#each internal_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}
+{{#if external_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      external_zones:
+        {{#each external_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}
 {{#if tcp_options}}
 {{tcp_options}}
 {{/if}}

--- a/packages/cisco_ftd/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_ftd/data_stream/log/agent/stream/udp.yml.hbs
@@ -14,3 +14,21 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if internal_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      internal_zones:
+        {{#each internal_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}
+{{#if external_zones.length}}
+- add_fields:
+    target: _temp_
+    fields:
+      external_zones:
+        {{#each external_zones as |zone i|}}
+        - {{zone}}
+        {{/each}}
+{{/if}}

--- a/packages/cisco_ftd/data_stream/log/manifest.yml
+++ b/packages/cisco_ftd/data_stream/log/manifest.yml
@@ -29,6 +29,18 @@ streams:
         required: true
         show_user: true
         default: 9003
+      - name: internal_zones
+        type: text
+        title: Internal Zones
+        multi: true
+        required: false
+        show_user: false
+      - name: external_zones
+        type: text
+        title: External Zones
+        multi: true
+        required: false
+        show_user: false
       - name: preserve_original_event
         required: true
         show_user: true
@@ -74,6 +86,18 @@ streams:
         required: true
         show_user: true
         default: 9003
+      - name: internal_zones
+        type: text
+        title: Internal Zones
+        multi: true
+        required: false
+        show_user: false
+      - name: external_zones
+        type: text
+        title: External Zones
+        multi: true
+        required: false
+        show_user: false
       - name: preserve_original_event
         required: true
         show_user: true
@@ -125,6 +149,22 @@ streams:
         show_user: true
         default:
           - /var/log/cisco-ftd.log
+      - name: internal_zones
+        type: text
+        title: Internal Zones
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - trust
+      - name: external_zones
+        type: text
+        title: External Zones
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - untrust
       - name: tags
         type: text
         title: Tags

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ftd
 title: Cisco FTD
-version: "2.5.1"
+version: "2.6.0"
 license: basic
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This adds user configuration for internal and external zones. The logic for configured internal and external zones was already present but not used, for example [here](https://github.com/elastic/integrations/blob/f754dbe2c945613720c5895708b00bf48159227e/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml#L1837-L1900) for FTD.

The format and logic of the config options is taken from the Checkpoint integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
