### PR TITLE
[Cloud Posture] Deprecate Transform POC

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.6"
+  changes:
+    - description: Deprecate Transform POC
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4968
 - version: "1.2.5"
   changes:
     - description: Add S3 fetcher to the AWS CSPM hbs file

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -1,10 +1,18 @@
 ---
 description: Pipeline for cloudbeat findings
 processors:
-- set:
-    field: event.ingested
-    value: '{{_ingest.timestamp}}'
+  - set:
+      field: event.ingested
+      value: "{{_ingest.timestamp}}"
+  - set:
+      field: cspm_id
+      value: "{{{resource.id}}}-{{{rule.id}}}"
+  - script:
+      lang: painless
+      source: >-
+        ctx._id = ctx.cspm_id;
+        ctx._index = "logs-cloud_security_posture.findings_latest-default"
 on_failure:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Security Posture Management (CSPM/KSPM)"
-version: 1.2.5
+version: 1.2.6
 release: ga
 license: basic
 description: "DO NOT USE MAIN TILE (WIP)"


### PR DESCRIPTION
## Summary
using ingest pipeline for deprecating CSPM transform. 

## related issues: 
- https://github.com/elastic/security-team/issues/5495