### PR TITLE
Azure App Insights: fix misspelled field name in app_state data stream

### DIFF
--- a/packages/azure_application_insights/changelog.yml
+++ b/packages/azure_application_insights/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.4"
+  changes:
+    - description: Fix misspelled field name in the app_state data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4754
 - version: "1.0.3"
   changes:
     - description: Updated Readme

--- a/packages/azure_application_insights/data_stream/app_state/fields/fields.yml
+++ b/packages/azure_application_insights/data_stream/app_state/fields/fields.yml
@@ -49,7 +49,7 @@
       description: >
         Browser timings send duration
 
-    - name: browser_timings_receive_uration.avg
+    - name: browser_timings_receive_duration.avg
       type: float
       description: >
         Browser timings receive duration

--- a/packages/azure_application_insights/docs/README.md
+++ b/packages/azure_application_insights/docs/README.md
@@ -152,7 +152,7 @@ An example event for `app_insights` looks as following:
 | @timestamp | Event timestamp. | date |
 | azure.app_state.browser_timings_network_duration.avg | Browser timings network duration | float |
 | azure.app_state.browser_timings_processing_duration.avg | Browser timings processing duration | float |
-| azure.app_state.browser_timings_receive_uration.avg | Browser timings receive duration | float |
+| azure.app_state.browser_timings_receive_duration.avg | Browser timings receive duration | float |
 | azure.app_state.browser_timings_send_duration.avg | Browser timings send duration | float |
 | azure.app_state.browser_timings_total_duration.avg | Browser timings total duration | float |
 | azure.app_state.end_date | The end date | date |

--- a/packages/azure_application_insights/docs/app_state.md
+++ b/packages/azure_application_insights/docs/app_state.md
@@ -20,7 +20,7 @@ Costs: Metric queries are charged based on the number of standard API calls. Mor
 | @timestamp | Event timestamp. | date |
 | azure.app_state.browser_timings_network_duration.avg | Browser timings network duration | float |
 | azure.app_state.browser_timings_processing_duration.avg | Browser timings processing duration | float |
-| azure.app_state.browser_timings_receive_uration.avg | Browser timings receive duration | float |
+| azure.app_state.browser_timings_receive_duration.avg | Browser timings receive duration | float |
 | azure.app_state.browser_timings_send_duration.avg | Browser timings send duration | float |
 | azure.app_state.browser_timings_total_duration.avg | Browser timings total duration | float |
 | azure.app_state.end_date | The end date | date |

--- a/packages/azure_application_insights/manifest.yml
+++ b/packages/azure_application_insights/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_application_insights
 title: Azure Application Insights Metrics Overview
-version: 1.0.3
+version: 1.0.4
 release: ga
 description: Collect application insights metrics from Azure Monitor with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Fix a misspelling in the field name `azure.app_state.browser_timings_receive_[d]uration` that was causing an error during Lens editing.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->


<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4753


<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
