### PR TITLE
[logstash] fix mappings

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.1-preview1"
+  changes:
+    - description: Fix mappings
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4594
 - version: "2.1.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.1.1-preview1"
   changes:
-    - description: Fix mappings
+    - description: Fix mappings of type nested
       type: bugfix
       link: https://github.com/elastic/integrations/pull/4594
 - version: "2.1.0-preview1"

--- a/packages/logstash/data_stream/node_stats/fields/fields.yml
+++ b/packages/logstash/data_stream/node_stats/fields/fields.yml
@@ -151,72 +151,64 @@
               type: long
             - name: pipelines
               type: nested
-              fields:
-                - name: id
-                  type: keyword
-                  description: id
-                - name: hash
-                  type: keyword
-                - name: ephemeral_id
-                  type: keyword
-                - name: reloads
-                  type: group
-                  fields:
-                    - name: failures
-                      type: long
-                    - name: successes
-                      type: long
-                - name: queue
-                  type: group
-                  fields:
-                    - name: events_count
-                      type: long
-                    - name: type
-                      type: keyword
-                    - name: queue_size_in_bytes
-                      type: long
-                    - name: max_queue_size_in_bytes
-                      type: long
-                - name: events
-                  type: group
-                  fields:
-                    - name: in
-                      type: long
-                    - name: out
-                      type: long
-                    - name: filtered
-                      type: long
-                    - name: duration_in_millis
-                      type: long
-                    - name: queue_push_duration_in_millis
-                      type: long
-                - name: vertices
-                  type: nested
-                  fields:
-                    - name: long_counters.name
-                      type: keyword
-                    - name: long_counters
-                      type: nested
-                      fields:
-                        - name: value
-                          type: long
-                    - name: duration_in_millis
-                      type: long
-                    - name: events_in
-                      type: long
-                    - name: pipeline_ephemeral_id
-                      type: keyword
-                      description: pipeline_ephemeral_id
-                    - name: events_out
-                      type: long
-                      description: events_out
-                    - name: queue_push_duration_in_millis
-                      type: long
-                      description: queue_push_duration_in_millis
-            - name: reloads
+            - name: pipelines.id
+              type: keyword
+            - name: pipelines.hash
+              type: keyword
+            - name: pipelines.ephemeral_id
+              type: keyword
+            - name: pipelines.reloads
               type: group
               fields:
                 - name: failures
                   type: long
                 - name: successes
                   type: long
+            - name: pipelines.queue
+              type: group
+              fields:
+                - name: events_count
+                  type: long
+                - name: type
+                  type: keyword
+                - name: queue_size_in_bytes
+                  type: long
+                - name: max_queue_size_in_bytes
+                  type: long
+            - name: pipelines.events
+              type: group
+              fields:
+                - name: in
+                  type: long
+                - name: out
+                  type: long
+                - name: filtered
+                  type: long
+                - name: duration_in_millis
+                  type: long
+                - name: queue_push_duration_in_millis
+                  type: long
+            - name: pipelines.vertices
+              type: nested
+            - name: pipelines.vertices.id
+              type: keyword
+              description: id
+            - name: pipelines.vertices.long_counters
+              type: nested
+            - name: pipelines.vertices.long_counters.name
+              type: keyword
+            - name: pipelines.vertices.long_counters.value
+              type: long
+            - name: pipelines.vertices.duration_in_millis
+              type: long
+            - name: pipelines.vertices.events_in
+              type: long
+            - name: pipelines.vertices.pipeline_ephemeral_id
+              type: keyword
+              description: pipeline_ephemeral_id
+            - name: pipelines.vertices.events_out
+              type: long
+              description: events_out
+            - name: pipelines.vertices.queue_push_duration_in_millis
+              type: long
+              description: queue_push_duration_in_millis

--- a/packages/logstash/data_stream/node_stats/fields/fields.yml
+++ b/packages/logstash/data_stream/node_stats/fields/fields.yml
@@ -16,6 +16,13 @@
         - name: stats
           type: group
           fields:
+            - name: reloads
+              type: group
+              fields:
+                - name: failures
+                  type: long
+                - name: successes
+                  type: long
             - name: timestamp
               type: date
             - name: jvm

--- a/packages/logstash/data_stream/node_stats/fields/package-fields.yml
+++ b/packages/logstash/data_stream/node_stats/fields/package-fields.yml
@@ -1,6 +1,8 @@
-- name: logstash.cluster.id
+- name: cluster_uuid
   type: alias
   path: logstash.elasticsearch.cluster.id
+- name: logstash.cluster.id
+  type: keyword
 - name: timestamp
   type: alias
   path: "@timestamp"

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.1.0-preview1
+version: 2.1.1-preview1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
### Summary
Regression in mappings were introduced [in previous change](https://github.com/elastic/integrations/pull/4443)

- cluster_uuid was removed
- nested properties were updated to use an unsupported syntax - see relevant issue https://github.com/elastic/kibana/issues/138596

### Testing
- build logstash package `elastic-package build`
- start a stack `elastic-package stack up -v -d --version 8.5.0-SNAPSHOT`
- start logstash service `elastic-package service up -v`
- install elasticsearch and logstash packages
- logstash appears in standalone and elasticsearch cluster