### PR TITLE
[TI OTX] Adding drop for empty documents

### DIFF
--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Add support to drop empty documents
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4877
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-empty-ndjson.log
+++ b/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-empty-ndjson.log
@@ -1,0 +1,1 @@
+{"count": 0, "results": {}}

--- a/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-empty-ndjson.log-expected.json
+++ b/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-empty-ndjson.log-expected.json
@@ -1,0 +1,5 @@
+{
+    "expected": [
+        null
+    ]
+}

--- a/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-sample-ndjson.log
+++ b/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-sample-ndjson.log
@@ -1,83 +1,83 @@
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":1588938}
-{"indicator":"90421f8531f963d81cf54245b72cde80","description":"MD5 of a5725af4391d21a232dc6d4ad33d7d915bd190bdac9b1826b73f364dc5c1aa65","title":"Win32:Hoblig-B","content":"","type":"FileHash-MD5","id":9751110}
-{"indicator":"ip.anysrc.net","description":null,"title":null,"content":"","type":"hostname","id":16782717}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":19901748}
-{"indicator":"d8c70ca70fd3555a0828fede6cc1f59e2c320ede80157039b6a2f09c336d5f7a","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":31612067}
-{"indicator":"f8e58af3ffefd4037fef246e93a55dc8","description":"MD5 of df9b37477a83189cd4541674e64ce29bf7bf98338ed0d635276660e0c6419d09","title":null,"content":"","type":"FileHash-MD5","id":34413770}
-{"indicator":"1c62f004d0c9b91d3467b1b8106772e667e7e2075470c2ec7982b63573c90c54","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":111154034}
-{"indicator":"8d24a14f2600482d0231396b6350cf21773335ec2f0b8919763317fdab78baae","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA256","id":151858953}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":311294364}
-{"indicator":"c758ec922b173820374e552c2f015ac53cc5d9f99cc92080e608652aaa63695b","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":406540408}
-{"indicator":"0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":565556753}
-{"indicator":"aeb08b0651bc8a13dcf5e5f6c0d482f8","description":"MD5 of 0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6","title":null,"content":"","type":"FileHash-MD5","id":565556755}
-{"indicator":"6df5e1a017dff52020c7ff6ad92fdd37494e31769e1be242f6b23d1ea2d60140","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":575672549}
-{"indicator":"c72fef3835f65cb380f6920b22c3488554d1af6d298562ccee92284f265c9619","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":575672550}
-{"indicator":"e711fcd0f182b214c6ec74011a395f4c853068d59eb7c57f90c4a3e1de64434a","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":995160791}
-{"indicator":"d3ec8f4a46b21fb189fc3d58f3d87bf9897653ecdf90b7952dcc71f3b4023b4e","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1011989699}
-{"indicator":"70447996722e5c04514d20b7a429d162b46546002fb0c87f512b40f16bac99bb","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1011989701}
-{"indicator":"29340643ca2e6677c19e1d3bf351d654","description":"MD5 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec","title":"Win64:Malware-gen","content":"","type":"FileHash-MD5","id":1472176322}
-{"indicator":"86c314bc2dc37ba84f7364acd5108c2b","description":"MD5 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2","title":"Win64:Malware-gen","content":"","type":"FileHash-MD5","id":1472457325}
-{"indicator":"cb0c1248d3899358a375888bb4e8f3fe","description":"MD5 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56","title":"Trojan:Win32/Occamy.B","content":"","type":"FileHash-MD5","id":1472457326}
-{"indicator":"d348f536e214a47655af387408b4fca5","description":"MD5 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4","title":"Win64:Malware-gen","content":"","type":"FileHash-MD5","id":1472457327}
-{"indicator":"29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413","description":null,"title":"vad_contains_network_strings","content":"","type":"FileHash-SHA256","id":1546012751}
-{"indicator":"b105891f90b2a8730bbadf02b5adeccbba539883bf75dec2ff7a5a97625dd222","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1546012939}
-{"indicator":"e4db5405ac7ab517d43722e1ca8d653ea4a32802bc8a5410d032275eedc7b7ee","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1546012967}
-{"indicator":"465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa","description":null,"title":"Win.Malware.TrickbotSystemInfo-6335590-0","content":"","type":"FileHash-SHA256","id":1564141498}
-{"indicator":"5051906d6ed1b2ae9c9a9f070ef73c9be8f591d2e41d144649a0dc96e28d0400","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1564141523}
-{"indicator":"14b74cb9be8cad8eb5fa8842d00bb692","description":"MD5 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa","title":"Win.Malware.TrickbotSystemInfo-6335590-0","content":"","type":"FileHash-MD5","id":1564142109}
-{"indicator":"a5b59f7d133e354dfc73f40517aab730f322f0ef","description":"SHA1 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa","title":"Win.Malware.TrickbotSystemInfo-6335590-0","content":"","type":"FileHash-SHA1","id":1564142964}
-{"indicator":"8d3f68b16f0710f858d8c1d2c699260e6f43161a5510abb0e7ba567bd72c965b","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1566067095}
-{"indicator":"ff2dcea4963e060a658f4dffbb119529","description":"MD5 of 5cb822616d2c9435c9ddd060d6abdbc286ab57cfcf6dc64768c52976029a925b","title":"vad_contains_network_strings","content":"","type":"FileHash-MD5","id":1566999970}
-{"indicator":"0d73f1a1c4b2f8723fffc83eb3d00f31","description":"MD5 of 29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413","title":"vad_contains_network_strings","content":"","type":"FileHash-MD5","id":1569290125}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":1592876453}
-{"indicator":"d35a30264c0698709ad554489004e0077e263d354ced0c54552a0b500f91ecc0","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1597058431}
-{"indicator":"5264b455f453820be629a324196131492ff03c80491e823ac06657c9387250dd","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1603343478}
-{"indicator":"1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56","description":null,"title":"Trojan:Win32/Occamy.B","content":"","type":"FileHash-SHA256","id":1606260302}
-{"indicator":"3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA256","id":1606260304}
-{"indicator":"b8e463789a076b16a90d1aae73cea9d3880ac0ead1fd16587b8cd79e37a1a3d8","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1606260305}
-{"indicator":"113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA256","id":1606260310}
-{"indicator":"9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA256","id":1606260311}
-{"indicator":"c51024bb119211c335f95e731cfa9a744fcdb645a57d35fb379d01b7dbdd098e","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1606260316}
-{"indicator":"ad20c6fac565f901c82a21b70f9739037eb54818","description":"SHA1 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2","title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":1606260341}
-{"indicator":"13f11e273f9a4a56557f03821c3bfd591cca6ebc","description":"SHA1 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4","title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":1606260344}
-{"indicator":"1581fe76e3c96dc33182daafd09c8cf5c17004e0","description":"SHA1 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec","title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":1606260353}
-{"indicator":"b72e75e9e901a44b655a5cf89cf0eadcaff46037","description":"SHA1 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56","title":"Trojan:Win32/Occamy.B","content":"","type":"FileHash-SHA1","id":1606260364}
-{"indicator":"maper.info","description":null,"title":null,"content":"","type":"domain","id":1634015726}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":1635374317}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":1756014820}
-{"indicator":"9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543412}
-{"indicator":"be9fb556a3c7aef0329e768d7f903e7dd42a821abc663e11fb637ce33b007087","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543416}
-{"indicator":"3bfec096c4837d1e6485fe0ae0ea6f1c0b44edc611d4f2204cc9cf73c985cbc2","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543440}
-{"indicator":"dff2e39b2e008ea89a3d6b36dcd9b8c927fb501d60c1ad5a52ed1ffe225da2e2","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543441}
-{"indicator":"6b4d271a48d118843aee3dee4481fa2930732ed7075db3241a8991418f00d92b","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543445}
-{"indicator":"26de4265303491bed1424d85b263481ac153c2b3513f9ee48ffb42c12312ac43","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543456}
-{"indicator":"02f54da6c6f2f87ff7b713d46e058dedac1cedabd693643bb7f6dfe994b2105d","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543458}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2114754074}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2114754077}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2114754078}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2114754080}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2117062744}
-{"indicator":"e999b83629355ec7ff3b6fda465ef53ce6992c9327344fbf124f7eb37808389d","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":2117884668}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2119746545}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2129763785}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2136050161}
-{"indicator":"89.160.20.156","description":null,"title":"Trickbot","content":"","type":"IPv4","id":2136079568}
-{"indicator":"fotmailz.com","description":null,"title":null,"content":"","type":"domain","id":2137741373}
-{"indicator":"pori89g5jqo3v8.com","description":null,"title":null,"content":"","type":"domain","id":2137741468}
-{"indicator":"sebco.co.ke","description":null,"title":null,"content":"","type":"domain","id":2178708355}
-{"indicator":"89.160.20.156","description":null,"title":"Trickbot","content":"","type":"IPv4","id":2180669102}
-{"indicator":"chishir.com","description":null,"title":null,"content":"","type":"domain","id":2186034800}
-{"indicator":"kostunivo.com","description":null,"title":null,"content":"","type":"domain","id":2186034803}
-{"indicator":"mangoclone.com","description":null,"title":null,"content":"","type":"domain","id":2186034805}
-{"indicator":"onixcellent.com","description":null,"title":null,"content":"","type":"domain","id":2186034807}
-{"indicator":"fc0efd612ad528795472e99cae5944b68b8e26dc","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":2186034891}
-{"indicator":"24d4bbc982a6a561f0426a683b9617de1a96a74a","description":null,"title":"Sf:ShellCode-DZ\\ [Trj]","content":"","type":"FileHash-SHA1","id":2186034903}
-{"indicator":"fa98074dc18ad7e2d357b5d168c00a91256d87d1","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":2186034912}
-{"indicator":"e5dc7c8bfa285b61dda1618f0ade9c256be75d1a","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":2186034924}
-{"indicator":"89.160.20.156","description":null,"title":"Trickbot","content":"","type":"IPv4","id":2189036445}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2189036446}
-{"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2190596263}
-{"indicator":"10ec3571596c30b9993b89f12d29d23c","description":"MD5 of 9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6","title":"xor_0x20_xord_javascript","content":"","type":"FileHash-MD5","id":2192837907}
-{"id":73,"indicator":"http://www.playboysplus.com","type":"URL","title":null,"description":null,"content":""}
-{"id":74,"indicator":"http://join.playboysplus.com/signup/","type":"URL","title":null,"description":null,"content":""}
-{"id":970,"indicator":"http://api.vk.com/method/wall.get?count=1&owner_id=-81972386","type":"URL","title":null,"description":null,"content":""}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":1588938}}
+{"count": 1, "results": {"indicator":"90421f8531f963d81cf54245b72cde80","description":"MD5 of a5725af4391d21a232dc6d4ad33d7d915bd190bdac9b1826b73f364dc5c1aa65","title":"Win32:Hoblig-B","content":"","type":"FileHash-MD5","id":9751110}}
+{"count": 1, "results": {"indicator":"ip.anysrc.net","description":null,"title":null,"content":"","type":"hostname","id":16782717}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":19901748}}
+{"count": 1, "results": {"indicator":"d8c70ca70fd3555a0828fede6cc1f59e2c320ede80157039b6a2f09c336d5f7a","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":31612067}}
+{"count": 1, "results": {"indicator":"f8e58af3ffefd4037fef246e93a55dc8","description":"MD5 of df9b37477a83189cd4541674e64ce29bf7bf98338ed0d635276660e0c6419d09","title":null,"content":"","type":"FileHash-MD5","id":34413770}}
+{"count": 1, "results": {"indicator":"1c62f004d0c9b91d3467b1b8106772e667e7e2075470c2ec7982b63573c90c54","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":111154034}}
+{"count": 1, "results": {"indicator":"8d24a14f2600482d0231396b6350cf21773335ec2f0b8919763317fdab78baae","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA256","id":151858953}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":311294364}}
+{"count": 1, "results": {"indicator":"c758ec922b173820374e552c2f015ac53cc5d9f99cc92080e608652aaa63695b","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":406540408}}
+{"count": 1, "results": {"indicator":"0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":565556753}}
+{"count": 1, "results": {"indicator":"aeb08b0651bc8a13dcf5e5f6c0d482f8","description":"MD5 of 0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6","title":null,"content":"","type":"FileHash-MD5","id":565556755}}
+{"count": 1, "results": {"indicator":"6df5e1a017dff52020c7ff6ad92fdd37494e31769e1be242f6b23d1ea2d60140","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":575672549}}
+{"count": 1, "results": {"indicator":"c72fef3835f65cb380f6920b22c3488554d1af6d298562ccee92284f265c9619","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":575672550}}
+{"count": 1, "results": {"indicator":"e711fcd0f182b214c6ec74011a395f4c853068d59eb7c57f90c4a3e1de64434a","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":995160791}}
+{"count": 1, "results": {"indicator":"d3ec8f4a46b21fb189fc3d58f3d87bf9897653ecdf90b7952dcc71f3b4023b4e","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1011989699}}
+{"count": 1, "results": {"indicator":"70447996722e5c04514d20b7a429d162b46546002fb0c87f512b40f16bac99bb","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1011989701}}
+{"count": 1, "results": {"indicator":"29340643ca2e6677c19e1d3bf351d654","description":"MD5 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec","title":"Win64:Malware-gen","content":"","type":"FileHash-MD5","id":1472176322}}
+{"count": 1, "results": {"indicator":"86c314bc2dc37ba84f7364acd5108c2b","description":"MD5 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2","title":"Win64:Malware-gen","content":"","type":"FileHash-MD5","id":1472457325}}
+{"count": 1, "results": {"indicator":"cb0c1248d3899358a375888bb4e8f3fe","description":"MD5 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56","title":"Trojan:Win32/Occamy.B","content":"","type":"FileHash-MD5","id":1472457326}}
+{"count": 1, "results": {"indicator":"d348f536e214a47655af387408b4fca5","description":"MD5 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4","title":"Win64:Malware-gen","content":"","type":"FileHash-MD5","id":1472457327}}
+{"count": 1, "results": {"indicator":"29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413","description":null,"title":"vad_contains_network_strings","content":"","type":"FileHash-SHA256","id":1546012751}}
+{"count": 1, "results": {"indicator":"b105891f90b2a8730bbadf02b5adeccbba539883bf75dec2ff7a5a97625dd222","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1546012939}}
+{"count": 1, "results": {"indicator":"e4db5405ac7ab517d43722e1ca8d653ea4a32802bc8a5410d032275eedc7b7ee","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1546012967}}
+{"count": 1, "results": {"indicator":"465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa","description":null,"title":"Win.Malware.TrickbotSystemInfo-6335590-0","content":"","type":"FileHash-SHA256","id":1564141498}}
+{"count": 1, "results": {"indicator":"5051906d6ed1b2ae9c9a9f070ef73c9be8f591d2e41d144649a0dc96e28d0400","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1564141523}}
+{"count": 1, "results": {"indicator":"14b74cb9be8cad8eb5fa8842d00bb692","description":"MD5 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa","title":"Win.Malware.TrickbotSystemInfo-6335590-0","content":"","type":"FileHash-MD5","id":1564142109}}
+{"count": 1, "results": {"indicator":"a5b59f7d133e354dfc73f40517aab730f322f0ef","description":"SHA1 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa","title":"Win.Malware.TrickbotSystemInfo-6335590-0","content":"","type":"FileHash-SHA1","id":1564142964}}
+{"count": 1, "results": {"indicator":"8d3f68b16f0710f858d8c1d2c699260e6f43161a5510abb0e7ba567bd72c965b","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1566067095}}
+{"count": 1, "results": {"indicator":"ff2dcea4963e060a658f4dffbb119529","description":"MD5 of 5cb822616d2c9435c9ddd060d6abdbc286ab57cfcf6dc64768c52976029a925b","title":"vad_contains_network_strings","content":"","type":"FileHash-MD5","id":1566999970}}
+{"count": 1, "results": {"indicator":"0d73f1a1c4b2f8723fffc83eb3d00f31","description":"MD5 of 29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413","title":"vad_contains_network_strings","content":"","type":"FileHash-MD5","id":1569290125}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":1592876453}}
+{"count": 1, "results": {"indicator":"d35a30264c0698709ad554489004e0077e263d354ced0c54552a0b500f91ecc0","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1597058431}}
+{"count": 1, "results": {"indicator":"5264b455f453820be629a324196131492ff03c80491e823ac06657c9387250dd","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1603343478}}
+{"count": 1, "results": {"indicator":"1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56","description":null,"title":"Trojan:Win32/Occamy.B","content":"","type":"FileHash-SHA256","id":1606260302}}
+{"count": 1, "results": {"indicator":"3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA256","id":1606260304}}
+{"count": 1, "results": {"indicator":"b8e463789a076b16a90d1aae73cea9d3880ac0ead1fd16587b8cd79e37a1a3d8","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1606260305}}
+{"count": 1, "results": {"indicator":"113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA256","id":1606260310}}
+{"count": 1, "results": {"indicator":"9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA256","id":1606260311}}
+{"count": 1, "results": {"indicator":"c51024bb119211c335f95e731cfa9a744fcdb645a57d35fb379d01b7dbdd098e","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":1606260316}}
+{"count": 1, "results": {"indicator":"ad20c6fac565f901c82a21b70f9739037eb54818","description":"SHA1 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2","title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":1606260341}}
+{"count": 1, "results": {"indicator":"13f11e273f9a4a56557f03821c3bfd591cca6ebc","description":"SHA1 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4","title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":1606260344}}
+{"count": 1, "results": {"indicator":"1581fe76e3c96dc33182daafd09c8cf5c17004e0","description":"SHA1 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec","title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":1606260353}}
+{"count": 1, "results": {"indicator":"b72e75e9e901a44b655a5cf89cf0eadcaff46037","description":"SHA1 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56","title":"Trojan:Win32/Occamy.B","content":"","type":"FileHash-SHA1","id":1606260364}}
+{"count": 1, "results": {"indicator":"maper.info","description":null,"title":null,"content":"","type":"domain","id":1634015726}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":1635374317}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":1756014820}}
+{"count": 1, "results": {"indicator":"9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543412}}
+{"count": 1, "results": {"indicator":"be9fb556a3c7aef0329e768d7f903e7dd42a821abc663e11fb637ce33b007087","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543416}}
+{"count": 1, "results": {"indicator":"3bfec096c4837d1e6485fe0ae0ea6f1c0b44edc611d4f2204cc9cf73c985cbc2","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543440}}
+{"count": 1, "results": {"indicator":"dff2e39b2e008ea89a3d6b36dcd9b8c927fb501d60c1ad5a52ed1ffe225da2e2","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543441}}
+{"count": 1, "results": {"indicator":"6b4d271a48d118843aee3dee4481fa2930732ed7075db3241a8991418f00d92b","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543445}}
+{"count": 1, "results": {"indicator":"26de4265303491bed1424d85b263481ac153c2b3513f9ee48ffb42c12312ac43","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543456}}
+{"count": 1, "results": {"indicator":"02f54da6c6f2f87ff7b713d46e058dedac1cedabd693643bb7f6dfe994b2105d","description":null,"title":"xor_0x20_xord_javascript","content":"","type":"FileHash-SHA256","id":2114543458}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2114754074}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2114754077}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2114754078}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2114754080}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2117062744}}
+{"count": 1, "results": {"indicator":"e999b83629355ec7ff3b6fda465ef53ce6992c9327344fbf124f7eb37808389d","description":null,"title":null,"content":"","type":"FileHash-SHA256","id":2117884668}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2119746545}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2129763785}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2136050161}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":"Trickbot","content":"","type":"IPv4","id":2136079568}}
+{"count": 1, "results": {"indicator":"fotmailz.com","description":null,"title":null,"content":"","type":"domain","id":2137741373}}
+{"count": 1, "results": {"indicator":"pori89g5jqo3v8.com","description":null,"title":null,"content":"","type":"domain","id":2137741468}}
+{"count": 1, "results": {"indicator":"sebco.co.ke","description":null,"title":null,"content":"","type":"domain","id":2178708355}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":"Trickbot","content":"","type":"IPv4","id":2180669102}}
+{"count": 1, "results": {"indicator":"chishir.com","description":null,"title":null,"content":"","type":"domain","id":2186034800}}
+{"count": 1, "results": {"indicator":"kostunivo.com","description":null,"title":null,"content":"","type":"domain","id":2186034803}}
+{"count": 1, "results": {"indicator":"mangoclone.com","description":null,"title":null,"content":"","type":"domain","id":2186034805}}
+{"count": 1, "results": {"indicator":"onixcellent.com","description":null,"title":null,"content":"","type":"domain","id":2186034807}}
+{"count": 1, "results": {"indicator":"fc0efd612ad528795472e99cae5944b68b8e26dc","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":2186034891}}
+{"count": 1, "results": {"indicator":"24d4bbc982a6a561f0426a683b9617de1a96a74a","description":null,"title":"Sf:ShellCode-DZ\\ [Trj]","content":"","type":"FileHash-SHA1","id":2186034903}}
+{"count": 1, "results": {"indicator":"fa98074dc18ad7e2d357b5d168c00a91256d87d1","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":2186034912}}
+{"count": 1, "results": {"indicator":"e5dc7c8bfa285b61dda1618f0ade9c256be75d1a","description":null,"title":"Win64:Malware-gen","content":"","type":"FileHash-SHA1","id":2186034924}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":"Trickbot","content":"","type":"IPv4","id":2189036445}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2189036446}}
+{"count": 1, "results": {"indicator":"89.160.20.156","description":null,"title":null,"content":"","type":"IPv4","id":2190596263}}
+{"count": 1, "results": {"indicator":"10ec3571596c30b9993b89f12d29d23c","description":"MD5 of 9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6","title":"xor_0x20_xord_javascript","content":"","type":"FileHash-MD5","id":2192837907}}
+{"count": 1, "results": {"id":73,"indicator":"http://www.playboysplus.com","type":"URL","title":null,"description":null,"content":""}}
+{"count": 1, "results": {"id":74,"indicator":"http://join.playboysplus.com/signup/","type":"URL","title":null,"description":null,"content":""}}
+{"count": 1, "results": {"id":970,"indicator":"http://api.vk.com/method/wall.get?count=1&owner_id=-81972386","type":"URL","title":null,"description":null,"content":""}}

--- a/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-sample-ndjson.log-expected.json
+++ b/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-sample-ndjson.log-expected.json
@@ -7,7 +7,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1588938}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1588938}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -28,7 +28,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"90421f8531f963d81cf54245b72cde80\",\"description\":\"MD5 of a5725af4391d21a232dc6d4ad33d7d915bd190bdac9b1826b73f364dc5c1aa65\",\"title\":\"Win32:Hoblig-B\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":9751110}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"90421f8531f963d81cf54245b72cde80\",\"description\":\"MD5 of a5725af4391d21a232dc6d4ad33d7d915bd190bdac9b1826b73f364dc5c1aa65\",\"title\":\"Win32:Hoblig-B\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":9751110}}",
                 "type": "indicator"
             },
             "otx": {
@@ -56,7 +56,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"ip.anysrc.net\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"hostname\",\"id\":16782717}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"ip.anysrc.net\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"hostname\",\"id\":16782717}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -79,7 +79,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":19901748}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":19901748}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -100,7 +100,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"d8c70ca70fd3555a0828fede6cc1f59e2c320ede80157039b6a2f09c336d5f7a\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":31612067}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"d8c70ca70fd3555a0828fede6cc1f59e2c320ede80157039b6a2f09c336d5f7a\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":31612067}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -125,7 +125,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"f8e58af3ffefd4037fef246e93a55dc8\",\"description\":\"MD5 of df9b37477a83189cd4541674e64ce29bf7bf98338ed0d635276660e0c6419d09\",\"title\":null,\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":34413770}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"f8e58af3ffefd4037fef246e93a55dc8\",\"description\":\"MD5 of df9b37477a83189cd4541674e64ce29bf7bf98338ed0d635276660e0c6419d09\",\"title\":null,\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":34413770}}",
                 "type": "indicator"
             },
             "otx": {
@@ -152,7 +152,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"1c62f004d0c9b91d3467b1b8106772e667e7e2075470c2ec7982b63573c90c54\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":111154034}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"1c62f004d0c9b91d3467b1b8106772e667e7e2075470c2ec7982b63573c90c54\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":111154034}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -177,7 +177,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"8d24a14f2600482d0231396b6350cf21773335ec2f0b8919763317fdab78baae\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":151858953}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"8d24a14f2600482d0231396b6350cf21773335ec2f0b8919763317fdab78baae\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":151858953}}",
                 "type": "indicator"
             },
             "otx": {
@@ -204,7 +204,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":311294364}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":311294364}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -225,7 +225,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"c758ec922b173820374e552c2f015ac53cc5d9f99cc92080e608652aaa63695b\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":406540408}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"c758ec922b173820374e552c2f015ac53cc5d9f99cc92080e608652aaa63695b\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":406540408}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -250,7 +250,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":565556753}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":565556753}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -275,7 +275,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"aeb08b0651bc8a13dcf5e5f6c0d482f8\",\"description\":\"MD5 of 0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6\",\"title\":null,\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":565556755}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"aeb08b0651bc8a13dcf5e5f6c0d482f8\",\"description\":\"MD5 of 0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6\",\"title\":null,\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":565556755}}",
                 "type": "indicator"
             },
             "otx": {
@@ -302,7 +302,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"6df5e1a017dff52020c7ff6ad92fdd37494e31769e1be242f6b23d1ea2d60140\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":575672549}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"6df5e1a017dff52020c7ff6ad92fdd37494e31769e1be242f6b23d1ea2d60140\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":575672549}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -327,7 +327,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"c72fef3835f65cb380f6920b22c3488554d1af6d298562ccee92284f265c9619\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":575672550}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"c72fef3835f65cb380f6920b22c3488554d1af6d298562ccee92284f265c9619\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":575672550}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -352,7 +352,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"e711fcd0f182b214c6ec74011a395f4c853068d59eb7c57f90c4a3e1de64434a\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":995160791}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"e711fcd0f182b214c6ec74011a395f4c853068d59eb7c57f90c4a3e1de64434a\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":995160791}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -377,7 +377,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"d3ec8f4a46b21fb189fc3d58f3d87bf9897653ecdf90b7952dcc71f3b4023b4e\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1011989699}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"d3ec8f4a46b21fb189fc3d58f3d87bf9897653ecdf90b7952dcc71f3b4023b4e\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1011989699}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -402,7 +402,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"70447996722e5c04514d20b7a429d162b46546002fb0c87f512b40f16bac99bb\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1011989701}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"70447996722e5c04514d20b7a429d162b46546002fb0c87f512b40f16bac99bb\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1011989701}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -427,7 +427,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"29340643ca2e6677c19e1d3bf351d654\",\"description\":\"MD5 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472176322}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"29340643ca2e6677c19e1d3bf351d654\",\"description\":\"MD5 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472176322}}",
                 "type": "indicator"
             },
             "otx": {
@@ -455,7 +455,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"86c314bc2dc37ba84f7364acd5108c2b\",\"description\":\"MD5 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457325}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"86c314bc2dc37ba84f7364acd5108c2b\",\"description\":\"MD5 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457325}}",
                 "type": "indicator"
             },
             "otx": {
@@ -483,7 +483,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"cb0c1248d3899358a375888bb4e8f3fe\",\"description\":\"MD5 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457326}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"cb0c1248d3899358a375888bb4e8f3fe\",\"description\":\"MD5 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457326}}",
                 "type": "indicator"
             },
             "otx": {
@@ -511,7 +511,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"d348f536e214a47655af387408b4fca5\",\"description\":\"MD5 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457327}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"d348f536e214a47655af387408b4fca5\",\"description\":\"MD5 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457327}}",
                 "type": "indicator"
             },
             "otx": {
@@ -539,7 +539,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413\",\"description\":null,\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012751}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413\",\"description\":null,\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012751}}",
                 "type": "indicator"
             },
             "otx": {
@@ -566,7 +566,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"b105891f90b2a8730bbadf02b5adeccbba539883bf75dec2ff7a5a97625dd222\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012939}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"b105891f90b2a8730bbadf02b5adeccbba539883bf75dec2ff7a5a97625dd222\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012939}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -591,7 +591,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"e4db5405ac7ab517d43722e1ca8d653ea4a32802bc8a5410d032275eedc7b7ee\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012967}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"e4db5405ac7ab517d43722e1ca8d653ea4a32802bc8a5410d032275eedc7b7ee\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012967}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -616,7 +616,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"description\":null,\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1564141498}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"description\":null,\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1564141498}}",
                 "type": "indicator"
             },
             "otx": {
@@ -643,7 +643,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"5051906d6ed1b2ae9c9a9f070ef73c9be8f591d2e41d144649a0dc96e28d0400\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1564141523}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"5051906d6ed1b2ae9c9a9f070ef73c9be8f591d2e41d144649a0dc96e28d0400\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1564141523}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -668,7 +668,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"14b74cb9be8cad8eb5fa8842d00bb692\",\"description\":\"MD5 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1564142109}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"14b74cb9be8cad8eb5fa8842d00bb692\",\"description\":\"MD5 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1564142109}}",
                 "type": "indicator"
             },
             "otx": {
@@ -696,7 +696,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"a5b59f7d133e354dfc73f40517aab730f322f0ef\",\"description\":\"SHA1 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1564142964}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"a5b59f7d133e354dfc73f40517aab730f322f0ef\",\"description\":\"SHA1 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1564142964}}",
                 "type": "indicator"
             },
             "otx": {
@@ -724,7 +724,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"8d3f68b16f0710f858d8c1d2c699260e6f43161a5510abb0e7ba567bd72c965b\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1566067095}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"8d3f68b16f0710f858d8c1d2c699260e6f43161a5510abb0e7ba567bd72c965b\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1566067095}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -749,7 +749,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"ff2dcea4963e060a658f4dffbb119529\",\"description\":\"MD5 of 5cb822616d2c9435c9ddd060d6abdbc286ab57cfcf6dc64768c52976029a925b\",\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1566999970}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"ff2dcea4963e060a658f4dffbb119529\",\"description\":\"MD5 of 5cb822616d2c9435c9ddd060d6abdbc286ab57cfcf6dc64768c52976029a925b\",\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1566999970}}",
                 "type": "indicator"
             },
             "otx": {
@@ -777,7 +777,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"0d73f1a1c4b2f8723fffc83eb3d00f31\",\"description\":\"MD5 of 29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413\",\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1569290125}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"0d73f1a1c4b2f8723fffc83eb3d00f31\",\"description\":\"MD5 of 29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413\",\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1569290125}}",
                 "type": "indicator"
             },
             "otx": {
@@ -805,7 +805,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1592876453}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1592876453}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -826,7 +826,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"d35a30264c0698709ad554489004e0077e263d354ced0c54552a0b500f91ecc0\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1597058431}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"d35a30264c0698709ad554489004e0077e263d354ced0c54552a0b500f91ecc0\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1597058431}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -851,7 +851,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"5264b455f453820be629a324196131492ff03c80491e823ac06657c9387250dd\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1603343478}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"5264b455f453820be629a324196131492ff03c80491e823ac06657c9387250dd\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1603343478}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -876,7 +876,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"description\":null,\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260302}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"description\":null,\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260302}}",
                 "type": "indicator"
             },
             "otx": {
@@ -903,7 +903,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260304}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260304}}",
                 "type": "indicator"
             },
             "otx": {
@@ -930,7 +930,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"b8e463789a076b16a90d1aae73cea9d3880ac0ead1fd16587b8cd79e37a1a3d8\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260305}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"b8e463789a076b16a90d1aae73cea9d3880ac0ead1fd16587b8cd79e37a1a3d8\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260305}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -955,7 +955,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260310}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260310}}",
                 "type": "indicator"
             },
             "otx": {
@@ -982,7 +982,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260311}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260311}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1009,7 +1009,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"c51024bb119211c335f95e731cfa9a744fcdb645a57d35fb379d01b7dbdd098e\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260316}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"c51024bb119211c335f95e731cfa9a744fcdb645a57d35fb379d01b7dbdd098e\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260316}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1034,7 +1034,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"ad20c6fac565f901c82a21b70f9739037eb54818\",\"description\":\"SHA1 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260341}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"ad20c6fac565f901c82a21b70f9739037eb54818\",\"description\":\"SHA1 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260341}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1062,7 +1062,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"13f11e273f9a4a56557f03821c3bfd591cca6ebc\",\"description\":\"SHA1 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260344}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"13f11e273f9a4a56557f03821c3bfd591cca6ebc\",\"description\":\"SHA1 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260344}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1090,7 +1090,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"1581fe76e3c96dc33182daafd09c8cf5c17004e0\",\"description\":\"SHA1 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260353}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"1581fe76e3c96dc33182daafd09c8cf5c17004e0\",\"description\":\"SHA1 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260353}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1118,7 +1118,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"b72e75e9e901a44b655a5cf89cf0eadcaff46037\",\"description\":\"SHA1 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260364}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"b72e75e9e901a44b655a5cf89cf0eadcaff46037\",\"description\":\"SHA1 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260364}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1146,7 +1146,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"maper.info\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":1634015726}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"maper.info\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":1634015726}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1169,7 +1169,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1635374317}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1635374317}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1190,7 +1190,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1756014820}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1756014820}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1211,7 +1211,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543412}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543412}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1238,7 +1238,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"be9fb556a3c7aef0329e768d7f903e7dd42a821abc663e11fb637ce33b007087\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543416}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"be9fb556a3c7aef0329e768d7f903e7dd42a821abc663e11fb637ce33b007087\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543416}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1265,7 +1265,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"3bfec096c4837d1e6485fe0ae0ea6f1c0b44edc611d4f2204cc9cf73c985cbc2\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543440}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"3bfec096c4837d1e6485fe0ae0ea6f1c0b44edc611d4f2204cc9cf73c985cbc2\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543440}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1292,7 +1292,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"dff2e39b2e008ea89a3d6b36dcd9b8c927fb501d60c1ad5a52ed1ffe225da2e2\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543441}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"dff2e39b2e008ea89a3d6b36dcd9b8c927fb501d60c1ad5a52ed1ffe225da2e2\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543441}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1319,7 +1319,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"6b4d271a48d118843aee3dee4481fa2930732ed7075db3241a8991418f00d92b\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543445}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"6b4d271a48d118843aee3dee4481fa2930732ed7075db3241a8991418f00d92b\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543445}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1346,7 +1346,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"26de4265303491bed1424d85b263481ac153c2b3513f9ee48ffb42c12312ac43\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543456}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"26de4265303491bed1424d85b263481ac153c2b3513f9ee48ffb42c12312ac43\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543456}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1373,7 +1373,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"02f54da6c6f2f87ff7b713d46e058dedac1cedabd693643bb7f6dfe994b2105d\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543458}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"02f54da6c6f2f87ff7b713d46e058dedac1cedabd693643bb7f6dfe994b2105d\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543458}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1400,7 +1400,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754074}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754074}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1421,7 +1421,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754077}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754077}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1442,7 +1442,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754078}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754078}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1463,7 +1463,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754080}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754080}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1484,7 +1484,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2117062744}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2117062744}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1505,7 +1505,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"e999b83629355ec7ff3b6fda465ef53ce6992c9327344fbf124f7eb37808389d\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2117884668}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"e999b83629355ec7ff3b6fda465ef53ce6992c9327344fbf124f7eb37808389d\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2117884668}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1530,7 +1530,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2119746545}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2119746545}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1551,7 +1551,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2129763785}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2129763785}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1572,7 +1572,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2136050161}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2136050161}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1593,7 +1593,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2136079568}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2136079568}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1616,7 +1616,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"fotmailz.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2137741373}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"fotmailz.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2137741373}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1639,7 +1639,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"pori89g5jqo3v8.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2137741468}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"pori89g5jqo3v8.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2137741468}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1662,7 +1662,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"sebco.co.ke\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2178708355}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"sebco.co.ke\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2178708355}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1685,7 +1685,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2180669102}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2180669102}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1708,7 +1708,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"chishir.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034800}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"chishir.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034800}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1731,7 +1731,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"kostunivo.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034803}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"kostunivo.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034803}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1754,7 +1754,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"mangoclone.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034805}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"mangoclone.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034805}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1777,7 +1777,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"onixcellent.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034807}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"onixcellent.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034807}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1800,7 +1800,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"fc0efd612ad528795472e99cae5944b68b8e26dc\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034891}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"fc0efd612ad528795472e99cae5944b68b8e26dc\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034891}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1827,7 +1827,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"24d4bbc982a6a561f0426a683b9617de1a96a74a\",\"description\":null,\"title\":\"Sf:ShellCode-DZ\\\\ [Trj]\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034903}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"24d4bbc982a6a561f0426a683b9617de1a96a74a\",\"description\":null,\"title\":\"Sf:ShellCode-DZ\\\\ [Trj]\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034903}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1854,7 +1854,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"fa98074dc18ad7e2d357b5d168c00a91256d87d1\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034912}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"fa98074dc18ad7e2d357b5d168c00a91256d87d1\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034912}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1881,7 +1881,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"e5dc7c8bfa285b61dda1618f0ade9c256be75d1a\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034924}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"e5dc7c8bfa285b61dda1618f0ade9c256be75d1a\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034924}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1908,7 +1908,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2189036445}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2189036445}}",
                 "type": "indicator"
             },
             "otx": {
@@ -1931,7 +1931,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2189036446}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2189036446}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1952,7 +1952,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2190596263}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2190596263}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -1973,7 +1973,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"indicator\":\"10ec3571596c30b9993b89f12d29d23c\",\"description\":\"MD5 of 9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6\",\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":2192837907}",
+                "original": "{\"count\": 1, \"results\": {\"indicator\":\"10ec3571596c30b9993b89f12d29d23c\",\"description\":\"MD5 of 9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6\",\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":2192837907}}",
                 "type": "indicator"
             },
             "otx": {
@@ -2001,7 +2001,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"id\":73,\"indicator\":\"http://www.playboysplus.com\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}",
+                "original": "{\"count\": 1, \"results\": {\"id\":73,\"indicator\":\"http://www.playboysplus.com\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -2028,7 +2028,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"id\":74,\"indicator\":\"http://join.playboysplus.com/signup/\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}",
+                "original": "{\"count\": 1, \"results\": {\"id\":74,\"indicator\":\"http://join.playboysplus.com/signup/\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}}",
                 "type": "indicator"
             },
             "otx": {},
@@ -2055,7 +2055,7 @@
             "event": {
                 "category": "threat",
                 "kind": "enrichment",
-                "original": "{\"id\":970,\"indicator\":\"http://api.vk.com/method/wall.get?count=1\u0026owner_id=-81972386\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}",
+                "original": "{\"count\": 1, \"results\": {\"id\":970,\"indicator\":\"http://api.vk.com/method/wall.get?count=1\u0026owner_id=-81972386\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}}",
                 "type": "indicator"
             },
             "otx": {},

--- a/packages/ti_otx/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_otx/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -35,6 +35,7 @@ request.transforms:
 
 response.split:
   target: body.results
+  keep_parent: true
 
 response.pagination:
 - set:

--- a/packages/ti_otx/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_otx/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -27,6 +27,18 @@ processors:
   - json:
       field: event.original
       target_field: otx
+  - drop:
+      if: ctx.otx?.count == 0
+  - rename:
+      field: otx.results
+      target_field: results
+      ignore_missing: true
+  - remove:
+      field: otx
+  - rename:
+      field: results
+      target_field: otx
+      ignore_missing: true
   - fingerprint:
       fields:
         - otx.id
@@ -161,8 +173,16 @@ processors:
         - otx.type
         - otx.id
         - message
+        - otx.count
+        - otx.next
+        - otx.previous
       ignore_missing: true
       if: ctx.threat?.indicator?.type != null
+  - remove:
+      field:
+        - otx
+      ignore_missing: true
+      if: ctx.otx == null
 on_failure:
   - set:
       field: error.message

--- a/packages/ti_otx/data_stream/threat/sample_event.json
+++ b/packages/ti_otx/data_stream/threat/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-04-11T09:14:18.594Z",
+    "@timestamp": "2022-12-21T09:24:01.501Z",
     "agent": {
-        "ephemeral_id": "26518763-fc35-4393-a414-ab320e780eee",
-        "id": "93ca38c5-fdea-4af2-acab-27edbc2b3434",
+        "ephemeral_id": "32ac7970-c892-46ef-baf2-d8a0ce377748",
+        "id": "a7d83bcb-0b6d-41f4-8edf-aa29923f67ec",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "ti_otx.threat",
@@ -16,18 +16,18 @@
         "version": "8.5.0"
     },
     "elastic_agent": {
-        "id": "93ca38c5-fdea-4af2-acab-27edbc2b3434",
+        "id": "a7d83bcb-0b6d-41f4-8edf-aa29923f67ec",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "threat",
-        "created": "2022-04-11T09:14:18.594Z",
+        "created": "2022-12-21T09:24:01.501Z",
         "dataset": "ti_otx.threat",
-        "ingested": "2022-04-11T09:14:19Z",
+        "ingested": "2022-12-21T09:24:02Z",
         "kind": "enrichment",
-        "original": "{\"content\":\"\",\"description\":null,\"id\":1251,\"indicator\":\"info.3000uc.com\",\"title\":null,\"type\":\"hostname\"}",
+        "original": "{\"count\":40359,\"next\":\"https://otx.alienvault.com/api/v1/indicators/export?types=domain%2CIPv4%2Chostname%2Curl%2CFileHash-SHA256\\u0026modified_since=2020-11-29T01%3A10%3A00+00%3A00\\u0026page=2\",\"previous\":null,\"results\":{\"content\":\"\",\"description\":null,\"id\":1251,\"indicator\":\"info.3000uc.com\",\"title\":null,\"type\":\"hostname\"}}",
         "type": "indicator"
     },
     "input": {

--- a/packages/ti_otx/docs/README.md
+++ b/packages/ti_otx/docs/README.md
@@ -101,13 +101,13 @@ An example event for `threat` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-04-11T09:14:18.594Z",
+    "@timestamp": "2022-12-21T09:24:01.501Z",
     "agent": {
-        "ephemeral_id": "26518763-fc35-4393-a414-ab320e780eee",
-        "id": "93ca38c5-fdea-4af2-acab-27edbc2b3434",
+        "ephemeral_id": "32ac7970-c892-46ef-baf2-d8a0ce377748",
+        "id": "a7d83bcb-0b6d-41f4-8edf-aa29923f67ec",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.3.3"
     },
     "data_stream": {
         "dataset": "ti_otx.threat",
@@ -118,18 +118,18 @@ An example event for `threat` looks as following:
         "version": "8.5.0"
     },
     "elastic_agent": {
-        "id": "93ca38c5-fdea-4af2-acab-27edbc2b3434",
+        "id": "a7d83bcb-0b6d-41f4-8edf-aa29923f67ec",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.3.3"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "threat",
-        "created": "2022-04-11T09:14:18.594Z",
+        "created": "2022-12-21T09:24:01.501Z",
         "dataset": "ti_otx.threat",
-        "ingested": "2022-04-11T09:14:19Z",
+        "ingested": "2022-12-21T09:24:02Z",
         "kind": "enrichment",
-        "original": "{\"content\":\"\",\"description\":null,\"id\":1251,\"indicator\":\"info.3000uc.com\",\"title\":null,\"type\":\"hostname\"}",
+        "original": "{\"count\":40359,\"next\":\"https://otx.alienvault.com/api/v1/indicators/export?types=domain%2CIPv4%2Chostname%2Curl%2CFileHash-SHA256\\u0026modified_since=2020-11-29T01%3A10%3A00+00%3A00\\u0026page=2\",\"previous\":null,\"results\":{\"content\":\"\",\"description\":null,\"id\":1251,\"indicator\":\"info.3000uc.com\",\"title\":null,\"type\":\"hostname\"}}",
         "type": "indicator"
     },
     "input": {

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.6.0"
+version: "1.6.1"
 release: ga
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

When OTX returns a count of 0, we should drop the empty documents

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


