### PR TITLE
Match timestamps without year in pipeline tests with regex

### DIFF
--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,6 @@
 dynamic_fields:
   event.ingested: ".*"
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,6 @@
+dynamic_fields:
+  "event.created": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event

--- a/packages/pfsense/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/pfsense/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event

--- a/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - forwarded

--- a/packages/zscaler_zia/data_stream/alerts/_dev/test/pipeline/test-common-config.yml
+++ b/packages/zscaler_zia/data_stream/alerts/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}"
 fields:
   tags:
     - preserve_original_event


### PR DESCRIPTION
## What does this PR do?

- Timestamps that are parsed without a year (such as those on BSD-style syslog messages) will have their expected values inherit the year the expected files are generated in. This means that tests will only pass in the year that the expected files are generated.
- The relevant timestamp field (@timestamp, for example) has been added to the pipeline test config as a dynamic field, and a regex pattern is used to match the expected format of the timestamp.

Fixes the tests for the following packages:

- cisco_aironet
- cisco_ftd
- cisco_ios
- cisco_ise
- cisco_secure_email_gateway
- infoblox_nios
- pfsense
- symantec_endpoint
- zscaler_zia

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- ~~[ ] I have added an entry to my package's `changelog.yml` file.~~
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #4950
