### PR TITLE
okta: handle already set event.original more robustly

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Handle already set event.original more robustly.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4808
 - version: "1.11.2"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -14,7 +14,7 @@ processors:
   - rename:
       field: message
       target_field: event.original
-      ignore_failure: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: json

--- a/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -4,9 +4,17 @@ processors:
   - set:
       field: ecs.version
       value: '8.5.0'
+  # Keep message as event.original.
+  # Warn if event.original has already been set. This is most likely due to logstash ecs_compatibility setting.
+  - append:
+     if: ctx.event?.original != null
+     field: error.message
+     value: 'event.original is set before start of ingest pipeline'
+  # keep message as event.original if it has not already been set.
   - rename:
       field: message
       target_field: event.original
+      ignore_failure: true
   - json:
       field: event.original
       target_field: json
@@ -623,6 +631,6 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
-  - set:
+  - append:
       field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "1.11.2"
+version: "1.12.0"
 release: ga
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This ensures that already-set event.original documents can still be ingested.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4782

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
