### PR TITLE
Check kibana version prepare stack

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -302,7 +302,7 @@ def isPrAffected(integrationName) {
 }
 
 def flattenMap(Map manifest, String separator) {
-  return map.collectEntries { k, v ->
+  return manifest.collectEntries { k, v ->
     v instanceof Map ?
       flattenMap(v, separator).collectEntries { q, r ->
         [(k + separator + q): r] } : [(k):v]

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -312,7 +312,7 @@ def flattenMap(Map manifest, String separator) {
 def kibanaVersionConditionFromManifest(manifest) {
   def flattened = flattenMap(manifest, ".")
   // echo "Manifest flattened all: ${flattened}"
-  echo "Manifest flattened version: ${flattened["conditions.kibana.version"]}"
+  echo "Manifest flattened version: ${flattened["conditions.kibana.version"]} - ${flattened[nonexist]}"
 
   def version = manifest["conditions"]["kibana.version"]
   if (version == null) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -252,10 +252,7 @@ def isPrAffected(integrationName) {
 
   // Packages supported in Kibana >= 8.0.0, shouldn't be included in daily tests of the stack 7.x
   if (manifest != null && manifest['conditions'] != null) {
-    def kibanaVersionCondition = manifest['conditions']['kibana.version']
-    if (kibanaVersionCondition == null) {
-      kibanaVersionCondition = manifest['conditions']['kibana']['version']
-    }
+    def kibanaVersionCondition = kibanaVersionConditionFromManifest(manifest)
 
     if (kibanaVersionCondition != null) {
       if (!kibanaVersionCondition.contains('^7.') && "${env.STACK_VERSION}".startsWith('7.')) {
@@ -304,6 +301,22 @@ def isPrAffected(integrationName) {
   return false
 }
 
+def flattenMap(Map manifest, String separator) {
+  return map.collectEntries { k, v ->
+    v instanceof Map ?
+      flattenMap(v, separator).collectEntries { q, r ->
+        [(k + separator + q): r] } : [(k):v]
+  }
+}
+
+def kibanaVersionConditionFromManifest(manifest) {
+  def version = manifest["conditions"]["kibana.version"]
+  if (version == null) {
+    version = manifest['conditions']['kibana']['version']
+  }
+  return version
+}
+
 def withKubernetes(Closure body) {
     def r = sh(label: "git-diff: check if Kubernetes service deployer is used",
                script: "find . -type d | egrep '_dev/deploy/k8s\$'",
@@ -344,9 +357,11 @@ def prepareStack() {
     stackArgs += " --version ${env.STACK_VERSION}"
   } else {
     def manifest = readYaml(file: "manifest.yml")
+    def kibanaVersionCondition = null
 
     if (manifest != null && manifest["conditions"] != null) {
-      def kibanaVersionCondition = manifest["conditions"]["kibana.version"]
+      kibanaVersionCondition = kibanaVersionConditionFromManifest(manifest)
+
       if (kibanaVersionCondition != null) {
         def version = findOldestSupportedVersion(versionCondition: kibanaVersionCondition)
         stackArgs += " --version ${version}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -310,6 +310,9 @@ def flattenMap(Map manifest, String separator) {
 }
 
 def kibanaVersionConditionFromManifest(manifest) {
+  def flattened = flattenMap(manifest, ".")
+  echo "Manifest flattened: ${flattened}"
+
   def version = manifest["conditions"]["kibana.version"]
   if (version == null) {
     version = manifest['conditions']['kibana']['version']

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -311,7 +311,8 @@ def flattenMap(Map manifest, String separator) {
 
 def kibanaVersionConditionFromManifest(manifest) {
   def flattened = flattenMap(manifest, ".")
-  echo "Manifest flattened: ${flattened}"
+  // echo "Manifest flattened all: ${flattened}"
+  echo "Manifest flattened version: ${flattened["conditions.kibana.version"]}"
 
   def version = manifest["conditions"]["kibana.version"]
   if (version == null) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -312,7 +312,7 @@ def flattenMap(Map manifest, String separator) {
 def kibanaVersionConditionFromManifest(manifest) {
   def flattened = flattenMap(manifest, ".")
   // echo "Manifest flattened all: ${flattened}"
-  echo "Manifest flattened version: ${flattened["conditions.kibana.version"]} - ${flattened[nonexist]}"
+  echo "Manifest flattened version: ${flattened["conditions.kibana.version"]} - ${flattened["nonexist"]}"
 
   def version = manifest["conditions"]["kibana.version"]
   if (version == null) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -311,14 +311,7 @@ def flattenMap(Map manifest, String separator) {
 
 def kibanaVersionConditionFromManifest(manifest) {
   def flattened = flattenMap(manifest, ".")
-  // echo "Manifest flattened all: ${flattened}"
-  echo "Manifest flattened version: ${flattened["conditions.kibana.version"]} - ${flattened["nonexist"]}"
-
-  def version = manifest["conditions"]["kibana.version"]
-  if (version == null) {
-    version = manifest['conditions']['kibana']['version']
-  }
-  return version
+  return flattened["conditions.kibana.version"]
 }
 
 def withKubernetes(Closure body) {


### PR DESCRIPTION
## What does this PR do?

This PR adds a method to obtain the kibana version condition independently on how it is defined in the YAML manifest file.

Example of the version value retrieved when manifest YAML is flattened ([link](https://fleet-ci.elastic.co/job/Ingest-manager/job/integrations/job/PR-4838/5/consoleText)):
- that `null` was to check there was no error when accessing elements that are not in the map.
```
[2022-12-15T13:20:37.537Z] [Pipeline] readYaml
[2022-12-15T13:20:37.572Z] [Pipeline] echo
[2022-12-15T13:20:37.572Z] Manifest flattened version: ^7.16.0 || ^8.0.0 - null
[2022-12-15T13:20:37.586Z] [Pipeline] sh
[2022-12-15T13:20:37.615Z] + egrep -v ^(packages/|.github/CODEOWNERS)
[2022-12-15T13:20:37.615Z] + git merge-base origin/main 0e378fe25e932ec6d8234218cc902fa4e36d1f4d
[2022-12-15T13:20:37.615Z] + git diff --name-only 72d76635dbfa0ac5f0fe7f65d67abd7b8da33881 0e378fe25e932ec6d8234218cc902fa4e36d1f4d
[2022-12-15T13:20:37.615Z] .ci/Jenkinsfile
[2022-12-15T13:20:37.725Z] [Pipeline] echo
[2022-12-15T13:20:37.726Z] [atlassian_bitbucket] PR is affected: found non-package files
```