### PR TITLE
Add mappings for components in elastic_agent logs

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0-beta1"
+  changes:
+    - description: Add new fields for Elastic Agent v2 components
+      type: enhancement
+      link: TODO
 - version: "1.3.5"
   changes:
     - description: Fix the external ECS fields not being properly resolved during the package build

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
-- version: "1.4.0-beta1"
+- version: "1.4.0"
   changes:
     - description: Add new fields for Elastic Agent v2 components
       type: enhancement
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/4888
 - version: "1.3.5"
   changes:
     - description: Fix the external ECS fields not being properly resolved during the package build

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.4.0"
   changes:
-    - description: Add new fields for Elastic Agent v2 components
+    - description: Add new fields for Elastic Agent v2 components and units
       type: enhancement
       link: https://github.com/elastic/integrations/pull/4888
 - version: "1.3.5"

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -28,52 +28,37 @@
       example: 7.11.0
 - name: component
   type: group
-  description: Agent components that caused the log message, only available on Elastic Agent 8.6.0+
+  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard
       ignore_above: 1024
       description: Component id
-    - name: binary
-      type: keyword
-      ignore_above: 1024
-      description: Component binary
-    - name: type
-      type: keyword
-      ignore_above: 1024
-      description: Component type
     - name: state
       type: keyword
       ignore_above: 1024
-      description: Component health
-    - name: message
-      type: text
-      description: Component status message
-    - name: inputs
-      type: group
-      fields:
-        - name: id
-          type: wildcard
-          ignore_above: 1024
-          description: Input id
-        - name: state
-          type: keyword
-          ignore_above: 1024
-          description: Input health
-        - name: message
-          type: text
-          description: Input status message
-    - name: output
-      type: group
-      fields:
-        - name: id
-          type: wildcard
-          ignore_above: 1024
-          description: Input id
-        - name: state
-          type: keyword
-          ignore_above: 1024
-          description: Input health
-        - name: message
-          type: text
-          description: Input status message
+      description: Current component health
+    - name: old_state
+      type: keyword
+      ignore_above: 1024
+      description: Previous component health
+- name: unit
+  type: group
+  description: Agent unit that the log message is about, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: wildcard
+      ignore_above: 1024
+      description: Unit id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the unit (input, output, etc.)
+    - name: state
+      type: keyword
+      ignore_above: 1024
+      description: Current unit health
+    - name: old_state
+      type: keyword
+      ignore_above: 1024
+      description: Previous unit health

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -34,6 +34,15 @@
       type: wildcard
       ignore_above: 1024
       description: Component id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the component
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
     - name: state
       type: keyword
       ignore_above: 1024
@@ -53,7 +62,8 @@
     - name: type
       type: keyword
       ignore_above: 1024
-      description: The type of the unit (input, output, etc.)
+      description: The type of the unit
+      example: input
     - name: state
       type: keyword
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -26,3 +26,46 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+- name: component
+  type: group
+  description: Agent components that caused the log message, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: state
+      type: keyword
+      ignore_above: 1024
+      description: Component health
+    - name: message
+      type: text
+      description: Component status message
+    - name: inputs
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          ignore_above: 1024
+          description: Input id
+        - name: state
+          type: keyword
+          ignore_above: 1024
+          description: Input health
+        - name: message
+          type: text
+          description: Input status message
+    - name: outputs
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          ignore_above: 1024
+          description: Input id
+        - name: state
+          type: keyword
+          ignore_above: 1024
+          description: Input health
+        - name: message
+          type: text
+          description: Input status message

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -31,9 +31,17 @@
   description: Agent components that caused the log message, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
-      type: keyword
+      type: wildcard
       ignore_above: 1024
       description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: Component binary
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: Component type
     - name: state
       type: keyword
       ignore_above: 1024
@@ -45,7 +53,7 @@
       type: group
       fields:
         - name: id
-          type: keyword
+          type: wildcard
           ignore_above: 1024
           description: Input id
         - name: state
@@ -55,11 +63,11 @@
         - name: message
           type: text
           description: Input status message
-    - name: outputs
+    - name: output
       type: group
       fields:
         - name: id
-          type: keyword
+          type: wildcard
           ignore_above: 1024
           description: Input id
         - name: state

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.4.0-beta1
+version: 1.4.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,7 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.3.5
-release: ga
+version: 1.4.0-beta1
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Adds new mapping fields to the elastic_agent logs data stream for the individualized `component` fields to allow for searching and filtering for logs on a particular agent component.

Future follow ups will add new visualizations for things like top unhealthy input and output messages, top unhealthy input types, unhealthy output types etc.

I'm keeping this compatible with older Kibana versions as it will not break older stacks and allows us to continue to ship new dashboards and fixes to older stack versions.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] Re-test against latest agent builds

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related to https://github.com/elastic/elastic-agent/issues/1954

## Screenshots

Logs can be filtered by things like the individual component that produced them:

<img width="1882" alt="image" src="https://user-images.githubusercontent.com/1813008/209360329-9a8c07f3-910c-41b3-9bc3-97a24e37489a.png">
