### PR TITLE
Fix broken k8s Nodes dashboard for CSPs

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -2,8 +2,8 @@
 - version: "1.29.0"
   changes:
     - description: Remove "Control Plane" column from Node Information table
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/9999
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4691
 - version: "1.28.2"
   changes:
     - description: Fix Pod Memory usage panel title

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.0"
+  changes:
+    - description: Remove "Control Plane" column from Node Information table
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.28.2"
   changes:
     - description: Fix Pod Memory usage panel title

--- a/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -243,29 +243,12 @@
                                                 "b0d6d768-94b4-4a60-8703-d4e2f7a04df2",
                                                 "7ccec911-2e78-4c28-ade7-94447ebb88b2",
                                                 "802c8bea-aecf-4d1b-9b54-84d527d1fc18",
-                                                "370e0d18-2e9c-46ae-9174-9fed8a48bf49",
                                                 "968ccc98-9aab-42e0-9ae1-bb2767d38edb",
                                                 "d9dbaa39-4e9e-41a9-b6ce-dbe76d4e865e",
                                                 "f17d0cb7-9045-4bc8-a26a-0777b34a90e6",
                                                 "f146f523-db5b-4965-8486-615c98de32f7"
                                             ],
                                             "columns": {
-                                                "370e0d18-2e9c-46ae-9174-9fed8a48bf49": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.labels.node-role_kubernetes_io/control-plane: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Control Plane",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.labels.node-role_kubernetes_io/control-plane"
-                                                },
                                                 "6efc3318-f2d7-4e8b-ad3c-138a8cf9522d": {
                                                     "customLabel": true,
                                                     "dataType": "string",
@@ -458,10 +441,6 @@
                                     },
                                     {
                                         "columnId": "7ccec911-2e78-4c28-ade7-94447ebb88b2",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "370e0d18-2e9c-46ae-9174-9fed8a48bf49",
                                         "isTransposed": false
                                     },
                                     {

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.28.2
+version: 1.29.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/elastic/integrations/issues/4537.
The issue exists for all k8s cluster that are not created with `kubeadm`. This means all cloud provider are affected. 
Since the information of `Control Plane` column is not crucial we can completely remove it since it makes the whole panel to brake in many cases.

## Screenshot

![k8snodesCrappy](https://user-images.githubusercontent.com/11754898/203295833-9435847b-2626-4c9d-b808-163b154e46b6.png)
