### PR TITLE
Add parameter to force checking all integrations

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
     PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH = "gs://elastic-bekitzur-package-storage-internal/queue-publishing/${env.REPO_BUILD_TAG}"
 
     INTEGRATIONS_TESTED = "0"
+    FORCE_CHECK_ALL = "${params.force_check_all}"
   }
   options {
     timeout(time: 4, unit: 'HOURS')
@@ -55,6 +56,7 @@ pipeline {
   }
   parameters {
     string(name: 'stackVersion', defaultValue: '', description: 'Version of the stack to use for testing.')
+    booleanParam(name: 'force_check_all', defaultValue: false, description: 'Force checking all integrations.')
   }
   stages {
     stage('Prepare workspace') {
@@ -270,6 +272,10 @@ def isPrAffected(integrationName) {
         return false
       }
     }
+  }
+
+  if (env.FORCE_CHECK_ALL == "true") {
+    return true
   }
 
   // Setting default values for a PR.

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -275,7 +275,7 @@ def isPrAffected(integrationName) {
   }
 
   if (env.FORCE_CHECK_ALL == "true") {
-    echo("\"force_check_all\" parameter enabled: PR affected")
+    echo "[${integrationName}] PR is affected: \"force_check_all\" parameter enabled"
     return true
   }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -275,6 +275,7 @@ def isPrAffected(integrationName) {
   }
 
   if (env.FORCE_CHECK_ALL == "true") {
+    echo("\"force_check_all\" parameter enabled: PR affected")
     return true
   }
 

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -28,7 +28,7 @@ pipeline {
           steps {
             build(
               job: env.INTEGRATION_JOB,
-              parameters: [stringParam(name: 'stackVersion', value: '7.17-SNAPSHOT')],
+              parameters: [stringParam(name: 'stackVersion', value: '7.17-SNAPSHOT', force_check_all: true)],
               quietPeriod: 0,
               wait: true,
               propagate: true,
@@ -39,7 +39,7 @@ pipeline {
           steps {
             build(
               job: env.INTEGRATION_JOB,
-              parameters: [stringParam(name: 'stackVersion', value: '8.6.0-SNAPSHOT')],
+              parameters: [stringParam(name: 'stackVersion', value: '8.6.0-SNAPSHOT', force_check_all: true)],
               quietPeriod: 0,
               wait: true,
               propagate: true,


### PR DESCRIPTION
## What does this PR do?

Add parameter to allow checking all the integrations independently of the latest commits. This will be used mainly to run the schedule-daily job.
