### PR TITLE
[Dashboard] [Metrics Kubernetes] Controller Manager: URL does not exist in local clusters

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.3"
+  changes:
+    - description: Fix label url from controller manager dashboard
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.29.2"
   changes:
     - description: Fix function for memory node usage

--- a/packages/kubernetes/kibana/dashboard/kubernetes-bf9389f0-0c14-11ed-b760-5d1bccb47f56.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-bf9389f0-0c14-11ed-b760-5d1bccb47f56.json
@@ -228,7 +228,7 @@
                 "panelIndex": "2158ddb3-913e-4aa5-8694-e6708be54b20",
                 "title": "Controller Process [Metrics Kubernetes]",
                 "type": "visualization",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -241,6 +241,7 @@
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "indexpattern": {
                                     "layers": {
@@ -257,7 +258,7 @@
                                                 "35a11916-4ca3-421b-9df2-521f52f21fbb": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Top 50 values of kubernetes.controllermanager.url",
+                                                    "label": "Top 50 values of kubernetes.controllermanager.host",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "missingBucket": false,
@@ -274,7 +275,7 @@
                                                         "size": 50
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "kubernetes.controllermanager.url"
+                                                    "sourceField": "kubernetes.controllermanager.host"
                                                 },
                                                 "43097f7a-e478-47bc-81c1-7541bd899d46": {
                                                     "customLabel": true,
@@ -374,6 +375,7 @@
                                 }
                             },
                             "filters": [],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -419,9 +421,9 @@
                     "y": 0
                 },
                 "panelIndex": "1bd24fa1-319e-4cae-9d45-d821b06a8034",
-                "title": "Average Request Latency per Url [Metrics Kubernetes]",
+                "title": "Average Request Latency per Host [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -535,7 +537,7 @@
                 "panelIndex": "1604f0de-edd6-456e-8670-ab9b33988abb",
                 "title": "Controller CPU [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -667,7 +669,7 @@
                 "panelIndex": "303702e1-ba33-49f2-b337-4cc7d7305606",
                 "title": "Controller Memory in Bytes [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -808,7 +810,7 @@
                 "panelIndex": "74dcc137-b625-44d5-ae91-072040ef4b0a",
                 "title": "Controller Workqueue adds [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -949,7 +951,7 @@
                 "panelIndex": "d680bbc4-b3dd-4237-9825-5394ff9d402c",
                 "title": "Controller Workqueue retries [Metrics Kubernetes] ",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -1081,7 +1083,7 @@
                 "panelIndex": "0be041d4-096a-4131-ab5b-f9ae02eb685a",
                 "title": "Controller Longest running processor [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -1213,7 +1215,7 @@
                 "panelIndex": "a015a089-006e-4eb8-ad45-7f9d5f16eecb",
                 "title": "Controller Unfinished jobs sec [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             },
             {
                 "embeddableConfig": {
@@ -1396,17 +1398,17 @@
                 "panelIndex": "bf28ccd1-0c7a-4672-9c32-0576e8b0c67f",
                 "title": "NodeController Informations [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.4.0-SNAPSHOT"
+                "version": "8.5.1"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics Kubernetes] Controller Manager",
         "version": 1
     },
-    "coreMigrationVersion": "8.4.0",
+    "coreMigrationVersion": "8.5.1",
     "id": "kubernetes-bf9389f0-0c14-11ed-b760-5d1bccb47f56",
     "migrationVersion": {
-        "dashboard": "8.3.0"
+        "dashboard": "8.5.0"
     },
     "references": [
         {
@@ -1453,6 +1455,16 @@
             "id": "metrics-*",
             "name": "bf28ccd1-0c7a-4672-9c32-0576e8b0c67f:indexpattern-datasource-layer-c46cb227-5f12-45ee-a3f0-58f837655aeb",
             "type": "index-pattern"
+        },
+        {
+            "id": "kubernetes-fleet-managed-default",
+            "name": "tag-fleet-managed-default",
+            "type": "tag"
+        },
+        {
+            "id": "kubernetes-fleet-pkg-kubernetes-default",
+            "name": "tag-fleet-pkg-kubernetes-default",
+            "type": "tag"
         }
     ],
     "type": "dashboard"

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.29.2
+version: 1.29.3
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Switch the field `kubernetes.controllermanager.url` to `kubernetes.controllermanager.host`, as the first does not exist in local clusters.


## Screenshots
Before:
![image](https://user-images.githubusercontent.com/113898685/205918613-56fca9a2-ac6a-4040-b4c8-2cd08d4d667e.png)


After:
![image](https://user-images.githubusercontent.com/113898685/205918591-8d693546-ae01-46ca-8e44-f9774b04ca28.png)
