### PR TITLE
[Metrics Kubernetes] Nodes: Fix memory usage by node

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.2"
+  changes:
+    - description: Fix function for memory node usage
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.29.1"
   changes:
     - description: Fix removed condition setting for container_logs

--- a/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -46,8 +46,7 @@
                         "title": "",
                         "type": "markdown",
                         "uiState": {}
-                    },
-                    "type": "visualization"
+                    }
                 },
                 "gridData": {
                     "h": 4,
@@ -59,7 +58,7 @@
                 "panelIndex": "1d9fa4a6-44fe-489d-be4f-53a2eb02a2d5",
                 "title": "Kubernetes Dashboards [Metrics Kubernetes]",
                 "type": "visualization",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -205,8 +204,7 @@
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 8,
@@ -218,7 +216,7 @@
                 "panelIndex": "c6bb8ec0-dae3-4438-ab76-0bff97321124",
                 "title": "Allocated and Allocatable Pods per Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -473,8 +471,7 @@
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 8,
@@ -486,7 +483,7 @@
                 "panelIndex": "2a2da54b-f923-4b1f-b36c-0b1d283405b9",
                 "title": "Node Informations by Labels [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -734,8 +731,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 13,
@@ -747,7 +743,7 @@
                 "panelIndex": "f11dcb2d-3850-430c-b365-e925473ffe81",
                 "title": "CPU usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -760,11 +756,12 @@
                             },
                             {
                                 "id": "metrics-*",
-                                "name": "63208367-420e-4cf0-aa41-a96650281919",
+                                "name": "af1f3d5e-32e8-44fa-8a79-8e2d25c0b089",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "indexpattern": {
                                     "layers": {
@@ -825,7 +822,7 @@
                                                                 "decimals": 2
                                                             }
                                                         },
-                                                        "formula": "average(kubernetes.node.memory.usage.bytes)/max(kubernetes.node.memory.allocatable.bytes)",
+                                                        "formula": "average(kubernetes.node.memory.usage.bytes)/max(kubernetes.node.memory.capacity.bytes)",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
@@ -855,7 +852,7 @@
                                                         "emptyAsNull": false
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "kubernetes.node.memory.allocatable.bytes"
+                                                    "sourceField": "kubernetes.node.memory.capacity.bytes"
                                                 },
                                                 "b8d52304-59e9-4635-80b0-dac037233757X2": {
                                                     "customLabel": true,
@@ -870,11 +867,11 @@
                                                                 "b8d52304-59e9-4635-80b0-dac037233757X1"
                                                             ],
                                                             "location": {
-                                                                "max": 89,
+                                                                "max": 86,
                                                                 "min": 0
                                                             },
                                                             "name": "divide",
-                                                            "text": "average(kubernetes.node.memory.usage.bytes)/max(kubernetes.node.memory.allocatable.bytes)",
+                                                            "text": "average(kubernetes.node.memory.usage.bytes)/max(kubernetes.node.memory.capacity.bytes)",
                                                             "type": "function"
                                                         }
                                                     },
@@ -898,14 +895,18 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "63208367-420e-4cf0-aa41-a96650281919",
+                                        "index": "af1f3d5e-32e8-44fa-8a79-8e2d25c0b089",
                                         "key": "event.dataset",
                                         "negate": false,
                                         "params": [
                                             "kubernetes.node",
                                             "kubernetes.state_node"
                                         ],
-                                        "type": "phrases"
+                                        "type": "phrases",
+                                        "value": [
+                                            "kubernetes.node",
+                                            "kubernetes.state_node"
+                                        ]
                                     },
                                     "query": {
                                         "bool": {
@@ -926,6 +927,7 @@
                                     }
                                 }
                             ],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -981,8 +983,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 13,
@@ -994,7 +995,7 @@
                 "panelIndex": "64187c9b-8038-47a3-b7df-6562d740840f",
                 "title": "Memory usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -1228,8 +1229,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 13,
@@ -1241,7 +1241,7 @@
                 "panelIndex": "b228c756-7cbd-4982-b61b-c6dbb78c1ced",
                 "title": "Working set Memory usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -1419,8 +1419,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 13,
@@ -1432,7 +1431,7 @@
                 "panelIndex": "93d7f58a-ee13-4ca2-968a-a6c8bcf249a4",
                 "title": "Network in by node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -1610,8 +1609,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 13,
@@ -1623,7 +1621,7 @@
                 "panelIndex": "7c066a0c-0e3d-483d-a4fd-89dd6444d2d3",
                 "title": "Network out by node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -1817,8 +1815,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 13,
@@ -1830,7 +1827,7 @@
                 "panelIndex": "5c839f9c-a8bc-46e0-bd23-9300c03e6ed5",
                 "title": "Filesystem usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -2004,8 +2001,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 13,
@@ -2017,7 +2013,7 @@
                 "panelIndex": "5eef3516-509a-414c-b0ad-f6c8af1647bb",
                 "title": "Filesystem Inodes usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.5.0"
+                "version": "8.5.1"
             }
         ],
         "timeRestore": false,
@@ -2067,7 +2063,7 @@
         },
         {
             "id": "metrics-*",
-            "name": "64187c9b-8038-47a3-b7df-6562d740840f:63208367-420e-4cf0-aa41-a96650281919",
+            "name": "64187c9b-8038-47a3-b7df-6562d740840f:af1f3d5e-32e8-44fa-8a79-8e2d25c0b089",
             "type": "index-pattern"
         },
         {
@@ -2122,12 +2118,12 @@
         },
         {
             "id": "kubernetes-fleet-managed-default",
-            "name": "tag-ref-fleet-managed-default",
+            "name": "tag-fleet-managed-default",
             "type": "tag"
         },
         {
             "id": "kubernetes-fleet-pkg-kubernetes-default",
-            "name": "tag-ref-fleet-pkg-kubernetes-default",
+            "name": "tag-fleet-pkg-kubernetes-default",
             "type": "tag"
         }
     ],

--- a/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -46,7 +46,8 @@
                         "title": "",
                         "type": "markdown",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 4,
@@ -58,7 +59,7 @@
                 "panelIndex": "1d9fa4a6-44fe-489d-be4f-53a2eb02a2d5",
                 "title": "Kubernetes Dashboards [Metrics Kubernetes]",
                 "type": "visualization",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -204,7 +205,8 @@
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 8,
@@ -216,7 +218,7 @@
                 "panelIndex": "c6bb8ec0-dae3-4438-ab76-0bff97321124",
                 "title": "Allocated and Allocatable Pods per Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -471,7 +473,8 @@
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 8,
@@ -483,7 +486,7 @@
                 "panelIndex": "2a2da54b-f923-4b1f-b36c-0b1d283405b9",
                 "title": "Node Informations by Labels [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -731,7 +734,8 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 13,
@@ -743,7 +747,7 @@
                 "panelIndex": "f11dcb2d-3850-430c-b365-e925473ffe81",
                 "title": "CPU usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -977,7 +981,8 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 13,
@@ -989,7 +994,7 @@
                 "panelIndex": "64187c9b-8038-47a3-b7df-6562d740840f",
                 "title": "Memory usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -1223,7 +1228,8 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 13,
@@ -1235,7 +1241,7 @@
                 "panelIndex": "b228c756-7cbd-4982-b61b-c6dbb78c1ced",
                 "title": "Working set Memory usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -1413,7 +1419,8 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 13,
@@ -1425,7 +1432,7 @@
                 "panelIndex": "93d7f58a-ee13-4ca2-968a-a6c8bcf249a4",
                 "title": "Network in by node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -1603,7 +1610,8 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 13,
@@ -1615,7 +1623,7 @@
                 "panelIndex": "7c066a0c-0e3d-483d-a4fd-89dd6444d2d3",
                 "title": "Network out by node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -1809,7 +1817,8 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 13,
@@ -1821,7 +1830,7 @@
                 "panelIndex": "5c839f9c-a8bc-46e0-bd23-9300c03e6ed5",
                 "title": "Filesystem usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -1995,7 +2004,8 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 13,
@@ -2007,17 +2017,17 @@
                 "panelIndex": "5eef3516-509a-414c-b0ad-f6c8af1647bb",
                 "title": "Filesystem Inodes usage by Node [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics Kubernetes] Nodes",
         "version": 1
     },
-    "coreMigrationVersion": "8.4.0",
+    "coreMigrationVersion": "8.5.1",
     "id": "kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013",
     "migrationVersion": {
-        "dashboard": "8.3.0"
+        "dashboard": "8.5.0"
     },
     "references": [
         {
@@ -2109,6 +2119,16 @@
             "id": "metrics-*",
             "name": "controlGroup_6c029002-b266-42ef-af36-fdcd73bfadef:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "id": "kubernetes-fleet-managed-default",
+            "name": "tag-ref-fleet-managed-default",
+            "type": "tag"
+        },
+        {
+            "id": "kubernetes-fleet-pkg-kubernetes-default",
+            "name": "tag-ref-fleet-pkg-kubernetes-default",
+            "type": "tag"
         }
     ],
     "type": "dashboard"

--- a/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -756,7 +756,7 @@
                             },
                             {
                                 "id": "metrics-*",
-                                "name": "af1f3d5e-32e8-44fa-8a79-8e2d25c0b089",
+                                "name": "aa872c1d-88ab-474e-87cc-7db51d417372",
                                 "type": "index-pattern"
                             }
                         ],
@@ -895,7 +895,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "af1f3d5e-32e8-44fa-8a79-8e2d25c0b089",
+                                        "index": "aa872c1d-88ab-474e-87cc-7db51d417372",
                                         "key": "event.dataset",
                                         "negate": false,
                                         "params": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "metrics-*",
-            "name": "64187c9b-8038-47a3-b7df-6562d740840f:af1f3d5e-32e8-44fa-8a79-8e2d25c0b089",
+            "name": "64187c9b-8038-47a3-b7df-6562d740840f:aa872c1d-88ab-474e-87cc-7db51d417372",
             "type": "index-pattern"
         },
         {

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.29.1
+version: 1.29.2
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fix the function to calculate pod memory usage.

## Screenshots

Since, the total memory node used in the function was  `kubernetes.node.memory.allocatable.bytes`, every memory used by system daemons was not being considered. Changing it to `kubernetes.node.memory.capacity.bytes` fix problems like the one mentioned in elastic/integrations#4577.

Before:
![image](https://user-images.githubusercontent.com/113898685/205322871-2a6f3119-5523-4d9c-991e-78f12fa77859.png)


After:
![image](https://user-images.githubusercontent.com/113898685/205322733-f354eea0-eacd-4875-9743-03ae2ee4a727.png)
