### PR TITLE
[Cisco_Secure_Endpoint] Add drop processor for empty events

### DIFF
--- a/packages/cisco_secure_endpoint/changelog.yml
+++ b/packages/cisco_secure_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added processor to drop empty documents when there are no events
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4285
+      link: https://github.com/elastic/integrations/pull/4719
 - version: "2.7.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cisco_secure_endpoint/changelog.yml
+++ b/packages/cisco_secure_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.1"
+  changes:
+    - description: Added processor to drop empty documents when there are no events
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4285
 - version: "2.7.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cisco_secure_endpoint/data_stream/event/_dev/test/pipeline/test-cisco-amp-empty.log
+++ b/packages/cisco_secure_endpoint/data_stream/event/_dev/test/pipeline/test-cisco-amp-empty.log
@@ -1,0 +1,1 @@
+{"data":[],"metadata":{"links":{"self":"https://api.eu.amp.cisco.com/v1/events?limit=100u0026offset=0u0026start_date=2022-11-09T11%3A09%3A35%2B00%3A00"},"results":{"current_item_count":0,"index":0,"items_per_page":100,"total":0}},"version":"v1.2.0"}

--- a/packages/cisco_secure_endpoint/data_stream/event/_dev/test/pipeline/test-cisco-amp-empty.log-expected.json
+++ b/packages/cisco_secure_endpoint/data_stream/event/_dev/test/pipeline/test-cisco-amp-empty.log-expected.json
@@ -1,0 +1,5 @@
+{
+    "expected": [
+        null
+    ]
+}

--- a/packages/cisco_secure_endpoint/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_secure_endpoint/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -12,6 +12,8 @@ processors:
     field: event.original
     target_field: json
     if: ctx?.json == null
+- drop:
+    if: ctx.json?.data.isEmpty()
 #########################
 ## ECS General Mapping ##
 #########################

--- a/packages/cisco_secure_endpoint/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_secure_endpoint/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -13,7 +13,7 @@ processors:
     target_field: json
     if: ctx?.json == null
 - drop:
-    if: ctx.json?.data.isEmpty()
+    if: ctx.json?.data != null && ctx.json?.data.isEmpty()
 #########################
 ## ECS General Mapping ##
 #########################

--- a/packages/cisco_secure_endpoint/manifest.yml
+++ b/packages/cisco_secure_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_secure_endpoint
 title: Cisco Secure Endpoint
-version: "2.7.0"
+version: "2.7.1"
 license: basic
 description: Collect logs from Cisco Secure Endpoint (AMP) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

If there are no events for the 24 hour interval, the Cisco API endpoint returns an empty data array, and the ingest pipeline processor returns processor failures because of this.

Its better to drop the empty event rather than storing ingest failures.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

