### PR TITLE
[aws] Remove duplicate content_type from aws.waf

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Remove duplicate 'content_type' config that causes errors while configurating the integration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4592
 - version: "1.25.0"
   changes:
     - description: Force content type where json content is expected

--- a/packages/aws/data_stream/waf/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws/data_stream/waf/agent/stream/aws-s3.yml.hbs
@@ -36,7 +36,6 @@ fips_enabled: {{fips_enabled}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}
-content_type: "application/json"
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.25.0
+version: 1.25.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Remove duplicate `content_type` from aws.waf.

Fixes #4587

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Fixes #4587
- Caused by: https://github.com/elastic/integrations/pull/4532