### PR TITLE
Adds udp options to udp inputs

### DIFF
--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "2.4.1"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "2.4.1"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/cef/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cef/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cef/data_stream/log/manifest.yml
+++ b/packages/cef/data_stream/log/manifest.yml
@@ -94,6 +94,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cef/manifest.yml
+++ b/packages/cef/manifest.yml
@@ -1,6 +1,6 @@
 name: cef
 title: Common Event Format (CEF)
-version: "2.4.1"
+version: "2.5.0"
 release: ga
 description: Collect logs from CEF Logs with Elastic Agent.
 type: integration

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.9.1"
   changes:
     - description: Support `checkpoint.time` field as both UNIX and UNIX_MS

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.9.1"
   changes:
     - description: Support `checkpoint.time` field as both UNIX and UNIX_MS

--- a/packages/checkpoint/data_stream/firewall/agent/stream/udp.yml.hbs
+++ b/packages/checkpoint/data_stream/firewall/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/checkpoint/data_stream/firewall/manifest.yml
+++ b/packages/checkpoint/data_stream/firewall/manifest.yml
@@ -19,6 +19,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: checkpoint
 title: Check Point
-version: "1.9.1"
+version: "1.10.0"
 release: ga
 description: Collect logs from Check Point with Elastic Agent.
 type: integration

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "0.13.3"
   changes:
     - description: Update readme file

--- a/packages/cisco/changelog.yml
+++ b/packages/cisco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.14.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "0.13.3"
   changes:
     - description: Update readme file

--- a/packages/cisco/data_stream/asa/agent/stream/udp.yml.hbs
+++ b/packages/cisco/data_stream/asa/agent/stream/udp.yml.hbs
@@ -1,5 +1,8 @@
 udp:
 host: "{{udp_host}}:{{udp_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco/data_stream/asa/manifest.yml
+++ b/packages/cisco/data_stream/asa/manifest.yml
@@ -38,6 +38,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco/data_stream/ftd/agent/stream/udp.yml.hbs
+++ b/packages/cisco/data_stream/ftd/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{udp_host}}:{{udp_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco/data_stream/ftd/manifest.yml
+++ b/packages/cisco/data_stream/ftd/manifest.yml
@@ -38,6 +38,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco/data_stream/ios/agent/stream/udp.yml.hbs
+++ b/packages/cisco/data_stream/ios/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco/data_stream/ios/manifest.yml
+++ b/packages/cisco/data_stream/ios/manifest.yml
@@ -38,6 +38,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco/manifest.yml
+++ b/packages/cisco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco
 title: Cisco
-version: 0.13.3
+version: 0.14.0
 license: basic
 description: Deprecated. Use a specific Cisco package instead.
 type: integration

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "0.1.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "0.1.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cisco_aironet/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_aironet/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{udp_host}}:{{udp_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco_aironet/data_stream/log/manifest.yml
+++ b/packages/cisco_aironet/data_stream/log/manifest.yml
@@ -47,6 +47,17 @@ streams:
         show_user: false
         default: UTC
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "0.1.0"
+version: "0.2.0"
 release: beta
 license: basic
 description: "Integration for Cisco Aironet WLC Logs"

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "2.10.1"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "2.10.1"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/cisco_asa/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{udp_host}}:{{udp_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco_asa/data_stream/log/manifest.yml
+++ b/packages/cisco_asa/data_stream/log/manifest.yml
@@ -51,6 +51,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.10.1"
+version: "2.11.0"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "2.6.0"
   changes:
     - description: Allow configuration of internal/external zones

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "2.6.0"
   changes:
     - description: Allow configuration of internal/external zones

--- a/packages/cisco_ftd/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_ftd/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{udp_host}}:{{udp_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco_ftd/data_stream/log/manifest.yml
+++ b/packages/cisco_ftd/data_stream/log/manifest.yml
@@ -49,6 +49,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ftd
 title: Cisco FTD
-version: "2.6.0"
+version: "2.7.0"
 license: basic
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cisco_ios/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_ios/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco_ios/data_stream/log/manifest.yml
+++ b/packages/cisco_ios/data_stream/log/manifest.yml
@@ -45,6 +45,17 @@ streams:
         show_user: false
         default: UTC
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ios
 title: Cisco IOS
-version: "1.10.0"
+version: "1.11.0"
 license: basic
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration

--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.4.0"
   changes:
     - description: Update Aggregation visualizations to Lens, Add an on_failure processor to the convert and date processors, remove unnecessary white spaces, and convert double quotes to single quotes.

--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.4.0"
   changes:
     - description: Update Aggregation visualizations to Lens, Add an on_failure processor to the convert and date processors, remove unnecessary white spaces, and convert double quotes to single quotes.

--- a/packages/cisco_ise/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_ise/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{listen_address}}:{{listen_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco_ise/data_stream/log/manifest.yml
+++ b/packages/cisco_ise/data_stream/log/manifest.yml
@@ -53,6 +53,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco_ise/manifest.yml
+++ b/packages/cisco_ise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_ise
 title: Cisco ISE
-version: "1.4.0"
+version: "1.5.0"
 license: basic
 description: Collect logs from Cisco ISE with Elastic Agent.
 type: integration

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.3.1"
   changes:
     - description: Enhanced error handling for timezone field

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.3.1"
   changes:
     - description: Enhanced error handling for timezone field

--- a/packages/cisco_meraki/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_meraki/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,5 +1,7 @@
 host: "{{listen_address}}:{{listen_port}}"
-max_message_size: 1 MiB
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 
 tags:
 {{#if preserve_original_event}}

--- a/packages/cisco_meraki/data_stream/log/manifest.yml
+++ b/packages/cisco_meraki/data_stream/log/manifest.yml
@@ -49,6 +49,17 @@ streams:
         show_user: false
         default: UTC
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          max_message_size: 1MiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.3.1"
+version: "1.4.0"
 license: basic
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration

--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.3.1"
   changes:
     - description: Fix grok pattern to extract additional fields

--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.3.1"
   changes:
     - description: Fix grok pattern to extract additional fields

--- a/packages/cisco_secure_email_gateway/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_secure_email_gateway/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{listen_address}}:{{listen_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cisco_secure_email_gateway/data_stream/log/manifest.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/manifest.yml
@@ -95,6 +95,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cisco_secure_email_gateway/manifest.yml
+++ b/packages/cisco_secure_email_gateway/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_secure_email_gateway
 title: Cisco Secure Email Gateway
-version: "1.3.1"
+version: "1.4.0"
 license: basic
 description: Collect logs from Cisco Secure Email Gateway with Elastic Agent.
 type: integration

--- a/packages/cyberark_pta/changelog.yml
+++ b/packages/cyberark_pta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "0.2.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cyberark_pta/changelog.yml
+++ b/packages/cyberark_pta/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "0.2.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cyberark_pta/data_stream/events/agent/stream/udp.yml.hbs
+++ b/packages/cyberark_pta/data_stream/events/agent/stream/udp.yml.hbs
@@ -1,5 +1,8 @@
 udp:
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cyberark_pta/data_stream/events/manifest.yml
+++ b/packages/cyberark_pta/data_stream/events/manifest.yml
@@ -37,6 +37,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cyberark_pta/manifest.yml
+++ b/packages/cyberark_pta/manifest.yml
@@ -1,6 +1,6 @@
 name: cyberark_pta
 title: Cyberark Privileged Threat Analytics
-version: "0.2.0"
+version: "0.3.0"
 release: beta
 license: basic
 description: Collect security logs from Cyberark PTA integration.

--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "2.7.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "2.7.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/cyberarkpas/data_stream/audit/agent/stream/udp.yml.hbs
+++ b/packages/cyberarkpas/data_stream/audit/agent/stream/udp.yml.hbs
@@ -1,5 +1,8 @@
 udp:
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/cyberarkpas/data_stream/audit/manifest.yml
+++ b/packages/cyberarkpas/data_stream/audit/manifest.yml
@@ -129,6 +129,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/cyberarkpas/manifest.yml
+++ b/packages/cyberarkpas/manifest.yml
@@ -1,6 +1,6 @@
 name: cyberarkpas
 title: CyberArk Privileged Access Security
-version: "2.7.0"
+version: "2.8.0"
 release: ga
 description: Collect logs from CyberArk Privileged Access Security with Elastic Agent.
 type: integration

--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.8.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/fireeye/data_stream/nx/agent/stream/udp.yml.hbs
+++ b/packages/fireeye/data_stream/nx/agent/stream/udp.yml.hbs
@@ -1,5 +1,8 @@
 udp:
 host: "{{udp_host}}:{{udp_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
 - preserve_original_event

--- a/packages/fireeye/data_stream/nx/manifest.yml
+++ b/packages/fireeye/data_stream/nx/manifest.yml
@@ -87,6 +87,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/fireeye/manifest.yml
+++ b/packages/fireeye/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: fireeye
 title: "FireEye Network Security"
-version: "1.7.0"
+version: "1.8.0"
 license: basic
 description: Collect logs from FireEye NX with Elastic Agent.
 type: integration

--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.8.1"
   changes:
     - description: Deprecating Fortinet package in favor of new product specific packages

--- a/packages/fortinet/changelog.yml
+++ b/packages/fortinet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.8.1"
   changes:
     - description: Deprecating Fortinet package in favor of new product specific packages

--- a/packages/fortinet/data_stream/firewall/agent/stream/udp.yml.hbs
+++ b/packages/fortinet/data_stream/firewall/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/fortinet/data_stream/firewall/manifest.yml
+++ b/packages/fortinet/data_stream/firewall/manifest.yml
@@ -104,6 +104,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/fortinet/manifest.yml
+++ b/packages/fortinet/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet
 title: Fortinet
-version: "1.8.1"
+version: "1.9.0"
 release: ga
 description: Deprecated. Collect logs from Fortinet instances with Elastic Agent.
 type: integration

--- a/packages/fortinet_fortiedr/changelog.yml
+++ b/packages/fortinet_fortiedr/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.2.0"
   changes:
     - description: Improve configuration documentation.

--- a/packages/fortinet_fortiedr/changelog.yml
+++ b/packages/fortinet_fortiedr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.2.0"
   changes:
     - description: Improve configuration documentation.

--- a/packages/fortinet_fortiedr/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/fortinet_fortiedr/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,5 +1,8 @@
 udp:
 host: "{{udp_host}}:{{udp_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/fortinet_fortiedr/data_stream/log/manifest.yml
+++ b/packages/fortinet_fortiedr/data_stream/log/manifest.yml
@@ -64,6 +64,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/fortinet_fortiedr/manifest.yml
+++ b/packages/fortinet_fortiedr/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortiedr
 title: Fortinet FortiEDR Logs
-version: "1.2.0"
+version: "1.3.0"
 release: ga
 description: Collect logs from Fortinet FortiEDR instances with Elastic Agent.
 type: integration

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.4.0"
   changes:
     - description: Add source and destination NAT IPs to `related.ip`.

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.4.0"
   changes:
     - description: Add source and destination NAT IPs to `related.ip`.

--- a/packages/fortinet_fortigate/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/fortinet_fortigate/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/fortinet_fortigate/data_stream/log/manifest.yml
+++ b/packages/fortinet_fortigate/data_stream/log/manifest.yml
@@ -125,6 +125,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: "1.4.0"
+version: "1.5.0"
 release: ga
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: '1.4.2'
   changes:
     - description: Remove duplicate fields.

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: '1.4.2'
   changes:
     - description: Remove duplicate fields.

--- a/packages/infoblox_nios/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/infoblox_nios/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{listen_address}}:{{listen_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/infoblox_nios/data_stream/log/manifest.yml
+++ b/packages/infoblox_nios/data_stream/log/manifest.yml
@@ -110,6 +110,17 @@ streams:
         default: local
         description: >-
           By default, datetimes in the logs will be interpreted as relative to the timezone configured in the host where the agent is running. If ingesting logs from a host on a different timezone, use this field to set the timezone offset so that datetimes are correctly parsed. Acceptable timezone formats are: a canonical ID (e.g. "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential (e.g. "-05:00") from UCT.
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: infoblox_nios
 title: Infoblox NIOS
-version: '1.4.2'
+version: '1.5.0'
 license: basic
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration

--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.2.1"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.2.1"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/iptables/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/iptables/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/iptables/data_stream/log/manifest.yml
+++ b/packages/iptables/data_stream/log/manifest.yml
@@ -40,6 +40,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/iptables/manifest.yml
+++ b/packages/iptables/manifest.yml
@@ -1,6 +1,6 @@
 name: iptables
 title: Iptables
-version: "1.2.1"
+version: "1.3.0"
 release: ga
 description: Collect logs from Iptables with Elastic Agent.
 type: integration

--- a/packages/juniper/changelog.yml
+++ b/packages/juniper/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.1.1"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/juniper/changelog.yml
+++ b/packages/juniper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.1.1"
   changes:
     - description: Add documentation for multi-fields

--- a/packages/juniper/data_stream/srx/agent/stream/udp.yml.hbs
+++ b/packages/juniper/data_stream/srx/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/juniper/data_stream/srx/manifest.yml
+++ b/packages/juniper/data_stream/srx/manifest.yml
@@ -79,6 +79,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/juniper/manifest.yml
+++ b/packages/juniper/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: juniper
 title: Juniper Logs
-version: 1.1.1
+version: "1.2.0"
 description: Deprecated. Use a specific Juniper package instead.
 categories: ["network", "security"]
 release: ga

--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.6.1"
   changes:
     - description: Remove duplicate fields.

--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.6.1"
   changes:
     - description: Remove duplicate fields.

--- a/packages/juniper_srx/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/juniper_srx/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/juniper_srx/data_stream/log/manifest.yml
+++ b/packages/juniper_srx/data_stream/log/manifest.yml
@@ -100,6 +100,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/juniper_srx/manifest.yml
+++ b/packages/juniper_srx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: juniper_srx
 title: Juniper SRX
-version: "1.6.1"
+version: "1.7.0"
 description: Collect logs from Juniper SRX devices with Elastic Agent.
 categories: ["network", "security"]
 release: ga

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.4.2"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.4.2"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/pfsense/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/pfsense/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/pfsense/data_stream/log/manifest.yml
+++ b/packages/pfsense/data_stream/log/manifest.yml
@@ -58,6 +58,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,6 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.4.2"
+version: "1.5.0"
 release: ga
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration

--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.3.1"
   changes:
     - description: Remove duplicate fields.

--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.3.1"
   changes:
     - description: Remove duplicate fields.

--- a/packages/pulse_connect_secure/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/pulse_connect_secure/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/pulse_connect_secure/data_stream/log/manifest.yml
+++ b/packages/pulse_connect_secure/data_stream/log/manifest.yml
@@ -34,6 +34,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/pulse_connect_secure/manifest.yml
+++ b/packages/pulse_connect_secure/manifest.yml
@@ -1,6 +1,6 @@
 name: pulse_connect_secure
 title: Pulse Connect Secure
-version: "1.3.1"
+version: "1.4.0"
 release: ga
 description: Collect logs from Pulse Connect Secure with Elastic Agent.
 type: integration

--- a/packages/qnap_nas/changelog.yml
+++ b/packages/qnap_nas/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.5.1"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/qnap_nas/changelog.yml
+++ b/packages/qnap_nas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.5.1"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/qnap_nas/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/qnap_nas/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/qnap_nas/data_stream/log/manifest.yml
+++ b/packages/qnap_nas/data_stream/log/manifest.yml
@@ -109,6 +109,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/qnap_nas/manifest.yml
+++ b/packages/qnap_nas/manifest.yml
@@ -1,6 +1,6 @@
 name: qnap_nas
 title: QNAP NAS
-version: "1.5.1"
+version: "1.6.0"
 release: ga
 description: Collect logs from QNAP NAS devices with Elastic Agent.
 type: integration

--- a/packages/snort/changelog.yml
+++ b/packages/snort/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.2.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/snort/changelog.yml
+++ b/packages/snort/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.2.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/snort/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/snort/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/snort/data_stream/log/manifest.yml
+++ b/packages/snort/data_stream/log/manifest.yml
@@ -117,6 +117,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/snort/manifest.yml
+++ b/packages/snort/manifest.yml
@@ -1,6 +1,6 @@
 name: snort
 title: Snort
-version: "1.2.0"
+version: "1.3.0"
 release: ga
 description: Collect logs from Snort with Elastic Agent.
 type: integration

--- a/packages/sonicwall_firewall/changelog.yml
+++ b/packages/sonicwall_firewall/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "1.1.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/sonicwall_firewall/changelog.yml
+++ b/packages/sonicwall_firewall/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "1.1.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/sonicwall_firewall/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/sonicwall_firewall/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/sonicwall_firewall/data_stream/log/manifest.yml
+++ b/packages/sonicwall_firewall/data_stream/log/manifest.yml
@@ -24,6 +24,17 @@ streams:
         required: true
         show_user: true
         default: 9514
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
   - input: logfile
     enabled: false
     template_path: logfile.yml.hbs

--- a/packages/sonicwall_firewall/manifest.yml
+++ b/packages/sonicwall_firewall/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sonicwall_firewall
 title: "SonicWall Firewall"
-version: "1.1.0"
+version: "1.2.0"
 license: basic
 release: ga
 description: "Integration for SonicWall firewall logs"

--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "2.5.1"
   changes:
     - description: Remove duplicate fields.

--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "2.5.1"
   changes:
     - description: Remove duplicate fields.

--- a/packages/sophos/data_stream/xg/agent/stream/udp.yml.hbs
+++ b/packages/sophos/data_stream/xg/agent/stream/udp.yml.hbs
@@ -1,4 +1,7 @@
 udp:
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 host: "{{syslog_host}}:{{syslog_port}}"
 tags:
 {{#if preserve_original_event}}

--- a/packages/sophos/data_stream/xg/manifest.yml
+++ b/packages/sophos/data_stream/xg/manifest.yml
@@ -148,6 +148,17 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          #max_message_size: 50KiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sophos
 title: Sophos
-version: "2.5.1"
+version: "2.6.0"
 description: Collect logs from Sophos with Elastic Agent.
 categories: ["security"]
 release: ga

--- a/packages/symantec_endpoint/changelog.yml
+++ b/packages/symantec_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0"
+  changes:
+    - description: Add `udp_options` to the UDP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR-NUMBER
 - version: "2.1.1"
   changes:
     - description: Remove duplicate fields.

--- a/packages/symantec_endpoint/changelog.yml
+++ b/packages/symantec_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `udp_options` to the UDP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR-NUMBER
+      link: https://github.com/elastic/integrations/pull/4863
 - version: "2.1.1"
   changes:
     - description: Remove duplicate fields.

--- a/packages/symantec_endpoint/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/symantec_endpoint/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,5 +1,7 @@
 host: "{{listen_address}}:{{listen_port}}"
-max_message_size: 1 MiB
+{{#if udp_options}}
+{{udp_options}}
+{{/if}}
 
 tags:
 {{#if preserve_original_event}}

--- a/packages/symantec_endpoint/data_stream/log/manifest.yml
+++ b/packages/symantec_endpoint/data_stream/log/manifest.yml
@@ -49,6 +49,17 @@ streams:
         show_user: false
         default: UTC
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+      - name: udp_options
+        type: yaml
+        title: Custom UDP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #read_buffer: 100MiB
+          max_message_size: 1MiB
+          #timeout: 300s
+        description: Specify custom configuration options for the UDP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/symantec_endpoint/manifest.yml
+++ b/packages/symantec_endpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: symantec_endpoint
 title: Symantec Endpoint Protection
-version: "2.1.1"
+version: "2.2.0"
 release: ga
 description: Collect logs from Symantec Endpoint Protection with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds `udp_options` setting to udp inputs missing it to be able to configure timeouts, read_buffer, etc.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
