### PR TITLE
okta: make okta.debug_context.debug_data.risk_reasons visible to search

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Make debug_data risk reasons visible to search.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4861
 - version: "1.12.1"
   changes:
     - description: Make extra efforts to extract risk information from debug_data.

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.json-expected.json
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.json-expected.json
@@ -669,6 +669,10 @@
                         "request_id": "XkccyyMli2Uay2I93ZgRzQAAB0c",
                         "request_uri": "/api/v1/authn",
                         "risk_level": "HIGH",
+                        "risk_reasons": [
+                            "Anomalous Location",
+                            "Anomalous Device"
+                        ],
                         "threat_suspected": "false",
                         "url": "/api/v1/authn?"
                     }
@@ -1008,6 +1012,10 @@
                         "request_id": "Y5elHFMngoYoVKvakwnp2wAAAKo",
                         "request_uri": "/api/v1/authn",
                         "risk_level": "HIGH",
+                        "risk_reasons": [
+                            "Anomalous Device",
+                            "Anomalous Location"
+                        ],
                         "threat_suspected": "false",
                         "url": "/api/v1/authn?"
                     }

--- a/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -354,10 +354,20 @@ processors:
       field: okta.debug_context.debug_data.risk_level
       value: "{{{okta.debug_context.debug_data.flattened.logOnlySecurityData.risk.level}}}"
       if: 'ctx.okta?.debug_context?.debug_data?.flattened?.logOnlySecurityData?.risk?.level != null && ctx.okta?.debug_context?.debug_data?.flattened?.logOnlySecurityData?.risk?.level != ""'
+  - split:
+      field: okta.debug_context.debug_data.flattened.logOnlySecurityData.risk.reasons
+      target_field: okta.debug_context.debug_data.risk_reasons
+      separator: ',\s*'
+      if: 'ctx.okta?.debug_context?.debug_data?.flattened?.logOnlySecurityData?.risk?.reasons != null && ctx.okta?.debug_context?.debug_data?.flattened?.logOnlySecurityData?.risk?.reasons != ""'
   - set:
       field: okta.debug_context.debug_data.risk_level
       value: "{{{okta.debug_context.debug_data.flattened.risk.level}}}"
-      if: 'ctx.okta?.debug_context?.debug_data?.risk_level == null && ctx.okta?.debug_context?.debug_data?.flattened?.risk != null && ctx.okta?.debug_context?.debug_data?.flattened?.risk != ""'
+      if: 'ctx.okta?.debug_context?.debug_data?.risk_level == null && ctx.okta?.debug_context?.debug_data?.flattened?.risk?.level != null && ctx.okta?.debug_context?.debug_data?.flattened?.risk?.level != ""'
+  - split:
+      field: okta.debug_context.debug_data.flattened.risk.reasons
+      target_field: okta.debug_context.debug_data.risk_reasons
+      separator: ',\s*'
+      if: 'ctx.okta?.debug_context?.debug_data?.risk_reasons == null && ctx.okta?.debug_context?.debug_data?.flattened?.risk?.reasons != null && ctx.okta?.debug_context?.debug_data?.flattened?.risk?.reasons != ""'
   - rename:
       field: json.authenticationContext.authenticationProvider
       target_field: okta.authentication_context.authentication_provider

--- a/packages/okta/data_stream/system/fields/fields.yml
+++ b/packages/okta/data_stream/system/fields/fields.yml
@@ -151,6 +151,10 @@
           type: keyword
           description: |
             The risk level assigned to the sign in attempt.
+        - name: risk_reasons
+          type: keyword
+          description: |
+            The reasons for the risk.
         - name: url
           type: keyword
           description: |

--- a/packages/okta/data_stream/system/sample_event.json
+++ b/packages/okta/data_stream/system/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-02-14T20:18:57.718Z",
     "agent": {
-        "ephemeral_id": "77828d7c-b45f-46a7-ae95-601b4c1bb310",
-        "id": "541f4fe3-4f0f-482a-9582-0ac9c9a98fda",
+        "ephemeral_id": "59b98987-ef64-4e87-ac33-62a9a2c30b33",
+        "id": "51b552c8-1ca2-4a7c-8e6f-a956eea9818d",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.0"
+        "version": "8.5.1"
     },
     "client": {
         "geo": {
@@ -32,9 +32,9 @@
         "version": "8.5.0"
     },
     "elastic_agent": {
-        "id": "541f4fe3-4f0f-482a-9582-0ac9c9a98fda",
+        "id": "51b552c8-1ca2-4a7c-8e6f-a956eea9818d",
         "snapshot": false,
-        "version": "8.1.0"
+        "version": "8.5.1"
     },
     "event": {
         "action": "user.session.start",
@@ -43,10 +43,10 @@
             "authentication",
             "session"
         ],
-        "created": "2022-11-14T19:14:59.223Z",
+        "created": "2022-12-18T06:24:35.608Z",
         "dataset": "okta.system",
         "id": "3aeede38-4f67-11ea-abd3-1f5d113f2546",
-        "ingested": "2022-11-14T19:15:00Z",
+        "ingested": "2022-12-18T06:24:36Z",
         "kind": "event",
         "original": "{\"actor\":{\"alternateId\":\"xxxxxx@elastic.co\",\"detailEntry\":null,\"displayName\":\"xxxxxx\",\"id\":\"00u1abvz4pYqdM8ms4x6\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"102bZDNFfWaQSyEZQuDgWt-uQ\",\"interface\":null,\"issuer\":null},\"client\":{\"device\":\"Computer\",\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"id\":null,\"ipAddress\":\"108.255.197.247\",\"userAgent\":{\"browser\":\"FIREFOX\",\"os\":\"Mac OS X\",\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0\"},\"zone\":\"null\"},\"debugContext\":{\"debugData\":{\"deviceFingerprint\":\"541daf91d15bef64a7e08c946fd9a9d0\",\"requestId\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"requestUri\":\"/api/v1/authn\",\"threatSuspected\":\"false\",\"url\":\"/api/v1/authn?\"}},\"displayMessage\":\"User login to Okta\",\"eventType\":\"user.session.start\",\"legacyEventType\":\"core.user_auth.login_success\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2020-02-14T20:18:57.718Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"ip\":\"108.255.197.247\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":null,\"asOrg\":null,\"domain\":null,\"isProxy\":null,\"isp\":null},\"severity\":\"INFO\",\"target\":null,\"transaction\":{\"detail\":{},\"id\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"type\":\"WEB\"},\"uuid\":\"3aeede38-4f67-11ea-abd3-1f5d113f2546\",\"version\":\"0\"}",
         "outcome": "success",

--- a/packages/okta/docs/README.md
+++ b/packages/okta/docs/README.md
@@ -14,11 +14,11 @@ An example event for `system` looks as following:
 {
     "@timestamp": "2020-02-14T20:18:57.718Z",
     "agent": {
-        "ephemeral_id": "77828d7c-b45f-46a7-ae95-601b4c1bb310",
-        "id": "541f4fe3-4f0f-482a-9582-0ac9c9a98fda",
+        "ephemeral_id": "59b98987-ef64-4e87-ac33-62a9a2c30b33",
+        "id": "51b552c8-1ca2-4a7c-8e6f-a956eea9818d",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.0"
+        "version": "8.5.1"
     },
     "client": {
         "geo": {
@@ -45,9 +45,9 @@ An example event for `system` looks as following:
         "version": "8.5.0"
     },
     "elastic_agent": {
-        "id": "541f4fe3-4f0f-482a-9582-0ac9c9a98fda",
+        "id": "51b552c8-1ca2-4a7c-8e6f-a956eea9818d",
         "snapshot": false,
-        "version": "8.1.0"
+        "version": "8.5.1"
     },
     "event": {
         "action": "user.session.start",
@@ -56,10 +56,10 @@ An example event for `system` looks as following:
             "authentication",
             "session"
         ],
-        "created": "2022-11-14T19:14:59.223Z",
+        "created": "2022-12-18T06:24:35.608Z",
         "dataset": "okta.system",
         "id": "3aeede38-4f67-11ea-abd3-1f5d113f2546",
-        "ingested": "2022-11-14T19:15:00Z",
+        "ingested": "2022-12-18T06:24:36Z",
         "kind": "event",
         "original": "{\"actor\":{\"alternateId\":\"xxxxxx@elastic.co\",\"detailEntry\":null,\"displayName\":\"xxxxxx\",\"id\":\"00u1abvz4pYqdM8ms4x6\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"102bZDNFfWaQSyEZQuDgWt-uQ\",\"interface\":null,\"issuer\":null},\"client\":{\"device\":\"Computer\",\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"id\":null,\"ipAddress\":\"108.255.197.247\",\"userAgent\":{\"browser\":\"FIREFOX\",\"os\":\"Mac OS X\",\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0\"},\"zone\":\"null\"},\"debugContext\":{\"debugData\":{\"deviceFingerprint\":\"541daf91d15bef64a7e08c946fd9a9d0\",\"requestId\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"requestUri\":\"/api/v1/authn\",\"threatSuspected\":\"false\",\"url\":\"/api/v1/authn?\"}},\"displayMessage\":\"User login to Okta\",\"eventType\":\"user.session.start\",\"legacyEventType\":\"core.user_auth.login_success\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2020-02-14T20:18:57.718Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"ip\":\"108.255.197.247\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":null,\"asOrg\":null,\"domain\":null,\"isProxy\":null,\"isp\":null},\"severity\":\"INFO\",\"target\":null,\"transaction\":{\"detail\":{},\"id\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"type\":\"WEB\"},\"uuid\":\"3aeede38-4f67-11ea-abd3-1f5d113f2546\",\"version\":\"0\"}",
         "outcome": "success",
@@ -280,6 +280,7 @@ An example event for `system` looks as following:
 | okta.debug_context.debug_data.request_id | The identifier of the request. | keyword |
 | okta.debug_context.debug_data.request_uri | The request URI. | keyword |
 | okta.debug_context.debug_data.risk_level | The risk level assigned to the sign in attempt. | keyword |
+| okta.debug_context.debug_data.risk_reasons | The reasons for the risk. | keyword |
 | okta.debug_context.debug_data.threat_suspected | Threat suspected. | keyword |
 | okta.debug_context.debug_data.url | The URL. | keyword |
 | okta.display_message | The display message of the LogEvent. | keyword |

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "1.12.1"
+version: "1.13.0"
 release: ga
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Makes okta.debug_context.debug_data.risk_reasons visible to search.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For elastic/beats#33677.

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
