### PR TITLE
[Kibana] Added ssl config support to kibana module

### DIFF
--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0-preview1"
+  changes:
+    - description: Add `ssl` configuration option for metricsets
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/4666
 - version: "2.1.0-preview1"
   changes:
     - description: Fix logo

--- a/packages/kibana/data_stream/cluster_actions/agent/stream/stream.yml.hbs
+++ b/packages/kibana/data_stream/cluster_actions/agent/stream/stream.yml.hbs
@@ -13,4 +13,7 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 

--- a/packages/kibana/data_stream/cluster_rules/agent/stream/stream.yml.hbs
+++ b/packages/kibana/data_stream/cluster_rules/agent/stream/stream.yml.hbs
@@ -13,4 +13,7 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 

--- a/packages/kibana/data_stream/node_actions/agent/stream/stream.yml.hbs
+++ b/packages/kibana/data_stream/node_actions/agent/stream/stream.yml.hbs
@@ -13,4 +13,7 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 

--- a/packages/kibana/data_stream/node_rules/agent/stream/stream.yml.hbs
+++ b/packages/kibana/data_stream/node_rules/agent/stream/stream.yml.hbs
@@ -13,4 +13,7 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 

--- a/packages/kibana/data_stream/stats/agent/stream/stream.yml.hbs
+++ b/packages/kibana/data_stream/stats/agent/stream/stream.yml.hbs
@@ -13,4 +13,7 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
 

--- a/packages/kibana/data_stream/status/agent/stream/stream.yml.hbs
+++ b/packages/kibana/data_stream/status/agent/stream/stream.yml.hbs
@@ -13,3 +13,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -53,7 +53,7 @@ policy_templates:
             description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
             multi: false
             required: false
-            show_user: true
+            show_user: false
             default: |
               #certificate_authorities: ["/etc/ca.crt"]
               #certificate: "/etc/client.crt"

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.1.0-preview1
+version: 2.2.0-preview1
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:
@@ -47,5 +47,16 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+          - name: ssl
+            type: yaml
+            title: SSL Configuration
+            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+            multi: false
+            required: false
+            show_user: true
+            default: |
+              #certificate_authorities: ["/etc/ca.crt"]
+              #certificate: "/etc/client.crt"
+              #key: "/etc/client.key"
 owner:
   github: elastic/infra-monitoring-ui


### PR DESCRIPTION
## What does this PR do?

Add `ssl` configuration options for kibana integration module

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that the new ssl configuration is being passed properly to the metricbeat module

## How to this PR was tested
- Applied changes locally, and used [elastic-package](https://github.com/elastic/elastic-package) to spawn up a complete stack locally.
- Made sure the new fields are visible in the UI as below:
<img width="755" alt="Screenshot 2022-12-22 at 15 21 23" src="https://user-images.githubusercontent.com/11225826/209171391-3e8073d6-4565-4ac8-86f1-63d253f8f847.png">

- Checked that the policy has the new fields mapped properly
![Screenshot 2023-01-02 at 15 19 23](https://user-images.githubusercontent.com/11225826/210238388-0bca83cf-ba2a-441f-b980-699daf4d325f.png)


- Spawned an Elastic agent locally and checked the matribeat logs to make sure that it initially fails when connecting to ES and then succeeds to establish a connection to ES when ssl configuration are passed properly

## Related issues

- subtask of [#4666 ](https://github.com/elastic/integrations/issues/4666)