### PR TITLE
[AWS] Change Kinesis integration documentation to Kinesis Data Stream

### DIFF
--- a/packages/aws/_dev/build/docs/kinesis.md
+++ b/packages/aws/_dev/build/docs/kinesis.md
@@ -1,8 +1,10 @@
-# Amazon Kinesis
+# Amazon Kinesis Data Stream
 
-The Amazon Kinesis integration allows you to monitor [Amazon Kinesis](https://aws.amazon.com/kinesis/)—a streaming data processor.
+The Amazon Kinesis integration allows you to monitor [Amazon Kinesis Data Stream](https://aws.amazon.com/kinesis/data-streams/)—
+a serverless streaming data service that makes it easy to capture, process, and store data streams at any scale.
 
-Use the Amazon Kinesis integration to monitor Amazon Kinesis. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference metrics when troubleshooting an issue.
+Use the Amazon Kinesis integration to monitor Amazon Kinesis Data Streams. Then visualize that data in Kibana, create 
+alerts to notify you if something goes wrong, and reference metrics when troubleshooting an issue.
 
 ## Data streams
 

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adjust kinesis integration to kinesis data stream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4641
+      link: https://github.com/elastic/integrations/pull/4794
 - version: "1.28.0"
   changes:
     - description: Enhance S3 integration dashboard

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.1"
+  changes:
+    - description: Adjust kinesis integration to kinesis data stream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4641
 - version: "1.28.0"
   changes:
     - description: Enhance S3 integration dashboard

--- a/packages/aws/data_stream/kinesis/manifest.yml
+++ b/packages/aws/data_stream/kinesis/manifest.yml
@@ -1,4 +1,4 @@
-title: AWS Kinesis metrics
+title: AWS Kinesis Data Stream metrics
 type: metrics
 streams:
   - input: aws/metrics
@@ -31,5 +31,5 @@ streams:
         default: |
           # - key: "created-by"
             # value: "foo"
-    title: AWS Kinesis metrics
-    description: Collect AWS Kinesis metrics
+    title: AWS Kinesis Data Stream metrics
+    description: Collect AWS Kinesis Data Stream metrics

--- a/packages/aws/docs/kinesis.md
+++ b/packages/aws/docs/kinesis.md
@@ -1,8 +1,10 @@
-# Amazon Kinesis
+# Amazon Kinesis Data Stream
 
-The Amazon Kinesis integration allows you to monitor [Amazon Kinesis](https://aws.amazon.com/kinesis/)—a streaming data processor.
+The Amazon Kinesis integration allows you to monitor [Amazon Kinesis Data Stream](https://aws.amazon.com/kinesis/data-streams/)—
+a serverless streaming data service that makes it easy to capture, process, and store data streams at any scale.
 
-Use the Amazon Kinesis integration to monitor Amazon Kinesis. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference metrics when troubleshooting an issue.
+Use the Amazon Kinesis integration to monitor Amazon Kinesis Data Streams. Then visualize that data in Kibana, create 
+alerts to notify you if something goes wrong, and reference metrics when troubleshooting an issue.
 
 ## Data streams
 

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.28.0
+version: 1.28.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration
@@ -614,14 +614,14 @@ policy_templates:
         size: 2640x2240
         type: image/png
   - name: kinesis
-    title: Amazon Kinesis
-    description: Collect Amazon Kinesis metrics with Elastic Agent
+    title: Amazon Kinesis Data Stream
+    description: Collect Amazon Kinesis Data Stream metrics with Elastic Agent
     data_streams:
       - kinesis
     inputs:
       - type: aws/metrics
-        title: Collect Amazon Kinesis metrics
-        description: Collect Amazon Kinesis metrics using AWS CloudWatch
+        title: Collect Amazon Kinesis Data Stream metrics
+        description: Collect Amazon Kinesis Data Stream metrics using AWS CloudWatch
         input_group: metrics
     icons:
       - src: /img/logo_kinesis.svg


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to adjust Kinesis integration documentation to specify that this integration is to collect metrics for Kinesis Data Streams from CloudWatch.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/integrations/issues/4757

## Screenshots
<img width="1346" alt="Screen Shot 2022-12-08 at 12 45 18 PM" src="https://user-images.githubusercontent.com/14081635/206553126-0a5d7762-0628-4be7-bd40-0c248a9865d1.png">
