### PR TITLE
Osquery_manager: Update kibana constraint to ^8.6 for 1.5.1

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update kibana constraint to ^8.6
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/4640
 - version: "1.5.0"
   changes:
     - description: Update schema for osquery 5.5.1

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Update kibana constraint to ^8.6
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.5.0"
   changes:
     - description: Update schema for osquery 5.5.1

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.5.0
+version: 1.5.1
 license: basic
 description: Deploy osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
@@ -11,7 +11,7 @@ categories:
   - os_system
   - config_management
 conditions:
-  kibana.version: ^8.4.0
+  kibana.version: ^8.6.0
 icons:
   - src: /img/logo_osquery.svg
     title: logo osquery


### PR DESCRIPTION
## What does this PR do?

Updates kibana constraint to ^8.6 for 1.5.1

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

