### PR TITLE
[google_workspace] Fix cursor value and pagination

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.8.1"
+- version: "1.9.0"
   changes:
     - description: Use event time as cursor instead of current time.
       type: bugfix

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use event time as cursor instead of current time.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/4602
     - description: Fix pagination logic and avoid showing error on last page.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -7,6 +7,9 @@
     - description: Fix pagination logic and avoid showing error on last page.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/4602
+    - description: Allow each data stream to define its own interval.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4602
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -6,7 +6,7 @@
       link: https://github.com/elastic/integrations/pull/4602
     - description: Fix pagination logic and avoid showing error on last page.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/4602
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Use event time as cursor instead of current time.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
+    - description: Fix pagination logic and avoid showing error on last page.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -13,7 +13,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
+      value: '[[.cursor.last_execution_datetime]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
@@ -22,12 +22,34 @@ response.split:
     keep_parent: true
 response.pagination:
   - set:
+      target: url.params.startTime
+      value: '[[.last_response.url.params.Get "startTime"]]'
+      fail_on_template_error: true
+  - set:
       target: url.params.pageToken
-      value: "[[.last_response.body.nextPageToken]]"
+      value: >-
+        [[- if index .last_response.body "nextPageToken" -]]
+          [[- .last_response.body.nextPageToken -]]
+        [[- end -]]
       fail_on_template_error: true
 cursor:
   last_execution_datetime:
-    value: "[[formatDate now]]"
+    value: >-
+      [[- $time := .last_event.id.time -]]
+      [[- if not (parseDate $time "RFC3339").IsZero -]]
+        [[- $time -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05.999Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05.999Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
+      [[- else -]]
+        [[- formatDate now -]]
+      [[- end -]]
+
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/admin/manifest.yml
+++ b/packages/google_workspace/data_stream/admin/manifest.yml
@@ -6,6 +6,16 @@ streams:
     title: Admin logs (httpjson)
     description: Collect admin logs using httpjson input
     vars:
+      - name: interval
+        type: text
+        title: Interval
+        description: >
+          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay.  For more details on this, you can read more at https://support.google.com/a/answer/7061566.
+
+        multi: false
+        required: true
+        show_user: true
+        default: 2h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -13,7 +13,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
+      value: '[[.cursor.last_execution_datetime]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
@@ -22,12 +22,33 @@ response.split:
     keep_parent: true
 response.pagination:
   - set:
+      target: url.params.startTime
+      value: '[[.last_response.url.params.Get "startTime"]]'
+      fail_on_template_error: true
+  - set:
       target: url.params.pageToken
-      value: "[[.last_response.body.nextPageToken]]"
+      value: >-
+        [[- if index .last_response.body "nextPageToken" -]]
+          [[- .last_response.body.nextPageToken -]]
+        [[- end -]]
       fail_on_template_error: true
 cursor:
   last_execution_datetime:
-    value: "[[formatDate now]]"
+    value: >-
+      [[- $time := .last_event.id.time -]]
+      [[- if not (parseDate $time "RFC3339").IsZero -]]
+        [[- $time -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05.999Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05.999Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
+      [[- else -]]
+        [[- formatDate now -]]
+      [[- end -]]
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/drive/manifest.yml
+++ b/packages/google_workspace/data_stream/drive/manifest.yml
@@ -6,6 +6,16 @@ streams:
     title: Drive logs (httpjson)
     description: Collect drive logs using httpjson input
     vars:
+      - name: interval
+        type: text
+        title: Interval
+        description: >
+          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay.  For more details on this, you can read more at https://support.google.com/a/answer/7061566.
+
+        multi: false
+        required: true
+        show_user: true
+        default: 2h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -13,7 +13,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
+      value: '[[.cursor.last_execution_datetime]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
@@ -22,12 +22,33 @@ response.split:
     keep_parent: true
 response.pagination:
   - set:
+      target: url.params.startTime
+      value: '[[.last_response.url.params.Get "startTime"]]'
+      fail_on_template_error: true
+  - set:
       target: url.params.pageToken
-      value: "[[.last_response.body.nextPageToken]]"
+      value: >-
+        [[- if index .last_response.body "nextPageToken" -]]
+          [[- .last_response.body.nextPageToken -]]
+        [[- end -]]
       fail_on_template_error: true
 cursor:
   last_execution_datetime:
-    value: "[[formatDate now]]"
+    value: >-
+      [[- $time := .last_event.id.time -]]
+      [[- if not (parseDate $time "RFC3339").IsZero -]]
+        [[- $time -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05.999Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05.999Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
+      [[- else -]]
+        [[- formatDate now -]]
+      [[- end -]]
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/groups/manifest.yml
+++ b/packages/google_workspace/data_stream/groups/manifest.yml
@@ -6,6 +6,16 @@ streams:
     title: Groups logs (httpjson)
     description: Collect groups logs using httpjson input
     vars:
+      - name: interval
+        type: text
+        title: Interval
+        description: >
+          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay.  For more details on this, you can read more at https://support.google.com/a/answer/7061566.
+
+        multi: false
+        required: true
+        show_user: true
+        default: 2h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -13,7 +13,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
+      value: '[[.cursor.last_execution_datetime]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
@@ -22,12 +22,33 @@ response.split:
     keep_parent: true
 response.pagination:
   - set:
+      target: url.params.startTime
+      value: '[[.last_response.url.params.Get "startTime"]]'
+      fail_on_template_error: true
+  - set:
       target: url.params.pageToken
-      value: "[[.last_response.body.nextPageToken]]"
+      value: >-
+        [[- if index .last_response.body "nextPageToken" -]]
+          [[- .last_response.body.nextPageToken -]]
+        [[- end -]]
       fail_on_template_error: true
 cursor:
   last_execution_datetime:
-    value: "[[formatDate now]]"
+    value: >-
+      [[- $time := .last_event.id.time -]]
+      [[- if not (parseDate $time "RFC3339").IsZero -]]
+        [[- $time -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05.999Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05.999Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
+      [[- else -]]
+        [[- formatDate now -]]
+      [[- end -]]
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/login/manifest.yml
+++ b/packages/google_workspace/data_stream/login/manifest.yml
@@ -6,6 +6,16 @@ streams:
     title: Login logs (httpjson)
     description: Collect login logs using httpjson input
     vars:
+      - name: interval
+        type: text
+        title: Interval
+        description: >
+          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay.  For more details on this, you can read more at https://support.google.com/a/answer/7061566.
+
+        multi: false
+        required: true
+        show_user: true
+        default: 2h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -13,7 +13,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
+      value: '[[.cursor.last_execution_datetime]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
@@ -22,12 +22,33 @@ response.split:
     keep_parent: true
 response.pagination:
   - set:
+      target: url.params.startTime
+      value: '[[.last_response.url.params.Get "startTime"]]'
+      fail_on_template_error: true
+  - set:
       target: url.params.pageToken
-      value: "[[.last_response.body.nextPageToken]]"
+      value: >-
+        [[- if index .last_response.body "nextPageToken" -]]
+          [[- .last_response.body.nextPageToken -]]
+        [[- end -]]
       fail_on_template_error: true
 cursor:
   last_execution_datetime:
-    value: "[[formatDate now]]"
+    value: >-
+      [[- $time := .last_event.id.time -]]
+      [[- if not (parseDate $time "RFC3339").IsZero -]]
+        [[- $time -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05.999Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05.999Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
+      [[- else -]]
+        [[- formatDate now -]]
+      [[- end -]]
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/saml/manifest.yml
+++ b/packages/google_workspace/data_stream/saml/manifest.yml
@@ -6,6 +6,16 @@ streams:
     title: SAML logs (httpjson)
     description: Collect SAML logs using httpjson input
     vars:
+      - name: interval
+        type: text
+        title: Interval
+        description: >
+          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay.  For more details on this, you can read more at https://support.google.com/a/answer/7061566.
+
+        multi: false
+        required: true
+        show_user: true
+        default: 2h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -13,7 +13,7 @@ request.timeout: {{http_client_timeout}}
 request.transforms:
   - set:
       target: url.params.startTime
-      value: '[[if eq .last_response.page 0]][[.cursor.last_execution_datetime]][[else]][[.last_response.url.params.Get "startTime"]][[end]]'
+      value: '[[.cursor.last_execution_datetime]]'
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
@@ -22,12 +22,33 @@ response.split:
     keep_parent: true
 response.pagination:
   - set:
+      target: url.params.startTime
+      value: '[[.last_response.url.params.Get "startTime"]]'
+      fail_on_template_error: true
+  - set:
       target: url.params.pageToken
-      value: "[[.last_response.body.nextPageToken]]"
+      value: >-
+        [[- if index .last_response.body "nextPageToken" -]]
+          [[- .last_response.body.nextPageToken -]]
+        [[- end -]]
       fail_on_template_error: true
 cursor:
   last_execution_datetime:
-    value: "[[formatDate now]]"
+    value: >-
+      [[- $time := .last_event.id.time -]]
+      [[- if not (parseDate $time "RFC3339").IsZero -]]
+        [[- $time -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05.999Z").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05.999Z") -]]
+      [[- else if not (parseDate $time "2006-01-02T15:04:05 MST").IsZero -]]
+        [[- formatDate (parseDate $time "2006-01-02T15:04:05 MST") -]]
+      [[- else -]]
+        [[- formatDate now -]]
+      [[- end -]]
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/user_accounts/manifest.yml
+++ b/packages/google_workspace/data_stream/user_accounts/manifest.yml
@@ -6,6 +6,16 @@ streams:
     title: User accounts logs (httpjson)
     description: Collect user accounts logs using httpjson input
     vars:
+      - name: interval
+        type: text
+        title: Interval
+        description: >
+          Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay.  For more details on this, you can read more at https://support.google.com/a/answer/7061566.
+
+        multi: false
+        required: true
+        show_user: true
+        default: 2h
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "1.8.0"
+version: "1.8.1"
 release: ga
 description: Collect logs from Google Workspace with Elastic Agent.
 type: integration

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "1.8.1"
+version: "1.9.0"
 release: ga
 description: Collect logs from Google Workspace with Elastic Agent.
 type: integration

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -68,16 +68,6 @@ policy_templates:
             required: true
             show_user: true
             default: all
-          - name: interval
-            type: text
-            title: Interval
-            description: >
-              Duration between requests to the API. Google Workspace defaults to a 2 hour polling interval because Google reports can go from some minutes up to 3 days of delay.  For more details on this, you can read more at https://support.google.com/a/answer/7061566.
-
-            multi: false
-            required: true
-            show_user: true
-            default: 2h
           - name: api_host
             type: text
             title: API Host.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

- Uses last event date as cursor instead of current time  for better error recovery on agent crashes
  - Supports all formats for last_event.id.time that are also supported as part of the pipelines
- Adds conditional to avoid showing errors on last page
- Fixes pagination logic by avoiding page == 0 conditions

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
