### PR TITLE
Cloudbeat decision logs fields

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Cloudbeat decision logs support
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/4953
 - version: "1.4.0"
   changes:
     - description: Add new fields for Elastic Agent v2 components and units

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Cloudbeat decision logs support
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.4.0"
   changes:
     - description: Add new fields for Elastic Agent v2 components and units

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -1,6 +1,18 @@
 - name: message
   type: text
   title: Log Message
+- name: decision_id
+  type: text
+  title: Decision ID
+- name: input
+  type: object
+  title: Decision Input
+- name: result
+  type: object
+  title: Decision Result
+- name: error
+  type: text
+  title: Decision Error
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -10,9 +10,6 @@
 - name: result
   type: object
   title: Decision Result
-- name: error
-  type: text
-  title: Decision Error
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.4.0
+version: 1.4.1
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Support OPA decision log fields in the fleet UI log screen.
Resolves https://github.com/elastic/cloudbeat/issues/533
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
