### PR TITLE
[Microsoft SQS Server] Auto Support all user databases for transaction log metrics.

### DIFF
--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Auto Support all user databases for transaction log.
       type: enhancement
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/4903
 - version: "1.11.0"
   changes:
     - description: Support user databases for transaction log.

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Auto Support all user databases for transaction log.
+      type: enhancement
+      link: tbd
 - version: "1.11.0"
   changes:
     - description: Support user databases for transaction log.

--- a/packages/microsoft_sqlserver/data_stream/transaction_log/agent/stream/stream.yml.hbs
+++ b/packages/microsoft_sqlserver/data_stream/transaction_log/agent/stream/stream.yml.hbs
@@ -7,12 +7,12 @@ driver: mssql
 raw_data.enabled: true
 # Collect the transaction logs from the system database
 sql_queries:
+  - query: "SELECT @@servername AS server_name, @@servicename AS instance_name, name As 'database_name', database_id FROM sys.databases;"
+    response_format: table
+  - query: "SELECT @@servername AS server_name, @@servicename AS instance_name, name As 'database_name', s.database_id, total_log_size_mb, active_log_size_mb,log_backup_time,log_since_last_log_backup_mb,log_since_last_checkpoint_mb,log_recovery_size_mb from sys.databases As s CROSS APPLY sys.dm_db_log_stats(s.database_id);"
+    response_format: table
 {{#if databases}}
 {{#each databases as |database_name i|}}
-  - query: "SELECT @@servername AS server_name, @@servicename AS instance_name, name As 'database_name', database_id FROM sys.databases WHERE name='{{database_name}}';"
-    response_format: table
-  - query: "SELECT @@servername AS server_name, @@servicename AS instance_name, name As 'database_name', l.database_id, l.total_log_size_mb, l.active_log_size_mb,l.log_backup_time,l.log_since_last_log_backup_mb,l.log_since_last_checkpoint_mb,l.log_recovery_size_mb from sys.dm_db_log_stats(DB_ID('{{database_name}}')) l INNER JOIN sys.databases s ON l.database_id = s.database_id WHERE s.database_id = DB_ID('{{database_name}}') ;"
-    response_format: table
   - query: "USE {{database_name}} ; SELECT @@servername AS server_name, @@servicename AS instance_name, name As 'database_name', l.database_id, l.total_log_size_in_bytes As total_log_size_bytes, l.used_log_space_in_bytes As used_log_space_bytes, l.used_log_space_in_percent As used_log_space_pct, l.log_space_in_bytes_since_last_backup from sys.dm_db_log_space_usage l INNER JOIN sys.databases s ON l.database_id = s.database_id WHERE s.database_id = DB_ID('{{database_name}}') ;"
     response_format: table
 {{/each}}

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "1.11.0"
+version: "1.12.0"
 license: basic
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration


### PR DESCRIPTION
- Enhancement


## What does this PR do?

The MSSQL Integration currently loads "transaction_log metrics" from system dbs and provide user dbs metrics where user database can be manually provided.  
This PR has updated the integration to load "transaction_log metrics" from all the dbs except from the metrics from sys.dm_db_log_space_usage table. A list of user databases can be specified to get the same.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Add Microsoft sql server integration and add the config or server details and check the metrics.

## Related issues


- Relates #4108 
