### PR TITLE
Fix pod memory usage panel title

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.28.1"
+- version: "1.28.2"
   changes:
     - description: Fix Pod Memory usage panel title
       type: bugfix

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,9 +1,14 @@
 # newer versions go on top
 - version: "1.28.1"
   changes:
+    - description: Fix Pod Memory usage panel title
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4671
+- version: "1.28.1"
+  changes:
     - description: Delete statefulset, job and cronjob visualizations from Cluster Overview dashboard
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4646
+      link: https://github.com/elastic/integrations/pull/4672
 - version: "1.28.0"
   changes:
     - description: Adding banner for Kube-state metrics

--- a/packages/kubernetes/kibana/dashboard/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -968,7 +968,7 @@
                     "y": 34
                 },
                 "panelIndex": "5575d413-c4a4-4e34-8605-54f82e5e05b3",
-                "title": "Memory Usage as Pct of the Total Node Memory [Metrics Kubernetes]",
+                "title": "Memory Usage as Pct of the Defined Pod Limit [Metrics Kubernetes]",
                 "type": "lens",
                 "version": "8.4.0-SNAPSHOT"
             },

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.28.1
+version: 1.28.2
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fix the title of the Pod memory usage panel to properly indicate how the "pct" is calculated.

Before:
![AgentUsage](https://user-images.githubusercontent.com/11754898/202405882-bf337881-5737-4d44-952d-dc23b7a51d06.png)

After:
![kibana](https://user-images.githubusercontent.com/11754898/202405873-5ae3c480-2970-48af-9122-13da7223c0b5.png)

