### PR TITLE
[RabbitMQ] Add support for new timestamp format

### DIFF
--- a/packages/rabbitmq/_dev/build/docs/README.md
+++ b/packages/rabbitmq/_dev/build/docs/README.md
@@ -19,6 +19,7 @@ The application logs dataset parses single file format introduced in 3.7.0.
 ### Application Logs
 
 Application logs collects standard RabbitMQ logs.
+It will only support RabbitMQ default i.e RFC 3339 timestamp format.
 
 {{fields "log"}}
 

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.5.0"
+  changes:
+    - description: Add support of a new RabbitMQ timestamp format.
+      type: enhancement
+      link: tbd
 - version: "1.4.0"
   changes:
     - description: Added infrastructure category.

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add support of a new RabbitMQ timestamp format.
       type: enhancement
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/4918
 - version: "1.4.0"
   changes:
     - description: Added infrastructure category.

--- a/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log
+++ b/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log
@@ -1,26 +1,169 @@
-2023-01-03 07:20:19.811276+00:00 [info] <0.229.0> Created user 'guest'
-2023-01-03 07:20:19.812335+00:00 [info] <0.229.0> Successfully set user tags for user 'guest' to [administrator]
-2023-01-03 07:20:19.813219+00:00 [info] <0.229.0> Successfully set permissions for 'guest' in virtual host '/' to '.*', '.*', '.*'
-2023-01-03 07:20:19.813249+00:00 [info] <0.229.0> Running boot step rabbit_observer_cli defined by app rabbit
-2023-01-03 07:20:19.813297+00:00 [info] <0.229.0> Running boot step rabbit_looking_glass defined by app rabbit
-2023-01-03 07:20:19.813314+00:00 [info] <0.229.0> Running boot step rabbit_core_metrics_gc defined by app rabbit
-2023-01-03 07:20:19.813405+00:00 [info] <0.229.0> Running boot step background_gc defined by app rabbit
-2023-01-03 07:20:19.813473+00:00 [info] <0.229.0> Running boot step routing_ready defined by app rabbit
-2023-01-03 07:20:19.813495+00:00 [info] <0.229.0> Running boot step pre_flight defined by app rabbit
-2023-01-03 07:20:19.813507+00:00 [info] <0.229.0> Running boot step notify_cluster defined by app rabbit
-2023-01-03 07:20:19.813522+00:00 [info] <0.229.0> Running boot step networking defined by app rabbit
-2023-01-03 07:20:19.813558+00:00 [info] <0.229.0> Running boot step definition_import_worker_pool defined by app rabbit
-2023-01-03 07:20:19.813584+00:00 [info] <0.286.0> Starting worker pool 'definition_import_pool' with 5 processes in it
-2023-01-03 07:20:19.813855+00:00 [info] <0.229.0> Running boot step cluster_name defined by app rabbit
-2023-01-03 07:20:19.813932+00:00 [info] <0.229.0> Initialising internal cluster ID to 'rabbitmq-cluster-id-l0b5cMVBVtihO_6zHjXFTA'
-2023-01-03 07:20:19.814968+00:00 [info] <0.229.0> Running boot step direct_client defined by app rabbit
-2023-01-03 07:20:19.815021+00:00 [info] <0.229.0> Running boot step rabbit_maintenance_mode_state defined by app rabbit
-2023-01-03 07:20:19.815037+00:00 [info] <0.229.0> Creating table rabbit_node_maintenance_states for maintenance mode status
-2023-01-03 07:20:19.818283+00:00 [info] <0.229.0> Running boot step rabbit_management_load_definitions defined by app rabbitmq_management
-2023-01-03 07:20:19.818437+00:00 [info] <0.723.0> Resetting node maintenance status
-2023-01-03 07:20:19.826261+00:00 [info] <0.782.0> Management plugin: HTTP (non-TLS) listener started on port 15672
-2023-01-03 07:20:19.826356+00:00 [info] <0.810.0> Statistics database started.
-2023-01-03 07:20:19.826405+00:00 [info] <0.809.0> Starting worker pool 'management_worker_pool' with 3 processes in it
-2023-01-03 07:20:19.831459+00:00 [info] <0.824.0> Prometheus metrics: HTTP (non-TLS) listener started on port 15692
-2023-01-03 07:20:19.831562+00:00 [info] <0.723.0> Ready to start client connection listeners
-2023-01-03 07:20:19.833523+00:00 [info] <0.868.0> started TCP listener on [::]:5672
+2023-01-24 10:38:45.236018+00:00 [info] <0.229.0>  
+node           : rabbit@af6809c8510d
+home dir       : /var/lib/rabbitmq
+config file(s) : /etc/rabbitmq/conf.d/10-defaults.conf
+cookie hash    : ibMcme1ZByOOJPIBTHvhzg==
+log(s)         : /var/log/rabbitmq/rabbit@af6809c8510d_upgrade.log
+               : <stdout>
+database dir   : /var/lib/rabbitmq/mnesia/rabbit@af6809c8510d
+2023-01-24 10:38:48.987396+00:00 [info] <0.229.0> Running boot step pre_boot defined by app rabbit
+2023-01-24 10:38:48.987465+00:00 [info] <0.229.0> Running boot step rabbit_global_counters defined by app rabbit
+2023-01-24 10:38:48.987714+00:00 [info] <0.229.0> Running boot step rabbit_osiris_metrics defined by app rabbit
+2023-01-24 10:38:48.987809+00:00 [info] <0.229.0> Running boot step rabbit_core_metrics defined by app rabbit
+2023-01-24 10:38:48.988086+00:00 [info] <0.229.0> Running boot step rabbit_alarm defined by app rabbit
+2023-01-24 10:38:48.992459+00:00 [info] <0.299.0> Memory high watermark set to 3140 MiB (3293097164 bytes) of 7851 MiB (8232742912 bytes) total
+2023-01-24 10:38:48.997524+00:00 [info] <0.301.0> Enabling free disk space monitoring (disk free space: 45286498304, total memory: 8232742912)
+2023-01-24 10:38:48.997742+00:00 [info] <0.301.0> Disk free limit set to 50MB
+2023-01-24 10:38:49.001012+00:00 [info] <0.229.0> Running boot step code_server_cache defined by app rabbit
+2023-01-24 10:38:49.001076+00:00 [info] <0.229.0> Running boot step file_handle_cache defined by app rabbit
+2023-01-24 10:38:49.001201+00:00 [info] <0.304.0> Limiting to approx 1048479 file handles (943629 sockets)
+2023-01-24 10:38:49.001251+00:00 [info] <0.305.0> FHC read buffering: OFF
+2023-01-24 10:38:49.001270+00:00 [info] <0.305.0> FHC write buffering: ON
+2023-01-24 10:38:49.002188+00:00 [info] <0.229.0> Running boot step worker_pool defined by app rabbit
+2023-01-24 10:38:49.002241+00:00 [info] <0.286.0> Will use 5 processes for default worker pool
+2023-01-24 10:38:49.002287+00:00 [info] <0.286.0> Starting worker pool 'worker_pool' with 5 processes in it
+2023-01-24 10:38:49.002531+00:00 [info] <0.229.0> Running boot step database defined by app rabbit
+2023-01-24 10:38:49.003858+00:00 [info] <0.229.0> Node database directory at /var/lib/rabbitmq/mnesia/rabbit@af6809c8510d is empty. Assuming we need to join an existing cluster or initialise from scratch...
+2023-01-24 10:38:49.003915+00:00 [info] <0.229.0> Configured peer discovery backend: rabbit_peer_discovery_classic_config
+2023-01-24 10:38:49.003932+00:00 [info] <0.229.0> Will try to lock with peer discovery backend rabbit_peer_discovery_classic_config
+2023-01-24 10:38:49.003976+00:00 [info] <0.229.0> All discovered existing cluster peers:
+2023-01-24 10:38:49.003989+00:00 [info] <0.229.0> Discovered no peer nodes to cluster with. Some discovery backends can filter nodes out based on a readiness criteria. Enabling debug logging might help troubleshoot.
+2023-01-24 10:38:49.005308+00:00 [notice] <0.44.0> Application mnesia exited with reason: stopped
+2023-01-24 10:38:49.119439+00:00 [info] <0.229.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
+2023-01-24 10:38:49.119725+00:00 [info] <0.229.0> Successfully synced tables from a peer
+2023-01-24 10:38:49.126213+00:00 [info] <0.229.0> Feature flags: `feature_flags_v2`: supported, attempt to enable...
+2023-01-24 10:38:49.147034+00:00 [notice] <0.287.0> Feature flags: attempt to enable `classic_mirrored_queue_version`...
+2023-01-24 10:38:49.165936+00:00 [notice] <0.287.0> Feature flags: `classic_mirrored_queue_version` enabled
+2023-01-24 10:38:49.166232+00:00 [notice] <0.287.0> Feature flags: attempt to enable `classic_queue_type_delivery_support`...
+2023-01-24 10:38:49.177853+00:00 [notice] <0.287.0> Feature flags: attempt to enable `stream_queue`...
+2023-01-24 10:38:49.198546+00:00 [notice] <0.287.0> Feature flags: `stream_queue` enabled
+2023-01-24 10:38:49.209504+00:00 [notice] <0.287.0> Feature flags: `classic_queue_type_delivery_support` enabled
+2023-01-24 10:38:49.209837+00:00 [notice] <0.287.0> Feature flags: attempt to enable `direct_exchange_routing_v2`...
+2023-01-24 10:38:49.220869+00:00 [info] <0.499.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
+2023-01-24 10:38:49.220981+00:00 [info] <0.499.0> Successfully synced tables from a peer
+2023-01-24 10:38:49.236521+00:00 [notice] <0.287.0> Feature flags: `direct_exchange_routing_v2` enabled
+2023-01-24 10:38:49.236958+00:00 [notice] <0.287.0> Feature flags: attempt to enable `drop_unroutable_metric`...
+2023-01-24 10:38:49.257024+00:00 [notice] <0.287.0> Feature flags: `drop_unroutable_metric` enabled
+2023-01-24 10:38:49.257352+00:00 [notice] <0.287.0> Feature flags: attempt to enable `empty_basic_get_metric`...
+2023-01-24 10:38:49.278835+00:00 [notice] <0.287.0> Feature flags: `empty_basic_get_metric` enabled
+2023-01-24 10:38:49.279849+00:00 [notice] <0.287.0> Feature flags: attempt to enable `listener_records_in_ets`...
+2023-01-24 10:38:49.394930+00:00 [notice] <0.287.0> Feature flags: `listener_records_in_ets` enabled
+2023-01-24 10:38:49.395827+00:00 [notice] <0.287.0> Feature flags: attempt to enable `stream_single_active_consumer`...
+2023-01-24 10:38:49.412055+00:00 [notice] <0.287.0> Feature flags: `stream_single_active_consumer` enabled
+2023-01-24 10:38:49.412372+00:00 [notice] <0.287.0> Feature flags: attempt to enable `tracking_records_in_ets`...
+2023-01-24 10:38:49.429212+00:00 [notice] <0.287.0> Feature flags: `tracking_records_in_ets` enabled
+2023-01-24 10:38:49.429984+00:00 [info] <0.229.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
+2023-01-24 10:38:49.430060+00:00 [info] <0.229.0> Successfully synced tables from a peer
+2023-01-24 10:38:49.437978+00:00 [info] <0.229.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
+2023-01-24 10:38:49.438072+00:00 [info] <0.229.0> Successfully synced tables from a peer
+2023-01-24 10:38:49.438095+00:00 [info] <0.229.0> Peer discovery backend rabbit_peer_discovery_classic_config does not support registration, skipping registration.
+2023-01-24 10:38:49.438118+00:00 [info] <0.229.0> Will try to unlock with peer discovery backend rabbit_peer_discovery_classic_config
+2023-01-24 10:38:49.438156+00:00 [info] <0.229.0> Running boot step tracking_metadata_store defined by app rabbit
+2023-01-24 10:38:49.438205+00:00 [info] <0.621.0> Setting up a table for connection tracking on this node: tracked_connection
+2023-01-24 10:38:49.438234+00:00 [info] <0.621.0> Setting up a table for per-vhost connection counting on this node: tracked_connection_per_vhost
+2023-01-24 10:38:49.438258+00:00 [info] <0.621.0> Setting up a table for per-user connection counting on this node: tracked_connection_per_user
+2023-01-24 10:38:49.438277+00:00 [info] <0.621.0> Setting up a table for channel tracking on this node: tracked_channel
+2023-01-24 10:38:49.438295+00:00 [info] <0.621.0> Setting up a table for channel tracking on this node: tracked_channel_per_user
+2023-01-24 10:38:49.438329+00:00 [info] <0.229.0> Running boot step networking_metadata_store defined by app rabbit
+2023-01-24 10:38:49.438388+00:00 [info] <0.229.0> Running boot step database_sync defined by app rabbit
+2023-01-24 10:38:49.438478+00:00 [info] <0.229.0> Running boot step feature_flags defined by app rabbit
+2023-01-24 10:38:49.438605+00:00 [info] <0.229.0> Running boot step codec_correctness_check defined by app rabbit
+2023-01-24 10:38:49.438629+00:00 [info] <0.229.0> Running boot step external_infrastructure defined by app rabbit
+2023-01-24 10:38:49.438647+00:00 [info] <0.229.0> Running boot step rabbit_event defined by app rabbit
+2023-01-24 10:38:49.438692+00:00 [info] <0.229.0> Running boot step rabbit_registry defined by app rabbit
+2023-01-24 10:38:49.438720+00:00 [info] <0.229.0> Running boot step rabbit_auth_mechanism_amqplain defined by app rabbit
+2023-01-24 10:38:49.438745+00:00 [info] <0.229.0> Running boot step rabbit_auth_mechanism_cr_demo defined by app rabbit
+2023-01-24 10:38:49.438772+00:00 [info] <0.229.0> Running boot step rabbit_auth_mechanism_plain defined by app rabbit
+2023-01-24 10:38:49.438862+00:00 [info] <0.229.0> Running boot step rabbit_exchange_type_direct defined by app rabbit
+2023-01-24 10:38:49.438903+00:00 [info] <0.229.0> Running boot step rabbit_exchange_type_fanout defined by app rabbit
+2023-01-24 10:38:49.438931+00:00 [info] <0.229.0> Running boot step rabbit_exchange_type_headers defined by app rabbit
+2023-01-24 10:38:49.438951+00:00 [info] <0.229.0> Running boot step rabbit_exchange_type_topic defined by app rabbit
+2023-01-24 10:38:49.438968+00:00 [info] <0.229.0> Running boot step rabbit_mirror_queue_mode_all defined by app rabbit
+2023-01-24 10:38:49.438988+00:00 [info] <0.229.0> Running boot step rabbit_mirror_queue_mode_exactly defined by app rabbit
+2023-01-24 10:38:49.439063+00:00 [info] <0.229.0> Running boot step rabbit_mirror_queue_mode_nodes defined by app rabbit
+2023-01-24 10:38:49.439206+00:00 [info] <0.229.0> Running boot step rabbit_priority_queue defined by app rabbit
+2023-01-24 10:38:49.439229+00:00 [info] <0.229.0> Priority queues enabled, real BQ is rabbit_variable_queue
+2023-01-24 10:38:49.439270+00:00 [info] <0.229.0> Running boot step rabbit_queue_location_client_local defined by app rabbit
+2023-01-24 10:38:49.439317+00:00 [info] <0.229.0> Running boot step rabbit_queue_location_min_masters defined by app rabbit
+2023-01-24 10:38:49.439371+00:00 [info] <0.229.0> Running boot step rabbit_queue_location_random defined by app rabbit
+2023-01-24 10:38:49.439396+00:00 [info] <0.229.0> Running boot step kernel_ready defined by app rabbit
+2023-01-24 10:38:49.439409+00:00 [info] <0.229.0> Running boot step rabbit_sysmon_minder defined by app rabbit
+2023-01-24 10:38:49.439472+00:00 [info] <0.229.0> Running boot step rabbit_epmd_monitor defined by app rabbit
+2023-01-24 10:38:49.440338+00:00 [info] <0.630.0> epmd monitor knows us, inter-node communication (distribution) port: 25672
+2023-01-24 10:38:49.440435+00:00 [info] <0.229.0> Running boot step guid_generator defined by app rabbit
+2023-01-24 10:38:49.442470+00:00 [info] <0.229.0> Running boot step rabbit_node_monitor defined by app rabbit
+2023-01-24 10:38:49.442662+00:00 [info] <0.634.0> Starting rabbit_node_monitor
+2023-01-24 10:38:49.442771+00:00 [info] <0.229.0> Running boot step delegate_sup defined by app rabbit
+2023-01-24 10:38:49.443132+00:00 [info] <0.229.0> Running boot step rabbit_memory_monitor defined by app rabbit
+2023-01-24 10:38:49.443294+00:00 [info] <0.229.0> Running boot step rabbit_fifo_dlx_sup defined by app rabbit
+2023-01-24 10:38:49.443391+00:00 [info] <0.229.0> Running boot step core_initialized defined by app rabbit
+2023-01-24 10:38:49.443408+00:00 [info] <0.229.0> Running boot step upgrade_queues defined by app rabbit
+2023-01-24 10:38:49.449150+00:00 [info] <0.229.0> message_store upgrades: 1 to apply
+2023-01-24 10:38:49.449264+00:00 [info] <0.229.0> message_store upgrades: Applying rabbit_variable_queue:move_messages_to_vhost_store
+2023-01-24 10:38:49.449357+00:00 [info] <0.229.0> message_store upgrades: No durable queues found. Skipping message store migration
+2023-01-24 10:38:49.449397+00:00 [info] <0.229.0> message_store upgrades: Removing the old message store data
+2023-01-24 10:38:49.450369+00:00 [info] <0.229.0> message_store upgrades: All upgrades applied successfully
+2023-01-24 10:38:49.455431+00:00 [info] <0.229.0> Running boot step channel_tracking defined by app rabbit
+2023-01-24 10:38:49.455483+00:00 [info] <0.229.0> Running boot step rabbit_channel_tracking_handler defined by app rabbit
+2023-01-24 10:38:49.455582+00:00 [info] <0.229.0> Running boot step connection_tracking defined by app rabbit
+2023-01-24 10:38:49.455613+00:00 [info] <0.229.0> Running boot step rabbit_connection_tracking_handler defined by app rabbit
+2023-01-24 10:38:49.455630+00:00 [info] <0.229.0> Running boot step rabbit_definitions_hashing defined by app rabbit
+2023-01-24 10:38:49.455879+00:00 [info] <0.229.0> Running boot step rabbit_exchange_parameters defined by app rabbit
+2023-01-24 10:38:49.456053+00:00 [info] <0.229.0> Running boot step rabbit_mirror_queue_misc defined by app rabbit
+2023-01-24 10:38:49.456174+00:00 [info] <0.229.0> Running boot step rabbit_policies defined by app rabbit
+2023-01-24 10:38:49.456355+00:00 [info] <0.229.0> Running boot step rabbit_policy defined by app rabbit
+2023-01-24 10:38:49.456400+00:00 [info] <0.229.0> Running boot step rabbit_queue_location_validator defined by app rabbit
+2023-01-24 10:38:49.456427+00:00 [info] <0.229.0> Running boot step rabbit_quorum_memory_manager defined by app rabbit
+2023-01-24 10:38:49.456451+00:00 [info] <0.229.0> Running boot step rabbit_stream_coordinator defined by app rabbit
+2023-01-24 10:38:49.456914+00:00 [info] <0.229.0> Running boot step rabbit_vhost_limit defined by app rabbit
+2023-01-24 10:38:49.457013+00:00 [info] <0.229.0> Running boot step rabbit_mgmt_reset_handler defined by app rabbitmq_management
+2023-01-24 10:38:49.457042+00:00 [info] <0.229.0> Running boot step rabbit_mgmt_db_handler defined by app rabbitmq_management_agent
+2023-01-24 10:38:49.457064+00:00 [info] <0.229.0> Management plugin: using rates mode 'basic'
+2023-01-24 10:38:49.457315+00:00 [info] <0.229.0> Running boot step recovery defined by app rabbit
+2023-01-24 10:38:49.459760+00:00 [info] <0.229.0> Running boot step empty_db_check defined by app rabbit
+2023-01-24 10:38:49.459815+00:00 [info] <0.229.0> Will seed default virtual host and user...
+2023-01-24 10:38:49.459877+00:00 [info] <0.229.0> Adding vhost '/' (description: 'Default virtual host', tags: [])
+2023-01-24 10:38:49.462284+00:00 [info] <0.229.0> Applying default limits to vhost '<<"/">>': []
+2023-01-24 10:38:49.475207+00:00 [info] <0.676.0> Making sure data directory '/var/lib/rabbitmq/mnesia/rabbit@af6809c8510d/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L' for vhost '/' exists
+2023-01-24 10:38:49.477540+00:00 [info] <0.676.0> Setting segment_entry_count for vhost '/' with 0 queues to '2048'
+2023-01-24 10:38:49.480811+00:00 [info] <0.676.0> Starting message stores for vhost '/'
+2023-01-24 10:38:49.481068+00:00 [info] <0.681.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_transient": using rabbit_msg_store_ets_index to provide index
+2023-01-24 10:38:49.482916+00:00 [info] <0.676.0> Started message store of type transient for vhost '/'
+2023-01-24 10:38:49.483023+00:00 [info] <0.685.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": using rabbit_msg_store_ets_index to provide index
+2023-01-24 10:38:49.484168+00:00 [warning] <0.685.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": rebuilding indices from scratch
+2023-01-24 10:38:49.485324+00:00 [info] <0.676.0> Started message store of type persistent for vhost '/'
+2023-01-24 10:38:49.485389+00:00 [info] <0.676.0> Recovering 0 queues of type rabbit_classic_queue took 7ms
+2023-01-24 10:38:49.485419+00:00 [info] <0.676.0> Recovering 0 queues of type rabbit_quorum_queue took 0ms
+2023-01-24 10:38:49.485436+00:00 [info] <0.676.0> Recovering 0 queues of type rabbit_stream_queue took 0ms
+2023-01-24 10:38:49.487133+00:00 [info] <0.229.0> Created user 'guest'
+2023-01-24 10:38:49.488641+00:00 [info] <0.229.0> Successfully set user tags for user 'guest' to [administrator]
+2023-01-24 10:38:49.490051+00:00 [info] <0.229.0> Successfully set permissions for 'guest' in virtual host '/' to '.*', '.*', '.*'
+2023-01-24 10:38:49.490128+00:00 [info] <0.229.0> Running boot step rabbit_observer_cli defined by app rabbit
+2023-01-24 10:38:49.490236+00:00 [info] <0.229.0> Running boot step rabbit_looking_glass defined by app rabbit
+2023-01-24 10:38:49.490291+00:00 [info] <0.229.0> Running boot step rabbit_core_metrics_gc defined by app rabbit
+2023-01-24 10:38:49.490360+00:00 [info] <0.229.0> Running boot step background_gc defined by app rabbit
+2023-01-24 10:38:49.490413+00:00 [info] <0.229.0> Running boot step routing_ready defined by app rabbit
+2023-01-24 10:38:49.490435+00:00 [info] <0.229.0> Running boot step pre_flight defined by app rabbit
+2023-01-24 10:38:49.490446+00:00 [info] <0.229.0> Running boot step notify_cluster defined by app rabbit
+2023-01-24 10:38:49.490460+00:00 [info] <0.229.0> Running boot step networking defined by app rabbit
+2023-01-24 10:38:49.490477+00:00 [info] <0.229.0> Running boot step definition_import_worker_pool defined by app rabbit
+2023-01-24 10:38:49.490500+00:00 [info] <0.286.0> Starting worker pool 'definition_import_pool' with 5 processes in it
+2023-01-24 10:38:49.490717+00:00 [info] <0.229.0> Running boot step cluster_name defined by app rabbit
+2023-01-24 10:38:49.490758+00:00 [info] <0.229.0> Initialising internal cluster ID to 'rabbitmq-cluster-id-nZJPoEIR_-4jZYWewYYOZQ'
+2023-01-24 10:38:49.492308+00:00 [info] <0.229.0> Running boot step direct_client defined by app rabbit
+2023-01-24 10:38:49.492420+00:00 [info] <0.229.0> Running boot step rabbit_maintenance_mode_state defined by app rabbit
+2023-01-24 10:38:49.492454+00:00 [info] <0.229.0> Creating table rabbit_node_maintenance_states for maintenance mode status
+2023-01-24 10:38:49.499616+00:00 [info] <0.229.0> Running boot step rabbit_management_load_definitions defined by app rabbitmq_management
+2023-01-24 10:38:49.499816+00:00 [info] <0.723.0> Resetting node maintenance status
+2023-01-24 10:38:49.519074+00:00 [info] <0.782.0> Management plugin: HTTP (non-TLS) listener started on port 15672
+2023-01-24 10:38:49.519174+00:00 [info] <0.810.0> Statistics database started.
+2023-01-24 10:38:49.519212+00:00 [info] <0.809.0> Starting worker pool 'management_worker_pool' with 3 processes in it
+2023-01-24 10:38:49.524893+00:00 [info] <0.824.0> Prometheus metrics: HTTP (non-TLS) listener started on port 15692
+2023-01-24 10:38:49.525012+00:00 [info] <0.723.0> Ready to start client connection listeners
+2023-01-24 10:38:49.525875+00:00 [info] <0.868.0> started TCP listener on [::]:5672
+ completed with 4 plugins.
+2023-01-24 10:38:49.664998+00:00 [info] <0.723.0> Server startup complete; 4 plugins started.
+* rabbitmq_prometheus
+* rabbitmq_management
+* rabbitmq_web_dispatch
+* rabbitmq_management_agent

--- a/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log
+++ b/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log
@@ -1,78 +1,26 @@
-2019-04-03 11:13:15.076 [info] <0.8.0> Log file opened with Lager
-2019-04-03 11:13:15.510 [info] <0.222.0> 
- Starting RabbitMQ 3.7.14 on Erlang 21.3.2
- Copyright (C) 2007-2019 Pivotal Software, Inc.
- Licensed under the MPL.  See https://www.rabbitmq.com/
-2019-04-03 11:13:15.512 [info] <0.222.0>  
- node           : rabbit@localhost
- home dir       : /Users/jfsiii
- config file(s) : (none)
- cookie hash    : 1FLKC2GJUcbFjO6klcgs8Q==
- log(s)         : /usr/local/var/log/rabbitmq/rabbit@localhost.log
-                : /usr/local/var/log/rabbitmq/rabbit@localhost_upgrade.log
- database dir   : /usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost
-2019-04-12 10:00:53.458 [info] <0.1398.0> RabbitMQ is asked to stop...
-2019-04-12 10:00:53.550 [info] <0.1398.0> Stopping RabbitMQ applications and their dependencies in the following order:
-    rabbitmq_management
-    rabbitmq_stomp
-    rabbitmq_amqp1_0
-    rabbitmq_mqtt
-    amqp_client
-    rabbitmq_web_dispatch
-    cowboy
-    cowlib
-    rabbitmq_management_agent
-    rabbit
-    mnesia
-    rabbit_common
-    sysmon_handler
-    os_mon
-    amqp10_common
-2019-04-12 10:00:53.550 [info] <0.1398.0> Stopping application 'rabbitmq_management'
-2019-04-12 10:00:54.553 [warning] <0.490.0> RabbitMQ HTTP listener registry could not find context rabbitmq_management_tls
-2019-04-12 10:00:54.555 [info] <0.43.0> Application rabbitmq_management exited with reason: stopped
-2019-04-12 10:00:54.567 [info] <0.1398.0> Stopping application 'rabbit'
-2019-04-12 10:00:54.567 [info] <0.286.0> Peer discovery backend rabbit_peer_discovery_classic_config does not support registration, skipping unregistration.
-2019-04-12 10:00:54.568 [info] <0.419.0> stopped TCP listener on 127.0.0.1:5672
-2019-04-12 10:00:54.569 [info] <0.324.0> Closing all connections in vhost '/' on node 'rabbit@localhost' because the vhost is stopping
-2019-04-12 10:00:54.579 [info] <0.374.0> Stopping message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent'
-2019-04-12 10:00:54.588 [info] <0.374.0> Message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent' is stopped
-2019-04-12 10:00:54.589 [info] <0.371.0> Stopping message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_transient'
-2019-04-12 10:00:54.598 [info] <0.371.0> Message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_transient' is stopped
-2019-04-12 10:00:54.606 [info] <0.43.0> Application rabbit exited with reason: stopped
-2019-04-12 10:00:54.615 [info] <0.1398.0> Successfully stopped RabbitMQ and its dependencies
-2019-04-12 10:00:54.615 [info] <0.1398.0> Halting Erlang VM with the following applications:
-    ranch
-    ssl
-    public_key
-    sasl
-    inets
-    asn1
-    crypto
-    jsx
-    xmerl
-    recon
-    lager
-    goldrush
-    compiler
-    syntax_tools
-    stdlib
-    kernel
-2019-04-12 10:01:01.031 [info] <0.8.0> Server startup complete; 6 plugins started.
- * rabbitmq_stomp
- * rabbitmq_management
- * rabbitmq_web_dispatch
- * rabbitmq_amqp1_0
- * rabbitmq_mqtt
- * rabbitmq_management_agent
-2019-04-12 10:11:15.094 [info] <0.1345.0> accepting AMQP connection <0.1345.0> (127.0.0.1:64875 -> 127.0.0.1:5672)
-2019-04-12 10:11:15.101 [info] <0.1345.0> connection <0.1345.0> (127.0.0.1:64875 -> 127.0.0.1:5672): user 'guest' authenticated and granted access to vhost '/'
-2019-04-12 10:19:14.450 [error] <0.1345.0> Error on AMQP connection <0.1345.0> (127.0.0.1:64875 -> 127.0.0.1:5672, vhost: '/', user: 'guest', state: running), channel 0:
- operation none caused a connection exception connection_forced: [240,159,145,
-                                                                 139,240,159,
-                                                                 143,190,240,
-                                                                 159,144,135,
-                                                                 240,159,164,
-                                                                 163]
-2019-04-12 10:19:14.450 [info] <0.1902.0> Closing connection <0.1345.0> because <<240,159,145,139,240,159,143,190,240,159,144,135,240,159,164,163>>
-2019-04-12 10:19:14.451 [info] <0.1345.0> closing AMQP connection <0.1345.0> (127.0.0.1:64875 -> 127.0.0.1:5672, vhost: '/', user: 'guest')
+2023-01-03 07:20:19.811276+00:00 [info] <0.229.0> Created user 'guest'
+2023-01-03 07:20:19.812335+00:00 [info] <0.229.0> Successfully set user tags for user 'guest' to [administrator]
+2023-01-03 07:20:19.813219+00:00 [info] <0.229.0> Successfully set permissions for 'guest' in virtual host '/' to '.*', '.*', '.*'
+2023-01-03 07:20:19.813249+00:00 [info] <0.229.0> Running boot step rabbit_observer_cli defined by app rabbit
+2023-01-03 07:20:19.813297+00:00 [info] <0.229.0> Running boot step rabbit_looking_glass defined by app rabbit
+2023-01-03 07:20:19.813314+00:00 [info] <0.229.0> Running boot step rabbit_core_metrics_gc defined by app rabbit
+2023-01-03 07:20:19.813405+00:00 [info] <0.229.0> Running boot step background_gc defined by app rabbit
+2023-01-03 07:20:19.813473+00:00 [info] <0.229.0> Running boot step routing_ready defined by app rabbit
+2023-01-03 07:20:19.813495+00:00 [info] <0.229.0> Running boot step pre_flight defined by app rabbit
+2023-01-03 07:20:19.813507+00:00 [info] <0.229.0> Running boot step notify_cluster defined by app rabbit
+2023-01-03 07:20:19.813522+00:00 [info] <0.229.0> Running boot step networking defined by app rabbit
+2023-01-03 07:20:19.813558+00:00 [info] <0.229.0> Running boot step definition_import_worker_pool defined by app rabbit
+2023-01-03 07:20:19.813584+00:00 [info] <0.286.0> Starting worker pool 'definition_import_pool' with 5 processes in it
+2023-01-03 07:20:19.813855+00:00 [info] <0.229.0> Running boot step cluster_name defined by app rabbit
+2023-01-03 07:20:19.813932+00:00 [info] <0.229.0> Initialising internal cluster ID to 'rabbitmq-cluster-id-l0b5cMVBVtihO_6zHjXFTA'
+2023-01-03 07:20:19.814968+00:00 [info] <0.229.0> Running boot step direct_client defined by app rabbit
+2023-01-03 07:20:19.815021+00:00 [info] <0.229.0> Running boot step rabbit_maintenance_mode_state defined by app rabbit
+2023-01-03 07:20:19.815037+00:00 [info] <0.229.0> Creating table rabbit_node_maintenance_states for maintenance mode status
+2023-01-03 07:20:19.818283+00:00 [info] <0.229.0> Running boot step rabbit_management_load_definitions defined by app rabbitmq_management
+2023-01-03 07:20:19.818437+00:00 [info] <0.723.0> Resetting node maintenance status
+2023-01-03 07:20:19.826261+00:00 [info] <0.782.0> Management plugin: HTTP (non-TLS) listener started on port 15672
+2023-01-03 07:20:19.826356+00:00 [info] <0.810.0> Statistics database started.
+2023-01-03 07:20:19.826405+00:00 [info] <0.809.0> Starting worker pool 'management_worker_pool' with 3 processes in it
+2023-01-03 07:20:19.831459+00:00 [info] <0.824.0> Prometheus metrics: HTTP (non-TLS) listener started on port 15692
+2023-01-03 07:20:19.831562+00:00 [info] <0.723.0> Ready to start client connection listeners
+2023-01-03 07:20:19.833523+00:00 [info] <0.868.0> started TCP listener on [::]:5672

--- a/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log-expected.json
+++ b/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log-expected.json
@@ -1,14 +1,3134 @@
 {
     "expected": [
         {
-            "@timestamp": "2023-01-03T07:20:19.811Z",
+            "@timestamp": "2023-01-24T10:38:45.236Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966237877Z",
+                "ingested": "2023-01-24T12:22:48.205488509Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.811276+00:00 [info] \u003c0.229.0\u003e Created user 'guest'",
+                "original": "2023-01-24 10:38:45.236018+00:00 [info] \u003c0.229.0\u003e  \nnode           : rabbit@af6809c8510d\nhome dir       : /var/lib/rabbitmq\nconfig file(s) : /etc/rabbitmq/conf.d/10-defaults.conf\ncookie hash    : ibMcme1ZByOOJPIBTHvhzg==\nlog(s)         : /var/log/rabbitmq/rabbit@af6809c8510d_upgrade.log\n               : \u003cstdout\u003e\ndatabase dir   : /var/lib/rabbitmq/mnesia/rabbit@af6809c8510d",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": " \nnode           : rabbit@af6809c8510d\nhome dir       : /var/lib/rabbitmq\nconfig file(s) : /etc/rabbitmq/conf.d/10-defaults.conf\ncookie hash    : ibMcme1ZByOOJPIBTHvhzg==\nlog(s)         : /var/log/rabbitmq/rabbit@af6809c8510d_upgrade.log\n               : \u003cstdout\u003e\ndatabase dir   : /var/lib/rabbitmq/mnesia/rabbit@af6809c8510d",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:48.987Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205826717Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:48.987396+00:00 [info] \u003c0.229.0\u003e Running boot step pre_boot defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step pre_boot defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:48.987Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205833634Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:48.987465+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_global_counters defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_global_counters defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:48.987Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205837842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:48.987714+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_osiris_metrics defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_osiris_metrics defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:48.987Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205842051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:48.987809+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_core_metrics defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_core_metrics defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:48.988Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205845801Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:48.988086+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_alarm defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_alarm defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:48.992Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205849551Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:48.992459+00:00 [info] \u003c0.299.0\u003e Memory high watermark set to 3140 MiB (3293097164 bytes) of 7851 MiB (8232742912 bytes) total",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Memory high watermark set to 3140 MiB (3293097164 bytes) of 7851 MiB (8232742912 bytes) total",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.299.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:48.997Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205853259Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:48.997524+00:00 [info] \u003c0.301.0\u003e Enabling free disk space monitoring (disk free space: 45286498304, total memory: 8232742912)",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Enabling free disk space monitoring (disk free space: 45286498304, total memory: 8232742912)",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.301.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:48.997Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205856926Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:48.997742+00:00 [info] \u003c0.301.0\u003e Disk free limit set to 50MB",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Disk free limit set to 50MB",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.301.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.001Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205860676Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.001012+00:00 [info] \u003c0.229.0\u003e Running boot step code_server_cache defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step code_server_cache defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.001Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205864342Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.001076+00:00 [info] \u003c0.229.0\u003e Running boot step file_handle_cache defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step file_handle_cache defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.001Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205868217Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.001201+00:00 [info] \u003c0.304.0\u003e Limiting to approx 1048479 file handles (943629 sockets)",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Limiting to approx 1048479 file handles (943629 sockets)",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.304.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.001Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205888051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.001251+00:00 [info] \u003c0.305.0\u003e FHC read buffering: OFF",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "FHC read buffering: OFF",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.305.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.001Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205891967Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.001270+00:00 [info] \u003c0.305.0\u003e FHC write buffering: ON",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "FHC write buffering: ON",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.305.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.002Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205895676Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.002188+00:00 [info] \u003c0.229.0\u003e Running boot step worker_pool defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step worker_pool defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.002Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205899301Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.002241+00:00 [info] \u003c0.286.0\u003e Will use 5 processes for default worker pool",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Will use 5 processes for default worker pool",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.286.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.002Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205903051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.002287+00:00 [info] \u003c0.286.0\u003e Starting worker pool 'worker_pool' with 5 processes in it",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Starting worker pool 'worker_pool' with 5 processes in it",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.286.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.002Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205906884Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.002531+00:00 [info] \u003c0.229.0\u003e Running boot step database defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step database defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.003Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205910926Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.003858+00:00 [info] \u003c0.229.0\u003e Node database directory at /var/lib/rabbitmq/mnesia/rabbit@af6809c8510d is empty. Assuming we need to join an existing cluster or initialise from scratch...",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Node database directory at /var/lib/rabbitmq/mnesia/rabbit@af6809c8510d is empty. Assuming we need to join an existing cluster or initialise from scratch...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.003Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205914592Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.003915+00:00 [info] \u003c0.229.0\u003e Configured peer discovery backend: rabbit_peer_discovery_classic_config",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Configured peer discovery backend: rabbit_peer_discovery_classic_config",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.003Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205918259Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.003932+00:00 [info] \u003c0.229.0\u003e Will try to lock with peer discovery backend rabbit_peer_discovery_classic_config",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Will try to lock with peer discovery backend rabbit_peer_discovery_classic_config",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.003Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205921801Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.003976+00:00 [info] \u003c0.229.0\u003e All discovered existing cluster peers:",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "All discovered existing cluster peers:",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.003Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205925426Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.003989+00:00 [info] \u003c0.229.0\u003e Discovered no peer nodes to cluster with. Some discovery backends can filter nodes out based on a readiness criteria. Enabling debug logging might help troubleshoot.",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Discovered no peer nodes to cluster with. Some discovery backends can filter nodes out based on a readiness criteria. Enabling debug logging might help troubleshoot.",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.005Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205930384Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.005308+00:00 [notice] \u003c0.44.0\u003e Application mnesia exited with reason: stopped",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Application mnesia exited with reason: stopped",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.44.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.119Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205934134Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.119439+00:00 [info] \u003c0.229.0\u003e Waiting for Mnesia tables for 30000 ms, 9 retries left",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Waiting for Mnesia tables for 30000 ms, 9 retries left",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.119Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205938634Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.119725+00:00 [info] \u003c0.229.0\u003e Successfully synced tables from a peer",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Successfully synced tables from a peer",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.126Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205942384Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.126213+00:00 [info] \u003c0.229.0\u003e Feature flags: `feature_flags_v2`: supported, attempt to enable...",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Feature flags: `feature_flags_v2`: supported, attempt to enable...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.147Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205946051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.147034+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `classic_mirrored_queue_version`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `classic_mirrored_queue_version`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.165Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205950009Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.165936+00:00 [notice] \u003c0.287.0\u003e Feature flags: `classic_mirrored_queue_version` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `classic_mirrored_queue_version` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.166Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205953842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.166232+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `classic_queue_type_delivery_support`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `classic_queue_type_delivery_support`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.177Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205957467Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.177853+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `stream_queue`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `stream_queue`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.198Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205961134Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.198546+00:00 [notice] \u003c0.287.0\u003e Feature flags: `stream_queue` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `stream_queue` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.209Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205964759Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.209504+00:00 [notice] \u003c0.287.0\u003e Feature flags: `classic_queue_type_delivery_support` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `classic_queue_type_delivery_support` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.209Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205968342Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.209837+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `direct_exchange_routing_v2`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `direct_exchange_routing_v2`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.220Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205972051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.220869+00:00 [info] \u003c0.499.0\u003e Waiting for Mnesia tables for 30000 ms, 9 retries left",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Waiting for Mnesia tables for 30000 ms, 9 retries left",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.499.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.220Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205975717Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.220981+00:00 [info] \u003c0.499.0\u003e Successfully synced tables from a peer",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Successfully synced tables from a peer",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.499.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.236Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205979342Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.236521+00:00 [notice] \u003c0.287.0\u003e Feature flags: `direct_exchange_routing_v2` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `direct_exchange_routing_v2` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.236Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205983217Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.236958+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `drop_unroutable_metric`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `drop_unroutable_metric`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.257Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205987467Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.257024+00:00 [notice] \u003c0.287.0\u003e Feature flags: `drop_unroutable_metric` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `drop_unroutable_metric` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.257Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205991092Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.257352+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `empty_basic_get_metric`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `empty_basic_get_metric`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.278Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.205994676Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.278835+00:00 [notice] \u003c0.287.0\u003e Feature flags: `empty_basic_get_metric` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `empty_basic_get_metric` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.279Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206008676Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.279849+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `listener_records_in_ets`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `listener_records_in_ets`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.394Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206013384Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.394930+00:00 [notice] \u003c0.287.0\u003e Feature flags: `listener_records_in_ets` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `listener_records_in_ets` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.395Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206018176Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.395827+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `stream_single_active_consumer`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `stream_single_active_consumer`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.412Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206021967Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.412055+00:00 [notice] \u003c0.287.0\u003e Feature flags: `stream_single_active_consumer` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `stream_single_active_consumer` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.412Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206025592Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.412372+00:00 [notice] \u003c0.287.0\u003e Feature flags: attempt to enable `tracking_records_in_ets`...",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: attempt to enable `tracking_records_in_ets`...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.429Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206029176Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.429212+00:00 [notice] \u003c0.287.0\u003e Feature flags: `tracking_records_in_ets` enabled",
+                "type": "info"
+            },
+            "log": {
+                "level": "notice"
+            },
+            "message": "Feature flags: `tracking_records_in_ets` enabled",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.287.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.429Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206032842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.429984+00:00 [info] \u003c0.229.0\u003e Waiting for Mnesia tables for 30000 ms, 9 retries left",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Waiting for Mnesia tables for 30000 ms, 9 retries left",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.430Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206036426Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.430060+00:00 [info] \u003c0.229.0\u003e Successfully synced tables from a peer",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Successfully synced tables from a peer",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.437Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206040051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.437978+00:00 [info] \u003c0.229.0\u003e Waiting for Mnesia tables for 30000 ms, 9 retries left",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Waiting for Mnesia tables for 30000 ms, 9 retries left",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206043842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438072+00:00 [info] \u003c0.229.0\u003e Successfully synced tables from a peer",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Successfully synced tables from a peer",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206047467Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438095+00:00 [info] \u003c0.229.0\u003e Peer discovery backend rabbit_peer_discovery_classic_config does not support registration, skipping registration.",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Peer discovery backend rabbit_peer_discovery_classic_config does not support registration, skipping registration.",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206051051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438118+00:00 [info] \u003c0.229.0\u003e Will try to unlock with peer discovery backend rabbit_peer_discovery_classic_config",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Will try to unlock with peer discovery backend rabbit_peer_discovery_classic_config",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206054634Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438156+00:00 [info] \u003c0.229.0\u003e Running boot step tracking_metadata_store defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step tracking_metadata_store defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206061384Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438205+00:00 [info] \u003c0.621.0\u003e Setting up a table for connection tracking on this node: tracked_connection",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Setting up a table for connection tracking on this node: tracked_connection",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.621.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206065092Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438234+00:00 [info] \u003c0.621.0\u003e Setting up a table for per-vhost connection counting on this node: tracked_connection_per_vhost",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Setting up a table for per-vhost connection counting on this node: tracked_connection_per_vhost",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.621.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206069551Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438258+00:00 [info] \u003c0.621.0\u003e Setting up a table for per-user connection counting on this node: tracked_connection_per_user",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Setting up a table for per-user connection counting on this node: tracked_connection_per_user",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.621.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206073342Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438277+00:00 [info] \u003c0.621.0\u003e Setting up a table for channel tracking on this node: tracked_channel",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Setting up a table for channel tracking on this node: tracked_channel",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.621.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206077009Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438295+00:00 [info] \u003c0.621.0\u003e Setting up a table for channel tracking on this node: tracked_channel_per_user",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Setting up a table for channel tracking on this node: tracked_channel_per_user",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.621.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206080551Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438329+00:00 [info] \u003c0.229.0\u003e Running boot step networking_metadata_store defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step networking_metadata_store defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206084176Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438388+00:00 [info] \u003c0.229.0\u003e Running boot step database_sync defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step database_sync defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206087884Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438478+00:00 [info] \u003c0.229.0\u003e Running boot step feature_flags defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step feature_flags defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206091509Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438605+00:00 [info] \u003c0.229.0\u003e Running boot step codec_correctness_check defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step codec_correctness_check defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206095259Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438629+00:00 [info] \u003c0.229.0\u003e Running boot step external_infrastructure defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step external_infrastructure defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206098926Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438647+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_event defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_event defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206102551Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438692+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_registry defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_registry defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206106217Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438720+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_auth_mechanism_amqplain defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_auth_mechanism_amqplain defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206109842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438745+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_auth_mechanism_cr_demo defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_auth_mechanism_cr_demo defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206195051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438772+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_auth_mechanism_plain defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_auth_mechanism_plain defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206203842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438862+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_exchange_type_direct defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_exchange_type_direct defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206207884Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438903+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_exchange_type_fanout defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_exchange_type_fanout defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206211842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438931+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_exchange_type_headers defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_exchange_type_headers defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206215759Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438951+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_exchange_type_topic defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_exchange_type_topic defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206219384Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438968+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_mirror_queue_mode_all defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_mirror_queue_mode_all defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.438Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206223217Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.438988+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_mirror_queue_mode_exactly defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_mirror_queue_mode_exactly defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206226842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439063+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_mirror_queue_mode_nodes defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_mirror_queue_mode_nodes defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206230426Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439206+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_priority_queue defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_priority_queue defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206234009Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439229+00:00 [info] \u003c0.229.0\u003e Priority queues enabled, real BQ is rabbit_variable_queue",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Priority queues enabled, real BQ is rabbit_variable_queue",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206238551Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439270+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_queue_location_client_local defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_queue_location_client_local defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206242217Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439317+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_queue_location_min_masters defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_queue_location_min_masters defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206245842Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439371+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_queue_location_random defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_queue_location_random defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206249426Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439396+00:00 [info] \u003c0.229.0\u003e Running boot step kernel_ready defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step kernel_ready defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206266967Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439409+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_sysmon_minder defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_sysmon_minder defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.439Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206271176Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.439472+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_epmd_monitor defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_epmd_monitor defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.440Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206274926Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.440338+00:00 [info] \u003c0.630.0\u003e epmd monitor knows us, inter-node communication (distribution) port: 25672",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "epmd monitor knows us, inter-node communication (distribution) port: 25672",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.630.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.440Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206279676Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.440435+00:00 [info] \u003c0.229.0\u003e Running boot step guid_generator defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step guid_generator defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.442Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206283342Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.442470+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_node_monitor defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_node_monitor defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.442Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206286926Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.442662+00:00 [info] \u003c0.634.0\u003e Starting rabbit_node_monitor",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Starting rabbit_node_monitor",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.634.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.442Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206290551Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.442771+00:00 [info] \u003c0.229.0\u003e Running boot step delegate_sup defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step delegate_sup defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.443Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206294134Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.443132+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_memory_monitor defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_memory_monitor defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.443Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206297759Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.443294+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_fifo_dlx_sup defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_fifo_dlx_sup defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.443Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206301384Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.443391+00:00 [info] \u003c0.229.0\u003e Running boot step core_initialized defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step core_initialized defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.443Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206305009Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.443408+00:00 [info] \u003c0.229.0\u003e Running boot step upgrade_queues defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step upgrade_queues defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.449Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206308634Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.449150+00:00 [info] \u003c0.229.0\u003e message_store upgrades: 1 to apply",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "message_store upgrades: 1 to apply",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.449Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206312217Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.449264+00:00 [info] \u003c0.229.0\u003e message_store upgrades: Applying rabbit_variable_queue:move_messages_to_vhost_store",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "message_store upgrades: Applying rabbit_variable_queue:move_messages_to_vhost_store",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.449Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206315884Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.449357+00:00 [info] \u003c0.229.0\u003e message_store upgrades: No durable queues found. Skipping message store migration",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "message_store upgrades: No durable queues found. Skipping message store migration",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.449Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206319676Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.449397+00:00 [info] \u003c0.229.0\u003e message_store upgrades: Removing the old message store data",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "message_store upgrades: Removing the old message store data",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.450Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206323301Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.450369+00:00 [info] \u003c0.229.0\u003e message_store upgrades: All upgrades applied successfully",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "message_store upgrades: All upgrades applied successfully",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.455Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206326884Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.455431+00:00 [info] \u003c0.229.0\u003e Running boot step channel_tracking defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step channel_tracking defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.455Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206330467Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.455483+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_channel_tracking_handler defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_channel_tracking_handler defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.455Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206334259Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.455582+00:00 [info] \u003c0.229.0\u003e Running boot step connection_tracking defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step connection_tracking defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.455Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206337926Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.455613+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_connection_tracking_handler defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_connection_tracking_handler defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.455Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206341717Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.455630+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_definitions_hashing defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_definitions_hashing defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.455Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206345342Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.455879+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_exchange_parameters defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_exchange_parameters defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.456Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206348926Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.456053+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_mirror_queue_misc defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_mirror_queue_misc defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.456Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206352551Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.456174+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_policies defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_policies defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.456Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206356134Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.456355+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_policy defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_policy defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.456Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206359717Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.456400+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_queue_location_validator defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_queue_location_validator defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.456Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206363301Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.456427+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_quorum_memory_manager defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_quorum_memory_manager defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.456Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206367009Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.456451+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_stream_coordinator defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_stream_coordinator defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.456Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206370676Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.456914+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_vhost_limit defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_vhost_limit defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.457Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206374384Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.457013+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_mgmt_reset_handler defined by app rabbitmq_management",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_mgmt_reset_handler defined by app rabbitmq_management",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.457Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206377967Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.457042+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_mgmt_db_handler defined by app rabbitmq_management_agent",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step rabbit_mgmt_db_handler defined by app rabbitmq_management_agent",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.457Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206381509Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.457064+00:00 [info] \u003c0.229.0\u003e Management plugin: using rates mode 'basic'",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Management plugin: using rates mode 'basic'",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.457Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206385092Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.457315+00:00 [info] \u003c0.229.0\u003e Running boot step recovery defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step recovery defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.459Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206388676Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.459760+00:00 [info] \u003c0.229.0\u003e Running boot step empty_db_check defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step empty_db_check defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.459Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206392342Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.459815+00:00 [info] \u003c0.229.0\u003e Will seed default virtual host and user...",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Will seed default virtual host and user...",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.459Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206395926Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.459877+00:00 [info] \u003c0.229.0\u003e Adding vhost '/' (description: 'Default virtual host', tags: [])",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Adding vhost '/' (description: 'Default virtual host', tags: [])",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.462Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206399467Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.462284+00:00 [info] \u003c0.229.0\u003e Applying default limits to vhost '\u003c\u003c\"/\"\u003e\u003e': []",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Applying default limits to vhost '\u003c\u003c\"/\"\u003e\u003e': []",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.475Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206403051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.475207+00:00 [info] \u003c0.676.0\u003e Making sure data directory '/var/lib/rabbitmq/mnesia/rabbit@af6809c8510d/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L' for vhost '/' exists",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Making sure data directory '/var/lib/rabbitmq/mnesia/rabbit@af6809c8510d/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L' for vhost '/' exists",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.676.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.477Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206406634Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.477540+00:00 [info] \u003c0.676.0\u003e Setting segment_entry_count for vhost '/' with 0 queues to '2048'",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Setting segment_entry_count for vhost '/' with 0 queues to '2048'",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.676.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.480Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206410301Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.480811+00:00 [info] \u003c0.676.0\u003e Starting message stores for vhost '/'",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Starting message stores for vhost '/'",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.676.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.481Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206414009Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.481068+00:00 [info] \u003c0.681.0\u003e Message store \"628WB79CIFDYO9LJI6DKMI09L/msg_store_transient\": using rabbit_msg_store_ets_index to provide index",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Message store \"628WB79CIFDYO9LJI6DKMI09L/msg_store_transient\": using rabbit_msg_store_ets_index to provide index",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.681.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.482Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206424134Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.482916+00:00 [info] \u003c0.676.0\u003e Started message store of type transient for vhost '/'",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Started message store of type transient for vhost '/'",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.676.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.483Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206427967Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.483023+00:00 [info] \u003c0.685.0\u003e Message store \"628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent\": using rabbit_msg_store_ets_index to provide index",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Message store \"628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent\": using rabbit_msg_store_ets_index to provide index",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.685.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.484Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206432134Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.484168+00:00 [warning] \u003c0.685.0\u003e Message store \"628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent\": rebuilding indices from scratch",
+                "type": "info"
+            },
+            "log": {
+                "level": "warning"
+            },
+            "message": "Message store \"628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent\": rebuilding indices from scratch",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.685.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.485Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206436467Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.485324+00:00 [info] \u003c0.676.0\u003e Started message store of type persistent for vhost '/'",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Started message store of type persistent for vhost '/'",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.676.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.485Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206441551Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.485389+00:00 [info] \u003c0.676.0\u003e Recovering 0 queues of type rabbit_classic_queue took 7ms",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Recovering 0 queues of type rabbit_classic_queue took 7ms",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.676.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.485Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206446592Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.485419+00:00 [info] \u003c0.676.0\u003e Recovering 0 queues of type rabbit_quorum_queue took 0ms",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Recovering 0 queues of type rabbit_quorum_queue took 0ms",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.676.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.485Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206450467Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.485436+00:00 [info] \u003c0.676.0\u003e Recovering 0 queues of type rabbit_stream_queue took 0ms",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Recovering 0 queues of type rabbit_stream_queue took 0ms",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.676.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.487Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206454051Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.487133+00:00 [info] \u003c0.229.0\u003e Created user 'guest'",
                 "type": "info"
             },
             "log": {
@@ -25,14 +3145,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.812Z",
+            "@timestamp": "2023-01-24T10:38:49.488Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966252336Z",
+                "ingested": "2023-01-24T12:22:48.206457759Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.812335+00:00 [info] \u003c0.229.0\u003e Successfully set user tags for user 'guest' to [administrator]",
+                "original": "2023-01-24 10:38:49.488641+00:00 [info] \u003c0.229.0\u003e Successfully set user tags for user 'guest' to [administrator]",
                 "type": "info"
             },
             "log": {
@@ -49,14 +3169,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966253919Z",
+                "ingested": "2023-01-24T12:22:48.206461384Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813219+00:00 [info] \u003c0.229.0\u003e Successfully set permissions for 'guest' in virtual host '/' to '.*', '.*', '.*'",
+                "original": "2023-01-24 10:38:49.490051+00:00 [info] \u003c0.229.0\u003e Successfully set permissions for 'guest' in virtual host '/' to '.*', '.*', '.*'",
                 "type": "info"
             },
             "log": {
@@ -73,14 +3193,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966255044Z",
+                "ingested": "2023-01-24T12:22:48.206464967Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813249+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_observer_cli defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490128+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_observer_cli defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -97,14 +3217,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966337169Z",
+                "ingested": "2023-01-24T12:22:48.206468551Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813297+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_looking_glass defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490236+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_looking_glass defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -121,14 +3241,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966345461Z",
+                "ingested": "2023-01-24T12:22:48.206472092Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813314+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_core_metrics_gc defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490291+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_core_metrics_gc defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -145,14 +3265,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966348502Z",
+                "ingested": "2023-01-24T12:22:48.206475676Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813405+00:00 [info] \u003c0.229.0\u003e Running boot step background_gc defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490360+00:00 [info] \u003c0.229.0\u003e Running boot step background_gc defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -169,14 +3289,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966353711Z",
+                "ingested": "2023-01-24T12:22:48.206479259Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813473+00:00 [info] \u003c0.229.0\u003e Running boot step routing_ready defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490413+00:00 [info] \u003c0.229.0\u003e Running boot step routing_ready defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -193,14 +3313,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966355211Z",
+                "ingested": "2023-01-24T12:22:48.206482801Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813495+00:00 [info] \u003c0.229.0\u003e Running boot step pre_flight defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490435+00:00 [info] \u003c0.229.0\u003e Running boot step pre_flight defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -217,14 +3337,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966357002Z",
+                "ingested": "2023-01-24T12:22:48.206486384Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813507+00:00 [info] \u003c0.229.0\u003e Running boot step notify_cluster defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490446+00:00 [info] \u003c0.229.0\u003e Running boot step notify_cluster defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -241,14 +3361,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966358252Z",
+                "ingested": "2023-01-24T12:22:48.206489926Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813522+00:00 [info] \u003c0.229.0\u003e Running boot step networking defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490460+00:00 [info] \u003c0.229.0\u003e Running boot step networking defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -265,14 +3385,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966359544Z",
+                "ingested": "2023-01-24T12:22:48.206493509Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813558+00:00 [info] \u003c0.229.0\u003e Running boot step definition_import_worker_pool defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490477+00:00 [info] \u003c0.229.0\u003e Running boot step definition_import_worker_pool defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -289,14 +3409,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966360711Z",
+                "ingested": "2023-01-24T12:22:48.206497092Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813584+00:00 [info] \u003c0.286.0\u003e Starting worker pool 'definition_import_pool' with 5 processes in it",
+                "original": "2023-01-24 10:38:49.490500+00:00 [info] \u003c0.286.0\u003e Starting worker pool 'definition_import_pool' with 5 processes in it",
                 "type": "info"
             },
             "log": {
@@ -313,14 +3433,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966361919Z",
+                "ingested": "2023-01-24T12:22:48.206500717Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813855+00:00 [info] \u003c0.229.0\u003e Running boot step cluster_name defined by app rabbit",
+                "original": "2023-01-24 10:38:49.490717+00:00 [info] \u003c0.229.0\u003e Running boot step cluster_name defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -337,20 +3457,20 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "@timestamp": "2023-01-24T10:38:49.490Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966363086Z",
+                "ingested": "2023-01-24T12:22:48.206504259Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.813932+00:00 [info] \u003c0.229.0\u003e Initialising internal cluster ID to 'rabbitmq-cluster-id-l0b5cMVBVtihO_6zHjXFTA'",
+                "original": "2023-01-24 10:38:49.490758+00:00 [info] \u003c0.229.0\u003e Initialising internal cluster ID to 'rabbitmq-cluster-id-nZJPoEIR_-4jZYWewYYOZQ'",
                 "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "message": "Initialising internal cluster ID to 'rabbitmq-cluster-id-l0b5cMVBVtihO_6zHjXFTA'",
+            "message": "Initialising internal cluster ID to 'rabbitmq-cluster-id-nZJPoEIR_-4jZYWewYYOZQ'",
             "rabbitmq": {
                 "log": {
                     "pid": "\u003c0.229.0\u003e"
@@ -361,14 +3481,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.814Z",
+            "@timestamp": "2023-01-24T10:38:49.492Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966364169Z",
+                "ingested": "2023-01-24T12:22:48.206507801Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.814968+00:00 [info] \u003c0.229.0\u003e Running boot step direct_client defined by app rabbit",
+                "original": "2023-01-24 10:38:49.492308+00:00 [info] \u003c0.229.0\u003e Running boot step direct_client defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -385,14 +3505,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.815Z",
+            "@timestamp": "2023-01-24T10:38:49.492Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966365336Z",
+                "ingested": "2023-01-24T12:22:48.206511467Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.815021+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_maintenance_mode_state defined by app rabbit",
+                "original": "2023-01-24 10:38:49.492420+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_maintenance_mode_state defined by app rabbit",
                 "type": "info"
             },
             "log": {
@@ -409,14 +3529,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.815Z",
+            "@timestamp": "2023-01-24T10:38:49.492Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966366419Z",
+                "ingested": "2023-01-24T12:22:48.206515009Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.815037+00:00 [info] \u003c0.229.0\u003e Creating table rabbit_node_maintenance_states for maintenance mode status",
+                "original": "2023-01-24 10:38:49.492454+00:00 [info] \u003c0.229.0\u003e Creating table rabbit_node_maintenance_states for maintenance mode status",
                 "type": "info"
             },
             "log": {
@@ -433,14 +3553,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.818Z",
+            "@timestamp": "2023-01-24T10:38:49.499Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966367544Z",
+                "ingested": "2023-01-24T12:22:48.206518551Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.818283+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_management_load_definitions defined by app rabbitmq_management",
+                "original": "2023-01-24 10:38:49.499616+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_management_load_definitions defined by app rabbitmq_management",
                 "type": "info"
             },
             "log": {
@@ -457,14 +3577,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.818Z",
+            "@timestamp": "2023-01-24T10:38:49.499Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966369377Z",
+                "ingested": "2023-01-24T12:22:48.206522176Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.818437+00:00 [info] \u003c0.723.0\u003e Resetting node maintenance status",
+                "original": "2023-01-24 10:38:49.499816+00:00 [info] \u003c0.723.0\u003e Resetting node maintenance status",
                 "type": "info"
             },
             "log": {
@@ -481,14 +3601,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.826Z",
+            "@timestamp": "2023-01-24T10:38:49.519Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966370502Z",
+                "ingested": "2023-01-24T12:22:48.206525717Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.826261+00:00 [info] \u003c0.782.0\u003e Management plugin: HTTP (non-TLS) listener started on port 15672",
+                "original": "2023-01-24 10:38:49.519074+00:00 [info] \u003c0.782.0\u003e Management plugin: HTTP (non-TLS) listener started on port 15672",
                 "type": "info"
             },
             "log": {
@@ -505,14 +3625,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.826Z",
+            "@timestamp": "2023-01-24T10:38:49.519Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966371627Z",
+                "ingested": "2023-01-24T12:22:48.206529259Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.826356+00:00 [info] \u003c0.810.0\u003e Statistics database started.",
+                "original": "2023-01-24 10:38:49.519174+00:00 [info] \u003c0.810.0\u003e Statistics database started.",
                 "type": "info"
             },
             "log": {
@@ -529,14 +3649,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.826Z",
+            "@timestamp": "2023-01-24T10:38:49.519Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966372711Z",
+                "ingested": "2023-01-24T12:22:48.206533009Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.826405+00:00 [info] \u003c0.809.0\u003e Starting worker pool 'management_worker_pool' with 3 processes in it",
+                "original": "2023-01-24 10:38:49.519212+00:00 [info] \u003c0.809.0\u003e Starting worker pool 'management_worker_pool' with 3 processes in it",
                 "type": "info"
             },
             "log": {
@@ -553,14 +3673,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.831Z",
+            "@timestamp": "2023-01-24T10:38:49.524Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966373877Z",
+                "ingested": "2023-01-24T12:22:48.206536926Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.831459+00:00 [info] \u003c0.824.0\u003e Prometheus metrics: HTTP (non-TLS) listener started on port 15692",
+                "original": "2023-01-24 10:38:49.524893+00:00 [info] \u003c0.824.0\u003e Prometheus metrics: HTTP (non-TLS) listener started on port 15692",
                 "type": "info"
             },
             "log": {
@@ -577,14 +3697,14 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.831Z",
+            "@timestamp": "2023-01-24T10:38:49.525Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966375002Z",
+                "ingested": "2023-01-24T12:22:48.206540551Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.831562+00:00 [info] \u003c0.723.0\u003e Ready to start client connection listeners",
+                "original": "2023-01-24 10:38:49.525012+00:00 [info] \u003c0.723.0\u003e Ready to start client connection listeners",
                 "type": "info"
             },
             "log": {
@@ -601,23 +3721,47 @@
             ]
         },
         {
-            "@timestamp": "2023-01-03T07:20:19.833Z",
+            "@timestamp": "2023-01-24T10:38:49.525Z",
             "ecs": {
                 "version": "8.0.0"
             },
             "event": {
-                "ingested": "2023-01-03T07:24:28.966376127Z",
+                "ingested": "2023-01-24T12:22:48.206544134Z",
                 "kind": "event",
-                "original": "2023-01-03 07:20:19.833523+00:00 [info] \u003c0.868.0\u003e started TCP listener on [::]:5672",
+                "original": "2023-01-24 10:38:49.525875+00:00 [info] \u003c0.868.0\u003e started TCP listener on [::]:5672\n completed with 4 plugins.",
                 "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "message": "started TCP listener on [::]:5672",
+            "message": "started TCP listener on [::]:5672\n completed with 4 plugins.",
             "rabbitmq": {
                 "log": {
                     "pid": "\u003c0.868.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-24T10:38:49.664Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-24T12:22:48.206547717Z",
+                "kind": "event",
+                "original": "2023-01-24 10:38:49.664998+00:00 [info] \u003c0.723.0\u003e Server startup complete; 4 plugins started.\n* rabbitmq_prometheus\n* rabbitmq_management\n* rabbitmq_web_dispatch\n* rabbitmq_management_agent",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Server startup complete; 4 plugins started.\n* rabbitmq_prometheus\n* rabbitmq_management\n* rabbitmq_web_dispatch\n* rabbitmq_management_agent",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.723.0\u003e"
                 }
             },
             "tags": [

--- a/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log-expected.json
+++ b/packages/rabbitmq/data_stream/log/_dev/test/pipeline/test-rabbitmq.log-expected.json
@@ -1,23 +1,23 @@
 {
     "expected": [
         {
-            "@timestamp": "2019-04-03T11:13:15.076Z",
+            "@timestamp": "2023-01-03T07:20:19.811Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966237877Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.811276+00:00 [info] \u003c0.229.0\u003e Created user 'guest'",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673089222Z",
-                "original": "2019-04-03 11:13:15.076 [info] \u003c0.8.0\u003e Log file opened with Lager",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Log file opened with Lager",
+            "message": "Created user 'guest'",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.8.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -25,23 +25,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-03T11:13:15.510Z",
+            "@timestamp": "2023-01-03T07:20:19.812Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966252336Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.812335+00:00 [info] \u003c0.229.0\u003e Successfully set user tags for user 'guest' to [administrator]",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673092094Z",
-                "original": "2019-04-03 11:13:15.510 [info] \u003c0.222.0\u003e \n Starting RabbitMQ 3.7.14 on Erlang 21.3.2\n Copyright (C) 2007-2019 Pivotal Software, Inc.\n Licensed under the MPL.  See https://www.rabbitmq.com/",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "\n Starting RabbitMQ 3.7.14 on Erlang 21.3.2\n Copyright (C) 2007-2019 Pivotal Software, Inc.\n Licensed under the MPL.  See https://www.rabbitmq.com/",
+            "message": "Successfully set user tags for user 'guest' to [administrator]",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.222.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -49,23 +49,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-03T11:13:15.512Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966253919Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813219+00:00 [info] \u003c0.229.0\u003e Successfully set permissions for 'guest' in virtual host '/' to '.*', '.*', '.*'",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673093281Z",
-                "original": "2019-04-03 11:13:15.512 [info] \u003c0.222.0\u003e  \n node           : rabbit@localhost\n home dir       : /Users/jfsiii\n config file(s) : (none)\n cookie hash    : 1FLKC2GJUcbFjO6klcgs8Q==\n log(s)         : /usr/local/var/log/rabbitmq/rabbit@localhost.log\n                : /usr/local/var/log/rabbitmq/rabbit@localhost_upgrade.log\n database dir   : /usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": " \n node           : rabbit@localhost\n home dir       : /Users/jfsiii\n config file(s) : (none)\n cookie hash    : 1FLKC2GJUcbFjO6klcgs8Q==\n log(s)         : /usr/local/var/log/rabbitmq/rabbit@localhost.log\n                : /usr/local/var/log/rabbitmq/rabbit@localhost_upgrade.log\n database dir   : /usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost",
+            "message": "Successfully set permissions for 'guest' in virtual host '/' to '.*', '.*', '.*'",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.222.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -73,23 +73,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:53.458Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966255044Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813249+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_observer_cli defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673094283Z",
-                "original": "2019-04-12 10:00:53.458 [info] \u003c0.1398.0\u003e RabbitMQ is asked to stop...",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "RabbitMQ is asked to stop...",
+            "message": "Running boot step rabbit_observer_cli defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1398.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -97,23 +97,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:53.550Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966337169Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813297+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_looking_glass defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673095206Z",
-                "original": "2019-04-12 10:00:53.550 [info] \u003c0.1398.0\u003e Stopping RabbitMQ applications and their dependencies in the following order:\n    rabbitmq_management\n    rabbitmq_stomp\n    rabbitmq_amqp1_0\n    rabbitmq_mqtt\n    amqp_client\n    rabbitmq_web_dispatch\n    cowboy\n    cowlib\n    rabbitmq_management_agent\n    rabbit\n    mnesia\n    rabbit_common\n    sysmon_handler\n    os_mon\n    amqp10_common",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Stopping RabbitMQ applications and their dependencies in the following order:\n    rabbitmq_management\n    rabbitmq_stomp\n    rabbitmq_amqp1_0\n    rabbitmq_mqtt\n    amqp_client\n    rabbitmq_web_dispatch\n    cowboy\n    cowlib\n    rabbitmq_management_agent\n    rabbit\n    mnesia\n    rabbit_common\n    sysmon_handler\n    os_mon\n    amqp10_common",
+            "message": "Running boot step rabbit_looking_glass defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1398.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -121,23 +121,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:53.550Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966345461Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813314+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_core_metrics_gc defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673096136Z",
-                "original": "2019-04-12 10:00:53.550 [info] \u003c0.1398.0\u003e Stopping application 'rabbitmq_management'",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Stopping application 'rabbitmq_management'",
+            "message": "Running boot step rabbit_core_metrics_gc defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1398.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -145,23 +145,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.553Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
             },
-            "log": {
-                "level": "warning"
-            },
             "event": {
-                "ingested": "2022-01-12T03:47:52.673097062Z",
-                "original": "2019-04-12 10:00:54.553 [warning] \u003c0.490.0\u003e RabbitMQ HTTP listener registry could not find context rabbitmq_management_tls",
-                "type": "info",
-                "kind": "event"
+                "ingested": "2023-01-03T07:24:28.966348502Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813405+00:00 [info] \u003c0.229.0\u003e Running boot step background_gc defined by app rabbit",
+                "type": "info"
             },
-            "message": "RabbitMQ HTTP listener registry could not find context rabbitmq_management_tls",
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step background_gc defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.490.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -169,23 +169,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.555Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966353711Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813473+00:00 [info] \u003c0.229.0\u003e Running boot step routing_ready defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673098018Z",
-                "original": "2019-04-12 10:00:54.555 [info] \u003c0.43.0\u003e Application rabbitmq_management exited with reason: stopped",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Application rabbitmq_management exited with reason: stopped",
+            "message": "Running boot step routing_ready defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.43.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -193,23 +193,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.567Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966355211Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813495+00:00 [info] \u003c0.229.0\u003e Running boot step pre_flight defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673098947Z",
-                "original": "2019-04-12 10:00:54.567 [info] \u003c0.1398.0\u003e Stopping application 'rabbit'",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Stopping application 'rabbit'",
+            "message": "Running boot step pre_flight defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1398.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -217,20 +217,92 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.567Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966357002Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813507+00:00 [info] \u003c0.229.0\u003e Running boot step notify_cluster defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673099882Z",
-                "original": "2019-04-12 10:00:54.567 [info] \u003c0.286.0\u003e Peer discovery backend rabbit_peer_discovery_classic_config does not support registration, skipping unregistration.",
-                "type": "info",
-                "kind": "event"
+            "message": "Running boot step notify_cluster defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
             },
-            "message": "Peer discovery backend rabbit_peer_discovery_classic_config does not support registration, skipping unregistration.",
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966358252Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813522+00:00 [info] \u003c0.229.0\u003e Running boot step networking defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step networking defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966359544Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813558+00:00 [info] \u003c0.229.0\u003e Running boot step definition_import_worker_pool defined by app rabbit",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Running boot step definition_import_worker_pool defined by app rabbit",
+            "rabbitmq": {
+                "log": {
+                    "pid": "\u003c0.229.0\u003e"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-01-03T07:20:19.813Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966360711Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813584+00:00 [info] \u003c0.286.0\u003e Starting worker pool 'definition_import_pool' with 5 processes in it",
+                "type": "info"
+            },
+            "log": {
+                "level": "info"
+            },
+            "message": "Starting worker pool 'definition_import_pool' with 5 processes in it",
             "rabbitmq": {
                 "log": {
                     "pid": "\u003c0.286.0\u003e"
@@ -241,23 +313,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.568Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966361919Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813855+00:00 [info] \u003c0.229.0\u003e Running boot step cluster_name defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673100803Z",
-                "original": "2019-04-12 10:00:54.568 [info] \u003c0.419.0\u003e stopped TCP listener on 127.0.0.1:5672",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "stopped TCP listener on 127.0.0.1:5672",
+            "message": "Running boot step cluster_name defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.419.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -265,23 +337,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.569Z",
+            "@timestamp": "2023-01-03T07:20:19.813Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966363086Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.813932+00:00 [info] \u003c0.229.0\u003e Initialising internal cluster ID to 'rabbitmq-cluster-id-l0b5cMVBVtihO_6zHjXFTA'",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673101883Z",
-                "original": "2019-04-12 10:00:54.569 [info] \u003c0.324.0\u003e Closing all connections in vhost '/' on node 'rabbit@localhost' because the vhost is stopping",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Closing all connections in vhost '/' on node 'rabbit@localhost' because the vhost is stopping",
+            "message": "Initialising internal cluster ID to 'rabbitmq-cluster-id-l0b5cMVBVtihO_6zHjXFTA'",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.324.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -289,23 +361,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.579Z",
+            "@timestamp": "2023-01-03T07:20:19.814Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966364169Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.814968+00:00 [info] \u003c0.229.0\u003e Running boot step direct_client defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673102810Z",
-                "original": "2019-04-12 10:00:54.579 [info] \u003c0.374.0\u003e Stopping message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent'",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Stopping message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent'",
+            "message": "Running boot step direct_client defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.374.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -313,23 +385,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.588Z",
+            "@timestamp": "2023-01-03T07:20:19.815Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966365336Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.815021+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_maintenance_mode_state defined by app rabbit",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673103743Z",
-                "original": "2019-04-12 10:00:54.588 [info] \u003c0.374.0\u003e Message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent' is stopped",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent' is stopped",
+            "message": "Running boot step rabbit_maintenance_mode_state defined by app rabbit",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.374.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -337,23 +409,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.589Z",
+            "@timestamp": "2023-01-03T07:20:19.815Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966366419Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.815037+00:00 [info] \u003c0.229.0\u003e Creating table rabbit_node_maintenance_states for maintenance mode status",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673104680Z",
-                "original": "2019-04-12 10:00:54.589 [info] \u003c0.371.0\u003e Stopping message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_transient'",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Stopping message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_transient'",
+            "message": "Creating table rabbit_node_maintenance_states for maintenance mode status",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.371.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -361,23 +433,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.598Z",
+            "@timestamp": "2023-01-03T07:20:19.818Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966367544Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.818283+00:00 [info] \u003c0.229.0\u003e Running boot step rabbit_management_load_definitions defined by app rabbitmq_management",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673105617Z",
-                "original": "2019-04-12 10:00:54.598 [info] \u003c0.371.0\u003e Message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_transient' is stopped",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Message store for directory '/usr/local/var/lib/rabbitmq/mnesia/rabbit@localhost/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_transient' is stopped",
+            "message": "Running boot step rabbit_management_load_definitions defined by app rabbitmq_management",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.371.0\u003e"
+                    "pid": "\u003c0.229.0\u003e"
                 }
             },
             "tags": [
@@ -385,23 +457,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.606Z",
+            "@timestamp": "2023-01-03T07:20:19.818Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966369377Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.818437+00:00 [info] \u003c0.723.0\u003e Resetting node maintenance status",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673106639Z",
-                "original": "2019-04-12 10:00:54.606 [info] \u003c0.43.0\u003e Application rabbit exited with reason: stopped",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Application rabbit exited with reason: stopped",
+            "message": "Resetting node maintenance status",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.43.0\u003e"
+                    "pid": "\u003c0.723.0\u003e"
                 }
             },
             "tags": [
@@ -409,23 +481,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.615Z",
+            "@timestamp": "2023-01-03T07:20:19.826Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966370502Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.826261+00:00 [info] \u003c0.782.0\u003e Management plugin: HTTP (non-TLS) listener started on port 15672",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673107565Z",
-                "original": "2019-04-12 10:00:54.615 [info] \u003c0.1398.0\u003e Successfully stopped RabbitMQ and its dependencies",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Successfully stopped RabbitMQ and its dependencies",
+            "message": "Management plugin: HTTP (non-TLS) listener started on port 15672",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1398.0\u003e"
+                    "pid": "\u003c0.782.0\u003e"
                 }
             },
             "tags": [
@@ -433,23 +505,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:00:54.615Z",
+            "@timestamp": "2023-01-03T07:20:19.826Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966371627Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.826356+00:00 [info] \u003c0.810.0\u003e Statistics database started.",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673108502Z",
-                "original": "2019-04-12 10:00:54.615 [info] \u003c0.1398.0\u003e Halting Erlang VM with the following applications:\n    ranch\n    ssl\n    public_key\n    sasl\n    inets\n    asn1\n    crypto\n    jsx\n    xmerl\n    recon\n    lager\n    goldrush\n    compiler\n    syntax_tools\n    stdlib\n    kernel",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Halting Erlang VM with the following applications:\n    ranch\n    ssl\n    public_key\n    sasl\n    inets\n    asn1\n    crypto\n    jsx\n    xmerl\n    recon\n    lager\n    goldrush\n    compiler\n    syntax_tools\n    stdlib\n    kernel",
+            "message": "Statistics database started.",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1398.0\u003e"
+                    "pid": "\u003c0.810.0\u003e"
                 }
             },
             "tags": [
@@ -457,23 +529,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:01:01.031Z",
+            "@timestamp": "2023-01-03T07:20:19.826Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966372711Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.826405+00:00 [info] \u003c0.809.0\u003e Starting worker pool 'management_worker_pool' with 3 processes in it",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673109437Z",
-                "original": "2019-04-12 10:01:01.031 [info] \u003c0.8.0\u003e Server startup complete; 6 plugins started.\n * rabbitmq_stomp\n * rabbitmq_management\n * rabbitmq_web_dispatch\n * rabbitmq_amqp1_0\n * rabbitmq_mqtt\n * rabbitmq_management_agent",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Server startup complete; 6 plugins started.\n * rabbitmq_stomp\n * rabbitmq_management\n * rabbitmq_web_dispatch\n * rabbitmq_amqp1_0\n * rabbitmq_mqtt\n * rabbitmq_management_agent",
+            "message": "Starting worker pool 'management_worker_pool' with 3 processes in it",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.8.0\u003e"
+                    "pid": "\u003c0.809.0\u003e"
                 }
             },
             "tags": [
@@ -481,23 +553,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:11:15.094Z",
+            "@timestamp": "2023-01-03T07:20:19.831Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966373877Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.831459+00:00 [info] \u003c0.824.0\u003e Prometheus metrics: HTTP (non-TLS) listener started on port 15692",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673110362Z",
-                "original": "2019-04-12 10:11:15.094 [info] \u003c0.1345.0\u003e accepting AMQP connection \u003c0.1345.0\u003e (127.0.0.1:64875 -\u003e 127.0.0.1:5672)",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "accepting AMQP connection \u003c0.1345.0\u003e (127.0.0.1:64875 -\u003e 127.0.0.1:5672)",
+            "message": "Prometheus metrics: HTTP (non-TLS) listener started on port 15692",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1345.0\u003e"
+                    "pid": "\u003c0.824.0\u003e"
                 }
             },
             "tags": [
@@ -505,23 +577,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:11:15.101Z",
+            "@timestamp": "2023-01-03T07:20:19.831Z",
             "ecs": {
                 "version": "8.0.0"
+            },
+            "event": {
+                "ingested": "2023-01-03T07:24:28.966375002Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.831562+00:00 [info] \u003c0.723.0\u003e Ready to start client connection listeners",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673111292Z",
-                "original": "2019-04-12 10:11:15.101 [info] \u003c0.1345.0\u003e connection \u003c0.1345.0\u003e (127.0.0.1:64875 -\u003e 127.0.0.1:5672): user 'guest' authenticated and granted access to vhost '/'",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "connection \u003c0.1345.0\u003e (127.0.0.1:64875 -\u003e 127.0.0.1:5672): user 'guest' authenticated and granted access to vhost '/'",
+            "message": "Ready to start client connection listeners",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1345.0\u003e"
+                    "pid": "\u003c0.723.0\u003e"
                 }
             },
             "tags": [
@@ -529,71 +601,23 @@
             ]
         },
         {
-            "@timestamp": "2019-04-12T10:19:14.450Z",
+            "@timestamp": "2023-01-03T07:20:19.833Z",
             "ecs": {
                 "version": "8.0.0"
-            },
-            "log": {
-                "level": "error"
             },
             "event": {
-                "ingested": "2022-01-12T03:47:52.673112210Z",
-                "original": "2019-04-12 10:19:14.450 [error] \u003c0.1345.0\u003e Error on AMQP connection \u003c0.1345.0\u003e (127.0.0.1:64875 -\u003e 127.0.0.1:5672, vhost: '/', user: 'guest', state: running), channel 0:\n operation none caused a connection exception connection_forced: [240,159,145,\n                                                                 139,240,159,\n                                                                 143,190,240,\n                                                                 159,144,135,\n                                                                 240,159,164,\n                                                                 163]",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Error on AMQP connection \u003c0.1345.0\u003e (127.0.0.1:64875 -\u003e 127.0.0.1:5672, vhost: '/', user: 'guest', state: running), channel 0:\n operation none caused a connection exception connection_forced: [240,159,145,\n                                                                 139,240,159,\n                                                                 143,190,240,\n                                                                 159,144,135,\n                                                                 240,159,164,\n                                                                 163]",
-            "rabbitmq": {
-                "log": {
-                    "pid": "\u003c0.1345.0\u003e"
-                }
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2019-04-12T10:19:14.450Z",
-            "ecs": {
-                "version": "8.0.0"
+                "ingested": "2023-01-03T07:24:28.966376127Z",
+                "kind": "event",
+                "original": "2023-01-03 07:20:19.833523+00:00 [info] \u003c0.868.0\u003e started TCP listener on [::]:5672",
+                "type": "info"
             },
             "log": {
                 "level": "info"
             },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673113283Z",
-                "original": "2019-04-12 10:19:14.450 [info] \u003c0.1902.0\u003e Closing connection \u003c0.1345.0\u003e because \u003c\u003c240,159,145,139,240,159,143,190,240,159,144,135,240,159,164,163\u003e\u003e",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "Closing connection \u003c0.1345.0\u003e because \u003c\u003c240,159,145,139,240,159,143,190,240,159,144,135,240,159,164,163\u003e\u003e",
+            "message": "started TCP listener on [::]:5672",
             "rabbitmq": {
                 "log": {
-                    "pid": "\u003c0.1902.0\u003e"
-                }
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2019-04-12T10:19:14.451Z",
-            "ecs": {
-                "version": "8.0.0"
-            },
-            "log": {
-                "level": "info"
-            },
-            "event": {
-                "ingested": "2022-01-12T03:47:52.673114207Z",
-                "original": "2019-04-12 10:19:14.451 [info] \u003c0.1345.0\u003e closing AMQP connection \u003c0.1345.0\u003e (127.0.0.1:64875 -\u003e 127.0.0.1:5672, vhost: '/', user: 'guest')",
-                "type": "info",
-                "kind": "event"
-            },
-            "message": "closing AMQP connection \u003c0.1345.0\u003e (127.0.0.1:64875 -\u003e 127.0.0.1:5672, vhost: '/', user: 'guest')",
-            "rabbitmq": {
-                "log": {
-                    "pid": "\u003c0.1345.0\u003e"
+                    "pid": "\u003c0.868.0\u003e"
                 }
             },
             "tags": [

--- a/packages/rabbitmq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/rabbitmq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -23,7 +23,7 @@ processors:
         GREEDYMULTILINE: "(.|\n)*"
         ERL_PID: "\\<%{INT}+\\.%{INT}+\\.%{INT}+\\>"
       patterns:
-      - "%{DATESTAMP:timestamp} \\[%{WORD:log.level}\\] %{ERL_PID:rabbitmq.log.pid}
+      - "%{TIMESTAMP_ISO8601:timestamp} \\[%{WORD:log.level}\\] %{ERL_PID:rabbitmq.log.pid}
         %{GREEDYMULTILINE:message}"
       ignore_missing: true
   - date:
@@ -31,14 +31,14 @@ processors:
       field: timestamp
       target_field: "@timestamp"
       formats:
-      - yy-MM-dd HH:mm:ss.SSS
+      - yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
   - date:
       if: "ctx.event.timezone != null"
       field: "timestamp"
       target_field: "@timestamp"
       timezone: "{{ event.timezone }}"
       formats:
-      - yy-MM-dd HH:mm:ss.SSS
+      - yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
   - remove:
       field:
         - timestamp

--- a/packages/rabbitmq/docs/README.md
+++ b/packages/rabbitmq/docs/README.md
@@ -19,6 +19,7 @@ The application logs dataset parses single file format introduced in 3.7.0.
 ### Application Logs
 
 Application logs collects standard RabbitMQ logs.
+It will only support RabbitMQ default i.e RFC 3339 timestamp format.
 
 **Exported fields**
 

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: rabbitmq
 title: RabbitMQ Logs
-version: 1.4.0
+version: 1.5.0
 license: basic
 description: Collect and parse logs from RabbitMQ servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement

## What does this PR do?

This PR supports RabbitMQ  new timestamp format with nanosecond precision and timezone "2022-03-23 13:16:58.000369+03:00".
Previous timestamp format "2019-04-12 10:11:15.094".
New DATETIME pattern is replaced by TIMESTAMP_ISO8601.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).




## Related issues


- Relates #2905 


