### PR TITLE
[Custom AWS Logs] Add latency config parameter into aws-cloudwatch input

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add latency config parameter for aws-cloudwatch input
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4158
+      link: https://github.com/elastic/integrations/pull/4859
 - version: "0.3.0"
   changes:
     - description: Expose Default Region setting to UI

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.3.1"
+  changes:
+    - description: Add latency config parameter for aws-cloudwatch input
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4158
 - version: "0.3.0"
   changes:
     - description: Expose Default Region setting to UI

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
@@ -17,6 +17,9 @@ log_group_arn: {{ log_group_arn }}
 {{#if log_group_name_prefix }}
 log_group_name_prefix: {{ log_group_name_prefix }}
 {{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
 {{/unless}}
 {{/unless}}
 
@@ -41,9 +44,6 @@ log_streams: {{ log_streams }}
 {{#unless log_streams}}
 {{#if log_stream_prefix }}
 log_stream_prefix: {{ log_stream_prefix }}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 {{/if}}
 {{/unless}}
 

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
@@ -41,6 +41,9 @@ log_streams: {{ log_streams }}
 {{#unless log_streams}}
 {{#if log_stream_prefix }}
 log_stream_prefix: {{ log_stream_prefix }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
 {{/if}}
 {{/unless}}
 
@@ -54,6 +57,10 @@ scan_frequency: {{ scan_frequency }}
 
 {{#if api_sleep }}
 api_sleep: {{ api_sleep }}
+{{/if}}
+
+{{#if latency }}
+latency: {{ latency }}
 {{/if}}
 
 {{#if credential_profile_name}}

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -35,6 +35,13 @@ streams:
         required: false
         show_user: false
         description: Region that the specified log group or log group prefix belongs to.
+      - name: number_of_workers
+        type: integer
+        title: Number of Workers
+        default: 1
+        required: false
+        show_user: false
+        description: Number of workers that will process the log groups with the given log_group_name_prefix. Default value is 1.
       - name: log_streams
         type: text
         title: Log Streams

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -81,6 +81,13 @@ streams:
         show_user: false
         default: 200ms
         description: This is used to sleep between AWS FilterLogEvents API calls inside the same collection period. `FilterLogEvents` API has a quota of 5 transactions per second (TPS)/account/Region. This value should only be adjusted when there are multiple Filebeats or multiple Filebeat inputs collecting logs from the same region and AWS account.
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: Some AWS services send logs to CloudWatch with a latency to process larger than aws-cloudwatch input scan_frequency. This case, please use this latency parameter so collection start time and end time will be shifted by the given latency amount.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: 0.3.0
+version: 0.3.1
 release: beta
 license: basic
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
This PR is to add `latency` config parameter into aws-cloudwatch input. During testing, I found we are also missing the `number_of_workers` parameter too.

Here is what the agent policy looks like after installing the integration with specifying `latency`:
```
inputs:
  - id: aws-cloudwatch-aws_logs-bcb0ad28-0671-41af-bc9a-9657b6d40f3e
    name: aws_logs-1
    revision: 1
    type: aws-cloudwatch
    use_output: default
    meta:
      package:
        name: aws_logs
        version: 0.3.2
    data_stream:
      namespace: default
    streams:
      - id: aws-cloudwatch-aws_logs.generic-bcb0ad28-0671-41af-bc9a-9657b6d40f3e
        data_stream:
          dataset: aws_logs.generic
        log_group_arn: >-
          arn:aws:logs:eu-west-1:123456789:log-group:/aws/lambda/apm-test-api-gateway-v1:*
        start_position: beginning
        scan_frequency: 1m
        api_sleep: 200ms
        latency: 30m
        access_key_id: a
        secret_access_key: b
        session_token: c
        tags:
          - forwarded
        publisher_pipeline.disable_host: true
```
and here is what the agent policy looks like with specifying `number_of_workers`:
```
inputs:
  - id: aws-cloudwatch-aws_logs-16342400-df06-4e9e-8ef6-9f163c25ef69
    name: aws_logs-1
    revision: 1
    type: aws-cloudwatch
    use_output: default
    meta:
      package:
        name: aws_logs
        version: 0.3.5
    data_stream:
      namespace: default
    streams:
      - id: aws-cloudwatch-aws_logs.generic-16342400-df06-4e9e-8ef6-9f163c25ef69
        data_stream:
          dataset: aws_logs.generic
        log_group_name_prefix: /kaiyan/test
        number_of_workers: 5
        region_name: null
        start_position: beginning
        scan_frequency: 1m
        api_sleep: 200ms
        access_key_id: a
        secret_access_key: b
        session_token: c
        tags:
          - forwarded
        publisher_pipeline.disable_host: true
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues
- Closes https://github.com/elastic/integrations/issues/4846

## Screenshot
<img width="396" alt="Screen Shot 2022-12-16 at 2 54 06 PM" src="https://user-images.githubusercontent.com/14081635/208195556-7a1286aa-dd23-4142-b92b-32864dab97b5.png">


