### PR TITLE
Fix PR URL in changelog

### DIFF
--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add custom logs and processors
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2538
+      link: https://github.com/elastic/integrations/pull/4568
 - version: "1.0.0"
   changes:
     - description: Release Custom Logs as GA


### PR DESCRIPTION
## What does this PR do?

Looks like I had a copy-and-paste issue when I opened https://github.com/elastic/integrations/pull/4568

This just changes the `changelog.yml` entry so it points at the correct PR, which is apparently used to generate docs.
