### PR TITLE
revert istio release from ga to beta

### DIFF
--- a/packages/istio/manifest.yml
+++ b/packages/istio/manifest.yml
@@ -4,7 +4,7 @@ title: Istio
 description: Collect logs and metrics from the service mesh Istio with Elastic Agent.
 type: integration
 version: 0.2.0
-release: ga
+release: beta
 license: basic
 categories:
   - containers


### PR DESCRIPTION
## What does this PR do?

Revert release of Istio integration from GA back to Beta

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #4253

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
