### PR TITLE
[Beats] Added ssl config support to beats module

### DIFF
--- a/packages/beat/changelog.yml
+++ b/packages/beat/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.1.0-preview1"
+  changes:
+    - description: Add `ssl` configuration option for metricsets
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/4666
 - version: 0.0.1
   changes:
     - description: initial release

--- a/packages/beat/changelog.yml
+++ b/packages/beat/changelog.yml
@@ -1,4 +1,4 @@
-- version: "0.1.0-preview1"
+- version: 0.1.0
   changes:
     - description: Add `ssl` configuration option for metricsets
       type: enhancement

--- a/packages/beat/data_stream/state/agent/stream/stream.yml.hbs
+++ b/packages/beat/data_stream/state/agent/stream/stream.yml.hbs
@@ -4,3 +4,6 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/beat/data_stream/stats/agent/stream/stream.yml.hbs
+++ b/packages/beat/data_stream/stats/agent/stream/stream.yml.hbs
@@ -4,3 +4,6 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}

--- a/packages/beat/manifest.yml
+++ b/packages/beat/manifest.yml
@@ -1,6 +1,6 @@
 name: beat
 title: Beat
-version: 0.0.1
+version: 0.1.0-preview1
 description: Beat Integration
 type: integration
 conditions:
@@ -29,5 +29,16 @@ policy_templates:
             show_user: true
             default:
               - http://localhost:5066
+          - name: ssl
+            type: yaml
+            title: SSL Configuration
+            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+            multi: false
+            required: false
+            show_user: false
+            default: |
+              #certificate_authorities: ["/etc/ca.crt"]
+              #certificate: "/etc/client.crt"
+              #key: "/etc/client.key"
         title: Collect Beat metrics for Stack Monitoring application
         description: Collecting state and stats metrics from Beat instances

--- a/packages/beat/manifest.yml
+++ b/packages/beat/manifest.yml
@@ -1,6 +1,6 @@
 name: beat
 title: Beat
-version: 0.1.0-preview1
+version: 0.1.0
 description: Beat Integration
 type: integration
 conditions:


### PR DESCRIPTION
## What does this PR do?

Add `ssl` configuration options for elasticsearch integration module

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that the new ssl configuration is being passed properly to the metricbeat module

## How to this PR was tested
- Applied changes locally, and used [elastic-package](https://github.com/elastic/elastic-package) to spawn up a complete stack locally.
- Made sure the new fields are visible in the UI as below:
<img width="755" alt="Screenshot 2022-12-22 at 15 21 23" src="https://user-images.githubusercontent.com/11225826/209171391-3e8073d6-4565-4ac8-86f1-63d253f8f847.png">

- Checked that the policy has the new fields mapped properly
<img width="645" alt="Screenshot 2022-12-22 at 15 46 55" src="https://user-images.githubusercontent.com/11225826/209171413-75fd62d1-b717-44f9-af93-c58f90e214be.png">

- Spawned an Elastic agent locally and checked the matribeat logs to make sure that it initially fails when connecting to ES and then succeeds to establish a connection to ES when ssl configuration are passed properly

## Related issues

- subtask of [#4666 ](https://github.com/elastic/integrations/issues/4666)