### PR TITLE
[Microsoft Defender Endpoint] Adds support for newer Oauth2 URL

### DIFF
--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.0"
+  changes:
+    - description: Adds support for newer Oauth Token URL
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4516
 - version: "2.5.2"
   changes:
     - description: Migrate the visualizations to by value in dashboards to minimize the saved object clutter and reduce time to load

--- a/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -2,7 +2,7 @@ config_version: "2"
 interval: {{interval}}
 auth.oauth2.client.id: {{client_id}}
 auth.oauth2.client.secret: {{client_secret}}
-auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/oauth2/token
+auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/{{token_url}}
 auth.oauth2.provider: azure
 auth.oauth2.azure.resource: {{azure_resource}}
 request.url: {{request_url}}

--- a/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
@@ -57,6 +57,13 @@ streams:
         show_user: false
         default: https://login.microsoftonline.com/
         description: "URL of Login server 'tenant-id/oauth2/token added automatically'"
+      - name: token_url
+        type: text
+        title: OAuth Token endpoint
+        required: true
+        show_user: false
+        default: oauth2/token
+        description: "Microsoft supports multiple Oauth2 URL endpoints, the default is oauth2/token, but can also be oauth2/v2.0/token"
       - name: request_url
         type: text
         title: Security Center URL

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.5.2"
+version: 2.6.0
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "network"


### PR DESCRIPTION
## What does this PR do?

Some customers uses a newer Oauth2 Token URL, so we have to make it configurable for now, while both are still possible to use.

In the end we should hardcode it to the new value, once its confirmed by Microsoft that it will work for everyone.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


