### PR TITLE
[suricata] Defensive copy of parameter lists

### DIFF
--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Defensive copy of parameter lists
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/4723
+      link: https://github.com/elastic/integrations/pull/4731
 - version: "2.5.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Defensive copy of parameter lists
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/4723
 - version: "2.5.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/default.yml
@@ -231,6 +231,8 @@ processors:
                 } else {
                     ctx.network.protocol = v;
                 }
+            } else if (v instanceof List) {
+                ctx.event[k] = new ArrayList(v);
             } else {
                 ctx.event[k] = v;
             }

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,6 +1,6 @@
 name: suricata
 title: Suricata
-version: "2.5.0"
+version: "2.5.1"
 release: ga
 description: Collect logs from Suricata with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fixes #4723. Adds a defensive copy of the lists that we use from the params map, very much in the style of what was done previously in #3492.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #4723
- Relates elastic/elasticsearch#91977