### PR TITLE
Update SentinelOne Threat Pipline to Set event.id for ECS

### DIFF
--- a/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -524,6 +524,10 @@ processors:
       field: json.description
       target_field: message
       ignore_missing: true
+  - set:
+      field: event.id
+      copy_from: json.id
+      if: ctx.json?.id != null
   - rename:
       field: json.id
       target_field: sentinel_one.threat.id


### PR DESCRIPTION
Adding ECS event.id Field from SentinelOne Threat ID

## What does this PR do?
Addint the event.id Field this discribes the Unique Threat ID in SentinelOne

## Checklist

- [x ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ x] I have verified that all data streams collect metrics or logs.
- [x ] I have added an entry to my package's `changelog.yml` file.
- [x ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

