### PR TITLE
[Elasticsearch] Added ssl configuration to ES module

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0-preview1"
+  changes:
+    - description: Add `ssl` configuration option for metricsets
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/4666
 - version: "1.1.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,9 +1,4 @@
 # newer versions go on top
-- version: "1.2.0-preview1"
-  changes:
-    - description: Add `ssl` configuration option for metricsets
-      type: enhancement
-      link: https://github.com/elastic/integrations/issues/4666
 - version: "1.1.0-preview1"
   changes:
     - description: Suffix `stack_monitoring` to the datasets

--- a/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
@@ -11,3 +11,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
@@ -11,6 +11,3 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
-{{#if ssl}}
-ssl: {{ssl}}
-{{/if}}

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.1.0-preview1
+version: 1.2.0-preview1
 description: Elasticsearch Integration
 type: integration
 icons:
@@ -56,5 +56,16 @@ policy_templates:
             required: true
             show_user: false
             default: node
+          - name: ssl
+            type: yaml
+            title: SSL Configuration
+            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+            multi: false
+            required: false
+            show_user: false
+            default: |
+              #certificate_authorities: ["/etc/ca.crt"]
+              #certificate: "/etc/client.crt"
+              #key: "/etc/client.key"
 owner:
   github: elastic/infra-monitoring-ui

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.2.0-preview1
+version: 1.1.0-preview1
 description: Elasticsearch Integration
 type: integration
 icons:
@@ -56,16 +56,5 @@ policy_templates:
             required: true
             show_user: false
             default: node
-          - name: ssl
-            type: yaml
-            title: SSL Configuration
-            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
-            multi: false
-            required: false
-            show_user: false
-            default: |
-              #certificate_authorities: ["/etc/ca.crt"]
-              #certificate: "/etc/client.crt"
-              #key: "/etc/client.key"
 owner:
   github: elastic/infra-monitoring-ui


### PR DESCRIPTION
## What does this PR do?

Add `ssl` configuration options for elasticsearch integration module

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that the new ssl configuration is being passed properly to the metricbeat module

## Related issues

- Closes [#4666 ](https://github.com/elastic/integrations/issues/4666)
