### PR TITLE
Add version compatibility information to HBS files.

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.9"
+  changes:
+    - description: Add version compatibility information
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4695
 - version: "1.0.8"
   changes:
     - description: Update screenshots and icon

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/eks.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/eks.yml.hbs
@@ -1,5 +1,10 @@
 name: Findings
-# Defines how often an event is sent to the output
+
+# Semantic version ranges for compatibility of stack components with
+# this version of cis_eks input.
+compatible_versions:
+  cloudbeat: >= v8.4.0
+
 fetchers:
   - name: kube-api
   - name: process
@@ -15,6 +20,7 @@ fetchers:
       "/hostfs/etc/kubernetes/kubelet/kubelet-config.json",
       "/hostfs/var/lib/kubelet/kubeconfig",
     ]
+
 processors:
   - add_cluster_id: ~
 

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/vanilla.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/vanilla.yml.hbs
@@ -1,5 +1,10 @@
 name: Findings
-# Defines how often an event is sent to the output
+
+# Semantic version ranges for compatibility of stack components with
+# this version of the cis_k8s input.
+compatible_versions:
+  cloudbeat: >= v8.3.0
+
 fetchers:
   - name: kube-api
   - name: process
@@ -28,6 +33,7 @@ fetchers:
       "/hostfs/var/lib/etcd",
       "/hostfs/etc/kubernetes/pki",
     ]
+
 processors:
   - add_cluster_id: ~
 

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Kubernetes Security Posture Management (KSPM)"
-version: 1.0.8
+version: 1.0.9
 release: ga
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Add information that lets stack components know if they can be run with the current version of this integration.

Corresponding cloudbeat change:
- https://github.com/elastic/cloudbeat/pull/538

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Set up the Elastic stack,
```
elastic-package stack up --version 8.6.0-SNAPSHOT --services kibana,package-registry,elasticsearch,fleet-server -vv
```

Install this version of the integration and run an Elastic Agent with it.

## Related issues

- Relates https://github.com/elastic/cloudbeat/issues/239
