### PR TITLE
ECS version update

### DIFF
--- a/packages/activemq/_dev/build/build.yml
+++ b/packages/activemq/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@v8.5.1

--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Update ECS version to 8.5.1.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4797
 - version: "0.5.0"
   changes:
     - description: Added infrastructure category.

--- a/packages/activemq/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/activemq/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -8,10 +8,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:15.107072383Z",
+                "ingested": "2022-12-08T15:06:10.692324051Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "INFO  | anonymous called org.apache.activemq.broker.jmx.QueueView.retryMessages[] at 27-11-2019 08:45:57,213 | qtp443290224-47",
@@ -38,10 +38,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:15.107087694Z",
+                "ingested": "2022-12-08T15:06:10.692336343Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "INFO  | admin called org.apache.activemq.broker.jmx.QueueView.retryMessages[] at 27-11-2019 08:45:57,229 | qtp443290224-45",
@@ -68,10 +68,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:15.107091313Z",
+                "ingested": "2022-12-08T15:06:10.692337760Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "WARN  | admin requested /admin/createDestination.action [JMSDestination='test' JMSDestinationType='queue' secret='4eb0bc3e-9d7a-4256-844c-24f40fda98f1' ] from 127.0.0.1 | qtp12205619-39",
@@ -98,10 +98,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:15.107094261Z",
+                "ingested": "2022-12-08T15:06:10.692338926Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "INFO  | guest requested /admin/purgeDestination.action [JMSDestination='test' JMSDestinationType='queue' secret='eff6a932-1b58-45da-a64a-1b30b246cfc9' ] from 127.0.0.1 | qtp12205619-36",

--- a/packages/activemq/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -31,7 +31,7 @@ processors:
       ignore_failure: true
   - set:
       field: ecs.version
-      value: 8.2.0
+      value: 8.5.1
       ignore_empty_value: true
       ignore_failure: true
   - script:

--- a/packages/activemq/data_stream/audit/sample_event.json
+++ b/packages/activemq/data_stream/audit/sample_event.json
@@ -1,16 +1,16 @@
 {
-    "@timestamp": "2022-09-15T08:37:04.078Z",
+    "@timestamp": "2022-12-09T04:17:31.785Z",
     "activemq": {
         "audit": {
             "thread": "RMI TCP Connection(1)-127.0.0.1"
         }
     },
     "agent": {
-        "ephemeral_id": "15ca0b7d-0d28-4688-abd6-0b827bc3fa0f",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "34b01ecd-6dff-4bc4-b2e2-a7388b1e20b2",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.audit",
@@ -18,17 +18,17 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.audit",
-        "ingested": "2022-09-15T08:37:07Z",
+        "ingested": "2022-12-09T04:17:32Z",
         "kind": "event",
         "module": "activemq",
         "type": [

--- a/packages/activemq/data_stream/broker/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/broker/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing ActiveMQ broker metrics.
 processors:
   - set:
       field: ecs.version
-      value: 8.2.0
+      value: 8.5.1
   - set:
       field: event.category
       value: [web]

--- a/packages/activemq/data_stream/broker/sample_event.json
+++ b/packages/activemq/data_stream/broker/sample_event.json
@@ -1,9 +1,9 @@
 {
-    "@timestamp": "2022-09-15T08:40:01.593Z",
+    "@timestamp": "2022-12-09T04:18:21.069Z",
     "activemq": {
         "broker": {
             "connections": {
-                "count": 18
+                "count": 9
             },
             "consumers": {
                 "count": 0
@@ -21,12 +21,12 @@
                 }
             },
             "messages": {
-                "count": 18,
+                "count": 9,
                 "dequeue": {
                     "count": 0
                 },
                 "enqueue": {
-                    "count": 38
+                    "count": 20
                 }
             },
             "name": "localhost",
@@ -36,11 +36,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "610c5ccb-2a67-4fcc-83fc-aa5904971538",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "04f37e48-28d9-4b56-a226-c480f4a8a5ae",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.broker",
@@ -48,12 +48,12 @@
         "type": "metrics"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -61,8 +61,8 @@
             "web"
         ],
         "dataset": "activemq.broker",
-        "duration": 14118688,
-        "ingested": "2022-09-15T08:40:05Z",
+        "duration": 22293625,
+        "ingested": "2022-12-09T04:18:22Z",
         "kind": "metric",
         "module": "activemq",
         "type": [
@@ -71,23 +71,24 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
             "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:12:00:07"
+            "02-42-AC-12-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.71.1.el7.x86_64",
+            "kernel": "5.15.49-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.5 LTS (Focal Fossa)"
         }
     },
     "metricset": {
@@ -95,7 +96,7 @@
         "period": 10000
     },
     "service": {
-        "address": "http://elastic-package-service_activemq_1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
+        "address": "http://elastic-package-service-activemq-1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
         "type": "activemq"
     },
     "tags": [

--- a/packages/activemq/data_stream/log/_dev/test/pipeline/test-activemq.log-expected.json
+++ b/packages/activemq/data_stream/log/_dev/test/pipeline/test-activemq.log-expected.json
@@ -9,10 +9,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048391747Z",
+                "ingested": "2022-12-08T15:06:10.818887635Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,491 | INFO  | KahaDB is version 6 | org.apache.activemq.store.kahadb.MessageDatabase | main",
@@ -37,10 +37,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048401891Z",
+                "ingested": "2022-12-08T15:06:10.818898093Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,531 | INFO  | PListStore:[/opt/activemq/data/localhost/tmp_storage] started | org.apache.activemq.store.kahadb.plist.PListStoreImpl | main",
@@ -65,10 +65,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048404970Z",
+                "ingested": "2022-12-08T15:06:10.818899385Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,538 | INFO  | Page File: /opt/activemq/data/kahadb/db.data. Recovered pageFile free list of size: 0 | org.apache.activemq.store.kahadb.disk.page.PageFile | KahaDB Index Free Page Recovery",
@@ -93,10 +93,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048407867Z",
+                "ingested": "2022-12-08T15:06:10.818900385Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,690 | INFO  | Apache ActiveMQ 5.15.9 (localhost, ID:5338986a6080-37033-1574867374550-0:1) is starting | org.apache.activemq.broker.BrokerService | main",
@@ -121,13 +121,13 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "error": {
                 "stack_trace": "at org.apache.activemq.util.IOExceptionSupport.create(IOExceptionSupport.java:28)[activemq-client-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.registerConnectorMBean(BrokerService.java:2264)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startTransportConnector(BrokerService.java:2744)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startAllConnectors(BrokerService.java:2640)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.doStartBroker(BrokerService.java:771)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startBroker(BrokerService.java:733)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.start(BrokerService.java:636)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.xbean.XBeanBrokerService.afterPropertiesSet(XBeanBrokerService.java:73)[activemq-spring-5.15.9.jar:5.15.9]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.8.0_212]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)[:1.8.0_212]\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.8.0_212]\n\tat java.lang.reflect.Method.invoke(Method.java:498)[:1.8.0_212]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1763)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1700)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048410776Z",
+                "ingested": "2022-12-08T15:06:10.818901468Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,712 | ERROR | Failed to start Apache ActiveMQ (localhost, ID:5338986a6080-37033-1574867374550-0:1) | org.apache.activemq.broker.BrokerService | main\n\tat org.apache.activemq.util.IOExceptionSupport.create(IOExceptionSupport.java:28)[activemq-client-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.registerConnectorMBean(BrokerService.java:2264)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startTransportConnector(BrokerService.java:2744)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startAllConnectors(BrokerService.java:2640)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.doStartBroker(BrokerService.java:771)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.startBroker(BrokerService.java:733)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.broker.BrokerService.start(BrokerService.java:636)[activemq-broker-5.15.9.jar:5.15.9]\n\tat org.apache.activemq.xbean.XBeanBrokerService.afterPropertiesSet(XBeanBrokerService.java:73)[activemq-spring-5.15.9.jar:5.15.9]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.8.0_212]\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)[:1.8.0_212]\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.8.0_212]\n\tat java.lang.reflect.Method.invoke(Method.java:498)[:1.8.0_212]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1763)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1700)[spring-beans-4.3.18.RELEASE.jar:4.3.18.RELEASE]",
@@ -152,10 +152,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048413672Z",
+                "ingested": "2022-12-08T15:06:10.818902343Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,716 | INFO  | Apache ActiveMQ 5.15.9 (localhost, ID:5338986a6080-37033-1574867374550-0:1) is shutting down | org.apache.activemq.broker.BrokerService | main",
@@ -180,10 +180,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048416604Z",
+                "ingested": "2022-12-08T15:06:10.818903260Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,718 | INFO  | Connector openwire stopped | org.apache.activemq.broker.TransportConnector | main",
@@ -208,10 +208,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048419441Z",
+                "ingested": "2022-12-08T15:06:10.818904218Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,719 | INFO  | Connector amqp stopped | org.apache.activemq.broker.TransportConnector | main",
@@ -236,10 +236,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048422257Z",
+                "ingested": "2022-12-08T15:06:10.818905135Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,721 | INFO  | Connector stomp stopped | org.apache.activemq.broker.TransportConnector | main",
@@ -264,10 +264,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048435312Z",
+                "ingested": "2022-12-08T15:06:10.818906093Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,722 | INFO  | Connector mqtt stopped | org.apache.activemq.broker.TransportConnector | main",
@@ -292,10 +292,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048439934Z",
+                "ingested": "2022-12-08T15:06:10.818907051Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,723 | INFO  | Connector ws stopped | org.apache.activemq.broker.TransportConnector | main",
@@ -320,10 +320,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048443338Z",
+                "ingested": "2022-12-08T15:06:10.818908260Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,727 | INFO  | PListStore:[/opt/activemq/data/localhost/tmp_storage] stopped | org.apache.activemq.store.kahadb.plist.PListStoreImpl | main",
@@ -348,10 +348,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048446262Z",
+                "ingested": "2022-12-08T15:06:10.818909218Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,728 | INFO  | Stopping async queue tasks | org.apache.activemq.store.kahadb.KahaDBStore | main",
@@ -376,10 +376,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048449080Z",
+                "ingested": "2022-12-08T15:06:10.818910135Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-27 15:09:34,730 | INFO  | Stopping async topic tasks | org.apache.activemq.store.kahadb.KahaDBStore | main",
@@ -404,10 +404,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048451962Z",
+                "ingested": "2022-12-08T15:06:10.818911010Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-29 10:59:49,515 | INFO  | No Spring WebApplicationInitializer types detected on classpath | /admin | main",
@@ -432,10 +432,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048454982Z",
+                "ingested": "2022-12-08T15:06:10.818911885Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2019-11-29 10:59:49,779 | INFO  | Initializing Spring FrameworkServlet 'dispatcher' | /admin | main",
@@ -460,10 +460,10 @@
                 }
             },
             "ecs": {
-                "version": "8.2.0"
+                "version": "8.5.1"
             },
             "event": {
-                "ingested": "2022-09-15T08:36:17.048458141Z",
+                "ingested": "2022-12-08T15:06:10.818913051Z",
                 "kind": "event",
                 "module": "activemq",
                 "original": "2022-06-17 12:19:13,443 | ERROR | Failed to load: class path resource [activemq.xml], reason: Configuration problem: Unexpected failure during bean definition parsing\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'; nested exception is org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host' | org.apache.activemq.xbean.XBeanBrokerFactory | main org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Unexpected failure during bean definition parsing\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'; nested exception is org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host'\\n\\tat org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:70)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:118)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.error(BeanDefinitionParserDelegate.java:308)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:561)\\n\\tat org.apache.xbean.spring.context.v2c.XBeanBeanDefinitionParserDelegate.parseBeanDefinitionElement(XBeanBeanDefinitionParserDelegate.java:58)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:459)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:428)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.processBeanDefinition(XBeanBeanDefinitionDocumentReader.java:188)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseDefaultElement(XBeanBeanDefinitionDocumentReader.java:115)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseBeanDefinitions(XBeanBeanDefinitionDocumentReader.java:95)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:142)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:94)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:508)\\n\\tat org.apache.xbean.spring.context.v2.XBeanXmlBeanDefinitionReader.registerBeanDefinitions(XBeanXmlBeanDefinitionReader.java:79)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:392)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:336)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:304)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.importBeanDefinitionResource(XBeanBeanDefinitionDocumentReader.java:143)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseDefaultElement(XBeanBeanDefinitionDocumentReader.java:109)\\n\\tat org.apache.xbean.spring.context.v2.XBeanBeanDefinitionDocumentReader.parseBeanDefinitions(XBeanBeanDefinitionDocumentReader.java:95)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:142)\\n\\tat org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:94)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:508)\\n\\tat org.apache.xbean.spring.context.v2.XBeanXmlBeanDefinitionReader.registerBeanDefinitions(XBeanXmlBeanDefinitionReader.java:79)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:392)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:336)\\n\\tat org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:304)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.loadBeanDefinitions(ResourceXmlApplicationContext.java:116)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.loadBeanDefinitions(ResourceXmlApplicationContext.java:104)\\n\\tat org.springframework.context.support.AbstractRefreshableApplicationContext.refreshBeanFactory(AbstractRefreshableApplicationContext.java:126)\\n\\tat org.springframework.context.support.AbstractApplicationContext.obtainFreshBeanFactory(AbstractApplicationContext.java:614)\\n\\tat org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:514)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.\u003cinit\u003e(ResourceXmlApplicationContext.java:64)\\n\\tat org.apache.xbean.spring.context.ResourceXmlApplicationContext.\u003cinit\u003e(ResourceXmlApplicationContext.java:52)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory$1.\u003cinit\u003e(XBeanBrokerFactory.java:104)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory.createApplicationContext(XBeanBrokerFactory.java:104)\\n\\tat org.apache.activemq.xbean.XBeanBrokerFactory.createBroker(XBeanBrokerFactory.java:67)\\n\\tat org.apache.activemq.broker.BrokerFactory.createBroker(BrokerFactory.java:71)\\n\\tat org.apache.activemq.broker.BrokerFactory.createBroker(BrokerFactory.java:54)\\n\\tat org.apache.activemq.console.command.StartCommand.runTask(StartCommand.java:87)\\n\\tat org.apache.activemq.console.command.AbstractCommand.execute(AbstractCommand.java:63)\\n\\tat org.apache.activemq.console.command.ShellCommand.runTask(ShellCommand.java:154)\\n\\tat org.apache.activemq.console.command.AbstractCommand.execute(AbstractCommand.java:63)\\n\\tat org.apache.activemq.console.command.ShellCommand.main(ShellCommand.java:104)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\n\\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\n\\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\\n\\tat org.apache.activemq.console.Main.runTaskClass(Main.java:262)\\n\\tat org.apache.activemq.console.Main.main(Main.java:115)\\nCaused by: org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Multiple 'property' definitions for property 'host'\\nOffending resource: class path resource [jetty.xml]\\nBean 'jettyPort'\\n\\t-\u003e Property 'host'\\n\\tat org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:70)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:118)\\n\\tat org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:110)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.error(BeanDefinitionParserDelegate.java:301)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parsePropertyElement(BeanDefinitionParserDelegate.java:897)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parsePropertyElements(BeanDefinitionParserDelegate.java:761)\\n\\tat org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseBeanDefinitionElement(BeanDefinitionParserDelegate.java:546)\\n\\t... 46 more",

--- a/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -46,7 +46,7 @@ processors:
       ignore_failure: true
   - set:
       field: ecs.version
-      value: 8.2.0
+      value: 8.5.1
       ignore_empty_value: true
       ignore_failure: true
   - script:

--- a/packages/activemq/data_stream/log/sample_event.json
+++ b/packages/activemq/data_stream/log/sample_event.json
@@ -7,11 +7,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "a6cef3a2-8ce9-432a-ae99-738b03dff6d3",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "71698f60-6a6f-4b4e-ac2a-20c0b1805cff",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.log",
@@ -19,17 +19,17 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.log",
-        "ingested": "2022-09-15T08:42:26Z",
+        "ingested": "2022-12-09T04:19:37Z",
         "kind": "event",
         "module": "activemq",
         "type": [

--- a/packages/activemq/data_stream/queue/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/queue/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing ActiveMQ queue metrics.
 processors:
   - set:
       field: ecs.version
-      value: 8.2.0
+      value: 8.5.1
   - set:
       field: event.category
       value: [web]

--- a/packages/activemq/data_stream/queue/sample_event.json
+++ b/packages/activemq/data_stream/queue/sample_event.json
@@ -1,5 +1,5 @@
 {
-    "@timestamp": "2022-09-15T08:45:02.912Z",
+    "@timestamp": "2022-12-09T04:20:29.290Z",
     "activemq": {
         "queue": {
             "consumers": {
@@ -19,7 +19,7 @@
                     "count": 0
                 },
                 "enqueue": {
-                    "count": 15,
+                    "count": 8,
                     "time": {
                         "avg": 0,
                         "max": 0,
@@ -40,15 +40,15 @@
             "producers": {
                 "count": 0
             },
-            "size": 15
+            "size": 8
         }
     },
     "agent": {
-        "ephemeral_id": "5820de34-199e-4c76-82a1-ad1392613bac",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "cf2dc538-c1ce-41e4-8c82-90a77985107b",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.queue",
@@ -56,12 +56,12 @@
         "type": "metrics"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -69,8 +69,8 @@
             "web"
         ],
         "dataset": "activemq.queue",
-        "duration": 13815751,
-        "ingested": "2022-09-15T08:45:06Z",
+        "duration": 21893167,
+        "ingested": "2022-12-09T04:20:30Z",
         "kind": "metric",
         "module": "activemq",
         "type": [
@@ -79,23 +79,24 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
             "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:12:00:07"
+            "02-42-AC-12-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.71.1.el7.x86_64",
+            "kernel": "5.15.49-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.5 LTS (Focal Fossa)"
         }
     },
     "metricset": {
@@ -103,7 +104,7 @@
         "period": 10000
     },
     "service": {
-        "address": "http://elastic-package-service_activemq_1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
+        "address": "http://elastic-package-service-activemq-1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
         "type": "activemq"
     },
     "tags": [

--- a/packages/activemq/data_stream/topic/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/topic/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing ActiveMQ topic metrics.
 processors:
   - set:
       field: ecs.version
-      value: 8.2.0
+      value: 8.5.1
   - set:
       field: event.category
       value: [web]

--- a/packages/activemq/data_stream/topic/sample_event.json
+++ b/packages/activemq/data_stream/topic/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-09-15T08:47:37.794Z",
+    "@timestamp": "2022-12-09T04:21:20.298Z",
     "activemq": {
         "topic": {
             "consumers": {
                 "count": 0
             },
-            "mbean": "org.apache.activemq:brokerName=localhost,destinationName=ActiveMQ.Advisory.Queue,destinationType=Topic,type=Broker",
+            "mbean": "org.apache.activemq:brokerName=localhost,destinationName=ActiveMQ.Advisory.MasterBroker,destinationType=Topic,type=Broker",
             "memory": {
                 "broker": {
                     "pct": 0
@@ -36,18 +36,18 @@
                     "avg": 1024
                 }
             },
-            "name": "ActiveMQ.Advisory.Queue",
+            "name": "ActiveMQ.Advisory.MasterBroker",
             "producers": {
                 "count": 0
             }
         }
     },
     "agent": {
-        "ephemeral_id": "7bd82d33-1d0a-4b91-a2b5-5fe43a1a3bec",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "cf2dc538-c1ce-41e4-8c82-90a77985107b",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.topic",
@@ -55,12 +55,12 @@
         "type": "metrics"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -68,8 +68,8 @@
             "web"
         ],
         "dataset": "activemq.topic",
-        "duration": 9457166,
-        "ingested": "2022-09-15T08:47:41Z",
+        "duration": 18261916,
+        "ingested": "2022-12-09T04:21:21Z",
         "kind": "metric",
         "module": "activemq",
         "type": [
@@ -78,23 +78,24 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
             "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:12:00:07"
+            "02-42-AC-12-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.71.1.el7.x86_64",
+            "kernel": "5.15.49-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.5 LTS (Focal Fossa)"
         }
     },
     "metricset": {
@@ -102,7 +103,7 @@
         "period": 10000
     },
     "service": {
-        "address": "http://elastic-package-service_activemq_1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
+        "address": "http://elastic-package-service-activemq-1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
         "type": "activemq"
     },
     "tags": [

--- a/packages/activemq/docs/README.md
+++ b/packages/activemq/docs/README.md
@@ -25,11 +25,11 @@ An example event for `log` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "a6cef3a2-8ce9-432a-ae99-738b03dff6d3",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "71698f60-6a6f-4b4e-ac2a-20c0b1805cff",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.log",
@@ -37,17 +37,17 @@ An example event for `log` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.log",
-        "ingested": "2022-09-15T08:42:26Z",
+        "ingested": "2022-12-09T04:19:37Z",
         "kind": "event",
         "module": "activemq",
         "type": [
@@ -109,18 +109,18 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-15T08:37:04.078Z",
+    "@timestamp": "2022-12-09T04:17:31.785Z",
     "activemq": {
         "audit": {
             "thread": "RMI TCP Connection(1)-127.0.0.1"
         }
     },
     "agent": {
-        "ephemeral_id": "15ca0b7d-0d28-4688-abd6-0b827bc3fa0f",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "34b01ecd-6dff-4bc4-b2e2-a7388b1e20b2",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.audit",
@@ -128,17 +128,17 @@ An example event for `audit` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "activemq.audit",
-        "ingested": "2022-09-15T08:37:07Z",
+        "ingested": "2022-12-09T04:17:32Z",
         "kind": "event",
         "module": "activemq",
         "type": [
@@ -233,11 +233,11 @@ An example event for `broker` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-15T08:40:01.593Z",
+    "@timestamp": "2022-12-09T04:18:21.069Z",
     "activemq": {
         "broker": {
             "connections": {
-                "count": 18
+                "count": 9
             },
             "consumers": {
                 "count": 0
@@ -255,12 +255,12 @@ An example event for `broker` looks as following:
                 }
             },
             "messages": {
-                "count": 18,
+                "count": 9,
                 "dequeue": {
                     "count": 0
                 },
                 "enqueue": {
-                    "count": 38
+                    "count": 20
                 }
             },
             "name": "localhost",
@@ -270,11 +270,11 @@ An example event for `broker` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "610c5ccb-2a67-4fcc-83fc-aa5904971538",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "04f37e48-28d9-4b56-a226-c480f4a8a5ae",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.broker",
@@ -282,12 +282,12 @@ An example event for `broker` looks as following:
         "type": "metrics"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -295,8 +295,8 @@ An example event for `broker` looks as following:
             "web"
         ],
         "dataset": "activemq.broker",
-        "duration": 14118688,
-        "ingested": "2022-09-15T08:40:05Z",
+        "duration": 22293625,
+        "ingested": "2022-12-09T04:18:22Z",
         "kind": "metric",
         "module": "activemq",
         "type": [
@@ -305,23 +305,24 @@ An example event for `broker` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
             "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:12:00:07"
+            "02-42-AC-12-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.71.1.el7.x86_64",
+            "kernel": "5.15.49-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.5 LTS (Focal Fossa)"
         }
     },
     "metricset": {
@@ -329,7 +330,7 @@ An example event for `broker` looks as following:
         "period": 10000
     },
     "service": {
-        "address": "http://elastic-package-service_activemq_1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
+        "address": "http://elastic-package-service-activemq-1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
         "type": "activemq"
     },
     "tags": [
@@ -380,7 +381,7 @@ An example event for `queue` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-15T08:45:02.912Z",
+    "@timestamp": "2022-12-09T04:20:29.290Z",
     "activemq": {
         "queue": {
             "consumers": {
@@ -400,7 +401,7 @@ An example event for `queue` looks as following:
                     "count": 0
                 },
                 "enqueue": {
-                    "count": 15,
+                    "count": 8,
                     "time": {
                         "avg": 0,
                         "max": 0,
@@ -421,15 +422,15 @@ An example event for `queue` looks as following:
             "producers": {
                 "count": 0
             },
-            "size": 15
+            "size": 8
         }
     },
     "agent": {
-        "ephemeral_id": "5820de34-199e-4c76-82a1-ad1392613bac",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "cf2dc538-c1ce-41e4-8c82-90a77985107b",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.queue",
@@ -437,12 +438,12 @@ An example event for `queue` looks as following:
         "type": "metrics"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -450,8 +451,8 @@ An example event for `queue` looks as following:
             "web"
         ],
         "dataset": "activemq.queue",
-        "duration": 13815751,
-        "ingested": "2022-09-15T08:45:06Z",
+        "duration": 21893167,
+        "ingested": "2022-12-09T04:20:30Z",
         "kind": "metric",
         "module": "activemq",
         "type": [
@@ -460,23 +461,24 @@ An example event for `queue` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
             "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:12:00:07"
+            "02-42-AC-12-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.71.1.el7.x86_64",
+            "kernel": "5.15.49-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.5 LTS (Focal Fossa)"
         }
     },
     "metricset": {
@@ -484,7 +486,7 @@ An example event for `queue` looks as following:
         "period": 10000
     },
     "service": {
-        "address": "http://elastic-package-service_activemq_1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
+        "address": "http://elastic-package-service-activemq-1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
         "type": "activemq"
     },
     "tags": [
@@ -539,13 +541,13 @@ An example event for `topic` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-09-15T08:47:37.794Z",
+    "@timestamp": "2022-12-09T04:21:20.298Z",
     "activemq": {
         "topic": {
             "consumers": {
                 "count": 0
             },
-            "mbean": "org.apache.activemq:brokerName=localhost,destinationName=ActiveMQ.Advisory.Queue,destinationType=Topic,type=Broker",
+            "mbean": "org.apache.activemq:brokerName=localhost,destinationName=ActiveMQ.Advisory.MasterBroker,destinationType=Topic,type=Broker",
             "memory": {
                 "broker": {
                     "pct": 0
@@ -576,18 +578,18 @@ An example event for `topic` looks as following:
                     "avg": 1024
                 }
             },
-            "name": "ActiveMQ.Advisory.Queue",
+            "name": "ActiveMQ.Advisory.MasterBroker",
             "producers": {
                 "count": 0
             }
         }
     },
     "agent": {
-        "ephemeral_id": "7bd82d33-1d0a-4b91-a2b5-5fe43a1a3bec",
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "ephemeral_id": "cf2dc538-c1ce-41e4-8c82-90a77985107b",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "activemq.topic",
@@ -595,12 +597,12 @@ An example event for `topic` looks as following:
         "type": "metrics"
     },
     "ecs": {
-        "version": "8.2.0"
+        "version": "8.5.1"
     },
     "elastic_agent": {
-        "id": "abd9aa75-4cf4-40e6-ac3c-8a1f152d8fa9",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -608,8 +610,8 @@ An example event for `topic` looks as following:
             "web"
         ],
         "dataset": "activemq.topic",
-        "duration": 9457166,
-        "ingested": "2022-09-15T08:47:41Z",
+        "duration": 18261916,
+        "ingested": "2022-12-09T04:21:21Z",
         "kind": "metric",
         "module": "activemq",
         "type": [
@@ -618,23 +620,24 @@ An example event for `topic` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
             "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:12:00:07"
+            "02-42-AC-12-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.71.1.el7.x86_64",
+            "kernel": "5.15.49-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.5 LTS (Focal Fossa)"
         }
     },
     "metricset": {
@@ -642,7 +645,7 @@ An example event for `topic` looks as following:
         "period": 10000
     },
     "service": {
-        "address": "http://elastic-package-service_activemq_1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
+        "address": "http://elastic-package-service-activemq-1:8161/api/jolokia/%3FignoreErrors=true\u0026canonicalNaming=false",
         "type": "activemq"
     },
     "tags": [

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,6 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: 0.5.0
+version: 0.6.0
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:

--- a/packages/apache/_dev/build/build.yml
+++ b/packages/apache/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@1.12
+    reference: git@v8.5.1

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Update ECS version to 8.5.1.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4797
 - version: "1.7.0"
   changes:
     - description: Added infrastructure category.

--- a/packages/apache/data_stream/access/_dev/test/pipeline/test-access-basic.log-expected.json
+++ b/packages/apache/data_stream/access/_dev/test/pipeline/test-access-basic.log-expected.json
@@ -10,12 +10,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200116114Z",
+                "ingested": "2022-12-08T15:09:52.409634501Z",
                 "kind": "event",
                 "original": "::1 - - [26/Dec/2016:16:16:29 +0200] \"GET /favicon.ico HTTP/1.1\" 404 209",
                 "outcome": "failure"
@@ -58,12 +58,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200149914Z",
+                "ingested": "2022-12-08T15:09:52.409644668Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:13 +0000] \"GET /hello HTTP/1.1\" 404 499 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0\"",
                 "outcome": "failure"
@@ -119,12 +119,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200158562Z",
+                "ingested": "2022-12-08T15:09:52.409645876Z",
                 "kind": "event",
                 "original": "::1 - - [26/Dec/2016:16:16:48 +0200] \"-\" 408 -",
                 "outcome": "failure"
@@ -155,12 +155,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200165012Z",
+                "ingested": "2022-12-08T15:09:52.409646876Z",
                 "kind": "event",
                 "original": "172.17.0.1 - - [29/May/2017:19:02:48 +0000] \"GET /stringpatch HTTP/1.1\" 404 612 \"-\" \"Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2\" \"-\"",
                 "outcome": "failure"
@@ -216,12 +216,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200170453Z",
+                "ingested": "2022-12-08T15:09:52.409647793Z",
                 "kind": "event",
                 "original": "monitoring-server - - [29/May/2017:19:02:48 +0000] \"GET /status HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2\" \"-\"",
                 "outcome": "success"
@@ -277,12 +277,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200175624Z",
+                "ingested": "2022-12-08T15:09:52.409648793Z",
                 "kind": "event",
                 "original": "127.0.0.1 - - [02/Feb/2019:05:38:45 +0100] \"-\" 408 152 \"-\" \"-\"",
                 "outcome": "failure"
@@ -326,12 +326,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200180593Z",
+                "ingested": "2022-12-08T15:09:52.409649793Z",
                 "kind": "event",
                 "original": "monitoring-server - - [29/May/2017:19:02:48 +0000] \"GET /A%20Beka%20G1%20Howe/029_AND_30/15%20reading%20elephants.mp4 HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2\" X-Forwarded-For=\"-\"",
                 "outcome": "success"
@@ -393,12 +393,12 @@
                 "ip": "10.0.0.2"
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200185417Z",
+                "ingested": "2022-12-08T15:09:52.409650668Z",
                 "kind": "event",
                 "original": "89.160.20.112 - - [29/May/2017:19:02:48 +0000] \"GET /A%20Beka%20G1%20Howe/029_AND_30/15%20reading%20elephants.mp4 HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2\" X-Forwarded-For=\"10.0.0.2,10.0.0.1\"",
                 "outcome": "success"
@@ -481,12 +481,12 @@
                 "ip": "10.225.192.17"
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200190094Z",
+                "ingested": "2022-12-08T15:09:52.409651543Z",
                 "kind": "event",
                 "original": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6 - - [29/May/2017:19:02:48 +0000] \"GET /A%20Beka%20G1%20Howe/029_AND_30/15%20reading%20elephants.mp4 HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2\" X-Forwarded-For=\"10.225.192.17, 10.2.2.121\"",
                 "outcome": "success"
@@ -559,12 +559,12 @@
                 "ip": "192.168.0.2"
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.200194779Z",
+                "ingested": "2022-12-08T15:09:52.409652876Z",
                 "kind": "event",
                 "original": "monitoring-server - - [17/May/2022:21:41:43 +0000] \"GET / HTTP/1.1\" 200 45 \"-\" \"curl/7.79.1\" X-Forwarded-For=\"192.168.0.2\"",
                 "outcome": "success"

--- a/packages/apache/data_stream/access/_dev/test/pipeline/test-access-darwin.log-expected.json
+++ b/packages/apache/data_stream/access/_dev/test/pipeline/test-access-darwin.log-expected.json
@@ -10,12 +10,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.405343801Z",
+                "ingested": "2022-12-08T15:09:52.483539043Z",
                 "kind": "event",
                 "original": "::1 - - [26/Dec/2016:16:16:28 +0200] \"GET / HTTP/1.1\" 200 45",
                 "outcome": "success"
@@ -57,12 +57,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.405359749Z",
+                "ingested": "2022-12-08T15:09:52.483550209Z",
                 "kind": "event",
                 "original": "::1 - - [26/Dec/2016:16:16:29 +0200] \"GET /favicon.ico HTTP/1.1\" 404 209",
                 "outcome": "failure"
@@ -105,12 +105,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.405365252Z",
+                "ingested": "2022-12-08T15:09:52.483551501Z",
                 "kind": "event",
                 "original": "::1 - - [26/Dec/2016:16:16:48 +0200] \"-\" 408 -",
                 "outcome": "failure"
@@ -141,12 +141,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.405369669Z",
+                "ingested": "2022-12-08T15:09:52.483552501Z",
                 "kind": "event",
                 "original": "89.160.20.156 - - [26/Dec/2016:18:23:35 +0200] \"GET / HTTP/1.1\" 200 45",
                 "outcome": "success"
@@ -206,12 +206,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.405373693Z",
+                "ingested": "2022-12-08T15:09:52.483553418Z",
                 "kind": "event",
                 "original": "89.160.20.156 - - [26/Dec/2016:18:23:41 +0200] \"GET /notfound HTTP/1.1\" 404 206",
                 "outcome": "failure"
@@ -271,12 +271,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.405377632Z",
+                "ingested": "2022-12-08T15:09:52.483554501Z",
                 "kind": "event",
                 "original": "89.160.20.156 - - [26/Dec/2016:18:23:45 +0200] \"GET /hmm HTTP/1.1\" 404 201",
                 "outcome": "failure"

--- a/packages/apache/data_stream/access/_dev/test/pipeline/test-access-ssl-request.log-expected.json
+++ b/packages/apache/data_stream/access/_dev/test/pipeline/test-access-ssl-request.log-expected.json
@@ -14,12 +14,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.472518977Z",
+                "ingested": "2022-12-08T15:09:52.533303168Z",
                 "kind": "event",
                 "original": "[10/Aug/2018:09:45:56 +0200] 172.30.0.119 TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256 \"GET /nagiosxi/ajaxhelper.php?cmd=getxicoreajax\u0026amp;opts=%7B%22func%22%3A%22get_admin_tasks_html%22%2C%22args%22%3A%22%22%7D\u0026amp;nsp=b5c7d5d4b6f7d0cf0c92f9cbdf737f6a5c838218425e6ae21 HTTP/1.1\" 1375"
             },
@@ -67,12 +67,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.472546575Z",
+                "ingested": "2022-12-08T15:09:52.533318376Z",
                 "kind": "event",
                 "original": "[16/Oct/2019:11:53:47 +0200] 89.160.20.156 TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256 \"GET /appl/ajaxhelper.php?cmd=getxicoreajax\u0026opts=%7B%22func%22%3A%22get_pagetop_alert_content_html%22%2C%22args%22%3A%22%22%7D\u0026nsp=c2700eab9797eda8a9f65a3ab17a6adbceccd60a6cca7708650a5923950d HTTP/1.1\" -"
             },

--- a/packages/apache/data_stream/access/_dev/test/pipeline/test-access-ubuntu.log-expected.json
+++ b/packages/apache/data_stream/access/_dev/test/pipeline/test-access-ubuntu.log-expected.json
@@ -10,12 +10,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531606809Z",
+                "ingested": "2022-12-08T15:09:52.577647543Z",
                 "kind": "event",
                 "original": "127.0.0.1 - - [26/Dec/2016:16:18:09 +0000] \"GET / HTTP/1.1\" 200 491 \"-\" \"Wget/1.13.4 (linux-gnu)\"",
                 "outcome": "success"
@@ -69,12 +69,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531626408Z",
+                "ingested": "2022-12-08T15:09:52.577659626Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:00 +0000] \"GET / HTTP/1.1\" 200 484 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\"",
                 "outcome": "success"
@@ -130,12 +130,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531632562Z",
+                "ingested": "2022-12-08T15:09:52.577660959Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:00 +0000] \"GET /favicon.ico HTTP/1.1\" 404 504 \"http://192.168.33.72/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\"",
                 "outcome": "failure"
@@ -192,12 +192,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531637660Z",
+                "ingested": "2022-12-08T15:09:52.577662126Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:08 +0000] \"GET / HTTP/1.1\" 200 484 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0\"",
                 "outcome": "success"
@@ -253,12 +253,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531642297Z",
+                "ingested": "2022-12-08T15:09:52.577663126Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:08 +0000] \"GET /favicon.ico HTTP/1.1\" 404 504 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0\"",
                 "outcome": "failure"
@@ -315,12 +315,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531646911Z",
+                "ingested": "2022-12-08T15:09:52.577664043Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:08 +0000] \"GET /favicon.ico HTTP/1.1\" 404 504 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0\"",
                 "outcome": "failure"
@@ -377,12 +377,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531651400Z",
+                "ingested": "2022-12-08T15:09:52.577664918Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:10 +0000] \"GET /test HTTP/1.1\" 404 498 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0\"",
                 "outcome": "failure"
@@ -438,12 +438,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531655775Z",
+                "ingested": "2022-12-08T15:09:52.577665918Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:13 +0000] \"GET /hello HTTP/1.1\" 404 499 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0\"",
                 "outcome": "failure"
@@ -499,12 +499,12 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.531660022Z",
+                "ingested": "2022-12-08T15:09:52.577666793Z",
                 "kind": "event",
                 "original": "192.168.33.1 - - [26/Dec/2016:16:22:17 +0000] \"GET /crap HTTP/1.1\" 404 499 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0\"",
                 "outcome": "failure"

--- a/packages/apache/data_stream/access/_dev/test/pipeline/test-access-vhost.log-expected.json
+++ b/packages/apache/data_stream/access/_dev/test/pipeline/test-access-vhost.log-expected.json
@@ -13,12 +13,12 @@
                 "domain": "vhost1.domaine.fr"
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
                 "created": "2020-04-28T11:07:58.223Z",
-                "ingested": "2022-07-29T12:32:45.625025669Z",
+                "ingested": "2022-12-08T15:09:52.634020126Z",
                 "kind": "event",
                 "original": "vhost1.domaine.fr 192.168.33.2 - - [26/Dec/2016:16:22:14 +0000] \"GET /hello HTTP/1.1\" 404 499 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0\"",
                 "outcome": "failure"

--- a/packages/apache/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: '1.12.0'
+      value: '8.5.1'
   - rename:
       field: message
       target_field: event.original

--- a/packages/apache/data_stream/access/sample_event.json
+++ b/packages/apache/data_stream/access/sample_event.json
@@ -1,11 +1,78 @@
 {
+    "@timestamp": "2022-12-09T03:54:22.000Z",
     "agent": {
-        "hostname": "4942ef7a8cfc",
-        "name": "4942ef7a8cfc",
-        "id": "73de002e-d848-49c7-829d-e903959d0d44",
+        "ephemeral_id": "d14551cd-5fc4-4f19-8a0e-5897ecaefbf7",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
+        "name": "docker-fleet-agent",
         "type": "filebeat",
-        "ephemeral_id": "e8970288-5c73-40e7-8626-8d297104f4eb",
-        "version": "7.11.0"
+        "version": "8.5.0"
+    },
+    "apache": {
+        "access": {
+            "remote_addresses": [
+                "127.0.0.1"
+            ]
+        }
+    },
+    "data_stream": {
+        "dataset": "apache.access",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "8.5.1"
+    },
+    "elastic_agent": {
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
+        "snapshot": false,
+        "version": "8.5.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "category": "web",
+        "created": "2022-12-09T03:54:39.182Z",
+        "dataset": "apache.access",
+        "ingested": "2022-12-09T03:54:40Z",
+        "kind": "event",
+        "outcome": "success"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
+        "ip": [
+            "172.18.0.7"
+        ],
+        "mac": [
+            "02-42-AC-12-00-07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.15.49-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.5 LTS (Focal Fossa)"
+        }
+    },
+    "http": {
+        "request": {
+            "method": "GET",
+            "referrer": "-"
+        },
+        "response": {
+            "body": {
+                "bytes": 45
+            },
+            "status_code": 200
+        },
+        "version": "1.1"
+    },
+    "input": {
+        "type": "log"
     },
     "log": {
         "file": {
@@ -13,74 +80,26 @@
         },
         "offset": 0
     },
-    "elastic_agent": {
-        "id": "6c69e2bc-7bb3-4bac-b7e9-41f22558321c",
-        "version": "7.11.0",
-        "snapshot": true
-    },
     "source": {
         "address": "127.0.0.1",
         "ip": "127.0.0.1"
     },
+    "tags": [
+        "apache-access"
+    ],
     "url": {
-        "original": "/"
-    },
-    "input": {
-        "type": "log"
-    },
-    "apache": {
-        "access": {}
-    },
-    "@timestamp": "2020-12-03T16:25:36.000Z",
-    "ecs": {
-        "version": "1.5.0"
-    },
-    "data_stream": {
-        "namespace": "ep",
-        "type": "logs",
-        "dataset": "apache.access"
-    },
-    "host": {
-        "hostname": "4942ef7a8cfc",
-        "os": {
-            "kernel": "4.9.184-linuxkit",
-            "codename": "Core",
-            "name": "CentOS Linux",
-            "family": "redhat",
-            "version": "7 (Core)",
-            "platform": "centos"
-        },
-        "containerized": true,
-        "ip": [
-            "192.168.0.4"
-        ],
-        "name": "4942ef7a8cfc",
-        "id": "06c26569966fd125c15acac5d7feffb6",
-        "mac": [
-            "02:42:c0:a8:00:04"
-        ],
-        "architecture": "x86_64"
-    },
-    "http": {
-        "request": {
-            "method": "GET"
-        },
-        "response": {
-            "status_code": 200,
-            "body": {
-                "bytes": 45
-            }
-        },
-        "version": "1.1"
-    },
-    "event": {
-        "kind": "event",
-        "created": "2020-12-03T16:25:53.907Z",
-        "category": "web",
-        "dataset": "apache.access",
-        "outcome": "success"
+        "original": "/",
+        "path": "/"
     },
     "user": {
         "name": "-"
+    },
+    "user_agent": {
+        "device": {
+            "name": "Other"
+        },
+        "name": "curl",
+        "original": "curl/7.64.0",
+        "version": "7.64.0"
     }
 }

--- a/packages/apache/data_stream/error/_dev/test/pipeline/test-error-basic.log-expected.json
+++ b/packages/apache/data_stream/error/_dev/test/pipeline/test-error-basic.log-expected.json
@@ -6,11 +6,11 @@
                 "error": {}
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:45.886133788Z",
+                "ingested": "2022-12-08T15:09:52.825498793Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:22:08 2016] [error] [client 192.168.33.1] File does not exist: /var/www/favicon.ico",
                 "timezone": "GMT+2",
@@ -39,11 +39,11 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:45.886154200Z",
+                "ingested": "2022-12-08T15:09:52.825508126Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:15:55.103786 2016] [core:notice] [pid 11379] AH00094: Command line: '/usr/local/Cellar/httpd24/2.4.23_2/bin/httpd'",
                 "timezone": "GMT+2",
@@ -68,11 +68,11 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:45.886161220Z",
+                "ingested": "2022-12-08T15:09:52.825509418Z",
                 "kind": "event",
                 "original": "[Fri Sep 09 10:42:29.902022 2011] [core:error] [pid 35708:tid 4328636416] [client 89.160.20.156] File does not exist: /usr/local/apache2/htdocs/favicon.ico",
                 "timezone": "GMT+2",
@@ -125,11 +125,11 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:45.886167076Z",
+                "ingested": "2022-12-08T15:09:52.825510418Z",
                 "kind": "event",
                 "original": "[Thu Jun 27 06:58:09.169510 2019] [include:warn] [pid 15934] [client 89.160.20.156:12345] AH01374: mod_include: Options +Includes (or IncludesNoExec) wasn't set, INCLUDES filter removed: /test.html",
                 "timezone": "GMT+2",

--- a/packages/apache/data_stream/error/_dev/test/pipeline/test-error-darwin.log-expected.json
+++ b/packages/apache/data_stream/error/_dev/test/pipeline/test-error-darwin.log-expected.json
@@ -8,11 +8,11 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:45.957125294Z",
+                "ingested": "2022-12-08T15:09:52.868538751Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:15:55.103522 2016] [mpm_prefork:notice] [pid 11379] AH00163: Apache/2.4.23 (Unix) configured -- resuming normal operations",
                 "timezone": "GMT+2",
@@ -37,11 +37,11 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:45.957148462Z",
+                "ingested": "2022-12-08T15:09:52.868553459Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:15:55.103786 2016] [core:notice] [pid 11379] AH00094: Command line: '/usr/local/Cellar/httpd24/2.4.23_2/bin/httpd'",
                 "timezone": "GMT+2",

--- a/packages/apache/data_stream/error/_dev/test/pipeline/test-error-trace.log-expected.json
+++ b/packages/apache/data_stream/error/_dev/test/pipeline/test-error-trace.log-expected.json
@@ -8,11 +8,11 @@
                 }
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:46.015505043Z",
+                "ingested": "2022-12-08T15:09:52.909886710Z",
                 "kind": "event",
                 "original": "[Wed Oct 20 19:20:59.121211 2021] [rewrite:trace3] [pid 121591:tid 140413273032448] mod_rewrite.c(470): [client 10.121.192.8:38350] 10.121.192.8 - - [dev.elastic.co/sid#55a374e851c8][rid#7fb438083ac0/initial] applying pattern '^/import/?(.*)$' to uri '/'",
                 "timezone": "GMT+2",

--- a/packages/apache/data_stream/error/_dev/test/pipeline/test-error-ubuntu.log-expected.json
+++ b/packages/apache/data_stream/error/_dev/test/pipeline/test-error-ubuntu.log-expected.json
@@ -6,11 +6,11 @@
                 "error": {}
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:46.067824384Z",
+                "ingested": "2022-12-08T15:09:52.947748626Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:17:53 2016] [notice] Apache/2.2.22 (Ubuntu) configured -- resuming normal operations",
                 "timezone": "GMT+2",
@@ -30,11 +30,11 @@
                 "error": {}
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:46.067850374Z",
+                "ingested": "2022-12-08T15:09:52.947760501Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:22:00 2016] [error] [client 192.168.33.1] File does not exist: /var/www/favicon.ico, referer: http://192.168.33.72/",
                 "timezone": "GMT+2",
@@ -66,11 +66,11 @@
                 "error": {}
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:46.067856458Z",
+                "ingested": "2022-12-08T15:09:52.947761668Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:22:08 2016] [error] [client 192.168.33.1] File does not exist: /var/www/favicon.ico",
                 "timezone": "GMT+2",
@@ -97,11 +97,11 @@
                 "error": {}
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:46.067861616Z",
+                "ingested": "2022-12-08T15:09:52.947762626Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:22:08 2016] [error] [client 192.168.33.1] File does not exist: /var/www/favicon.ico",
                 "timezone": "GMT+2",
@@ -128,11 +128,11 @@
                 "error": {}
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:46.067866350Z",
+                "ingested": "2022-12-08T15:09:52.947763501Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:22:10 2016] [error] [client 192.168.33.1] File does not exist: /var/www/test",
                 "timezone": "GMT+2",
@@ -159,11 +159,11 @@
                 "error": {}
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:46.067870964Z",
+                "ingested": "2022-12-08T15:09:52.947764335Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:22:13 2016] [error] [client 192.168.33.1] File does not exist: /var/www/hello",
                 "timezone": "GMT+2",
@@ -190,11 +190,11 @@
                 "error": {}
             },
             "ecs": {
-                "version": "1.12.0"
+                "version": "8.5.1"
             },
             "event": {
                 "category": "web",
-                "ingested": "2022-07-29T12:32:46.067875366Z",
+                "ingested": "2022-12-08T15:09:52.947765251Z",
                 "kind": "event",
                 "original": "[Mon Dec 26 16:22:17 2016] [error] [client 192.168.33.1] File does not exist: /var/www/crap",
                 "timezone": "GMT+2",

--- a/packages/apache/data_stream/error/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache/data_stream/error/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
       value: '{{_ingest.timestamp}}'
   - set:
       field: ecs.version
-      value: '1.12.0'
+      value: '8.5.1'
   - rename:
       field: message
       target_field: event.original

--- a/packages/apache/data_stream/error/sample_event.json
+++ b/packages/apache/data_stream/error/sample_event.json
@@ -1,74 +1,79 @@
 {
+    "@timestamp": "2022-12-09T03:55:04.929Z",
     "agent": {
-        "hostname": "4942ef7a8cfc",
-        "name": "4942ef7a8cfc",
-        "id": "73de002e-d848-49c7-829d-e903959d0d44",
-        "ephemeral_id": "e8970288-5c73-40e7-8626-8d297104f4eb",
+        "ephemeral_id": "d14551cd-5fc4-4f19-8a0e-5897ecaefbf7",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
+        "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.11.0"
+        "version": "8.5.0"
     },
-    "process": {
-        "pid": 1,
-        "thread": {
-            "id": 140503592395904
-        }
-    },
-    "log": {
-        "file": {
-            "path": "/tmp/service_logs/error.log"
-        },
-        "offset": 0,
-        "level": "notice"
-    },
-    "elastic_agent": {
-        "id": "6c69e2bc-7bb3-4bac-b7e9-41f22558321c",
-        "version": "7.11.0",
-        "snapshot": true
-    },
-    "message": "AH00489: Apache/2.4.46 (Unix) configured -- resuming normal operations",
-    "input": {
-        "type": "log"
-    },
-    "@timestamp": "2020-12-03T16:28:16.376Z",
     "apache": {
         "error": {
             "module": "mpm_event"
         }
     },
-    "ecs": {
-        "version": "1.5.0"
-    },
     "data_stream": {
+        "dataset": "apache.error",
         "namespace": "ep",
-        "type": "logs",
-        "dataset": "apache.error"
+        "type": "logs"
     },
-    "host": {
-        "hostname": "4942ef7a8cfc",
-        "os": {
-            "kernel": "4.9.184-linuxkit",
-            "codename": "Core",
-            "name": "CentOS Linux",
-            "family": "redhat",
-            "version": "7 (Core)",
-            "platform": "centos"
-        },
-        "containerized": true,
-        "ip": [
-            "192.168.0.4"
-        ],
-        "name": "4942ef7a8cfc",
-        "id": "06c26569966fd125c15acac5d7feffb6",
-        "mac": [
-            "02:42:c0:a8:00:04"
-        ],
-        "architecture": "x86_64"
+    "ecs": {
+        "version": "8.5.1"
+    },
+    "elastic_agent": {
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
+        "snapshot": false,
+        "version": "8.5.0"
     },
     "event": {
-        "timezone": "+00:00",
-        "kind": "event",
+        "agent_id_status": "verified",
         "category": "web",
-        "type": "info",
-        "dataset": "apache.error"
-    }
+        "dataset": "apache.error",
+        "ingested": "2022-12-09T03:55:22Z",
+        "kind": "event",
+        "timezone": "+00:00",
+        "type": "info"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
+        "ip": [
+            "172.18.0.7"
+        ],
+        "mac": [
+            "02-42-AC-12-00-07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.15.49-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.5 LTS (Focal Fossa)"
+        }
+    },
+    "input": {
+        "type": "log"
+    },
+    "log": {
+        "file": {
+            "path": "/tmp/service_logs/error.log"
+        },
+        "level": "notice",
+        "offset": 0
+    },
+    "message": "AH00489: Apache/2.4.46 (Unix) configured -- resuming normal operations",
+    "process": {
+        "pid": 1,
+        "thread": {
+            "id": 281473415361904
+        }
+    },
+    "tags": [
+        "apache-error"
+    ]
 }

--- a/packages/apache/data_stream/status/sample_event.json
+++ b/packages/apache/data_stream/status/sample_event.json
@@ -1,101 +1,111 @@
 {
-    "@timestamp": "2020-12-03T16:31:04.445Z",
+    "@timestamp": "2022-12-09T03:56:04.531Z",
+    "agent": {
+        "ephemeral_id": "de9a4641-fef3-4e54-b95a-cd2c722fb9d3",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.5.0"
+    },
+    "apache": {
+        "status": {
+            "bytes_per_request": 0,
+            "bytes_per_sec": 0,
+            "connections": {
+                "async": {
+                    "closing": 0,
+                    "keep_alive": 0,
+                    "writing": 0
+                },
+                "total": 0
+            },
+            "cpu": {
+                "children_system": 0,
+                "children_user": 0,
+                "load": 0.133333,
+                "system": 0.01,
+                "user": 0.01
+            },
+            "load": {
+                "1": 1.79,
+                "15": 1.04,
+                "5": 1.5
+            },
+            "requests_per_sec": 0.933333,
+            "scoreboard": {
+                "closing_connection": 0,
+                "dns_lookup": 0,
+                "gracefully_finishing": 0,
+                "idle_cleanup": 0,
+                "keepalive": 0,
+                "logging": 0,
+                "open_slot": 325,
+                "reading_request": 0,
+                "sending_reply": 1,
+                "starting_up": 0,
+                "total": 400,
+                "waiting_for_connection": 74
+            },
+            "total_accesses": 14,
+            "total_bytes": 0,
+            "uptime": {
+                "server_uptime": 15,
+                "uptime": 15
+            },
+            "workers": {
+                "busy": 1,
+                "idle": 74
+            }
+        }
+    },
     "data_stream": {
-        "type": "metrics",
         "dataset": "apache.status",
-        "namespace": "ep"
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
     },
     "elastic_agent": {
-        "version": "7.11.0",
-        "id": "6c69e2bc-7bb3-4bac-b7e9-41f22558321c",
-        "snapshot": true
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
+        "snapshot": false,
+        "version": "8.5.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "apache.status",
+        "duration": 6186792,
+        "ingested": "2022-12-09T03:56:04Z",
+        "module": "apache"
     },
     "host": {
-        "os": {
-            "platform": "centos",
-            "version": "7 (Core)",
-            "family": "redhat",
-            "name": "CentOS Linux",
-            "kernel": "4.9.184-linuxkit",
-            "codename": "Core"
-        },
-        "id": "06c26569966fd125c15acac5d7feffb6",
-        "name": "4942ef7a8cfc",
-        "containerized": true,
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
-            "192.168.0.4"
+            "172.18.0.7"
         ],
         "mac": [
-            "02:42:c0:a8:00:04"
+            "02-42-AC-12-00-07"
         ],
-        "hostname": "4942ef7a8cfc",
-        "architecture": "x86_64"
-    },
-    "agent": {
-        "hostname": "4942ef7a8cfc",
-        "ephemeral_id": "8371d3a3-5321-4436-9fd5-cafcabfe4c57",
-        "id": "af6f66ef-d7d0-4784-b9bb-3fddbcc151b5",
-        "name": "4942ef7a8cfc",
-        "type": "metricbeat",
-        "version": "7.11.0"
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.15.49-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.5 LTS (Focal Fossa)"
+        }
     },
     "metricset": {
         "name": "status",
         "period": 30000
     },
     "service": {
-        "address": "http://elastic-package-service_apache_1:80/server-status?auto=",
+        "address": "http://elastic-package-service-apache-1:80/server-status?auto=",
         "type": "apache"
-    },
-    "apache": {
-        "status": {
-            "load": {
-                "5": 1.89,
-                "15": 1.07,
-                "1": 1.53
-            },
-            "total_accesses": 11,
-            "connections": {
-                "total": 0,
-                "async": {
-                    "closing": 0,
-                    "writing": 0,
-                    "keep_alive": 0
-                }
-            },
-            "requests_per_sec": 0.916667,
-            "scoreboard": {
-                "starting_up": 0,
-                "keepalive": 0,
-                "sending_reply": 1,
-                "logging": 0,
-                "gracefully_finishing": 0,
-                "dns_lookup": 0,
-                "closing_connection": 0,
-                "open_slot": 325,
-                "total": 400,
-                "idle_cleanup": 0,
-                "waiting_for_connection": 74,
-                "reading_request": 0
-            },
-            "bytes_per_sec": 0,
-            "bytes_per_request": 0,
-            "uptime": {
-                "server_uptime": 12,
-                "uptime": 12
-            },
-            "total_bytes": 0,
-            "workers": {
-                "busy": 1,
-                "idle": 74
-            },
-            "cpu": {
-                "load": 0.583333,
-                "user": 0.03,
-                "system": 0.04,
-                "children_user": 0,
-                "children_system": 0
-            }
-        }
     }
 }

--- a/packages/apache/docs/README.md
+++ b/packages/apache/docs/README.md
@@ -39,7 +39,7 @@ Access logs collects the Apache access logs.
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
-| destination.domain | Destination domain. | keyword |
+| destination.domain | The domain name of the destination system. This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | error.message | Error message. | match_only_text |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
@@ -67,7 +67,7 @@ Access logs collects the Apache access logs.
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |
+| http.request.method | HTTP request method. The value should retain its casing from the original event. For example, `GET`, `get`, and `GeT` are all considered valid values for this field. | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
 | http.response.body.bytes | Size in bytes of the response body. | long |
 | http.response.status_code | HTTP response status code. | long |
@@ -84,7 +84,7 @@ Access logs collects the Apache access logs.
 | source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |
 | source.as.organization.name.text | Multi-field of `source.as.organization.name`. | match_only_text |
-| source.domain | Source domain. | keyword |
+| source.domain | The domain name of the source system. This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
@@ -189,7 +189,7 @@ Error logs collects the Apache error logs.
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |
+| http.request.method | HTTP request method. The value should retain its casing from the original event. For example, `GET`, `get`, and `GeT` are all considered valid values for this field. | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
 | http.response.body.bytes | Size in bytes of the response body. | long |
 | http.response.status_code | HTTP response status code. | long |
@@ -242,104 +242,114 @@ An example event for `status` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-12-03T16:31:04.445Z",
+    "@timestamp": "2022-12-09T03:56:04.531Z",
+    "agent": {
+        "ephemeral_id": "de9a4641-fef3-4e54-b95a-cd2c722fb9d3",
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.5.0"
+    },
+    "apache": {
+        "status": {
+            "bytes_per_request": 0,
+            "bytes_per_sec": 0,
+            "connections": {
+                "async": {
+                    "closing": 0,
+                    "keep_alive": 0,
+                    "writing": 0
+                },
+                "total": 0
+            },
+            "cpu": {
+                "children_system": 0,
+                "children_user": 0,
+                "load": 0.133333,
+                "system": 0.01,
+                "user": 0.01
+            },
+            "load": {
+                "1": 1.79,
+                "15": 1.04,
+                "5": 1.5
+            },
+            "requests_per_sec": 0.933333,
+            "scoreboard": {
+                "closing_connection": 0,
+                "dns_lookup": 0,
+                "gracefully_finishing": 0,
+                "idle_cleanup": 0,
+                "keepalive": 0,
+                "logging": 0,
+                "open_slot": 325,
+                "reading_request": 0,
+                "sending_reply": 1,
+                "starting_up": 0,
+                "total": 400,
+                "waiting_for_connection": 74
+            },
+            "total_accesses": 14,
+            "total_bytes": 0,
+            "uptime": {
+                "server_uptime": 15,
+                "uptime": 15
+            },
+            "workers": {
+                "busy": 1,
+                "idle": 74
+            }
+        }
+    },
     "data_stream": {
-        "type": "metrics",
         "dataset": "apache.status",
-        "namespace": "ep"
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
     },
     "elastic_agent": {
-        "version": "7.11.0",
-        "id": "6c69e2bc-7bb3-4bac-b7e9-41f22558321c",
-        "snapshot": true
+        "id": "46343e0c-0d8c-464b-a216-cacf63027d6f",
+        "snapshot": false,
+        "version": "8.5.0"
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "apache.status",
+        "duration": 6186792,
+        "ingested": "2022-12-09T03:56:04Z",
+        "module": "apache"
     },
     "host": {
-        "os": {
-            "platform": "centos",
-            "version": "7 (Core)",
-            "family": "redhat",
-            "name": "CentOS Linux",
-            "kernel": "4.9.184-linuxkit",
-            "codename": "Core"
-        },
-        "id": "06c26569966fd125c15acac5d7feffb6",
-        "name": "4942ef7a8cfc",
-        "containerized": true,
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
-            "192.168.0.4"
+            "172.18.0.7"
         ],
         "mac": [
-            "02:42:c0:a8:00:04"
+            "02-42-AC-12-00-07"
         ],
-        "hostname": "4942ef7a8cfc",
-        "architecture": "x86_64"
-    },
-    "agent": {
-        "hostname": "4942ef7a8cfc",
-        "ephemeral_id": "8371d3a3-5321-4436-9fd5-cafcabfe4c57",
-        "id": "af6f66ef-d7d0-4784-b9bb-3fddbcc151b5",
-        "name": "4942ef7a8cfc",
-        "type": "metricbeat",
-        "version": "7.11.0"
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.15.49-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.5 LTS (Focal Fossa)"
+        }
     },
     "metricset": {
         "name": "status",
         "period": 30000
     },
     "service": {
-        "address": "http://elastic-package-service_apache_1:80/server-status?auto=",
+        "address": "http://elastic-package-service-apache-1:80/server-status?auto=",
         "type": "apache"
-    },
-    "apache": {
-        "status": {
-            "load": {
-                "5": 1.89,
-                "15": 1.07,
-                "1": 1.53
-            },
-            "total_accesses": 11,
-            "connections": {
-                "total": 0,
-                "async": {
-                    "closing": 0,
-                    "writing": 0,
-                    "keep_alive": 0
-                }
-            },
-            "requests_per_sec": 0.916667,
-            "scoreboard": {
-                "starting_up": 0,
-                "keepalive": 0,
-                "sending_reply": 1,
-                "logging": 0,
-                "gracefully_finishing": 0,
-                "dns_lookup": 0,
-                "closing_connection": 0,
-                "open_slot": 325,
-                "total": 400,
-                "idle_cleanup": 0,
-                "waiting_for_connection": 74,
-                "reading_request": 0
-            },
-            "bytes_per_sec": 0,
-            "bytes_per_request": 0,
-            "uptime": {
-                "server_uptime": 12,
-                "uptime": 12
-            },
-            "total_bytes": 0,
-            "workers": {
-                "busy": 1,
-                "idle": 74
-            },
-            "cpu": {
-                "load": 0.583333,
-                "user": 0.03,
-                "system": 0.04,
-                "children_user": 0,
-                "children_system": 0
-            }
-        }
     }
 }
 ```

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache HTTP Server
-version: 1.7.0
+version: 1.8.0
 license: basic
 source:
   license: Elastic-2.0


### PR DESCRIPTION
- Enhancement


## What does this PR do?

Updates the ECS version to 8.5.1 from 1.12. The system and pipeline tests are executed to generate new sample events.

## Checklist

Refer #4792  for the checklist.

## How to test this PR locally

Run system and pipeline test for activemq and apache integrations and make sure nothing is breaking. Verify the changes with ecs release notes.

- Closes #4787 
- Closes #4785 