### PR TITLE
[panw] Fix handling of related.ip when host.ip is an array

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.1"
+  changes:
+    - description: Fix handling of related.ip when host.ip is an array.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/0001 # FIXME: Set real PR number.
 - version: "3.4.0"
   changes:
     - description: Process URL for THREAT url subtype.

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix handling of related.ip when host.ip is an array.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/0001 # FIXME: Set real PR number.
+      link: https://github.com/elastic/integrations/pull/4805
 - version: "3.4.0"
   changes:
     - description: Process URL for THREAT url subtype.

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json
@@ -13,6 +13,43 @@
                 "forwarded"
             ],
             "message": "Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0"
+        },
+        {
+            "@timestamp": "2020-12-09T20:52:27.235Z",
+            "log": {
+                "offset": 0,
+                "file": {
+                    "path": "/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/pan_inc_traffic.log"
+                }
+            },
+            "tags": [
+                "pan-os",
+                "forwarded"
+            ],
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "message": "Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0"
+        },
+        {
+            "@timestamp": "2020-12-09T20:52:27.235Z",
+            "log": {
+                "offset": 0,
+                "file": {
+                    "path": "/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/pan_inc_traffic.log"
+                }
+            },
+            "tags": [
+                "pan-os",
+                "forwarded"
+            ],
+            "host": {
+                "ip": [
+                    "127.0.0.1",
+                    "192.168.0.2"
+                ]
+            },
+            "message": "Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0"
         }
     ]
 }

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
@@ -165,6 +165,349 @@
                 "preserve_original_event",
                 "preserve_duplicate_custom_fields"
             ]
+        },
+        {
+            "@timestamp": "2012-04-10T04:39:58.000-05:00",
+            "destination": {
+                "bytes": 0,
+                "geo": {
+                    "city_name": "Changchun",
+                    "continent_name": "Asia",
+                    "country_iso_code": "CN",
+                    "country_name": "China",
+                    "location": {
+                        "lat": 43.88,
+                        "lon": 125.3228
+                    },
+                    "name": "United States",
+                    "region_iso_code": "CN-22",
+                    "region_name": "Jilin Sheng"
+                },
+                "ip": "175.16.199.1",
+                "packets": 0,
+                "port": 80
+            },
+            "ecs": {
+                "version": "8.5.0"
+            },
+            "event": {
+                "action": "flow_started",
+                "category": [
+                    "network"
+                ],
+                "created": "2012-10-30T09:46:12.000-05:00",
+                "duration": 0,
+                "end": "2012-04-10T04:39:59.000-05:00",
+                "kind": "event",
+                "original": "Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
+                "outcome": "success",
+                "start": "2012-04-10T04:39:59.000-05:00",
+                "timezone": "-05:00",
+                "type": [
+                    "allowed",
+                    "start",
+                    "connection"
+                ]
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "labels": {
+                "captive_portal": true
+            },
+            "log": {
+                "file": {
+                    "path": "/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/pan_inc_traffic.log"
+                },
+                "offset": 0
+            },
+            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
+            "network": {
+                "application": "web-browsing",
+                "bytes": 78,
+                "community_id": "1:yr/t+D7vuUqVI0fdtRb/nP4gu7g=",
+                "packets": 1,
+                "transport": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "ethernet1/1"
+                    },
+                    "zone": "untrust"
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "ethernet1/2"
+                    },
+                    "zone": "trust"
+                },
+                "product": "PAN-OS",
+                "serial_number": "01606001116",
+                "type": "firewall",
+                "vendor": "Palo Alto Networks"
+            },
+            "panw": {
+                "panos": {
+                    "action": "allow",
+                    "action_flags": "0x0",
+                    "bytes_received": 0,
+                    "bytes_sent": 78,
+                    "destination": {
+                        "ip": "175.16.199.1",
+                        "location": "United States",
+                        "nat": {
+                            "ip": "0.0.0.0",
+                            "port": 0
+                        },
+                        "port": 80,
+                        "zone": "untrust"
+                    },
+                    "elapsed_time": 0,
+                    "flow_id": "11449",
+                    "generated_time": "2012-04-10T04:39:58.000-05:00",
+                    "inbound_interface": "ethernet1/2",
+                    "log_profile": "forwardAll",
+                    "network": {
+                        "application": "web-browsing",
+                        "bytes": 78,
+                        "packets": 1
+                    },
+                    "observer": {
+                        "serial_number": "01606001116"
+                    },
+                    "outbound_interface": "ethernet1/1",
+                    "packets_received": 0,
+                    "packets_sent": 1,
+                    "protocol": "tcp",
+                    "received_time": "2012-10-30T09:46:12.000-05:00",
+                    "repeat_count": 1,
+                    "ruleset": "rule1",
+                    "sequence_number": "0",
+                    "source": {
+                        "ip": "192.168.0.2",
+                        "location": "192.168.0.0-192.168.255.255",
+                        "nat": {
+                            "ip": "0.0.0.0",
+                            "port": 0
+                        },
+                        "port": 59324,
+                        "user": "crusher",
+                        "zone": "trust"
+                    },
+                    "start_time": "2012-04-10T04:39:59.000-05:00",
+                    "sub_type": "start",
+                    "type": "TRAFFIC",
+                    "url": {
+                        "category": "any"
+                    },
+                    "virtual_sys": "vsys1"
+                }
+            },
+            "related": {
+                "ip": [
+                    "192.168.0.2",
+                    "175.16.199.1",
+                    "0.0.0.0",
+                    "127.0.0.1"
+                ],
+                "user": [
+                    "crusher"
+                ]
+            },
+            "rule": {
+                "name": "rule1"
+            },
+            "source": {
+                "bytes": 78,
+                "geo": {
+                    "name": "192.168.0.0-192.168.255.255"
+                },
+                "ip": "192.168.0.2",
+                "packets": 1,
+                "port": 59324,
+                "user": {
+                    "name": "crusher"
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        },
+        {
+            "@timestamp": "2012-04-10T04:39:58.000-05:00",
+            "destination": {
+                "bytes": 0,
+                "geo": {
+                    "city_name": "Changchun",
+                    "continent_name": "Asia",
+                    "country_iso_code": "CN",
+                    "country_name": "China",
+                    "location": {
+                        "lat": 43.88,
+                        "lon": 125.3228
+                    },
+                    "name": "United States",
+                    "region_iso_code": "CN-22",
+                    "region_name": "Jilin Sheng"
+                },
+                "ip": "175.16.199.1",
+                "packets": 0,
+                "port": 80
+            },
+            "ecs": {
+                "version": "8.5.0"
+            },
+            "event": {
+                "action": "flow_started",
+                "category": [
+                    "network"
+                ],
+                "created": "2012-10-30T09:46:12.000-05:00",
+                "duration": 0,
+                "end": "2012-04-10T04:39:59.000-05:00",
+                "kind": "event",
+                "original": "Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
+                "outcome": "success",
+                "start": "2012-04-10T04:39:59.000-05:00",
+                "timezone": "-05:00",
+                "type": [
+                    "allowed",
+                    "start",
+                    "connection"
+                ]
+            },
+            "host": {
+                "ip": [
+                    "127.0.0.1",
+                    "192.168.0.2"
+                ]
+            },
+            "labels": {
+                "captive_portal": true
+            },
+            "log": {
+                "file": {
+                    "path": "/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/pan_inc_traffic.log"
+                },
+                "offset": 0
+            },
+            "message": "192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0",
+            "network": {
+                "application": "web-browsing",
+                "bytes": 78,
+                "community_id": "1:yr/t+D7vuUqVI0fdtRb/nP4gu7g=",
+                "packets": 1,
+                "transport": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "ethernet1/1"
+                    },
+                    "zone": "untrust"
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "ethernet1/2"
+                    },
+                    "zone": "trust"
+                },
+                "product": "PAN-OS",
+                "serial_number": "01606001116",
+                "type": "firewall",
+                "vendor": "Palo Alto Networks"
+            },
+            "panw": {
+                "panos": {
+                    "action": "allow",
+                    "action_flags": "0x0",
+                    "bytes_received": 0,
+                    "bytes_sent": 78,
+                    "destination": {
+                        "ip": "175.16.199.1",
+                        "location": "United States",
+                        "nat": {
+                            "ip": "0.0.0.0",
+                            "port": 0
+                        },
+                        "port": 80,
+                        "zone": "untrust"
+                    },
+                    "elapsed_time": 0,
+                    "flow_id": "11449",
+                    "generated_time": "2012-04-10T04:39:58.000-05:00",
+                    "inbound_interface": "ethernet1/2",
+                    "log_profile": "forwardAll",
+                    "network": {
+                        "application": "web-browsing",
+                        "bytes": 78,
+                        "packets": 1
+                    },
+                    "observer": {
+                        "serial_number": "01606001116"
+                    },
+                    "outbound_interface": "ethernet1/1",
+                    "packets_received": 0,
+                    "packets_sent": 1,
+                    "protocol": "tcp",
+                    "received_time": "2012-10-30T09:46:12.000-05:00",
+                    "repeat_count": 1,
+                    "ruleset": "rule1",
+                    "sequence_number": "0",
+                    "source": {
+                        "ip": "192.168.0.2",
+                        "location": "192.168.0.0-192.168.255.255",
+                        "nat": {
+                            "ip": "0.0.0.0",
+                            "port": 0
+                        },
+                        "port": 59324,
+                        "user": "crusher",
+                        "zone": "trust"
+                    },
+                    "start_time": "2012-04-10T04:39:59.000-05:00",
+                    "sub_type": "start",
+                    "type": "TRAFFIC",
+                    "url": {
+                        "category": "any"
+                    },
+                    "virtual_sys": "vsys1"
+                }
+            },
+            "related": {
+                "ip": [
+                    "192.168.0.2",
+                    "175.16.199.1",
+                    "0.0.0.0",
+                    "127.0.0.1"
+                ],
+                "user": [
+                    "crusher"
+                ]
+            },
+            "rule": {
+                "name": "rule1"
+            },
+            "source": {
+                "bytes": 78,
+                "geo": {
+                    "name": "192.168.0.0-192.168.255.255"
+                },
+                "ip": "192.168.0.2",
+                "packets": 1,
+                "port": 59324,
+                "user": {
+                    "name": "crusher"
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
         }
     ]
 }

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -1256,9 +1256,18 @@ processors:
   - append:
       field: related.ip
       value: '{{{host.ip}}}'
-      if: ctx.host?.ip != null
+      if: ctx.host?.ip instanceof String
       allow_duplicates: false
       ignore_failure: true
+  - foreach:
+      field: host.ip
+      if: ctx.host?.ip instanceof List
+      processor:
+        append:
+          field: related.ip
+          value: '{{{_ingest._value}}}'
+          allow_duplicates: false
+          ignore_failure: true
   - append:
       field: related.ip
       value: '{{{panw.panos.xff.ip}}}'

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: 3.4.0
+version: 3.4.1
 release: ga
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

- Add a foreach processor to handle appending host.ip values to related.ip when it is an array. The if statement on this new processor verifies that host.ip is an instance of List. Changed the if statement on the related append processor to check if host.ip is an instance of String.
- Add pipeline tests

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/panw && elastic-package test
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates elastic/sdh-beats#2818
