### PR TITLE
netflow,netscout,netskope,o365,okta: remove duplicate fields

### DIFF
--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4632
 - version: "2.3.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/netflow/data_stream/log/fields/agent.yml
+++ b/packages/netflow/data_stream/log/fields/agent.yml
@@ -20,25 +20,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -57,30 +45,13 @@
       example: CONTOSO
       default_field: false
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Type of host.
-
-        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/netflow/data_stream/log/fields/ecs.yml
+++ b/packages/netflow/data_stream/log/fields/ecs.yml
@@ -89,15 +89,7 @@
 - external: ecs
   name: cloud.region
 - external: ecs
-  name: container.id
-- external: ecs
-  name: container.image.name
-- external: ecs
   name: container.image.tag
-- external: ecs
-  name: container.labels
-- external: ecs
-  name: container.name
 - external: ecs
   name: container.runtime
 - external: ecs
@@ -355,15 +347,7 @@
 - external: ecs
   name: host.os.full
 - external: ecs
-  name: host.os.kernel
-- external: ecs
   name: host.os.name
-- external: ecs
-  name: host.os.platform
-- external: ecs
-  name: host.os.version
-- external: ecs
-  name: host.type
 - external: ecs
   name: host.uptime
 - external: ecs

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow Records
-version: "2.3.0"
+version: "2.3.1"
 license: basic
 description: Collect flow records from NetFlow and IPFIX exporters with Elastic Agent.
 type: integration

--- a/packages/netscout/changelog.yml
+++ b/packages/netscout/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4632
 - version: "0.11.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/netscout/data_stream/sightline/fields/base-fields.yml
+++ b/packages/netscout/data_stream/sightline/fields/base-fields.yml
@@ -15,9 +15,6 @@
   type: constant_keyword
   description: Event dataset
   value: netscout.sightline
-- name: '@timestamp'
-  type: date
-  description: Event timestamp.
 - name: container.id
   description: Unique container id.
   ignore_above: 1024

--- a/packages/netscout/data_stream/sightline/fields/ecs.yml
+++ b/packages/netscout/data_stream/sightline/fields/ecs.yml
@@ -203,8 +203,6 @@
 - external: ecs
   name: source.top_level_domain
 - external: ecs
-  name: tags
-- external: ecs
   name: url.domain
 - external: ecs
   name: url.original

--- a/packages/netscout/manifest.yml
+++ b/packages/netscout/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netscout
 title: Arbor Peakflow SP Logs
-version: "0.11.0"
+version: "0.11.1"
 description: Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.
 categories: ["security"]
 release: experimental

--- a/packages/netskope/changelog.yml
+++ b/packages/netskope/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4632
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/netskope/data_stream/alerts/fields/agent.yml
+++ b/packages/netskope/data_stream/alerts/fields/agent.yml
@@ -6,13 +6,7 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
-
-        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
-      example: 666777888999
+      external: ecs
     - name: availability_zone
       level: extended
       type: keyword
@@ -43,11 +37,7 @@
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
@@ -106,12 +96,7 @@
       example: CONTOSO
       default_field: false
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      external: ecs
     - name: id
       level: core
       type: keyword
@@ -150,16 +135,7 @@
       description: Operating system kernel version as a raw string.
       example: 4.4.0-112-generic
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
       level: extended
       type: keyword

--- a/packages/netskope/data_stream/alerts/fields/ecs.yml
+++ b/packages/netskope/data_stream/alerts/fields/ecs.yml
@@ -3,8 +3,6 @@
 - external: ecs
   name: client.port
 - external: ecs
-  name: cloud.account.id
-- external: ecs
   name: cloud.account.name
 - external: ecs
   name: cloud.service.name
@@ -33,8 +31,6 @@
 - external: ecs
   name: destination.geo.timezone
 - external: ecs
-  name: destination.ip
-- external: ecs
   name: destination.port
 - external: ecs
   name: event.id
@@ -51,10 +47,6 @@
 - external: ecs
   name: file.size
 - external: ecs
-  name: host.hostname
-- external: ecs
-  name: host.os.name
-- external: ecs
   name: http.request.referrer
 - external: ecs
   name: network.protocol
@@ -64,8 +56,6 @@
   name: related.ip
 - external: ecs
   name: source.address
-- external: ecs
-  name: source.ip
 - external: ecs
   name: source.geo.city_name
 - external: ecs

--- a/packages/netskope/data_stream/events/fields/agent.yml
+++ b/packages/netskope/data_stream/events/fields/agent.yml
@@ -43,11 +43,7 @@
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
@@ -106,12 +102,7 @@
       example: CONTOSO
       default_field: false
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Hostname of the host.
-
-        It normally contains what the `hostname` command returns on the host machine.'
+      external: ecs
     - name: id
       level: core
       type: keyword

--- a/packages/netskope/data_stream/events/fields/ecs.yml
+++ b/packages/netskope/data_stream/events/fields/ecs.yml
@@ -5,15 +5,9 @@
 - external: ecs
   name: client.nat.ip
 - external: ecs
-  name: client.packets
-- external: ecs
   name: cloud.account.name
 - external: ecs
-  name: cloud.region
-- external: ecs
   name: cloud.service.name
-- external: ecs
-  name: client.bytes
 - external: ecs
   name: destination.address
 - external: ecs
@@ -64,8 +58,6 @@
   name: file.path
 - external: ecs
   name: file.size
-- external: ecs
-  name: host.hostname
 - external: ecs
   name: network.protocol
 - external: ecs

--- a/packages/netskope/docs/README.md
+++ b/packages/netskope/docs/README.md
@@ -67,7 +67,7 @@ Default port: _9021_
 | cloud.machine.type | Machine type of the host machine. | keyword |
 | cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
 | cloud.service.name | The cloud service name is intended to distinguish services running on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App Engine, Azure VM vs App Server. Examples: app engine, app service, cloud run, fargate, lambda. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |

--- a/packages/netskope/manifest.yml
+++ b/packages/netskope/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netskope
 title: "Netskope"
-version: "1.4.0"
+version: "1.4.1"
 license: basic
 description: Collect logs from Netskope with Elastic Agent.
 type: integration

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4632
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/o365/data_stream/audit/fields/agent.yml
+++ b/packages/o365/data_stream/audit/fields/agent.yml
@@ -63,10 +63,7 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
       level: extended
       type: keyword
@@ -113,14 +110,7 @@
 
         It normally contains what the `hostname` command returns on the host machine.'
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique host id.
-
-        As hostname is not always unique, use values that are meaningful in your environment.
-
-        Example: The current usage of `beat.name`.'
+      external: ecs
     - name: ip
       level: core
       type: ip
@@ -131,12 +121,7 @@
       ignore_above: 1024
       description: Host mac addresses.
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the host.
-
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+      external: ecs
     - name: os.family
       level: extended
       type: keyword

--- a/packages/o365/data_stream/audit/fields/ecs.yml
+++ b/packages/o365/data_stream/audit/fields/ecs.yml
@@ -7,8 +7,6 @@
 - external: ecs
   name: client.port
 - external: ecs
-  name: container.id
-- external: ecs
   name: destination.ip
 - external: ecs
   name: destination.user.email
@@ -50,10 +48,6 @@
   name: file.owner
 - external: ecs
   name: group.name
-- external: ecs
-  name: host.id
-- external: ecs
-  name: host.name
 - external: ecs
   name: message
 - external: ecs

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.9.0"
+version: "1.9.1"
 release: ga
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4632
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/okta/data_stream/system/fields/agent.yml
+++ b/packages/okta/data_stream/system/fields/agent.yml
@@ -63,10 +63,7 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
       level: extended
       type: keyword

--- a/packages/okta/data_stream/system/fields/ecs.yml
+++ b/packages/okta/data_stream/system/fields/ecs.yml
@@ -19,8 +19,6 @@
 - external: ecs
   name: client.user.id
 - external: ecs
-  name: container.id
-- external: ecs
   name: destination.as.number
 - external: ecs
   name: destination.as.organization.name

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "1.11.0"
+version: "1.11.1"
 release: ga
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This removes duplicate field definitions.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #4398

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
