### PR TITLE
[aws.vpcflow] Default max_number_of_messages to 1

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.0"
+  changes:
+    - description: Change default max_number_of_messages for vpcflow to 1 because VPC flow log files normally contain a high number of events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4599
 - version: "1.25.2"
   changes:
     - description: Update ec2 fields.yml doc

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -66,7 +66,7 @@ streams:
         type: integer
         title: Maximum Concurrent SQS Messages
         description: The maximum number of SQS messages that can be inflight at any time.
-        default: 5
+        default: 1
         required: false
         show_user: false
   - input: aws-cloudwatch

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.25.2
+version: 1.26.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

For users that are getting started with ingesting VPC flow logs with the aws-s3 input, using max_number_of_messages: 1 will provide a better experience. This is because each VPC flow log file usually contains many thousands of messages. For example a single S3 object might contain 100k events and this is suffiecient to keep the Agent's internal queue full. Having multiple S3 objects in flight by default often leads to timeouts or connection resets because the overall processing time for each object increases.

This setting usually needs to be tuned in conjunction with the queue.mem and output.elasaticsearch settings, and I think `max_number_of_messages: 1` is better aligned to the queue and output defaults than 5.

This change will not affect users that currently have the integration added to policies. It will only affect new additions to agent policies.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/284 (we can't tune to the queue so lower the max_number_of_messages to align with the current queue settings)

