### PR TITLE
[Cloud Posture] update minor version for indicating 8.7.0

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: CSPM support spaces for 8.7.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4891
 - version: "1.1.2"
   changes:
     - description: CSPM support spaces for 8.7.0

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: CSPM support spaces for 8.7.0
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4891
+      link: https://github.com/elastic/integrations/pull/4913
 - version: "1.1.2"
   changes:
     - description: CSPM support spaces for 8.7.0

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Security Posture Management (CSPM/KSPM)"
-version: 1.1.2
+version: 1.2.0
 release: ga
 license: basic
 description: "DO NOT USE MAIN TILE (WIP)"


### PR DESCRIPTION
Today CSPM 1.1.1 version referring for package that support 8.6.0  and 1.1.2 supports 8.7.0. 
This PR update the current version (support 8.7.0) to 1.2.0 in order to use the minor digit to distinguish between the two.