### PR TITLE
Cloud Security - Add a network fetcher to the AWS CSPM config

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add a network fetcher to the aws cspm hbs file
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4931
+      link: https://github.com/elastic/integrations/pull/4954
 - version: "1.2.2"
   changes:
     - description: Update cspm hbs file

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Add a network fetcher to the aws cspm hbs file
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4931
 - version: "1.2.2"
   changes:
     - description: Update cspm hbs file

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -1,5 +1,6 @@
 fetchers:
   - name: aws-iam
+  - name: aws-ec2-network
 config:
   v1:
     posture: {{posture}}

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Security Posture Management (CSPM/KSPM)"
-version: 1.2.2
+version: 1.2.3
 release: ga
 license: basic
 description: "DO NOT USE MAIN TILE (WIP)"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Adds a network fetcher to the agent config.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
