### PR TITLE
[Windows] Added support for custom processors on perfmon

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.3"
+  changes:
+    - description: Add support for custom processors in Windows Perfmon
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4956
 - version: "1.15.2"
   changes:
     - description: Fix translate_sid processor error in forwarded data stream.

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.15.3"
+- version: "1.16.0"
   changes:
     - description: Add support for custom processors in Windows Perfmon
       type: enhancement

--- a/packages/windows/data_stream/perfmon/agent/stream/stream.yml.hbs
+++ b/packages/windows/data_stream/perfmon/agent/stream/stream.yml.hbs
@@ -4,3 +4,7 @@ perfmon.group_measurements_by_instance: {{perfmon.group_measurements_by_instance
 perfmon.ignore_non_existent_counters: {{perfmon.ignore_non_existent_counters}}
 perfmon.queries: {{perfmon.queries}}
 period: {{period}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/windows/data_stream/perfmon/manifest.yml
+++ b/packages/windows/data_stream/perfmon/manifest.yml
@@ -41,5 +41,13 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+          type: yaml
+          title: Processors
+          multi: false
+          required: false
+          show_user: false
+          description: >
+            Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: Windows perfmon metrics
     description: Collect Windows perfmon metrics

--- a/packages/windows/data_stream/perfmon/manifest.yml
+++ b/packages/windows/data_stream/perfmon/manifest.yml
@@ -42,12 +42,12 @@ streams:
         show_user: true
         default: 10s
       - name: processors
-          type: yaml
-          title: Processors
-          multi: false
-          required: false
-          show_user: false
-          description: >
-            Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: Windows perfmon metrics
     description: Collect Windows perfmon metrics

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.15.2
+version: 1.16.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Adds support for the custom processor definition in windows perfmon.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.
