### PR TITLE
add KSPM to integration name

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add KSPM to integration name
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4496
+      link: https://github.com/elastic/integrations/pull/4664
 - version: "1.0.6"
   changes:
     - description: Removing the rule data yaml

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.7"
+  changes:
+    - description: Add KSPM to integration name
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4496
 - version: "1.0.6"
   changes:
     - description: Removing the rule data yaml

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Kubernetes Security Posture Management (KSPM)"
-version: 1.0.6
+version: 1.0.7
 release: ga
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,6 +1,6 @@
 format_version: 1.0.0
 name: cloud_security_posture
-title: "Kubernetes Security Posture Management"
+title: "Kubernetes Security Posture Management (KSPM)"
 version: 1.0.6
 release: ga
 license: basic


### PR DESCRIPTION
this is a [quick wins](https://docs.google.com/spreadsheets/d/1Bs-_nQkmab1be_6HYZi6B4gA1VSTAcWXYaPYMtmcwJ4/edit#gid=0) task


we want users to be able to search for KSPM and get our integration.
fleet UI looks at [these](https://github.com/elastic/kibana/blob/768d5b8b8c2465a2ee1d1f94c1b84ace168309b3/x-pack/plugins/fleet/public/applications/integrations/hooks/use_local_search.tsx#L14) fields (`title`, `name`)

so we update the title to include KSPM in it. 
 