### PR TITLE
Delete statefulset, job and cronjob visualizations from Cluster Overview dashboard due to errors and pop unwanted pop ups

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.1"
+  changes:
+    - description: Delete statefulset, job and cronjob visualizations from Cluster Overview dashboard
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4646
 - version: "1.28.0"
   changes:
     - description: Adding banner for Kube-state metrics

--- a/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
@@ -7,6 +7,7 @@
             "panelsJSON": "{\"748291db-2826-4242-9107-9a5226733a06\":{\"order\":0,\"width\":\"large\",\"grow\":false,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster Name\",\"id\":\"748291db-2826-4242-9107-9a5226733a06\",\"enhancements\":{},\"selectedOptions\":[]}},\"2da8af79-7928-4741-8d03-866642f3c2a0\":{\"order\":1,\"width\":\"large\",\"grow\":false,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.namespace\",\"title\":\"Namespace\",\"id\":\"2da8af79-7928-4741-8d03-866642f3c2a0\",\"selectedOptions\":[],\"enhancements\":{}}}}"
         },
         "description": "Overview of Kubernetes cluster metrics",
+        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [],
@@ -57,7 +58,7 @@
                 "panelIndex": "f1541205-b6eb-45a6-bdc5-9aaefa62af66",
                 "title": "Kubernetes Dashboards [Metrics Kubernetes]",
                 "type": "visualization",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -96,7 +97,7 @@
                 "panelIndex": "ace0daf9-5db7-44e5-9fc3-a1b1976b01c2",
                 "title": "Information",
                 "type": "visualization",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -433,299 +434,7 @@
                 "panelIndex": "33530265-ff62-49e7-9518-f430efb0dde0",
                 "title": "Nodes",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "indexpattern": {
-                                    "layers": {
-                                        "dfd1702f-213e-4fa2-98e3-5106657c62e7": {
-                                            "columnOrder": [
-                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
-                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
-                                                "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                            ],
-                                            "columns": {
-                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "30s"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "62125b6d-3199-420b-9d3b-46f159e15d7f": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.node.status.ready:\"true\" and event.dataset :\"kubernetes.state_node\" "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Total Memory",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "showArrayValues": false,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.node.memory.allocatable.bytes"
-                                                },
-                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 100000 values of kubernetes.node.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderAgg": {
-                                                            "customLabel": false,
-                                                            "dataType": "number",
-                                                            "isBucketed": false,
-                                                            "label": "Count of records",
-                                                            "operationType": "count",
-                                                            "params": {},
-                                                            "scale": "ratio",
-                                                            "sourceField": "___records___"
-                                                        },
-                                                        "orderBy": {
-                                                            "type": "custom"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 100000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.node.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        },
-                                        "dff09473-7596-48c7-bbf4-beccee70d845": {
-                                            "columnOrder": [
-                                                "6677e92c-5874-49c1-979e-c16c0d3838cd",
-                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
-                                                "307be273-94a6-41ab-b93b-0debde733492"
-                                            ],
-                                            "columns": {
-                                                "307be273-94a6-41ab-b93b-0debde733492": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "event.dataset :\"kubernetes.container\"    "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Memory Used",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "showArrayValues": false,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.container.memory.usage.bytes"
-                                                },
-                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "30s"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "6677e92c-5874-49c1-979e-c16c0d3838cd": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 100000 values of kubernetes.container.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderAgg": {
-                                                            "customLabel": false,
-                                                            "dataType": "number",
-                                                            "isBucketed": false,
-                                                            "label": "Count of records",
-                                                            "operationType": "count",
-                                                            "params": {},
-                                                            "scale": "ratio",
-                                                            "sourceField": "___records___"
-                                                        },
-                                                        "orderBy": {
-                                                            "type": "custom"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 100000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.container.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fillOpacity": 0.5,
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "307be273-94a6-41ab-b93b-0debde733492"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "dff09473-7596-48c7-bbf4-beccee70d845",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "default",
-                                            "type": "palette"
-                                        },
-                                        "seriesType": "area",
-                                        "splitAccessor": "6677e92c-5874-49c1-979e-c16c0d3838cd",
-                                        "xAccessor": "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#00bfb3",
-                                                "forAccessor": "307be273-94a6-41ab-b93b-0debde733492"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "accessors": [
-                                            "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "dfd1702f-213e-4fa2-98e3-5106657c62e7",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "negative",
-                                            "type": "palette"
-                                        },
-                                        "seriesType": "line",
-                                        "splitAccessor": "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
-                                        "xAccessor": "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#bd271e",
-                                                "forAccessor": "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "maxLines": 1,
-                                    "position": "top",
-                                    "shouldTruncate": true,
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "xTitle": "",
-                                "yLeftExtent": {
-                                    "mode": "full"
-                                },
-                                "yLeftScale": "linear",
-                                "yRightExtent": {
-                                    "mode": "full"
-                                },
-                                "yRightScale": "linear",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "a91d36c0-f405-4c04-8510-11134bd259f0",
-                    "w": 15,
-                    "x": 8,
-                    "y": 4
-                },
-                "panelIndex": "a91d36c0-f405-4c04-8510-11134bd259f0",
-                "title": "Memory used vs total memory",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1047,14 +756,878 @@
                 "gridData": {
                     "h": 9,
                     "i": "d0fadeee-3c79-443b-bfcb-b70e78d168e9",
-                    "w": 18,
-                    "x": 23,
+                    "w": 20,
+                    "x": 28,
                     "y": 4
                 },
                 "panelIndex": "d0fadeee-3c79-443b-bfcb-b70e78d168e9",
                 "title": "Cores used vs total cores",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "dfd1702f-213e-4fa2-98e3-5106657c62e7": {
+                                            "columnOrder": [
+                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
+                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
+                                                "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                                            ],
+                                            "columns": {
+                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "30s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "62125b6d-3199-420b-9d3b-46f159e15d7f": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.node.status.ready:\"true\" and event.dataset :\"kubernetes.state_node\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Total Memory",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.node.memory.allocatable.bytes"
+                                                },
+                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 100000 values of kubernetes.node.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "customLabel": false,
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 100000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.node.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        },
+                                        "dff09473-7596-48c7-bbf4-beccee70d845": {
+                                            "columnOrder": [
+                                                "6677e92c-5874-49c1-979e-c16c0d3838cd",
+                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
+                                                "307be273-94a6-41ab-b93b-0debde733492"
+                                            ],
+                                            "columns": {
+                                                "307be273-94a6-41ab-b93b-0debde733492": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "event.dataset :\"kubernetes.container\"    "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Memory Used",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.container.memory.usage.bytes"
+                                                },
+                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "30s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "6677e92c-5874-49c1-979e-c16c0d3838cd": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 100000 values of kubernetes.container.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "customLabel": false,
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 100000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.container.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "307be273-94a6-41ab-b93b-0debde733492"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "dff09473-7596-48c7-bbf4-beccee70d845",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "splitAccessor": "6677e92c-5874-49c1-979e-c16c0d3838cd",
+                                        "xAccessor": "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#00bfb3",
+                                                "forAccessor": "307be273-94a6-41ab-b93b-0debde733492"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "accessors": [
+                                            "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "dfd1702f-213e-4fa2-98e3-5106657c62e7",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "negative",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
+                                        "xAccessor": "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#bd271e",
+                                                "forAccessor": "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "top",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "xTitle": "",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "a91d36c0-f405-4c04-8510-11134bd259f0",
+                    "w": 20,
+                    "x": 8,
+                    "y": 4
+                },
+                "panelIndex": "a91d36c0-f405-4c04-8510-11134bd259f0",
+                "title": "Memory used vs total memory",
+                "type": "lens",
+                "version": "8.5.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                                    "name": "state-pods-adhoc",
+                                    "runtimeFieldMap": {
+                                        "failed": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "not_running": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "pending": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "running": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "succeeded": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubernetes.state_pod*"
+                                },
+                                "295ecdc5-f413-4f20-9f77-74927a10d33d": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                                    "name": "state_daemonset-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "not_ready": {
+                                            "script": {
+                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value != 0) {emit(1)}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "ready": {
+                                            "script": {
+                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value == 0) {emit(1)}"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubernetes.state_daemonset*"
+                                },
+                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
+                                    "name": "daemonsets-ad-hoc",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubernetes.state_daemonset*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "b7b25285-ced1-481d-999e-1886b3463594": {
+                                            "columnOrder": [
+                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308",
+                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
+                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                                            ],
+                                            "columns": {
+                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "not_ready: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "not_ready"
+                                                },
+                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "ready: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "ready"
+                                                },
+                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Filters",
+                                                    "operationType": "filters",
+                                                    "params": {
+                                                        "filters": [
+                                                            {
+                                                                "input": {
+                                                                    "language": "kuery",
+                                                                    "query": ""
+                                                                },
+                                                                "label": "Status"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "scale": "ordinal"
+                                                },
+                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of kubernetes.daemonset.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.daemonset.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                                        "key": "event.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.state_daemonset"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.dataset": "kubernetes.state_daemonset"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                                            "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "splitAccessor": "e36fb66d-f9b0-46d3-aec4-52638d34d308",
+                                        "xAccessor": "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
+                                        "yConfig": [
+                                            {
+                                                "color": "#bd271e",
+                                                "forAccessor": "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                                            },
+                                            {
+                                                "color": "#00bfb3",
+                                                "forAccessor": "0e2a3f8d-cc26-453d-bed1-b184e48756b2"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "bottom",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "show",
+                                "valuesInLegend": true,
+                                "xTitle": "",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "a45792c9-1600-4632-bf8e-a0a0984d82d9",
+                    "w": 10,
+                    "x": 28,
+                    "y": 13
+                },
+                "panelIndex": "a45792c9-1600-4632-bf8e-a0a0984d82d9",
+                "title": "DaemonSets",
+                "type": "lens",
+                "version": "8.5.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                                    "name": "state-pods-adhoc",
+                                    "runtimeFieldMap": {
+                                        "failed": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "not_running": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "pending": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "running": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "succeeded": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubernetes.state_pod*"
+                                },
+                                "dbfaeb6f-4fff-4043-8bf8-19d5345fd339": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
+                                    "name": "state_replicaset_ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "not_ready": {
+                                            "script": {
+                                                "source": "def ready = doc['kubernetes.replicaset.replicas.ready'].value;\ndef des = doc['kubernetes.replicaset.replicas.desired'].value;\nemit(des-ready)"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubernetes.state_replicaset*"
+                                },
+                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
+                                    "name": "daemonsets-ad-hoc",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubernetes.state_daemonset*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "b7b25285-ced1-481d-999e-1886b3463594": {
+                                            "columnOrder": [
+                                                "fcc76997-5b49-416b-81ba-37d65ea25296",
+                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1",
+                                                "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                                            ],
+                                            "columns": {
+                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Filters",
+                                                    "operationType": "filters",
+                                                    "params": {
+                                                        "filters": [
+                                                            {
+                                                                "input": {
+                                                                    "language": "kuery",
+                                                                    "query": ""
+                                                                },
+                                                                "label": "Status"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "scale": "ordinal"
+                                                },
+                                                "a51a9822-167b-4b8f-b7a6-3051da30164b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.replicaset.replicas.ready: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.replicaset.replicas.ready"
+                                                },
+                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "not_ready: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "not_ready"
+                                                },
+                                                "fcc76997-5b49-416b-81ba-37d65ea25296": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of kubernetes.replicaset.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.replicaset.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "metrics-*",
+                                        "key": "event.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.state_replicaset"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.dataset": "kubernetes.state_replicaset"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
+                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                                            "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "splitAccessor": "fcc76997-5b49-416b-81ba-37d65ea25296",
+                                        "xAccessor": "446fc0b3-a6c8-4f4d-914b-748d488083a1",
+                                        "yConfig": [
+                                            {
+                                                "color": "#bd271e",
+                                                "forAccessor": "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                                            },
+                                            {
+                                                "color": "#00bfb3",
+                                                "forAccessor": "a51a9822-167b-4b8f-b7a6-3051da30164b"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "show",
+                                "xTitle": "",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "eb118cf7-b033-4bcf-acdf-dab0b5da73e7",
+                    "w": 10,
+                    "x": 38,
+                    "y": 13
+                },
+                "panelIndex": "eb118cf7-b033-4bcf-acdf-dab0b5da73e7",
+                "title": "ReplicaSets",
+                "type": "lens",
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1198,16 +1771,16 @@
                     "hidePanelTitles": false
                 },
                 "gridData": {
-                    "h": 9,
+                    "h": 6,
                     "i": "64dd7c4e-b503-4cc4-8c61-e17c52204b54",
-                    "w": 7,
-                    "x": 41,
-                    "y": 4
+                    "w": 9,
+                    "x": 0,
+                    "y": 13
                 },
                 "panelIndex": "64dd7c4e-b503-4cc4-8c61-e17c52204b54",
                 "title": "Running pods per namespace",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1507,14 +2080,14 @@
                 "gridData": {
                     "h": 6,
                     "i": "91e43cd8-5259-43a8-b9d7-a098875ae5b3",
-                    "w": 7,
-                    "x": 0,
+                    "w": 9,
+                    "x": 9,
                     "y": 13
                 },
                 "panelIndex": "91e43cd8-5259-43a8-b9d7-a098875ae5b3",
                 "title": "Pods",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1820,1461 +2393,14 @@
                 "gridData": {
                     "h": 6,
                     "i": "9543898d-c036-4680-b122-45fe721c0226",
-                    "w": 7,
-                    "x": 7,
+                    "w": 10,
+                    "x": 18,
                     "y": 13
                 },
                 "panelIndex": "9543898d-c036-4680-b122-45fe721c0226",
                 "title": "Deployments",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_pod*"
-                                },
-                                "dbfaeb6f-4fff-4043-8bf8-19d5345fd339": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
-                                    "name": "state_replicaset_ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "def ready = doc['kubernetes.replicaset.replicas.ready'].value;\ndef des = doc['kubernetes.replicaset.replicas.desired'].value;\nemit(des-ready)"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_replicaset*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_daemonset*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "indexpattern": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "fcc76997-5b49-416b-81ba-37d65ea25296",
-                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1",
-                                                "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                            ],
-                                            "columns": {
-                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "a51a9822-167b-4b8f-b7a6-3051da30164b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.replicaset.replicas.ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.replicaset.replicas.ready"
-                                                },
-                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "fcc76997-5b49-416b-81ba-37d65ea25296": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.replicaset.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.replicaset.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "metrics-*",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_replicaset"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "kubernetes.state_replicaset"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                            "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "fcc76997-5b49-416b-81ba-37d65ea25296",
-                                        "xAccessor": "446fc0b3-a6c8-4f4d-914b-748d488083a1",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "a51a9822-167b-4b8f-b7a6-3051da30164b"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "eb118cf7-b033-4bcf-acdf-dab0b5da73e7",
-                    "w": 7,
-                    "x": 14,
-                    "y": 13
-                },
-                "panelIndex": "eb118cf7-b033-4bcf-acdf-dab0b5da73e7",
-                "title": "ReplicaSets",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_pod*"
-                                },
-                                "295ecdc5-f413-4f20-9f77-74927a10d33d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                    "name": "state_daemonset-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value != 0) {emit(1)}"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value == 0) {emit(1)}"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_daemonset*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_daemonset*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "indexpattern": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308",
-                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
-                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                            ],
-                                            "columns": {
-                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "ready"
-                                                },
-                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.daemonset.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.daemonset.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_daemonset"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "kubernetes.state_daemonset"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                            "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "e36fb66d-f9b0-46d3-aec4-52638d34d308",
-                                        "xAccessor": "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "0e2a3f8d-cc26-453d-bed1-b184e48756b2"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "bottom",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "valuesInLegend": true,
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "a45792c9-1600-4632-bf8e-a0a0984d82d9",
-                    "w": 7,
-                    "x": 21,
-                    "y": 13
-                },
-                "panelIndex": "a45792c9-1600-4632-bf8e-a0a0984d82d9",
-                "title": "DaemonSets",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0b9c02fc-3c21-47e2-abed-31cbc41b11cc": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0b9c02fc-3c21-47e2-abed-31cbc41b11cc",
-                                    "name": "state_deployment-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.deployment.replicas.desired\"].value - doc[\"kubernetes.deployment.replicas.available\"].value != 0) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.deployment.replicas.desired\"].value - doc[\"kubernetes.deployment.replicas.available\"].value == 0) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_deployment*"
-                                },
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_pod*"
-                                },
-                                "34c15200-5232-4a16-8fb0-36ca5a194638": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "34c15200-5232-4a16-8fb0-36ca5a194638",
-                                    "name": "deployments-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.deployment.paused'].value == true) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.deployment.paused'].value == false) { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_deployment*"
-                                },
-                                "c427d226-6bd3-4460-8302-e06f65bb47cc": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "c427d226-6bd3-4460-8302-e06f65bb47cc",
-                                    "name": "state_statefulset-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.statefulset.replicas.desired\"].value - doc[\"kubernetes.statefulset.replicas.ready\"].value != 0) {emit(1)}"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.statefulset.replicas.desired\"].value - doc[\"kubernetes.statefulset.replicas.ready\"].value == 0) {emit(1)}\n"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_statefulset*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_daemonset*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "indexpattern": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "ed36aa06-c296-4289-b727-a748c26d2b20",
-                                                "e61d3ce4-931f-4be7-a2ee-9300b33cc513",
-                                                "43277764-ffb5-4582-9686-a0fb24f85b11",
-                                                "716a5dad-243f-48da-9642-3911c2313ec8"
-                                            ],
-                                            "columns": {
-                                                "43277764-ffb5-4582-9686-a0fb24f85b11": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "ready"
-                                                },
-                                                "716a5dad-243f-48da-9642-3911c2313ec8": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "e61d3ce4-931f-4be7-a2ee-9300b33cc513": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "ed36aa06-c296-4289-b727-a748c26d2b20": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.statefulset.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "43277764-ffb5-4582-9686-a0fb24f85b11",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.statefulset.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "c427d226-6bd3-4460-8302-e06f65bb47cc",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_statefulset"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "kubernetes.state_statefulset"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "c427d226-6bd3-4460-8302-e06f65bb47cc",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "43277764-ffb5-4582-9686-a0fb24f85b11",
-                                            "716a5dad-243f-48da-9642-3911c2313ec8"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ed36aa06-c296-4289-b727-a748c26d2b20",
-                                        "xAccessor": "e61d3ce4-931f-4be7-a2ee-9300b33cc513",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "716a5dad-243f-48da-9642-3911c2313ec8"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "43277764-ffb5-4582-9686-a0fb24f85b11"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "edde41a0-360a-4844-b981-8b2f954ef542",
-                    "w": 6,
-                    "x": 28,
-                    "y": 13
-                },
-                "panelIndex": "edde41a0-360a-4844-b981-8b2f954ef542",
-                "title": "StatefulSets",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "a033157a-c507-4715-bc1c-00a3df790db6": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "a033157a-c507-4715-bc1c-00a3df790db6",
-                                    "name": "state_cronjob-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "suspended": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.cronjob.is_suspended\"].value == \"true\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_cronjob*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "indexpattern": {
-                                    "layers": {
-                                        "f12c9d4a-304c-4bd5-b2e2-ae4d24eebfbe": {
-                                            "columnOrder": [
-                                                "9e4f0304-edea-4da2-bcce-dfbffb7e741e",
-                                                "17764307-83b5-4075-a911-aa2c54a82336",
-                                                "d3fbf9fb-0129-46ee-ae97-79bea459437c",
-                                                "ddcb5878-3d1b-477d-9f22-4b806e4d1b22",
-                                                "10e6c0a3-2cbd-4511-a43d-8fa0dc47c2cd"
-                                            ],
-                                            "columns": {
-                                                "10e6c0a3-2cbd-4511-a43d-8fa0dc47c2cd": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "suspended: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Suspended",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "suspended"
-                                                },
-                                                "17764307-83b5-4075-a911-aa2c54a82336": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "9e4f0304-edea-4da2-bcce-dfbffb7e741e": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.cronjob.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "d3fbf9fb-0129-46ee-ae97-79bea459437c",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.cronjob.name"
-                                                },
-                                                "d3fbf9fb-0129-46ee-ae97-79bea459437c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Total",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.cronjob.name"
-                                                },
-                                                "ddcb5878-3d1b-477d-9f22-4b806e4d1b22": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.cronjob.active.count: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Active",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.cronjob.active.count"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "metrics-*",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_cronjob"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "kubernetes.state_cronjob"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "a033157a-c507-4715-bc1c-00a3df790db6",
-                                    "name": "indexpattern-datasource-layer-f12c9d4a-304c-4bd5-b2e2-ae4d24eebfbe",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d3fbf9fb-0129-46ee-ae97-79bea459437c",
-                                            "ddcb5878-3d1b-477d-9f22-4b806e4d1b22",
-                                            "10e6c0a3-2cbd-4511-a43d-8fa0dc47c2cd"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "f12c9d4a-304c-4bd5-b2e2-ae4d24eebfbe",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "9e4f0304-edea-4da2-bcce-dfbffb7e741e",
-                                        "xAccessor": "17764307-83b5-4075-a911-aa2c54a82336",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "10e6c0a3-2cbd-4511-a43d-8fa0dc47c2cd"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "d3fbf9fb-0129-46ee-ae97-79bea459437c"
-                                            },
-                                            {
-                                                "color": "#0077cc",
-                                                "forAccessor": "ddcb5878-3d1b-477d-9f22-4b806e4d1b22"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "33847f7e-e0c0-4dac-8744-2378b9919eca",
-                    "w": 7,
-                    "x": 34,
-                    "y": 13
-                },
-                "panelIndex": "33847f7e-e0c0-4dac-8744-2378b9919eca",
-                "title": "CronJobs",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "51b7c51f-d433-4e39-9d43-a713e5d5c3b0": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "51b7c51f-d433-4e39-9d43-a713e5d5c3b0",
-                                    "name": "state_job-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "active": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.job.pods.active\"].value \u003e 0) {\n    emit(1);\n}"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "complete": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.job.status.complete\"].size() != 0) {\n  if (doc[\"kubernetes.job.status.complete\"].value == \"true\") {\n      emit (1);\n      return;\n      }\n}\nemit (0);"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "completed": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.job.status.complete\"].value==\"true\") {emit(1)}\n"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.job.status.failed\"].size() != 0) {\n  if (doc[\"kubernetes.job.status.failed\"].value == \"true\") {\n      emit (1);\n      return;\n      }\n}\nemit (0);"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_job*"
-                                },
-                                "a033157a-c507-4715-bc1c-00a3df790db6": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "a033157a-c507-4715-bc1c-00a3df790db6",
-                                    "name": "state_cronjob-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "suspended": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.cronjob.is_suspended\"].value == \"true\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubernetes.state_cronjob*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "indexpattern": {
-                                    "layers": {
-                                        "f12c9d4a-304c-4bd5-b2e2-ae4d24eebfbe": {
-                                            "columnOrder": [
-                                                "670bca00-cc68-41e9-9909-ae0aa7173e6a",
-                                                "5c197303-4caf-40aa-ac0f-dba3bd614701",
-                                                "e800a191-7b41-4089-b1b1-f01811267e72",
-                                                "1aeb8015-1619-4ba7-962a-67926a587ae0",
-                                                "cfc83e3d-25de-49af-86db-9e9e76710183"
-                                            ],
-                                            "columns": {
-                                                "1aeb8015-1619-4ba7-962a-67926a587ae0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "active: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Active",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "active"
-                                                },
-                                                "5c197303-4caf-40aa-ac0f-dba3bd614701": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "670bca00-cc68-41e9-9909-ae0aa7173e6a": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.job.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "1aeb8015-1619-4ba7-962a-67926a587ae0",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.job.name"
-                                                },
-                                                "cfc83e3d-25de-49af-86db-9e9e76710183": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "failed: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Failed",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "failed"
-                                                },
-                                                "e800a191-7b41-4089-b1b1-f01811267e72": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "complete: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Completed",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "complete"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "metrics-*",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_job"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "kubernetes.state_job"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "51b7c51f-d433-4e39-9d43-a713e5d5c3b0",
-                                    "name": "indexpattern-datasource-layer-f12c9d4a-304c-4bd5-b2e2-ae4d24eebfbe",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "1aeb8015-1619-4ba7-962a-67926a587ae0",
-                                            "cfc83e3d-25de-49af-86db-9e9e76710183",
-                                            "e800a191-7b41-4089-b1b1-f01811267e72"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "f12c9d4a-304c-4bd5-b2e2-ae4d24eebfbe",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "670bca00-cc68-41e9-9909-ae0aa7173e6a",
-                                        "xAccessor": "5c197303-4caf-40aa-ac0f-dba3bd614701",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "cfc83e3d-25de-49af-86db-9e9e76710183"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "e800a191-7b41-4089-b1b1-f01811267e72"
-                                            },
-                                            {
-                                                "color": "#0077cc",
-                                                "forAccessor": "1aeb8015-1619-4ba7-962a-67926a587ae0"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "2e28a8d4-0a83-4230-be29-9884775aff60",
-                    "w": 7,
-                    "x": 41,
-                    "y": 13
-                },
-                "panelIndex": "2e28a8d4-0a83-4230-be29-9884775aff60",
-                "title": "Jobs",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -3420,7 +2546,7 @@
                 "panelIndex": "14ceb02d-63b6-448a-85fe-28a9e974e80c",
                 "title": "Top CPU intensive pods",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -3566,25 +2692,7 @@
                 "panelIndex": "783789d4-8473-40f5-acf0-7ae5c850cd3e",
                 "title": "Top memory intensive pods",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 11,
-                    "i": "a59fd3c5-5f33-425d-b14e-4713222cc729",
-                    "w": 24,
-                    "x": 24,
-                    "y": 30
-                },
-                "panelIndex": "a59fd3c5-5f33-425d-b14e-4713222cc729",
-                "panelRefName": "panel_a59fd3c5-5f33-425d-b14e-4713222cc729",
-                "title": "Latest Kubernetes warnings",
-                "type": "search",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -3781,29 +2889,37 @@
                 "panelIndex": "2525515f-80e7-455f-b88b-53e4abf31cd2",
                 "title": "Kubernetes warning events",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.5.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "a59fd3c5-5f33-425d-b14e-4713222cc729",
+                    "w": 24,
+                    "x": 24,
+                    "y": 30
+                },
+                "panelIndex": "a59fd3c5-5f33-425d-b14e-4713222cc729",
+                "panelRefName": "panel_a59fd3c5-5f33-425d-b14e-4713222cc729",
+                "title": "Latest Kubernetes warnings",
+                "type": "search",
+                "version": "8.5.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics Kubernetes] Cluster Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.6.0",
+    "coreMigrationVersion": "8.5.0",
     "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c",
     "migrationVersion": {
         "dashboard": "8.5.0"
     },
     "references": [
-        {
-            "id": "metrics-*",
-            "name": "a91d36c0-f405-4c04-8510-11134bd259f0:indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "a91d36c0-f405-4c04-8510-11134bd259f0:indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
-            "type": "index-pattern"
-        },
         {
             "id": "metrics-*",
             "name": "d0fadeee-3c79-443b-bfcb-b70e78d168e9:indexpattern-datasource-layer-c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
@@ -3812,6 +2928,16 @@
         {
             "id": "metrics-*",
             "name": "d0fadeee-3c79-443b-bfcb-b70e78d168e9:indexpattern-datasource-layer-dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a91d36c0-f405-4c04-8510-11134bd259f0:indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a91d36c0-f405-4c04-8510-11134bd259f0:indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
             "type": "index-pattern"
         },
         {
@@ -3830,11 +2956,6 @@
             "type": "index-pattern"
         },
         {
-            "id": "kubernetes-ee55101a-9f62-44da-b64c-ffa1eb5abad8",
-            "name": "a59fd3c5-5f33-425d-b14e-4713222cc729:panel_a59fd3c5-5f33-425d-b14e-4713222cc729",
-            "type": "search"
-        },
-        {
             "id": "metrics-*",
             "name": "2525515f-80e7-455f-b88b-53e4abf31cd2:indexpattern-datasource-layer-a69d8e15-2ebf-401c-af12-4b6762f230db",
             "type": "index-pattern"
@@ -3843,6 +2964,11 @@
             "id": "metrics-*",
             "name": "2525515f-80e7-455f-b88b-53e4abf31cd2:f20bfba9-9cbd-40f7-a373-cdbd3da134e7",
             "type": "index-pattern"
+        },
+        {
+            "id": "kubernetes-ee55101a-9f62-44da-b64c-ffa1eb5abad8",
+            "name": "a59fd3c5-5f33-425d-b14e-4713222cc729:panel_a59fd3c5-5f33-425d-b14e-4713222cc729",
+            "type": "search"
         },
         {
             "id": "metrics-*",
@@ -3856,22 +2982,22 @@
         },
         {
             "id": "kubernetes-managed",
-            "name": "tag-ref-kubernetes-managed",
+            "name": "tag-kubernetes-managed",
             "type": "tag"
         },
         {
             "id": "kubernetes-kubernetes",
-            "name": "tag-ref-kubernetes-kubernetes",
+            "name": "tag-kubernetes-kubernetes",
             "type": "tag"
         },
         {
             "id": "kubernetes-managed",
-            "name": "tag-ref-managed",
+            "name": "tag-managed",
             "type": "tag"
         },
         {
             "id": "kubernetes-kubernetes",
-            "name": "tag-ref-kubernetes",
+            "name": "tag-kubernetes",
             "type": "tag"
         }
     ],

--- a/packages/kubernetes/kibana/search/kubernetes-ee55101a-9f62-44da-b64c-ffa1eb5abad8.json
+++ b/packages/kubernetes/kibana/search/kubernetes-ee55101a-9f62-44da-b64c-ffa1eb5abad8.json
@@ -66,7 +66,7 @@
         "timeRestore": false,
         "title": "Kubernetes Warnings"
     },
-    "coreMigrationVersion": "8.6.0",
+    "coreMigrationVersion": "8.5.0",
     "id": "kubernetes-ee55101a-9f62-44da-b64c-ffa1eb5abad8",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/kubernetes/kibana/tag/kubernetes-324d9ef8-9631-4850-9617-8f5bd7a1b25c.json
+++ b/packages/kubernetes/kibana/tag/kubernetes-324d9ef8-9631-4850-9617-8f5bd7a1b25c.json
@@ -4,7 +4,7 @@
         "description": "",
         "name": "Managed"
     },
-    "coreMigrationVersion": "8.6.0",
+    "coreMigrationVersion": "8.5.0",
     "id": "kubernetes-324d9ef8-9631-4850-9617-8f5bd7a1b25c",
     "migrationVersion": {
         "tag": "8.0.0"

--- a/packages/kubernetes/kibana/tag/kubernetes-c7922c5e-cd6f-4926-82e3-d98e8106b190.json
+++ b/packages/kubernetes/kibana/tag/kubernetes-c7922c5e-cd6f-4926-82e3-d98e8106b190.json
@@ -4,7 +4,7 @@
         "description": "",
         "name": "Kubernetes"
     },
-    "coreMigrationVersion": "8.6.0",
+    "coreMigrationVersion": "8.5.0",
     "id": "kubernetes-c7922c5e-cd6f-4926-82e3-d98e8106b190",
     "migrationVersion": {
         "tag": "8.0.0"

--- a/packages/kubernetes/kibana/tag/kubernetes-kubernetes.json
+++ b/packages/kubernetes/kibana/tag/kubernetes-kubernetes.json
@@ -4,7 +4,7 @@
         "description": "",
         "name": "Kubernetes"
     },
-    "coreMigrationVersion": "8.6.0",
+    "coreMigrationVersion": "8.5.0",
     "id": "kubernetes-kubernetes",
     "migrationVersion": {
         "tag": "8.0.0"

--- a/packages/kubernetes/kibana/tag/kubernetes-managed.json
+++ b/packages/kubernetes/kibana/tag/kubernetes-managed.json
@@ -4,7 +4,7 @@
         "description": "",
         "name": "Managed"
     },
-    "coreMigrationVersion": "8.6.0",
+    "coreMigrationVersion": "8.5.0",
     "id": "kubernetes-managed",
     "migrationVersion": {
         "tag": "8.0.0"

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.28.0
+version: 1.28.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Due to some Lens open issues like https://github.com/elastic/kibana/issues/143673 and https://github.com/elastic/kibana/issues/141974 some of the visualisations in cluster overview dashboard create ugly and unnecessary error messages and pop ups.

<img width="1785" alt="errors" src="https://user-images.githubusercontent.com/26270880/202458325-550b7cba-522f-495b-a71f-77d5da66fbb9.png">

Because of that and until the errors change to warnings and customer messages can be shown to the user, it would be better to remove certain visualisations from the dash so that it has less bad noise.

The choice for the statefulset, cronjob and job visualisations was made based on the assumption that it is less probable that a user would have those resources deployed in their cluster comparing to pods(basic k8s unit), deployments(kube-state-metrics) and DaemonSets(elastic-agent).

So for now the Cluster overview dashboard will look like this

<img width="1782" alt="new" src="https://user-images.githubusercontent.com/26270880/202459255-cdf15646-6488-4018-aa8f-a94dda1d19d5.png">

