### PR TITLE
[Prototype] Test package with TSDB and synthetic source enabled

### DIFF
--- a/packages/system/data_stream/memory/fields/agent.yml
+++ b/packages/system/data_stream/memory/fields/agent.yml
@@ -25,6 +25,7 @@
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
+      dimension: true
     - name: instance.name
       level: extended
       type: keyword
@@ -67,6 +68,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+      dimension: true
     - name: image.name
       level: extended
       type: keyword

--- a/packages/system/data_stream/memory/fields/ecs.yml
+++ b/packages/system/data_stream/memory/fields/ecs.yml
@@ -8,6 +8,7 @@
   name: host.mac
 - external: ecs
   name: host.name
+  dimension: true
 - external: ecs
   name: host.os.family
 - external: ecs

--- a/packages/system/data_stream/memory/manifest.yml
+++ b/packages/system/data_stream/memory/manifest.yml
@@ -26,3 +26,7 @@ streams:
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: System memory metrics
     description: Collect System memory metrics
+
+elasticsearch:
+  source_mode: "synthetic"
+  index_mode: "time_series"

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,9 +1,9 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.20.4
+version: 1.20.5
 license: basic
-description: Collect system logs and metrics from your servers with Elastic Agent.
+description: Collect system logs and metrics from your servers with Elastic Agent and TSDB.
 type: integration
 categories:
   - os_system


### PR DESCRIPTION
This is a change to the system.memory dataset in the system package. The intention is to use time_series index, define the dimensions and turn synthetic source on. This follows the change in https://github.com/elastic/package-spec/pull/419.

This PR is for testing and discussion purpose, it is not expected that this PR will ever be merged, this is why is is only in draft.