### PR TITLE
atlassian_{bitbucket,confluence,jira}: fix handling of zero-length event lists

### DIFF
--- a/packages/atlassian_bitbucket/changelog.yml
+++ b/packages/atlassian_bitbucket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Fix handling of messages with no events.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4713
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/atlassian_bitbucket/data_stream/audit/_dev/test/pipeline/test-audit-api-empty.log
+++ b/packages/atlassian_bitbucket/data_stream/audit/_dev/test/pipeline/test-audit-api-empty.log
@@ -1,0 +1,1 @@
+{"entities":[],"pagingInfo":{"lastPage":true,"size":0}}

--- a/packages/atlassian_bitbucket/data_stream/audit/_dev/test/pipeline/test-audit-api-empty.log-expected.json
+++ b/packages/atlassian_bitbucket/data_stream/audit/_dev/test/pipeline/test-audit-api-empty.log-expected.json
@@ -1,0 +1,5 @@
+{
+    "expected": [
+        null
+    ]
+}

--- a/packages/atlassian_bitbucket/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_bitbucket/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -44,6 +44,7 @@ request.transforms:
 
 response.split:
   target: body.entities
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: url.value

--- a/packages/atlassian_bitbucket/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_bitbucket/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -10,6 +10,8 @@ processors:
 - json:
     field: event.original
     target_field: json
+- drop:
+    if: ctx.json?.entities instanceof List && ctx.json.entities.length == 0
 - set:
     field: _tmp.timestamp
     copy_from: json.timestamp

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: atlassian_bitbucket
 title: Atlassian Bitbucket
-version: "1.5.0"
+version: "1.5.1"
 license: basic
 description: Collect logs from Atlassian Bitbucket with Elastic Agent.
 type: integration

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Fix handling of messages with no events.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4713
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-api-empty.log
+++ b/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-api-empty.log
@@ -1,0 +1,1 @@
+{"entities":[],"pagingInfo":{"lastPage":true,"size":0}}

--- a/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-api-empty.log-expected.json
+++ b/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-api-empty.log-expected.json
@@ -1,0 +1,5 @@
+{
+    "expected": [
+        null
+    ]
+}

--- a/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-cloud-empty.log
+++ b/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-cloud-empty.log
@@ -1,0 +1,1 @@
+{"results":[],"start":2,"limit":2,"size":37,"_links":{"base":"https://test.atlassian.net/wiki","context":"/wiki","self":"https://test.atlassian.net/wiki/rest/api/audit"}}

--- a/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-cloud-empty.log-config.yml
+++ b/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-cloud-empty.log-config.yml
@@ -1,0 +1,5 @@
+fields:
+  _config:
+    atlassian_cloud: true
+  tags:
+    - preserve_original_event

--- a/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-cloud-empty.log-expected.json
+++ b/packages/atlassian_confluence/data_stream/audit/_dev/test/pipeline/test-audit-cloud-empty.log-expected.json
@@ -1,0 +1,5 @@
+{
+    "expected": [
+        null
+    ]
+}

--- a/packages/atlassian_confluence/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_confluence/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -43,6 +43,7 @@ request.transforms:
 
 response.split:
   target: body.results
+  ignore_empty_value: true
 
 response.pagination:
   - set:
@@ -93,6 +94,7 @@ request.transforms:
 
 response.split:
   target: body.entities
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/cloud.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/cloud.yml
@@ -1,6 +1,8 @@
 ---
 description: Pipeline for processing Atlassian Confluence Cloud audit logs.
 processors:
+- drop:
+    if: ctx.json?.results instanceof List && ctx.json.results.length == 0
 - date:
     field: json.creationDate
     formats:

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/self-hosted.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/self-hosted.yml
@@ -1,6 +1,8 @@
 ---
 description: Pipeline for processing self-hosted Atlassian Confluence audit logs.
 processors:
+- drop:
+    if: ctx.json?.entities instanceof List && ctx.json.entities.length == 0
 - set:
     field: _tmp.timestamp
     copy_from: json.timestamp

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.6.0"
+version: "1.6.1"
 license: basic
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Fix handling of messages with no events.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4713
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/atlassian_jira/data_stream/audit/_dev/test/pipeline/test-audit-empty.log
+++ b/packages/atlassian_jira/data_stream/audit/_dev/test/pipeline/test-audit-empty.log
@@ -1,0 +1,1 @@
+{"limit":1000,"offset":9001,"records":[],"total":144}

--- a/packages/atlassian_jira/data_stream/audit/_dev/test/pipeline/test-audit-empty.log-expected.json
+++ b/packages/atlassian_jira/data_stream/audit/_dev/test/pipeline/test-audit-empty.log-expected.json
@@ -1,0 +1,5 @@
+{
+    "expected": [
+        null
+    ]
+}

--- a/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -41,6 +41,7 @@ request.transforms:
       value: '0'
 response.split:
   target: body.records
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: url.value

--- a/packages/atlassian_jira/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_jira/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -10,6 +10,8 @@ processors:
 - json:
     field: event.original
     target_field: json
+- drop:
+    if: ctx.json?.records instanceof List && ctx.json.records.length == 0
 - pipeline:
     name: '{{ IngestPipeline "cloud" }}'
     if: "ctx._config?.atlassian_cloud != null"

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.6.0"
+version: "1.6.1"
 license: basic
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This drops messages that have a zero-length event list for the atlassian packages.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4712

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
