### PR TITLE
[Logstash] Added ssl config support to logstash module

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0-preview1"
+  changes:
+    - description: Add `ssl` configuration option for metricsets
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/4666
 - version: "2.1.1-preview1"
   changes:
     - description: Fix mappings of type nested

--- a/packages/logstash/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/logstash/data_stream/node/agent/stream/stream.yml.hbs
@@ -10,3 +10,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/logstash/data_stream/node_stats/agent/stream/stream.yml.hbs
+++ b/packages/logstash/data_stream/node_stats/agent/stream/stream.yml.hbs
@@ -10,3 +10,6 @@ username: {{username}}
 password: {{password}}
 {{/if}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.1.1-preview1
+version: 2.2.0-preview1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:
@@ -61,6 +61,17 @@ policy_templates:
             required: true
             show_user: true
             default: 10s
+          - name: ssl
+            type: yaml
+            title: SSL Configuration
+            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+            multi: false
+            required: false
+            show_user: false
+            default: |
+              #certificate_authorities: ["/etc/ca.crt"]
+              #certificate: "/etc/client.crt"
+              #key: "/etc/client.key"
         title: Collect Logstash node metrics and stats
         description: Collecting node metrics and stats from Logstash instances
 owner:


### PR DESCRIPTION
## What does this PR do?

Add `ssl` configuration options for logstash integration module

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that the new ssl configuration is being passed properly to the metricbeat module

## How to this PR was tested
- Applied changes locally, and used [elastic-package](https://github.com/elastic/elastic-package) to spawn up a complete stack locally.
- Made sure the new fields are visible in the UI as below:
<img width="755" alt="Screenshot 2022-12-22 at 15 21 23" src="https://user-images.githubusercontent.com/11225826/209171391-3e8073d6-4565-4ac8-86f1-63d253f8f847.png">

- Checked that the policy has the new fields mapped properly
<img width="645" alt="Screenshot 2022-12-22 at 15 46 55" src="https://user-images.githubusercontent.com/11225826/209171413-75fd62d1-b717-44f9-af93-c58f90e214be.png">

- Spawned an Elastic agent locally and checked the matribeat logs to make sure that it initially fails when connecting to ES and then succeeds to establish a connection to ES when ssl configuration are passed properly

## Related issues

- subtask of [#4666 ](https://github.com/elastic/integrations/issues/4666)