### PR TITLE
[MongoDB] Added remove processors in ingest pipeline for log datastream

### DIFF
--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Added remove processors in ingest pipeline yaml
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4173
+      link: https://github.com/elastic/integrations/pull/4837
 - version: "1.5.0"
   changes:
     - description: Add system test

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.5.1"
+  changes:
+    - description: Added remove processors in ingest pipeline yaml
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4173
 - version: "1.5.0"
   changes:
     - description: Add system test

--- a/packages/mongodb/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mongodb/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -48,6 +48,11 @@ processors:
 - remove:
     field:
     - first_char
+- remove:
+    field: event.original
+    if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+    ignore_failure: true
+    ignore_missing: true
 on_failure:
 - set:
     field: error.message

--- a/packages/mongodb/data_stream/log/sample_event.json
+++ b/packages/mongodb/data_stream/log/sample_event.json
@@ -1,12 +1,11 @@
 {
-    "@timestamp": "2022-10-20T11:23:04.602Z",
+    "@timestamp": "2022-12-16T07:30:07.376Z",
     "agent": {
-        "ephemeral_id": "3ec02007-5c86-4a8d-920a-6b1dafdf6f08",
-        "hostname": "docker-fleet-agent",
-        "id": "a326ccf1-3f91-4412-bc97-215ea856cd16",
+        "ephemeral_id": "d4efa095-1892-409c-96cf-691d6307b15b",
+        "id": "4729bacd-4e52-4243-ae58-793424154f42",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.14.0"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "mongodb.log",
@@ -14,46 +13,46 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "1.10.0"
+        "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "a326ccf1-3f91-4412-bc97-215ea856cd16",
+        "id": "4729bacd-4e52-4243-ae58-793424154f42",
         "snapshot": false,
-        "version": "7.14.0"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "database"
         ],
-        "created": "2022-10-20T11:23:20.331Z",
+        "created": "2022-12-16T07:30:25.369Z",
         "dataset": "mongodb.log",
-        "ingested": "2022-10-20T11:23:23.874455717Z",
+        "ingested": "2022-12-16T07:30:26Z",
         "kind": "event",
         "type": [
             "info"
         ]
     },
     "host": {
-        "architecture": "aarch64",
+        "architecture": "x86_64",
         "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "2347a1bd8a3945949da8ab5c29f60774",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
             "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:12:00:07"
+            "02-42-AC-12-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "AltArch",
-            "family": "redhat",
-            "kernel": "5.10.124-linuxkit",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.15.49-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (AltArch)"
+            "version": "20.04.5 LTS (Focal Fossa)"
         }
     },
     "input": {

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -47,14 +47,13 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-10-20T11:23:04.602Z",
+    "@timestamp": "2022-12-16T07:30:07.376Z",
     "agent": {
-        "ephemeral_id": "3ec02007-5c86-4a8d-920a-6b1dafdf6f08",
-        "hostname": "docker-fleet-agent",
-        "id": "a326ccf1-3f91-4412-bc97-215ea856cd16",
+        "ephemeral_id": "d4efa095-1892-409c-96cf-691d6307b15b",
+        "id": "4729bacd-4e52-4243-ae58-793424154f42",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.14.0"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "mongodb.log",
@@ -62,46 +61,46 @@ An example event for `log` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "1.10.0"
+        "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "a326ccf1-3f91-4412-bc97-215ea856cd16",
+        "id": "4729bacd-4e52-4243-ae58-793424154f42",
         "snapshot": false,
-        "version": "7.14.0"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "database"
         ],
-        "created": "2022-10-20T11:23:20.331Z",
+        "created": "2022-12-16T07:30:25.369Z",
         "dataset": "mongodb.log",
-        "ingested": "2022-10-20T11:23:23.874455717Z",
+        "ingested": "2022-12-16T07:30:26Z",
         "kind": "event",
         "type": [
             "info"
         ]
     },
     "host": {
-        "architecture": "aarch64",
+        "architecture": "x86_64",
         "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "2347a1bd8a3945949da8ab5c29f60774",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
             "172.18.0.7"
         ],
         "mac": [
-            "02:42:ac:12:00:07"
+            "02-42-AC-12-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "AltArch",
-            "family": "redhat",
-            "kernel": "5.10.124-linuxkit",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.15.49-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (AltArch)"
+            "version": "20.04.5 LTS (Focal Fossa)"
         }
     },
     "input": {

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: 1.5.0
+version: 1.5.1
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

This PR address the SDH on mongodb log data stream 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- Clone the PR.
- Run the elastic-package stack up command.
- Add the mongoDb integration.
- In Integration UI provide the mongod.log path and enable the preserve original event.
- Enrol the elastic agent.

## Related issues

- Closes #4836 