### PR TITLE
[Microsoft_defender_endpoint] Add support for Oauth2 scopes

### DIFF
--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.0"
+  changes:
+    - description: Adding support for Oauth2 scopes that is required for some users
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4576
 - version: "2.7.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adding support for Oauth2 scopes that is required for some users
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4576
+      link: https://github.com/elastic/integrations/pull/5014
 - version: "2.7.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -5,7 +5,7 @@ auth.oauth2.client.secret: {{client_secret}}
 auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/{{token_url}}
 {{#if scopes}}
 auth.oauth2.scopes:
-{{#each scopes as |scope i|}}
+{{#each scopes as |scope|}}
   - {{scope}}
 {{/each}}
 {{/if}}

--- a/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -8,11 +8,10 @@ auth.oauth2.scopes:
 {{#each scopes as |scope|}}
   - {{scope}}
 {{/each}}
-{{/if}}
-{{#unless scopes}}
+{{else}}
 auth.oauth2.provider: azure
 auth.oauth2.azure.resource: {{azure_resource}}
-{{/unless}}
+{{/if}}
 request.url: {{request_url}}
 request.method: GET
 {{#if proxy_url }}

--- a/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_defender_endpoint/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -3,8 +3,16 @@ interval: {{interval}}
 auth.oauth2.client.id: {{client_id}}
 auth.oauth2.client.secret: {{client_secret}}
 auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/{{token_url}}
+{{#if scopes}}
+auth.oauth2.scopes:
+{{#each scopes as |scope i|}}
+  - {{scope}}
+{{/each}}
+{{/if}}
+{{#unless scopes}}
 auth.oauth2.provider: azure
 auth.oauth2.azure.resource: {{azure_resource}}
+{{/unless}}
 request.url: {{request_url}}
 request.method: GET
 {{#if proxy_url }}

--- a/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
@@ -35,11 +35,18 @@ streams:
         show_user: true
         default: 5m
         description: The interval between requests to the HTTP API.
+      - name: scopes
+        type: text
+        title: Oauth2 Scopes
+        multi: true
+        required: false
+        show_user: false
+        description: One or more Oauth2 scopes required to authenticate with the Microsoft Security Center API. An example scope could be 'https://api.securitycenter.windows.com/.defaults'"
       - name: azure_resource
         type: text
         title: Azure Resource
         multi: false
-        required: true
+        required: false
         default: https://api.securitycenter.windows.com/
         show_user: false
         description: URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port>

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.7.0"
+version: 2.8.0
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "network"


### PR DESCRIPTION
## What does this PR do?

Some customers uses a different Oauth2 authentication flow, so I will keep the original Azure resource implementation while adding the optional support for Oauth2 scopes.

When a scope is defined, it will negate these two lines in httpjson:
```
auth.oauth2.provider: azure
auth.oauth2.azure.resource: {{azure_resource}}
```

The reason for this is the difference in Oauth2 flow, and the expected URL parameters and POST body format used. The earlier API versions was dependent on the concept of providing resources, and the provider parameter is simply used by the Golang Oauth2 library to provide certain Azure specific features.

Once the API changed, it now only requires Oauth2 scopes to provided instead of resources. We still want to support both for the people that are still using the old version, and if we can determine when/if the old way is deprecated, we can switch to scopes being the default option.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


