### PR TITLE
Fix lyve_cloud changelog

### DIFF
--- a/packages/lyve_cloud/changelog.yml
+++ b/packages/lyve_cloud/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: Initial implementation
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4617
+      link: https://github.com/elastic/integrations/pull/4702


### PR DESCRIPTION
## Summary

They lyve_cloud changelog entry points to the wrong PR. This PR updates the changelog to point to the correct PR.