### PR TITLE
[osquery_manager]: Fix osquery_manager data_stream values for 8.6.0 with ingest pipeline

### DIFF
--- a/packages/osquery_manager/data_stream/result/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/osquery_manager/data_stream/result/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,11 @@
+---
+description: Pipeline for setting data_stream values
+processors:
+- set:
+    field: data_stream.type
+    value: "logs"
+    ignore_empty_value: true
+- set:
+    field: data_stream.dataset
+    value: "osquery_manager.result"
+    ignore_empty_value: true

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.5.1
+version: 1.6.0
 license: basic
 description: Deploy osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration


### PR DESCRIPTION
## What does this PR do?

This adds the ingest pipeline to the osquery_manager in order to fix the known defect in 8.6.0 release where the data_stream fields on the document are set to incorrect values.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes https://github.com/elastic/beats/issues/34250

## Screenshots

This is the new ingest pipeline that shows up in kibana when the integration is installed

<img width="533" alt="Screen Shot 2023-01-12 at 10 33 56 PM" src="https://user-images.githubusercontent.com/872351/212233524-98d6ec82-37e7-4cda-9511-fbff09171790.png">

Confirmed that the document is indexed with correct data_stream values
<img width="763" alt="Screen Shot 2023-01-12 at 10 33 24 PM" src="https://user-images.githubusercontent.com/872351/212233681-f8acb3c4-20e0-4965-b71a-d0614bc09e2b.png">

