### PR TITLE
[apache_spark] Improvise README to explicitly call out the need for Spark to run standalone

### DIFF
--- a/packages/apache_spark/_dev/build/docs/README.md
+++ b/packages/apache_spark/_dev/build/docs/README.md
@@ -10,6 +10,8 @@ This integration has been tested against `Apache Spark version 3.2.0`
 
 In order to ingest data from Apache Spark, you must know the full hosts for the Main and Worker nodes.
 
+To proceed with the Jolokia setup, Apache Spark should be installed as a standalone setup. Make sure that the spark folder is installed in the `/usr/local` path. If not, then specify the path of spark folder in the further steps. You can install the standalone setup from the official download page of [Apache Spark](https://spark.apache.org/downloads.html).
+
 In order to gather Spark statistics, we need to download and enable Jolokia JVM Agent.
 
 ```

--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -4,7 +4,7 @@
   changes:
     - description: Update readme
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4585
 - version: "0.2.1"
   changes:
     - description: Remove unnecessary fields from fields.yml

--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
 
+- version: "0.2.2"
+  changes:
+    - description: Update readme
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.1"
   changes:
     - description: Remove unnecessary fields from fields.yml

--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -1,6 +1,6 @@
 # newer versions go on top
 
-- version: "0.2.2"
+- version: "0.3.0"
   changes:
     - description: Update readme
       type: enhancement

--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -1,5 +1,4 @@
 # newer versions go on top
-
 - version: "0.3.0"
   changes:
     - description: Update readme

--- a/packages/apache_spark/docs/README.md
+++ b/packages/apache_spark/docs/README.md
@@ -10,6 +10,8 @@ This integration has been tested against `Apache Spark version 3.2.0`
 
 In order to ingest data from Apache Spark, you must know the full hosts for the Main and Worker nodes.
 
+To proceed with the Jolokia setup, Apache Spark should be installed as a standalone setup. Make sure that the spark folder is installed in the `/usr/local` path. If not, then specify the path of spark folder in the further steps. You can install the standalone setup from the official download page of [Apache Spark](https://spark.apache.org/downloads.html).
+
 In order to gather Spark statistics, we need to download and enable Jolokia JVM Agent.
 
 ```

--- a/packages/apache_spark/manifest.yml
+++ b/packages/apache_spark/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache_spark
 title: Apache Spark
-version: 0.2.1
+version: 0.2.2
 license: basic
 description: Collect metrics from Apache Spark with Elastic Agent.
 type: integration

--- a/packages/apache_spark/manifest.yml
+++ b/packages/apache_spark/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache_spark
 title: Apache Spark
-version: 0.2.2
+version: 0.3.0
 license: basic
 description: Collect metrics from Apache Spark with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement
## What does this PR do?
Update README to explicitly add details for the end user to know that the Apache Spark integration uses Jolokia metricbeat module and hence, Jolokia needs to be set up as a third party dependency. Based on the documentation [link](https://spark.apache.org/docs/3.2.0/monitoring.html#component-instance--master), it can collect the metrics only when Spark is running standalone as master/worker.
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/apache_spark directory.
- Run the following command to run tests. 
> elastic-package test

## Related issues

- Relates #4523 