### PR TITLE
[Prometheus] remove Integration from the package name

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
-- version: "1.0.2"
+- version: "1.1.0"
   changes:
     - description: Remove "integration" from the package name
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4545
+      link: https://github.com/elastic/integrations/pull/4983
 - version: "1.0.1"
   changes:
     - description: Removing x-pack references and updating default values

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Remove "integration" from the package name
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4545
 - version: "1.0.1"
   changes:
     - description: Removing x-pack references and updating default values

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus
-version: 1.0.2
+version: 1.1.0
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
-title: Prometheus Integration
-version: 1.0.1
+title: Prometheus
+version: 1.0.2
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

remove duplicated "Integration" from the integration package name, that impact naming in documentation - https://docs.elastic.co/integrations/prometheus

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
