### PR TITLE
[Stack Monitoring] Add metricset name mapping

### DIFF
--- a/packages/beat/changelog.yml
+++ b/packages/beat/changelog.yml
@@ -1,3 +1,8 @@
+- version: 0.1.1
+  changes:
+    - description: Add metricset name mapping
+      type: enhancement
+      link: https://github.com/elastic/kibana/issues/140358
 - version: 0.1.0
   changes:
     - description: Add `ssl` configuration option for metricsets

--- a/packages/beat/data_stream/state/fields/base-fields.yml
+++ b/packages/beat/data_stream/state/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/beat/data_stream/stats/fields/base-fields.yml
+++ b/packages/beat/data_stream/stats/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/beat/docs/README.md
+++ b/packages/beat/docs/README.md
@@ -691,6 +691,7 @@ An example event for `stats` looks as following:
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | error.message | Error message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -860,6 +861,7 @@ An example event for `state` looks as following:
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | error.message | Error message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
 | timestamp |  | alias |

--- a/packages/beat/manifest.yml
+++ b/packages/beat/manifest.yml
@@ -1,6 +1,6 @@
 name: beat
 title: Beat
-version: 0.1.0
+version: 0.1.1
 description: Beat Integration
 type: integration
 conditions:

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1-preview1"
+  changes:
+    - description: Add metricset name mapping
+      type: enhancement
+      link: https://github.com/elastic/kibana/issues/140358
 - version: "1.2.0-preview1"
   changes:
     - description: Add `ssl` configuration option for metricsets

--- a/packages/elasticsearch/data_stream/audit/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/audit/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/ccr/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/ccr/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/cluster_stats/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/cluster_stats/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/deprecation/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/deprecation/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/enrich/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/enrich/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/gc/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/gc/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/index/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/index/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/index_recovery/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/index_recovery/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/index_summary/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/index_summary/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/ml_job/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/ml_job/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/node/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/node/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/node_stats/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/node_stats/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/pending_tasks/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/pending_tasks/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/server/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/server/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/shard/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/shard/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/data_stream/slowlog/fields/base-fields.yml
+++ b/packages/elasticsearch/data_stream/slowlog/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: '@timestamp'
   type: date
   description: Event timestamp.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/elasticsearch/docs/README.md
+++ b/packages/elasticsearch/docs/README.md
@@ -57,6 +57,7 @@ NOTE: Configure the `var.paths` setting to point to JSON logs.
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.offset |  | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | related.user |  | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
 | source | Source fields capture details about the sender of a network exchange/packet. These fields are populated from a network event, packet, or other event containing details of a network transaction. Source fields are usually populated in conjunction with destination fields. The source and destination fields are considered the baseline and should always be filled if an event contains source and destination details from a network transaction. If the event also contains identification of the client and server roles, then the client and server fields should also be populated. | group |
@@ -100,6 +101,7 @@ NOTE: Configure the `var.paths` setting to point to JSON logs.
 | log.logger | The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name. | keyword |
 | log.offset |  | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.thread.name | Thread name. | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -149,6 +151,7 @@ NOTE: Configure the `var.paths` setting to point to JSON logs.
 | log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.offset |  | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.pid | Process id. | long |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
 
@@ -186,6 +189,7 @@ NOTE: Configure the `var.paths` setting to point to JSON logs.
 | log.logger | The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name. | keyword |
 | log.offset |  | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.thread.name | Thread name. | keyword |
 | server.name |  | keyword |
 | server.type |  | keyword |
@@ -232,6 +236,7 @@ NOTE: Configure the `var.paths` setting to point to JSON logs.
 | log.logger | The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name. | keyword |
 | log.offset |  | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.thread.name | Thread name. | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -349,6 +354,7 @@ will not collect metrics. A DEBUG log message about this will be emitted in the 
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -617,6 +623,7 @@ An example event for `cluster_stats` looks as following:
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | license.status |  | alias |
 | license.type |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -756,6 +763,7 @@ An example event for `enrich` looks as following:
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -1050,6 +1058,7 @@ An example event for `index` looks as following:
 | indices_stats._all.total.indexing.index_total |  | alias |
 | indices_stats._all.total.search.query_time_in_millis |  | alias |
 | indices_stats._all.total.search.query_total |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -1229,6 +1238,7 @@ An example event for `index_recovery` looks as following:
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | index_recovery.shards.start_time_in_millis |  | alias |
 | index_recovery.shards.stop_time_in_millis |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -1464,6 +1474,7 @@ An example event for `index_summary` looks as following:
 | indices_stats._all.total.indexing.index_total |  | alias |
 | indices_stats._all.total.search.query_time_in_millis |  | alias |
 | indices_stats._all.total.search.query_total |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -1601,6 +1612,7 @@ An example event for `ml_job` looks as following:
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | job_stats.forecasts_stats.total |  | alias |
 | job_stats.job_id |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -1746,6 +1758,7 @@ An example event for `node` looks as following:
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -2238,6 +2251,7 @@ An example event for `node_stats` looks as following:
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | node_stats.fs.io_stats.total.operations |  | alias |
 | node_stats.fs.io_stats.total.read_operations |  | alias |
 | node_stats.fs.io_stats.total.write_operations |  | alias |
@@ -2409,6 +2423,7 @@ An example event for `pending_tasks` looks as following:
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
@@ -2550,6 +2565,7 @@ An example event for `shard` looks as following:
 | event.duration | Duration of the event in nanoseconds. If event.start and event.end are known this value should be the difference between the end and start time. | long |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Service address | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.2.0-preview1
+version: 1.2.1-preview1
 description: Elasticsearch Integration
 type: integration
 icons:

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.1-preview1"
+  changes:
+    - description: Add metricset name mapping
+      type: enhancement
+      link: https://github.com/elastic/kibana/issues/140358
 - version: "2.2.0-preview1"
   changes:
     - description: Add `ssl` configuration option for metricsets

--- a/packages/kibana/data_stream/audit/fields/base-fields.yml
+++ b/packages/kibana/data_stream/audit/fields/base-fields.yml
@@ -16,3 +16,6 @@
 - name: input.type
   type: keyword
   description: The input type from which the event was generated. This field is set to the value specified for the type option in the input section of the Filebeat config file.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/kibana/data_stream/cluster_actions/fields/base-fields.yml
+++ b/packages/kibana/data_stream/cluster_actions/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/kibana/data_stream/cluster_rules/fields/base-fields.yml
+++ b/packages/kibana/data_stream/cluster_rules/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/kibana/data_stream/log/fields/base-fields.yml
+++ b/packages/kibana/data_stream/log/fields/base-fields.yml
@@ -16,3 +16,6 @@
 - name: input.type
   type: keyword
   description: The input type from which the event was generated. This field is set to the value specified for the type option in the input section of the Filebeat config file
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/kibana/data_stream/node_actions/fields/base-fields.yml
+++ b/packages/kibana/data_stream/node_actions/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/kibana/data_stream/node_rules/fields/base-fields.yml
+++ b/packages/kibana/data_stream/node_rules/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/kibana/data_stream/stats/fields/base-fields.yml
+++ b/packages/kibana/data_stream/stats/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/kibana/data_stream/status/fields/base-fields.yml
+++ b/packages/kibana/data_stream/status/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/kibana/docs/README.md
+++ b/packages/kibana/docs/README.md
@@ -51,6 +51,7 @@ UI in Kibana. To enable this usage, set `xpack.enabled: true` on the package con
 | log.logger | The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name. | keyword |
 | log.offset | The file offset the reported line starts at. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.pid | Process id. | long |
 | related.user | All the user names or other user identifiers seen on the event. | keyword |
 | service.node.roles | Roles of a service node. This allows for distinction between different running roles of the same service. In the case of Kibana, the `service.node.role` could be `ui` or `background_tasks` or both. In the case of Elasticsearch, the `service.node.role` could be `master` or `data` or both. Other services could use this to distinguish between a `web` and `worker` role running as part of the service. | keyword |
@@ -99,6 +100,7 @@ UI in Kibana. To enable this usage, set `xpack.enabled: true` on the package con
 | log.logger | The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name. | keyword |
 | log.offset | The file offset the reported line starts at. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.eventLoopDelay |  | unsigned_long |
 | process.eventLoopDelayHistogram.50 |  | long |
 | process.eventLoopDelayHistogram.95 |  | long |
@@ -187,6 +189,7 @@ Stats data stream uses the stats endpoint of Kibana, which is available in 6.4 b
 | kibana_stats.response_times.average |  | alias |
 | kibana_stats.response_times.max |  | alias |
 | kibana_stats.timestamp |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.pid | Process id. | long |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.id | Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes. This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event. Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead. | keyword |
@@ -354,6 +357,7 @@ This status endpoint is available in 6.0 by default and can be enabled in Kibana
 | kibana.status.metrics.requests.total | Total number of connections. | long |
 | kibana.status.name | Kibana instance name. | keyword |
 | kibana.status.status.overall.state | Kibana overall state. | keyword |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | service.address | Address where data about this service was collected from. | keyword |
 | service.id | Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes. This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event. Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead. | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
@@ -470,6 +474,7 @@ Cluster actions metrics documentation
 | kibana_stats.kibana.uuid |  | alias |
 | kibana_stats.kibana.version |  | alias |
 | kibana_stats.timestamp |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.pid | Process id. | long |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.id | Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes. This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event. Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead. | keyword |
@@ -584,6 +589,7 @@ Cluster rules metrics
 | kibana_stats.kibana.uuid |  | alias |
 | kibana_stats.kibana.version |  | alias |
 | kibana_stats.timestamp |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.pid | Process id. | long |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.id | Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes. This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event. Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead. | keyword |
@@ -698,6 +704,7 @@ Node actions metrics
 | kibana_stats.kibana.uuid |  | alias |
 | kibana_stats.kibana.version |  | alias |
 | kibana_stats.timestamp |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.pid | Process id. | long |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.id | Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes. This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event. Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead. | keyword |
@@ -808,6 +815,7 @@ Node rules metrics
 | kibana_stats.kibana.uuid |  | alias |
 | kibana_stats.kibana.version |  | alias |
 | kibana_stats.timestamp |  | alias |
+| metricset.name | The name of the metricset that generated the event. | keyword |
 | process.pid | Process id. | long |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.id | Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes. This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event. Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead. | keyword |

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.2.0-preview1
+version: 2.2.1-preview1
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.1-preview1"
+  changes:
+    - description: Add metricset name mapping
+      type: enhancement
+      link: https://github.com/elastic/kibana/issues/140358
 - version: "2.2.0-preview1"
   changes:
     - description: Add `ssl` configuration option for metricsets

--- a/packages/logstash/data_stream/log/fields/base-fields.yml
+++ b/packages/logstash/data_stream/log/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/logstash/data_stream/node/fields/base-fields.yml
+++ b/packages/logstash/data_stream/node/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: service.hostname
   type: keyword
   description: Hostname of the service
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/logstash/data_stream/node_stats/fields/base-fields.yml
+++ b/packages/logstash/data_stream/node_stats/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: service.hostname
   type: keyword
   description: Hostname of the service
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/logstash/data_stream/slowlog/fields/base-fields.yml
+++ b/packages/logstash/data_stream/slowlog/fields/base-fields.yml
@@ -7,3 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: metricset.name
+  type: keyword
+  description: The name of the metricset that generated the event.

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.2.0-preview1
+version: 2.2.1-preview1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## What does this PR do?

This PR adds metricset name mapping in:
- Beat
- Elasticsearch
- Kibana
- Logstash

This is needed in order to display integration package errors in the health API endpoint in stack monitoring where we need the metricset name for the aggregation in order to filter the errors based on a metricset name (node, ccr, etc) so we can have a structure (similar to the solution we have for metricbeat) like: 

```
packageErrors: {
  products: {
       elasticsearch: {
          node: {....},
          node_stats: {...},
          ccr: {...}
       }, ...
   }
}
```
## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

🚧 Will be added in the stack monitoring PR, still WIP

## Related issues

Relates [#140358](https://github.com/elastic/kibana/issues/140358)
