### PR TITLE
Move back removed condition setting for container_logs

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix removed condition setting for container_logs
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9999
+      link: https://github.com/elastic/integrations/pull/4714
 - version: "1.29.0"
   changes:
     - description: Remove "Control Plane" column from Node Information table

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.1"
+  changes:
+    - description: Fix removed condition setting for container_logs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.29.0"
   changes:
     - description: Remove "Control Plane" column from Node Information table

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -4,6 +4,9 @@ paths:
   - {{this}}
 {{/each}}
 prospector.scanner.symlinks: {{ symlinks }}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 parsers:
 - container:
     stream: {{ containerParserStream }}

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.29.0
+version: 1.29.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Puts back the condition setting in `stream.yml.hbs` file of `container_logs` data_stream  added by https://github.com/elastic/integrations/commit/336cdfcbd08728a1a0ab1f3d946e9b7170c18a08  and which was removed accidentally when re-basing for https://github.com/elastic/integrations/pull/4363/files#diff-0357f29b430528695df420c2917a9cb06b6ade346ee0b1d71603e50befa1dcc2L7.