### PR TITLE
make nginx-ingress-controller work with k8s

### DIFF
--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Work with symlinks
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.5.0"
   changes:
     - description: Sync with Beats module & update to ECS 8.4.0

--- a/packages/nginx_ingress_controller/data_stream/access/agent/stream/stream.yml.hbs
+++ b/packages/nginx_ingress_controller/data_stream/access/agent/stream/stream.yml.hbs
@@ -18,3 +18,5 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+symlinks: {{ symlinks }}
+condition: {{ condition }}

--- a/packages/nginx_ingress_controller/data_stream/access/manifest.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/manifest.yml
@@ -10,7 +10,7 @@ streams:
         required: true
         show_user: true
         default:
-          - /var/log/nginx/ingress.log*
+          - /var/log/containers/*${kubernetes.container.id}.log
       - name: tags
         type: text
         title: Tags
@@ -35,6 +35,21 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
+      - name: symlinks
+        required: true
+        show_user: true
+        title: Symlinks
+        description: Parse Symlinks
+        type: bool
+        multi: false
+        default: true
+      - name: condition
+        title: Condition
+        description: Condition to filter when to apply this datastream
+        type: text
+        multi: false
+        required: true
+        show_user: true
+        default: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'
     title: Nginx Ingress Controller access logs
     description: Collect Nginx Ingress Controller access logs

--- a/packages/nginx_ingress_controller/manifest.yml
+++ b/packages/nginx_ingress_controller/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx_ingress_controller
 title: Nginx Ingress Controller Logs
-version: 1.5.0
+version: 1.6.0
 license: basic
 description: Collect and parse logs from Nginx Ingress Controller instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adapt the nginx-ingress-controller integration to work with logs from /var/log/containers/*.log since /var/log/nginx/access.log and /var/log/nginx/error.log are respectively symlinks to /dev/stdout and /dev/stderr

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes [#123](https://github.com/elastic/integrations/issues/4841)

