### PR TITLE
[Synthetics] add run_from.geo.name field

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.4"
+  changes:
+    - description: Remove run_from field to monitor config to preserve location name
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4673
 - version: "0.11.3"
   changes:
     - description: Add run_from field to monitor config

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "0.11.4"
   changes:
-    - description: Remove run_from field to monitor config to preserve location name
+    - description: Add run_from.geo.name field to monitor config to preserve location name
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4673
+      link: https://github.com/elastic/integrations/pull/4741
 - version: "0.11.3"
   changes:
     - description: Add run_from field to monitor config
@@ -13,7 +13,7 @@
   changes:
     - description: Change incorrectly typed `states.ends.duration` field from `date` to long
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4477
+      link: https://github.com/elastic/integrations/pull/4541
 - version: "0.11.1"
   changes:
     - description: Change incorrectly typed `states.duration` field from `date` to long

--- a/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
+++ b/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
@@ -84,9 +84,6 @@ source.zip_url.ssl.supported_protocols: {{source.zip_url.ssl.supported_protocols
 source.zip_url.proxy_url: {{source.zip_url.proxy_url}}
 {{/if}}
 processors:
-  - add_observer_metadata:
-      geo:
-        name: {{location_name}}
   - add_fields:
       target: ''
       fields:

--- a/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
+++ b/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
@@ -7,6 +7,12 @@ id: {{id}}
 {{#if origin}}
 origin: {{origin}}
 {{/if}}
+{{#if location_name}}
+run_from.id: {{location_name}}
+{{/if}}
+{{#if location_name}}
+run_from.geo.name: {{location_name}}
+{{/if}}
 enabled: {{enabled}}
 {{#if service.name}}
 service.name: {{service.name}}

--- a/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
+++ b/packages/synthetics/data_stream/browser/agent/stream/browser.yml.hbs
@@ -7,9 +7,6 @@ id: {{id}}
 {{#if origin}}
 origin: {{origin}}
 {{/if}}
-{{#if location_name}}
-run_from.id: {{location_name}}
-{{/if}}
 enabled: {{enabled}}
 {{#if service.name}}
 service.name: {{service.name}}

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -7,9 +7,6 @@ id: {{id}}
 {{#if origin}}
 origin: {{origin}}
 {{/if}}
-{{#if location_name}}
-run_from.id: {{location_name}}
-{{/if}}
 enabled: {{enabled}}
 urls: {{urls}}
 {{#if service.name}}

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -7,6 +7,12 @@ id: {{id}}
 {{#if origin}}
 origin: {{origin}}
 {{/if}}
+{{#if location_name}}
+run_from.id: {{location_name}}
+{{/if}}
+{{#if location_name}}
+run_from.geo.name: {{location_name}}
+{{/if}}
 enabled: {{enabled}}
 urls: {{urls}}
 {{#if service.name}}

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -73,9 +73,6 @@ ssl.verification_mode: {{ssl.verification_mode}}
 ssl.supported_protocols: {{ssl.supported_protocols}}
 {{/if}}
 processors:
-  - add_observer_metadata:
-      geo: 
-        name: {{location_name}}
   - add_fields:
       target: ''
       fields:

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -25,9 +25,6 @@ timeout: {{timeout}}
 tags: {{tags}}
 {{/if}}
 processors:
-  - add_observer_metadata:
-      geo: 
-        name: {{location_name}}
   - add_fields:
       target: ''
       fields:

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -7,9 +7,6 @@ id: {{id}}
 {{#if origin}}
 origin: {{origin}}
 {{/if}}
-{{#if location_name}}
-run_from.id: {{location_name}}
-{{/if}}
 enabled: {{enabled}}
 hosts: {{hosts}}
 {{#if service.name}}

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -7,6 +7,12 @@ id: {{id}}
 {{#if origin}}
 origin: {{origin}}
 {{/if}}
+{{#if location_name}}
+run_from.id: {{location_name}}
+{{/if}}
+{{#if location_name}}
+run_from.geo.name: {{location_name}}
+{{/if}}
 enabled: {{enabled}}
 hosts: {{hosts}}
 {{#if service.name}}

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -7,9 +7,6 @@ id: {{id}}
 {{#if origin}}
 origin: {{origin}}
 {{/if}}
-{{#if location_name}}
-run_from.id: {{location_name}}
-{{/if}}
 enabled: {{enabled}}
 hosts: {{hosts}}
 {{#if service.name}}

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -52,9 +52,6 @@ ssl.verification_mode: {{ssl.verification_mode}}
 ssl.supported_protocols: {{ssl.supported_protocols}}
 {{/if}}
 processors:
-  - add_observer_metadata:
-      geo: 
-        name: {{location_name}}
   - add_fields:
       target: ''
       fields:

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -7,6 +7,12 @@ id: {{id}}
 {{#if origin}}
 origin: {{origin}}
 {{/if}}
+{{#if location_name}}
+run_from.id: {{location_name}}
+{{/if}}
+{{#if location_name}}
+run_from.geo.name: {{location_name}}
+{{/if}}
 enabled: {{enabled}}
 hosts: {{hosts}}
 {{#if service.name}}

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.11.3
+version: 0.11.4
 categories: ["elastic_stack", "monitoring", "web"]
 release: beta
 type: integration


### PR DESCRIPTION
fixes https://github.com/elastic/integrations/issues/4735

Type of change
- Bug

## What does this PR do?

In https://github.com/elastic/integrations/pull/4673, the run_from fields were introduced to the synthetics integration. While these fields are meant to specify to heartbeat which location a monitor is run from, these fields currently interfere with the existing location name logic, causing the location name to become missing.

The solution is to add `run_from.geo.name` to ensure that the `observer.geo.name` properly is indexed correctly.

## Checklist

## How to test this PR locally

1. Check out this PR
2. Navigate to `packages/synthetics`
3. Run `elastic-package clean` then `elastic-package build`
4. In the same directory, run `elastic-package stack up --version 8.5.0-SNAPSHOT -v`
5. Navigate to `https://localhost:5601` and log in.
6. Navigate to Uptime Monitor Management and click add private location, then add a private location configured to elastic-agent
7. Click Add Monitor and create a monitor with that private location
8. Navigate to that monitor in Uptime. Confirm the location name appears in the History tab for that monitor
<img width="1520" alt="Screen Shot 2022-11-30 at 10 35 53 AM" src="https://user-images.githubusercontent.com/11356435/204841086-d395b9cf-7371-481e-a8b8-44750693b204.png">

