### PR TITLE
[Cloud Posture] support spaces 8.6.0 - fix

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: CSPM support spaces for 8.6 - fix
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4885
 - version: "1.0.9"
   changes:
     - description: CSPM support spaces for 8.6

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -54,8 +54,7 @@ streams:
         show_user: false
       - name: role_arn
         type: text
-        title: ARN Role 
+        title: ARN Role
         multi: false
         required: false
         show_user: false
-

--- a/packages/cloud_security_posture/kibana/index_pattern/cloud_security_posture-303eea10-c475-11ec-af18-c5b9b437dbbe.json
+++ b/packages/cloud_security_posture/kibana/index_pattern/cloud_security_posture-303eea10-c475-11ec-af18-c5b9b437dbbe.json
@@ -1,14 +1,14 @@
 {
-  "attributes": {
-    "description": "",
-    "title": "logs-cloud_security_posture.findings_latest-*",
-    "timeFieldName": "@timestamp",
-    "namespaces": "[*]"
-  },
-  "coreMigrationVersion": "8.3.0",
-  "id": "cloud_security_posture-303eea10-c475-11ec-af18-c5b9b437dbbe",
-  "migrationVersion": {
-    "index-pattern": "8.0.0"
-  },
-  "type": "index-pattern"
+    "attributes": {
+        "description": "",
+        "title": "logs-cloud_security_posture.findings_latest-*",
+        "timeFieldName": "@timestamp",
+        "namespaces": "[*]"
+    },
+    "coreMigrationVersion": "8.3.0",
+    "id": "cloud_security_posture-303eea10-c475-11ec-af18-c5b9b437dbbe",
+    "migrationVersion": {
+        "index-pattern": "8.0.0"
+    },
+    "type": "index-pattern"
 }

--- a/packages/cloud_security_posture/kibana/index_pattern/cloud_security_posture-9129a080-7f48-11ec-8249-431333f83c5f.json
+++ b/packages/cloud_security_posture/kibana/index_pattern/cloud_security_posture-9129a080-7f48-11ec-8249-431333f83c5f.json
@@ -1,14 +1,14 @@
 {
-  "attributes": {
-    "description": "",
-    "title": "logs-cloud_security_posture.findings-*",
-    "timeFieldName": "@timestamp",
-    "namespaces": "[*]"
-  },
-  "coreMigrationVersion": "8.1.0",
-  "id": "cloud_security_posture-9129a080-7f48-11ec-8249-431333f83c5f",
-  "migrationVersion": {
-    "index-pattern": "8.0.0"
-  },
-  "type": "index-pattern"
+    "attributes": {
+        "description": "",
+        "title": "logs-cloud_security_posture.findings-*",
+        "timeFieldName": "@timestamp",
+        "namespaces": "[*]"
+    },
+    "coreMigrationVersion": "8.1.0",
+    "id": "cloud_security_posture-9129a080-7f48-11ec-8249-431333f83c5f",
+    "migrationVersion": {
+        "index-pattern": "8.0.0"
+    },
+    "type": "index-pattern"
 }

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Kubernetes Security Posture Management (KSPM)"
-version: 1.0.9
+version: 1.1.1
 release: ga
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."


### PR DESCRIPTION
In https://github.com/elastic/integrations/pull/4804 we used lower version the the latest in order to indicate the change is for previous stack version. It seems wrong way (new pr to snapshot EPR wasn't created) - this PR only promote the version to be higher than before.