### PR TITLE
juniper_*,m365_defender,microsoft_defender_endpoint,mimecast,modsecurity: remove duplicate fields

### DIFF
--- a/packages/juniper_junos/changelog.yml
+++ b/packages/juniper_junos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4611
 - version: "0.5.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/juniper_junos/data_stream/log/fields/agent.yml
+++ b/packages/juniper_junos/data_stream/log/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/juniper_junos/data_stream/log/fields/ecs.yml
+++ b/packages/juniper_junos/data_stream/log/fields/ecs.yml
@@ -203,8 +203,6 @@
 - external: ecs
   name: source.top_level_domain
 - external: ecs
-  name: tags
-- external: ecs
   name: url.domain
 - external: ecs
   name: url.original

--- a/packages/juniper_junos/manifest.yml
+++ b/packages/juniper_junos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: juniper_junos
 title: Juniper JunOS
-version: "0.5.0"
+version: "0.5.1"
 description: Collect logs from Juniper JunOS with Elastic Agent.
 categories: ["network", "security"]
 release: experimental

--- a/packages/juniper_netscreen/changelog.yml
+++ b/packages/juniper_netscreen/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4611
 - version: "0.5.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/juniper_netscreen/data_stream/log/fields/agent.yml
+++ b/packages/juniper_netscreen/data_stream/log/fields/agent.yml
@@ -62,11 +62,6 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
     - name: image.name
       level: extended
       type: keyword

--- a/packages/juniper_netscreen/data_stream/log/fields/ecs.yml
+++ b/packages/juniper_netscreen/data_stream/log/fields/ecs.yml
@@ -203,8 +203,6 @@
 - external: ecs
   name: source.top_level_domain
 - external: ecs
-  name: tags
-- external: ecs
   name: url.domain
 - external: ecs
   name: url.original

--- a/packages/juniper_netscreen/manifest.yml
+++ b/packages/juniper_netscreen/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: juniper_netscreen
 title: Juniper NetScreen
-version: "0.5.0"
+version: "0.5.1"
 description: Collect logs from Juniper NetScreen with Elastic Agent.
 categories: ["network", "security"]
 release: experimental

--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4611
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/juniper_srx/data_stream/log/fields/ecs.yml
+++ b/packages/juniper_srx/data_stream/log/fields/ecs.yml
@@ -109,15 +109,7 @@
 - external: ecs
   name: code_signature.valid
 - external: ecs
-  name: container.id
-- external: ecs
-  name: container.image.name
-- external: ecs
   name: container.image.tag
-- external: ecs
-  name: container.labels
-- external: ecs
-  name: container.name
 - external: ecs
   name: container.runtime
 - external: ecs

--- a/packages/juniper_srx/manifest.yml
+++ b/packages/juniper_srx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: juniper_srx
 title: Juniper SRX
-version: "1.6.0"
+version: "1.6.1"
 description: Collect logs from Juniper SRX devices with Elastic Agent.
 categories: ["network", "security"]
 release: ga

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4611
 - version: "1.4.0"
   changes:
     - description: Add New Incident Data Stream.

--- a/packages/m365_defender/data_stream/log/fields/ecs.yml
+++ b/packages/m365_defender/data_stream/log/fields/ecs.yml
@@ -53,8 +53,6 @@
 - external: ecs
   name: observer.name
 - external: ecs
-  name: url.full
-- external: ecs
   name: url.domain
 - external: ecs
   name: url.full

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: m365_defender
 title: Microsoft M365 Defender
-version: 1.4.0
+version: 1.4.1
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "network"

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4611
 - version: "2.5.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/microsoft_defender_endpoint/data_stream/log/fields/ecs.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/fields/ecs.yml
@@ -1,13 +1,5 @@
 - external: ecs
-  name: container.id
-- external: ecs
-  name: container.image.name
-- external: ecs
   name: container.image.tag
-- external: ecs
-  name: container.labels
-- external: ecs
-  name: container.name
 - external: ecs
   name: container.runtime
 - external: ecs

--- a/packages/microsoft_defender_endpoint/data_stream/log/fields/fields.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: microsoft.defender_endpoint
   type: group
-  release: ga
   fields:
     - name: lastUpdateTime
       type: date

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.5.0"
+version: "2.5.1"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "network"

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4611
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/mimecast/data_stream/siem_logs/fields/ecs.yml
+++ b/packages/mimecast/data_stream/siem_logs/fields/ecs.yml
@@ -13,8 +13,6 @@
 - external: ecs
   name: email.attachments.file.name
 - external: ecs
-  name: email.attachments.file.name
-- external: ecs
   name: email.attachments.file.size
 - external: ecs
   name: email.direction
@@ -34,8 +32,6 @@
   name: error.message
 - external: ecs
   name: error.type
-- external: ecs
-  name: event.action
 - external: ecs
   name: event.action
 - external: ecs

--- a/packages/mimecast/data_stream/ttp_ap_logs/fields/ecs.yml
+++ b/packages/mimecast/data_stream/ttp_ap_logs/fields/ecs.yml
@@ -7,8 +7,6 @@
 - external: ecs
   name: email.attachments.file.mime_type
 - external: ecs
-  name: email.attachments.file.mime_type
-- external: ecs
   name: email.attachments.file.name
 - external: ecs
   name: email.direction
@@ -20,8 +18,6 @@
   name: email.subject
 - external: ecs
   name: email.to.address
-- external: ecs
-  name: event.action
 - external: ecs
   name: event.action
 - external: ecs

--- a/packages/mimecast/data_stream/ttp_ip_logs/fields/ecs.yml
+++ b/packages/mimecast/data_stream/ttp_ip_logs/fields/ecs.yml
@@ -11,8 +11,6 @@
 - external: ecs
   name: event.action
 - external: ecs
-  name: event.action
-- external: ecs
   name: event.created
 - external: ecs
   name: event.id

--- a/packages/mimecast/data_stream/ttp_url_logs/fields/ecs.yml
+++ b/packages/mimecast/data_stream/ttp_url_logs/fields/ecs.yml
@@ -13,8 +13,6 @@
 - external: ecs
   name: event.action
 - external: ecs
-  name: event.action
-- external: ecs
   name: event.created
 - external: ecs
   name: event.original

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 1.0.0
 name: mimecast
 title: "Mimecast"
-version: "1.4.0"
+version: "1.4.1"
 license: basic
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration

--- a/packages/modsecurity/changelog.yml
+++ b/packages/modsecurity/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4611
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/modsecurity/data_stream/auditlog/fields/agent.yml
+++ b/packages/modsecurity/data_stream/auditlog/fields/agent.yml
@@ -121,10 +121,6 @@
         As hostname is not always unique, use values that are meaningful in your environment.
 
         Example: The current usage of `beat.name`.'
-    - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
     - name: mac
       level: core
       type: keyword

--- a/packages/modsecurity/manifest.yml
+++ b/packages/modsecurity/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: modsecurity
 title: "ModSecurity Audit"
-version: "1.4.0"
+version: "1.4.1"
 license: basic
 description: Collect logs from ModSecurity with Elastic Agent
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This removes duplicate field definitions from juniper_junos, juniper_netscreen, juniper_srx, m365_defender, microsoft_defender_endpoint, mimecast and modsecurity.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #4398

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
