### PR TITLE
fix flattened process fields in default ingest pipeline

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Fix parse of flattened `process` fields in Falcon data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4709
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-events.log-expected.json
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-events.log-expected.json
@@ -85,14 +85,14 @@
             },
             "message": "Terminated a process related to the deletion of backups, which is often indicative of ransomware activity.",
             "process": {
+                "args": [
+                    "C:\\Windows\\Explorer.EXE"
+                ],
+                "command_line": "C:\\Windows\\Explorer.EXE",
+                "executable": "C:\\Windows\\Explorer.EXE",
                 "name": "explorer.exe",
                 "pid": 38684386611
             },
-            "process.args": [
-                "C:\\Windows\\Explorer.EXE"
-            ],
-            "process.command_line": "C:\\Windows\\Explorer.EXE",
-            "process.executable": "C:\\Windows\\Explorer.EXE",
             "related": {
                 "hash": [
                     "6a671b92a69755de6fd063fcbe4ba926d83b49f78c42dbaeed8cdb6bbc57576a",

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-sample.log-expected.json
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-sample.log-expected.json
@@ -512,6 +512,11 @@
             },
             "message": "This file meets the machine learning-based on-sensor AV protection's low confidence threshold for malicious files.",
             "process": {
+                "args": [
+                    "\"C:\\ProgramData\\file\\path\\filename.exe\""
+                ],
+                "command_line": "\"C:\\ProgramData\\file\\path\\filename.exe\"",
+                "executable": "\"C:\\ProgramData\\file\\path\\filename.exe\"",
                 "name": "filename.exe",
                 "parent": {
                     "command_line": "C:\\Windows\\Explorer.EXE",
@@ -519,11 +524,6 @@
                 },
                 "pid": 663790158277
             },
-            "process.args": [
-                "\"C:\\ProgramData\\file\\path\\filename.exe\""
-            ],
-            "process.command_line": "\"C:\\ProgramData\\file\\path\\filename.exe\"",
-            "process.executable": "\"C:\\ProgramData\\file\\path\\filename.exe\"",
             "related": {
                 "hash": [
                     "0a123b185f9a32fde1df59897089014c92e3d08a0533b54baa72ba2a93d64deb",

--- a/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
@@ -315,7 +315,7 @@ processors:
             ctx.process = [
               'command_line': commandLine,
               'args': args,
-              'executable': args.get(0),
+              'executable': args.get(0)
             ]
           }
         }

--- a/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
@@ -312,10 +312,11 @@ processors:
             def args = Arrays.asList(/ /.split(commandLine));
             args.removeIf(arg -> arg == "");
 
-            ctx['process'] = new HashMap();
-            ctx.process.command_line = commandLine;
-            ctx.process.args = args;
-            ctx.process.executable = args.get(0);
+            ctx.process = [
+              'command_line': commandLine,
+              'args': args,
+              'executable': args.get(0),
+            ]
           }
         }
   - pipeline:

--- a/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
@@ -312,9 +312,10 @@ processors:
             def args = Arrays.asList(/ /.split(commandLine));
             args.removeIf(arg -> arg == "");
 
-            ctx["process.command_line"] = commandLine;
-            ctx["process.args"] = args;
-            ctx["process.executable"] = args.get(0);
+            ctx['process'] = new HashMap();
+            ctx.process.command_line = commandLine;
+            ctx.process.args = args;
+            ctx.process.executable = args.get(0);
           }
         }
   - pipeline:

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.8.0"
+version: "1.8.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fix the parse of flattened `process` fields in the default Falcon ingest pipeline.
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #4707 
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
