### PR TITLE
Enabling kube-state metrics

### DIFF
--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -43,6 +43,8 @@ which is used in some configuration examples. But in general, and lately, this e
 
 #### state_* and event
 
+State_* datasets are  enabled by default.
+
 All datasets with the `state_` prefix require `hosts` field pointing to `kube-state-metrics`
 service within the cluster. As the service provides cluster-wide metrics, there's no need to fetch them per node,
 hence the recommendation is to run these datasets as part of an `Agent Deployment` with one only replica.
@@ -50,7 +52,6 @@ hence the recommendation is to run these datasets as part of an `Agent Deploymen
  Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration.
 
-state_* datasets are not enabled by default.
 
 ### apiserver
 

--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -43,7 +43,7 @@ which is used in some configuration examples. But in general, and lately, this e
 
 #### state_* and event
 
-State_* datasets are  enabled by default.
+State_* datasets are enabled by default.
 
 All datasets with the `state_` prefix require `hosts` field pointing to `kube-state-metrics`
 service within the cluster. As the service provides cluster-wide metrics, there's no need to fetch them per node,

--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -3,6 +3,11 @@
 This integration is used to collect logs and metrics from 
 [Kubernetes clusters](https://kubernetes.io/).
 
+| |
+| ------------- | 
+| **This integration requires kube-state-metrics, which is not included with Kubernetes by default. For dashboards to properly populate, the [kube-state-metrics service must be deployed to your Kubernetes cluster](https://github.com/kubernetes/kube-state-metrics)** |
+
+
 As one of the main pieces provided for Kubernetes monitoring, this integration is capable of fetching metrics from several components:
 
 - [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
@@ -42,10 +47,7 @@ All datasets with the `state_` prefix require `hosts` field pointing to `kube-st
 service within the cluster. As the service provides cluster-wide metrics, there's no need to fetch them per node,
 hence the recommendation is to run these datasets as part of an `Agent Deployment` with one only replica.
 
-> Note: 
-> Kube-state-metrics is not deployed by default in Kubernetes. For these cases, see Kubernetes's instructions on [Kubernetes Deployment](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment). 
-
-Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
+ Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration.
 
 state_* datasets are not enabled by default.

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.2"
+  changes:
+    - description: Enabling Kube-state Metrics by default
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4544
 - version: "1.27.1"
   changes:
     - description: Fix typo in cluster overview dashboard

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.27.2"
   changes:
-    - description: Enabling Kube-state Metrics by default
+    - description: Adding banner for Kube-state metrics
       type: enhancement
       link: https://github.com/elastic/integrations/pull/4646
 - version: "1.27.1"

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enabling Kube-state Metrics by default
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4544
+      link: https://github.com/elastic/integrations/pull/4646
 - version: "1.27.1"
   changes:
     - description: Fix typo in cluster overview dashboard

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.27.2"
+- version: "1.28.0"
   changes:
     - description: Adding banner for Kube-state metrics
       type: enhancement

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes Container metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes Cronjob metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes Deamonset metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes Deployment metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes Job metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes Node metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes PersistentVolume metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes PersistentVolumeClaim metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes Pod metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes state_replicaset metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes ResourceQuota metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes Service metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes StatefulSet metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -2,7 +2,7 @@ title: Kubernetes StorageClass metrics
 type: metrics
 streams:
   - input: kubernetes/metrics
-    enabled: false
+    enabled: true
     vars:
       - name: add_metadata
         type: bool

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -43,6 +43,8 @@ which is used in some configuration examples. But in general, and lately, this e
 
 #### state_* and event
 
+State_* datasets are  enabled by default.
+
 All datasets with the `state_` prefix require `hosts` field pointing to `kube-state-metrics`
 service within the cluster. As the service provides cluster-wide metrics, there's no need to fetch them per node,
 hence the recommendation is to run these datasets as part of an `Agent Deployment` with one only replica.
@@ -50,7 +52,6 @@ hence the recommendation is to run these datasets as part of an `Agent Deploymen
  Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration.
 
-state_* datasets are not enabled by default.
 
 ### apiserver
 

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -43,7 +43,7 @@ which is used in some configuration examples. But in general, and lately, this e
 
 #### state_* and event
 
-State_* datasets are  enabled by default.
+State_* datasets are enabled by default.
 
 All datasets with the `state_` prefix require `hosts` field pointing to `kube-state-metrics`
 service within the cluster. As the service provides cluster-wide metrics, there's no need to fetch them per node,

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -3,6 +3,11 @@
 This integration is used to collect logs and metrics from 
 [Kubernetes clusters](https://kubernetes.io/).
 
+| |
+| ------------- | 
+| **This integration requires kube-state-metrics, which is not included with Kubernetes by default. For dashboards to properly populate, the [kube-state-metrics service must be deployed to your Kubernetes cluster](https://github.com/kubernetes/kube-state-metrics)** |
+
+
 As one of the main pieces provided for Kubernetes monitoring, this integration is capable of fetching metrics from several components:
 
 - [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
@@ -42,10 +47,7 @@ All datasets with the `state_` prefix require `hosts` field pointing to `kube-st
 service within the cluster. As the service provides cluster-wide metrics, there's no need to fetch them per node,
 hence the recommendation is to run these datasets as part of an `Agent Deployment` with one only replica.
 
-> Note: 
-> Kube-state-metrics is not deployed by default in Kubernetes. For these cases, see Kubernetes's instructions on [Kubernetes Deployment](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment). 
-
-Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
+ Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration.
 
 state_* datasets are not enabled by default.

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.27.1
+version: 1.27.2
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.27.2
+version: 1.28.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
Enhancement

## What does this PR do?

Enables Kube state metrics by default
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

![Screenshot 2022-11-15 at 11 51 19 AM](https://user-images.githubusercontent.com/1685415/201890838-3ad0e792-86dd-4a9a-9387-225be2ef2183.png)

Upgrade to 1.27.2 version and check if kube-state metrics is enabled by default

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/4548

Logs:

Filebeat and Metricbeat started successfully:

```json
{"log.level":"info","@timestamp":"2022-11-15T09:54:20.257Z","log.origin":{"file.name":"stateresolver/stateresolver.go","file.line":49},"message":"Converging state requires execution of 3 step(s)","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-11-15T09:54:21.170Z","log.origin":{"file.name":"log/reporter.go","file.line":40},"message":"2022-11-15T09:54:21Z - message: Application: metricbeat--8.5.0[1a9c4b03-c1ba-458e-9557-8abef159c34f]: State changed to RUNNING: Running - type: 'STATE' - sub_type: 'RUNNING'","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-11-15T09:54:21.267Z","log.origin":{"file.name":"log/reporter.go","file.line":40},"message":"2022-11-15T09:54:21Z - message: Application: filebeat--8.5.0--36643631373035623733363936343635[1a9c4b03-c1ba-458e-9557-8abef159c34f]: State changed to RUNNING: Running - type: 'STATE' - sub_type: 'RUNNING'","ecs.version":"1.6.0"}
```

When installed kube-state metrics, relevant dataset appeared:


![Screenshot 2022-11-15 at 12 10 23 PM](https://user-images.githubusercontent.com/1685415/201892546-34e9df93-69dc-47e0-881f-7645a207c5ff.png)

