### PR TITLE
Remove need for autodiscovery to monitor Istiod service.

### DIFF
--- a/packages/istio/changelog.yml
+++ b/packages/istio/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Monitor Istiod service
       type: enhancement # can be one of: enhancement, bugfix, breaking-change
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4924
 - version: "0.2.1"
   changes:
     - description: Metrics for Istiod and Proxy sidecar container

--- a/packages/istio/changelog.yml
+++ b/packages/istio/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Monitor Istiod service
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.1"
   changes:
     - description: Metrics for Istiod and Proxy sidecar container

--- a/packages/istio/data_stream/istiod_metrics/_dev/test/system/test-default-config.yml
+++ b/packages/istio/data_stream/istiod_metrics/_dev/test/system/test-default-config.yml
@@ -5,4 +5,4 @@ data_stream:
     hosts:
       - "http://{{Hostname}}:8080"
     metrics_path: "/metrics/istiod.txt"
-    condition: "true"
+    leaderelection: false

--- a/packages/istio/data_stream/istiod_metrics/agent/stream/stream.yml.hbs
+++ b/packages/istio/data_stream/istiod_metrics/agent/stream/stream.yml.hbs
@@ -4,7 +4,9 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
-condition: {{ condition }}
+{{#if leaderelection}}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
 {{#if metrics_path}}
 metrics_path: {{metrics_path}}
 {{/if}}

--- a/packages/istio/data_stream/istiod_metrics/manifest.yml
+++ b/packages/istio/data_stream/istiod_metrics/manifest.yml
@@ -20,7 +20,7 @@ streams:
         required: true
         show_user: true
         default:
-          - ${kubernetes.pod.ip}:15014
+          - istiod.istio-system:15014
       - name: metrics_path
         type: text
         title: Metrics Path
@@ -29,14 +29,13 @@ streams:
         show_user: true
         default:
           - /metrics
-      - name: condition
-        title: Condition
-        description: Condition to filter when to apply this datastream
-        type: text
+      - name: leaderelection
+        type: bool
+        title: Leader Election
         multi: false
         required: true
         show_user: true
-        default: ${kubernetes.labels.app} == 'istiod' and ${kubernetes.annotations.prometheus.io/scrape} == 'true'
+        default: true
       - name: metrics_filters.exclude
         type: text
         title: Metrics Filters Exclude

--- a/packages/istio/manifest.yml
+++ b/packages/istio/manifest.yml
@@ -3,7 +3,7 @@ name: istio
 title: Istio
 description: Collect logs and metrics from the service mesh Istio with Elastic Agent.
 type: integration
-version: 0.2.1
+version: 0.2.2
 release: beta
 license: basic
 categories:
@@ -16,7 +16,7 @@ screenshots:
   - src: /img/istio_traffic.png
     title: Istio Traffic
     size: 1705x851
-    type: image/png  
+    type: image/png
   - src: /img/istio_overview.png
     title: Istio Overview
     size: 1699x1064


### PR DESCRIPTION
## What does this PR do?

Remove need for autodiscovery to monitor Istiod service.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

1. Setup Istio by following the steps at https://github.com/elastic/integrations/pull/3632
2. create a data view for the index pattern `metrics-istio.istiod*`
3. Switch to Discover and select the data view created at step 2
4. Check the field `error.message` is empty for all metric events. 
5. Add a filter `istio.istiod.metrics.pilot_inbound_updates.counter: exists` to view a sample of the dataset for one of the metrics used in the `[Metrics Istio] Overview` dashboard
6. Check the dashboard `[Metrics Istio] Overview` has no errors and some actual data.

## Related issues

- Relates #4678 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
