### PR TITLE
[Cloud Posture] Fix `commit_time` mapping

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: "1.2.1"
   changes:
+    - description: Fix commit_time map type
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4923
     - description: Update CSP mapping
       type: enhancement
       link: https://github.com/elastic/integrations/pull/4920

--- a/packages/cloud_security_posture/data_stream/findings/fields/cloudbeat.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/cloudbeat.yml
@@ -25,7 +25,7 @@
       default_field: false
     - name: commit_time
       level: extended
-      type: date
+      type: keyword
       description: The commit time of the Cloudbeat.
       default_field: false
     - name: kubernetes.version


### PR DESCRIPTION
## What does this PR do?

cloudbeat `commit_time` was mapped to date, which causes mappings problems:

```
"reason":"failed to parse field [cloudbeat.commit_time]  of type [date] in document with id '1ERnd4UBZY-REUBU-Pp9'. Preview of field's value: '2022-12-29 09:42:05 +0000 UTC'","caused_by":{"type":"illegal_argument_exception","reason":"failed to parse date field [2022-12-29 09:42:05 +0000 UTC] with format [strict_date_optional_time||epoch_millis]","caused_by":{"type":"date_time_parse_exception","reason":"date_time_parse_exception: Failed to parse with all enclosed parsers"}}}, dropping event!
```

This leads to cloudbeat not sending events at all.
