### PR TITLE
Fix filters in linux/services

### DIFF
--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix list type for filters
       type: bugfix
-      link: TBD
+      link: https://github.com/elastic/integrations/pull/4934
 - version: "0.6.8"
   changes:
     - description: Fix typo in docs.

--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.9"
+  changes:
+    - description: Fix list type for filters
+      type: bugfix
+      link: TBD
 - version: "0.6.8"
   changes:
     - description: Fix typo in docs.

--- a/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
@@ -1,11 +1,20 @@
 metricsets: ["service"]
 condition: ${host.platform} == 'linux'
-{{#if service.state_filter}}
-service.state_filter: {{service.state_filter}}
+
+{{#if service.state_filter.length}}
+service.state_filter:
+{{#each service.state_filter as |filter i|}}
+- {{filter}}
+{{/each}}
 {{/if}}
-{{#if service.pattern_filter}}
-service.pattern_filter: {{service.pattern_filter}}
+
+{{#if service.pattern_filter.length}}
+service.pattern_filter:
+{{#each service.pattern_filter as |filter i|}}
+- {{filter}}
+{{/each}}
 {{/if}}
+
 period: {{period}}
 {{#if system.hostfs}}
 hostfs: {{system.hostfs}}

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux Metrics
-version: 0.6.8
+version: 0.6.9
 license: basic
 description: Collect metrics from Linux servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/elastic/integrations/issues/4882

This properly formats the `state_filter` and `pattern_filter` fields.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
