### PR TITLE
[gcp] add condition for private callerIp in audit pipeline 

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.14.1"
+  changes:
+    - description: Add audit logs pipeline condition for private callerIp.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4606
 - version: "2.14.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -178,7 +178,7 @@ processors:
 # https://cloud.google.com/logging/docs/reference/audit/auditlog/rest/Shared.Types/AuditLog#requestmetadata
 ##
   - convert:
-      if: ctx.json?.protoPayload?.requestMetadata?.callerIp != null && ctx.json?.protoPayload?.requestMetadata?.callerIp != "gce-internal-ip" 
+      if: ctx.json?.protoPayload?.requestMetadata?.callerIp != null && ctx.json?.protoPayload?.requestMetadata?.callerIp != "gce-internal-ip" && ctx.json?.protoPayload?.requestMetadata?.callerIp != "private"
       type: ip
       field: json.protoPayload.requestMetadata.callerIp
       target_field: source.ip

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.14.0"
+version: "2.14.1"
 release: ga
 description: Collect logs from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Adds a condition in audit pipeline for `callerIp` of value `private`.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
