### PR TITLE
Drop header log line in CloudFront events

### DIFF
--- a/packages/aws/data_stream/cloudfront_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudfront_logs/elasticsearch/ingest_pipeline/default.yml
@@ -28,6 +28,9 @@ processors:
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
+  - drop: 
+      if: "ctx.event.original.startsWith('#')"
+      description: "Drop if logline contains header(s), which startswith `#`"
   - grok:
       field: event.original
       patterns:


### PR DESCRIPTION
By default the CloudFront stores these two lines as a header in each log file. Before this change it fails the pipeline and add message to error.message field.

Added the sample log line
#5016 6c95e2273bafde847a60a4ab3e185345c1a3c2d4