### PR TITLE
[Salesforce] Add pagination support for login_rest and logout_rest data streams

### DIFF
--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -3,7 +3,7 @@
 - version: 0.2.1
   changes:
     - description: Add pagination support for "login_rest" and "logout_rest".
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4866
       type: bugfix
 - version: 0.2.0
   changes:

--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
 
+- version: 0.2.1
+  changes:
+    - description: Add pagination support for "login_rest" and "logout_rest".
+      link: https://github.com/elastic/integrations/pull/1
+      type: bugfix
 - version: 0.2.0
   changes:
     - description: Salesforce integration package with "logout_rest" data stream.

--- a/packages/salesforce/data_stream/login_rest/agent/stream/httpjson.yml.hbs
+++ b/packages/salesforce/data_stream/login_rest/agent/stream/httpjson.yml.hbs
@@ -14,8 +14,11 @@ request.transforms:
       target: url.params.q
       value: "SELECT Id,CreatedDate,LogDate,LogFile FROM EventLogFile WHERE Interval = 'Hourly' AND EventType = 'Login' AND LogDate > [[.cursor.last_published_login]] ORDER BY LogDate ASC NULLS FIRST"
       default: "SELECT Id,CreatedDate,LogDate,LogFile FROM EventLogFile WHERE Interval = 'Hourly' AND EventType = 'Login' ORDER BY LogDate ASC NULLS FIRST"
-response.split:
-  target: body.records
+response.pagination:
+- set:
+    target: url.value
+    value: '[[if (ne .last_response.body.done true)]]{{instance_url}}[[.last_response.body.nextRecordsUrl]][[end]]'
+    fail_on_template_error: true
 chain:
   - step:
       request.url: {{instance_url}}/services/data/v54.0/sobjects/EventLogFile/$.records[:].Id/LogFile
@@ -23,7 +26,7 @@ chain:
       replace: $.records[:].Id
 cursor:
   last_published_login:
-    value: '[[.last_event.LogDate]]'
+    value: '[[(formatDate ((parseDate .last_event.TIMESTAMP_DERIVED "RFC3339").Add (parseDuration "-1h")))]]'
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/salesforce/data_stream/logout_rest/agent/stream/httpjson.yml.hbs
+++ b/packages/salesforce/data_stream/logout_rest/agent/stream/httpjson.yml.hbs
@@ -14,8 +14,11 @@ request.transforms:
       target: url.params.q
       value: "SELECT Id,CreatedDate,LogDate,LogFile FROM EventLogFile WHERE Interval = 'Hourly' AND EventType = 'Logout' AND LogDate > [[.cursor.last_published_logout]] ORDER BY CreatedDate ASC NULLS FIRST"
       default: "SELECT Id,CreatedDate,LogDate,LogFile FROM EventLogFile WHERE Interval = 'Hourly' AND EventType = 'Logout' ORDER BY LogDate ASC NULLS FIRST"
-response.split:
-  target: body.records
+response.pagination:
+- set:
+    target: url.value
+    value: '[[if (ne .last_response.body.done true)]]{{instance_url}}[[.last_response.body.nextRecordsUrl]][[end]]'
+    fail_on_template_error: true
 chain:
   - step:
       request.url: {{instance_url}}/services/data/v54.0/sobjects/EventLogFile/$.records[:].Id/LogFile
@@ -23,7 +26,7 @@ chain:
       replace: $.records[:].Id
 cursor:
   last_published_logout:
-    value: '[[.last_event.LogDate]]'
+    value: '[[(formatDate ((parseDate .last_event.TIMESTAMP_DERIVED "RFC3339").Add (parseDuration "-1h")))]]'
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/salesforce/manifest.yml
+++ b/packages/salesforce/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: salesforce
 title: Salesforce
-version: 0.2.0
+version: 0.2.1
 license: basic
 description: Collect logs from Salesforce with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
In the current Salesforce Integration, we don’t have pagination support for login-rest and logout-rest data streams. So if in any case, we have a response body with more than 2000 records, the next page is never called and the data will not be fetched.

Solution:
You can request the next batch of records using the provided URL with your instance and session information, and repeat until all records have been retrieved. These requests use `nextRecordsUrl` and don’t include any parameters. The final batch of records doesn’t have a `nextRecordsUrl` field and return `true` value for field `done`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
<!-- Recommended
## Author's Checklist


Add a checklist of things that are required to be reviewed in order to have the PR approved

- [ ]

## How to test this PR locally
-->
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #3940 
- Relates #4261
- Relates #4323
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Optional
## Screenshots


Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
