### PR TITLE
Enable selective testing of integrations on main and backport branches

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -279,7 +279,7 @@ def isPrAffected(integrationName) {
     from = "origin/${env.BRANCH_NAME}"
     // Check with GIT_PREVIOUS_SUCCESSFUL_COMMIT to check if the branch is still healthy.
     // If this value is not available, check with last commit.
-    to = "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT?.trim()}" ? env.GIT_PREVIOUS_SUCCESSFUL_COMMIT : "origin/${env.BRANCH_NAME}^"
+    to = env.GIT_PREVIOUS_SUCCESSFUL_COMMIT?.trim() ? env.GIT_PREVIOUS_SUCCESSFUL_COMMIT : "origin/${env.BRANCH_NAME}^"
   } else {
     // Source: https://github.com/elastic/apm-pipeline-library/blob/721115cf0fdb2b5a4e1cb6a576bfbb7035d14485/vars/getGitMatchingGroup.groovy#L40-L41
     from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -277,9 +277,9 @@ def isPrAffected(integrationName) {
   if (env.BRANCH_NAME == 'main' || env.BRANCH_NAME.startsWith('backport-')) {
     echo "[${integrationName}] PR is affected: running on ${env.BRANCH_NAME} branch"
     from = "origin/${env.BRANCH_NAME}"
-    // If GIT_PREVIOUS_COMMIT is not available, check with previous commit in the branch, this should
-    // be the same as we are squashing and merging single commits.
-    to = "env.GIT_PREVIOUS_COMMIT?.trim()" ? env.GIT_PREVIOUS_COMMIT : "origin/${env.BRANCH_NAME}^"
+    // Check with GIT_PREVIOUS_SUCCESSFUL_COMMIT to check if the branch is still healthy.
+    // If this value is not available, check with last commit.
+    to = "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT?.trim()}" ? env.GIT_PREVIOUS_SUCCESSFUL_COMMIT : "origin/${env.BRANCH_NAME}^"
   } else {
     // Source: https://github.com/elastic/apm-pipeline-library/blob/721115cf0fdb2b5a4e1cb6a576bfbb7035d14485/vars/getGitMatchingGroup.groovy#L40-L41
     from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -272,14 +272,19 @@ def isPrAffected(integrationName) {
     }
   }
 
-  if (env.BRANCH_NAME == "main") {
-    echo "[${integrationName}] PR is affected: running on main branch"
-    return true
+  def from = "";
+  def to = "";
+  if (env.BRANCH_NAME == 'main' || env.BRANCH_NAME.startsWith('backport-')) {
+    echo "[${integrationName}] PR is affected: running on ${env.BRANCH_NAME} branch"
+    from = "origin/${env.BRANCH_NAME}"
+    // If GIT_PREVIOUS_COMMIT is not available, check with previous commit in the branch, this should
+    // be the same as we are squashing and merging single commits.
+    to = "env.GIT_PREVIOUS_COMMIT?.trim()" ? env.GIT_PREVIOUS_COMMIT : "origin/${env.BRANCH_NAME}^"
+  } else {
+    // Source: https://github.com/elastic/apm-pipeline-library/blob/721115cf0fdb2b5a4e1cb6a576bfbb7035d14485/vars/getGitMatchingGroup.groovy#L40-L41
+    from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"
+    to = env.GIT_BASE_COMMIT
   }
-
-  // Source: https://github.com/elastic/apm-pipeline-library/blob/721115cf0fdb2b5a4e1cb6a576bfbb7035d14485/vars/getGitMatchingGroup.groovy#L40-L41
-  def from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"
-  def to = env.GIT_BASE_COMMIT
 
   def r = sh(label: "[${integrationName}] git-diff: check non-package files", script: "git diff --name-only \$(git merge-base ${from} ${to}) ${to} | egrep -v '^(packages/|.github/CODEOWNERS)'", returnStatus: true)
   if (r == 0) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -272,18 +272,18 @@ def isPrAffected(integrationName) {
     }
   }
 
-  def from = "";
-  def to = "";
+  // Setting default values for a PR.
+  // Source: https://github.com/elastic/apm-pipeline-library/blob/721115cf0fdb2b5a4e1cb6a576bfbb7035d14485/vars/getGitMatchingGroup.groovy#L40-L41
+  def from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"
+  def to = env.GIT_BASE_COMMIT
+
+  // If running for an integration branch (main, backport-*) check with
+  // GIT_PREVIOUS_SUCCESSFUL_COMMIT to check if the branch is still healthy.
+  // If this value is not available, check with last commit.
   if (env.BRANCH_NAME == 'main' || env.BRANCH_NAME.startsWith('backport-')) {
     echo "[${integrationName}] PR is affected: running on ${env.BRANCH_NAME} branch"
     from = "origin/${env.BRANCH_NAME}"
-    // Check with GIT_PREVIOUS_SUCCESSFUL_COMMIT to check if the branch is still healthy.
-    // If this value is not available, check with last commit.
     to = env.GIT_PREVIOUS_SUCCESSFUL_COMMIT?.trim() ? env.GIT_PREVIOUS_SUCCESSFUL_COMMIT : "origin/${env.BRANCH_NAME}^"
-  } else {
-    // Source: https://github.com/elastic/apm-pipeline-library/blob/721115cf0fdb2b5a4e1cb6a576bfbb7035d14485/vars/getGitMatchingGroup.groovy#L40-L41
-    from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"
-    to = env.GIT_BASE_COMMIT
   }
 
   def r = sh(label: "[${integrationName}] git-diff: check non-package files", script: "git diff --name-only \$(git merge-base ${from} ${to}) ${to} | egrep -v '^(packages/|.github/CODEOWNERS)'", returnStatus: true)


### PR DESCRIPTION
Running tests for all integrations after any merge launches dozens of jobs. If multiple branches
are merged in a short period of time, this can overload CI.