### PR TITLE
[auditd_manager] Add audit rule files option to auditd_manager

### DIFF
--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add audit rule files option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/4905
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add audit rule files option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.5.0.

--- a/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
+++ b/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
@@ -12,6 +12,10 @@ immutable: {{immutable}}
 resolve_ids: {{resolve_ids}}
 failure_mode: {{failure_mode}}
 audit_rules: {{escape_string audit_rules}}
+audit_rule_files:
+{{#each audit_rule_files as |file i|}}
+  - {{file}}
+{{/each}}
 backlog_limit: {{backlog_limit}}
 rate_limit: {{rate_limit}}
 include_warnings: {{include_warnings}}

--- a/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
+++ b/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
@@ -11,11 +11,15 @@ immutable: {{immutable}}
 {{/if}}
 resolve_ids: {{resolve_ids}}
 failure_mode: {{failure_mode}}
+{{#if audit_rules}}
 audit_rules: {{escape_string audit_rules}}
+{{/if}}
+{{#if audit_rule_files.length}}
 audit_rule_files:
 {{#each audit_rule_files as |file i|}}
   - {{file}}
 {{/each}}
+{{/if}}
 backlog_limit: {{backlog_limit}}
 rate_limit: {{rate_limit}}
 include_warnings: {{include_warnings}}

--- a/packages/auditd_manager/data_stream/auditd/manifest.yml
+++ b/packages/auditd_manager/data_stream/auditd/manifest.yml
@@ -65,7 +65,7 @@ streams:
       - name: audit_rules
         type: textarea
         title: Audit rules
-        required: true
+        required: false
         show_user: true
         description: |
           List of the audit rules that should be
@@ -74,6 +74,15 @@ streams:
           used by the Linux `auditctl` utility. `elastic-agent` supports adding file watches
           (`-w`) and syscall rules (`-a` or `-A`). For more information,
           see the integration detail page.
+      - name: audit_rule_files
+        type: text
+        title: Audit rule files
+        required: false
+        show_user: true
+        description: |
+          A list of files to load audit rules from. This files are loaded after the rules
+          declared in `Audit rules` are loaded. Wildcards are supported and will expand in
+          lexicographical order. The format is the same as that of the `Audit rules` field.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: auditd_manager
 title: "Auditd Manager"
-version: "1.4.0"
+version: "1.5.0"
 release: ga
 license: basic
 description: "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel."


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds the `audit_rule_files` option.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
