### PR TITLE
[Kubernetes] Add support for 1.26 k8s version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -13,8 +13,8 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${REPO}"
     AWS_ACCOUNT_SECRET = "secret/observability-team/ci/elastic-observability-aws-account-auth"
     HOME = "${env.WORKSPACE}"
-    KIND_VERSION = "v0.14.0"
-    K8S_VERSION = "v1.25.0"
+    KIND_VERSION = "v0.17.0"
+    K8S_VERSION = "v1.26.0"
     JOB_GCS_BUCKET = 'fleet-ci-temp'
     JOB_GCS_BUCKET_INTERNAL = 'fleet-ci-temp-internal'
     JOB_GCS_CREDENTIALS = 'fleet-ci-gcs-plugin'

--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -91,7 +91,7 @@ This defaults to `/var/log/kubernetes/kube-apiserver-audit.log`.
 
 ## Compatibility
 
-The Kubernetes package is tested with Kubernetes [1.18.x - 1.25.x] versions
+The Kubernetes package is tested with Kubernetes [1.23.x - 1.26.x] versions
 
 ## Dashboard
 

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -91,7 +91,7 @@ This defaults to `/var/log/kubernetes/kube-apiserver-audit.log`.
 
 ## Compatibility
 
-The Kubernetes package is tested with Kubernetes [1.18.x - 1.25.x] versions
+The Kubernetes package is tested with Kubernetes [1.23.x - 1.26.x] versions
 
 ## Dashboard
 


### PR DESCRIPTION
## What does this PR do?
Adds support for Kubernetes 1.26.x version and update kind version to 0.17.0


## Related issues

- Relates to https://github.com/elastic/observability-dev/issues/2345
