### PR TITLE
[AWS_Logs] Add support for worker count in non_aws_bucket settings

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add required field number of workers to support non aws buckets, and add default value.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4859
+      link: https://github.com/elastic/integrations/pull/4917
 - version: "0.3.1"
   changes:
     - description: Add latency config parameter for aws-cloudwatch input

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.3.2"
+  changes:
+    - description: Add required field number of workers to support non aws buckets, and add default value.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4859
 - version: "0.3.1"
   changes:
     - description: Add latency config parameter for aws-cloudwatch input

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
@@ -31,6 +31,9 @@ bucket_list_interval: {{ bucket_list_interval }}
 {{#if non_aws_bucket_name }}
 non_aws_bucket_name: {{ non_aws_bucket_name }}
 {{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
 {{#if bucket_list_interval }}
 bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -161,6 +161,7 @@ streams:
         title: Number of Workers
         multi: false
         required: false
+        default: 1
         show_user: true
         description: Number of workers that will process the S3 objects listed. (Required when `bucket_arn` is set).
       - name: bucket_list_interval

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: 0.3.1
+version: 0.3.2
 release: beta
 license: basic
 categories:


### PR DESCRIPTION
## What does this PR do?

Because of the `unless` statements in the AWS config template, it is not possible to set worker count when using `non_aws_bucket_name`.

Worker count is a required field, so this will fail.

I also added a default value just in case people forget about the setting.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


