### PR TITLE
[Metrics][Docker] Add link to Docker available keys

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.1"
+  changes:
+    - description: Add link to docker available keys
+      type: enhancement
+      link: http://github.com/elastic/integrations/pull/4952
 - version: "2.4.0"
   changes:
     - description: Improve package description and titles

--- a/packages/docker/data_stream/container_logs/manifest.yml
+++ b/packages/docker/data_stream/container_logs/manifest.yml
@@ -20,7 +20,7 @@ streams:
         default: all
       - name: condition
         title: Condition
-        description: Condition to filter when to apply this datastream
+        description: Condition to filter when to apply this datastream. Refer to [Docker provider](https://www.elastic.co/guide/en/fleet/current/docker-provider.html) to find the available keys.
         type: text
         multi: false
         required: false

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.4.0
+version: 2.4.1
 release: ga
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR adds a new line to the conditions form of the Docker package, linking to the available keys.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Screenshots

![image](https://user-images.githubusercontent.com/113898685/211354346-90285583-6929-41d5-86dd-a80d2cf43780.png)
