### PR TITLE
[Security Rules] Update security rules package to v8.4.2-beta.1

### DIFF
--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -2,7 +2,7 @@
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
 - changes:
     - description: Release security rules update
-      link: https://github.com/elastic/integrations/pulls/0000
+      link: https://github.com/elastic/integrations/pull/5027
       type: enhancement
   version: 8.4.2-beta.1
 - changes:

--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -2,6 +2,11 @@
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
 - changes:
     - description: Release security rules update
+      link: https://github.com/elastic/integrations/pulls/0000
+      type: enhancement
+  version: 8.4.2-beta.1
+- changes:
+    - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5024
       type: enhancement
   version: 8.3.4

--- a/packages/security_detection_engine/kibana/security_rule/02a23ee7-c8f8-4701-b99d-e9038ce313cb.json
+++ b/packages/security_detection_engine/kibana/security_rule/02a23ee7-c8f8-4701-b99d-e9038ce313cb.json
@@ -1,0 +1,107 @@
+{
+    "attributes": {
+        "author": [
+            "Elastic"
+        ],
+        "description": "Identifies the creation of a process running as SYSTEM and impersonating a Windows core binary privileges. Adversaries may create a new process with a different token to escalate privileges and bypass access controls.",
+        "from": "now-9m",
+        "index": [
+            "logs-endpoint.events.*"
+        ],
+        "language": "eql",
+        "license": "Elastic License v2",
+        "name": "Process Created with an Elevated Token",
+        "query": "/* This rule is only compatible with Elastic Endpoint 8.4+ */\n\nprocess where event.action == \"start\" and\n\n /* CreateProcessWithToken and effective parent is a privileged MS native binary used as a target for token theft */\n user.id : \"S-1-5-18\"  and\n\n /* Token Theft target process usually running as service are located in one of the following paths */\n process.Ext.effective_parent.executable :\n                (\"?:\\\\Windows\\\\*.exe\",\n                 \"?:\\\\Program Files\\\\*.exe\",\n                 \"?:\\\\Program Files (x86)\\\\*.exe\",\n                 \"?:\\\\ProgramData\\\\*\") and\n\n not (process.Ext.effective_parent.executable : \"?:\\\\Windows\\\\System32\\\\Utilman.exe\" and\n      process.parent.executable : \"?:\\\\Windows\\\\System32\\\\Utilman.exe\" and process.parent.args : \"/debug\") and\n\n not process.executable : (\"?:\\\\Windows\\\\System32\\\\WerFault.exe\",\n                           \"?:\\\\Windows\\\\SysWOW64\\\\WerFault.exe\",\n                           \"?:\\\\Windows\\\\System32\\\\WerFaultSecure.exe\",\n                           \"?:\\\\Windows\\\\SysWOW64\\\\WerFaultSecure.exe\",\n                           \"?:\\\\windows\\\\system32\\\\WerMgr.exe\",\n                           \"?:\\\\Windows\\\\SoftwareDistribution\\\\Download\\\\Install\\\\securityhealthsetup.exe\")  and\n\n not process.parent.executable : (\"?:\\\\Windows\\\\System32\\\\AtBroker.exe\", \"?:\\\\Windows\\\\system32\\\\svchost.exe\", \"?:\\\\Program Files (x86)\\\\*.exe\", \"?:\\\\Program Files\\\\*.exe\", \"?:\\\\Windows\\\\System32\\\\msiexec.exe\",\n \"C:\\\\Windows\\\\System32\\\\DriverStore\\\\*\") and\n\n\n not (process.code_signature.trusted == true and\n      process.code_signature.subject_name in (\"philandro Software GmbH\", \"Freedom Scientific Inc.\", \"TeamViewer Germany GmbH\", \"Projector.is, Inc.\", \"TeamViewer GmbH\", \"Cisco WebEx LLC\", \"Dell Inc\"))\n",
+        "references": [
+            "https://lengjibo.github.io/token/",
+            "https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createprocesswithtokenw"
+        ],
+        "related_integrations": [
+            {
+                "package": "endpoint",
+                "version": "^8.2.0"
+            }
+        ],
+        "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.action",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "process.Ext.effective_parent.executable",
+                "type": "unknown"
+            },
+            {
+                "ecs": true,
+                "name": "process.code_signature.subject_name",
+                "type": "keyword"
+            },
+            {
+                "ecs": true,
+                "name": "process.code_signature.trusted",
+                "type": "boolean"
+            },
+            {
+                "ecs": true,
+                "name": "process.executable",
+                "type": "keyword"
+            },
+            {
+                "ecs": true,
+                "name": "process.parent.args",
+                "type": "keyword"
+            },
+            {
+                "ecs": true,
+                "name": "process.parent.executable",
+                "type": "keyword"
+            },
+            {
+                "ecs": true,
+                "name": "user.id",
+                "type": "keyword"
+            }
+        ],
+        "risk_score": 73,
+        "rule_id": "02a23ee7-c8f8-4701-b99d-e9038ce313cb",
+        "severity": "high",
+        "tags": [
+            "Elastic",
+            "Host",
+            "Windows",
+            "Threat Detection",
+            "Privilege Escalation"
+        ],
+        "threat": [
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0004",
+                    "name": "Privilege Escalation",
+                    "reference": "https://attack.mitre.org/tactics/TA0004/"
+                },
+                "technique": [
+                    {
+                        "id": "T1134",
+                        "name": "Access Token Manipulation",
+                        "reference": "https://attack.mitre.org/techniques/T1134/",
+                        "subtechnique": [
+                            {
+                                "id": "T1134.002",
+                                "name": "Create Process with Token",
+                                "reference": "https://attack.mitre.org/techniques/T1134/002/"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "timestamp_override": "event.ingested",
+        "type": "eql",
+        "version": 2
+    },
+    "id": "02a23ee7-c8f8-4701-b99d-e9038ce313cb",
+    "type": "security-rule"
+}

--- a/packages/security_detection_engine/kibana/security_rule/07b5f85a-240f-11ed-b3d9-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/07b5f85a-240f-11ed-b3d9-f661ea17fbce.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -87,7 +87,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 4
+        "version": 104
     },
     "id": "07b5f85a-240f-11ed-b3d9-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/12a2f15d-597e-4334-88ff-38a02cb1330b.json
+++ b/packages/security_detection_engine/kibana/security_rule/12a2f15d-597e-4334-88ff-38a02cb1330b.json
@@ -14,13 +14,29 @@
         "license": "Elastic License v2",
         "name": "Kubernetes Suspicious Self-Subject Review",
         "note": "",
-        "query": "kubernetes.audit.verb:\"create\"\nand kubernetes.audit.objectRef.resource:(\"selfsubjectaccessreviews\" or \"selfsubjectrulesreviews\")\nand kubernetes.audit.user.username:(system\\:serviceaccount\\:* or system\\:node\\:*) or kubernetes.audit.impersonatedUser.username:(system\\:serviceaccount\\:* or system\\:node\\:*)\n",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.verb:\"create\"\n  and kubernetes.audit.objectRef.resource:(\"selfsubjectaccessreviews\" or \"selfsubjectrulesreviews\")\n  and (kubernetes.audit.user.username:(system\\:serviceaccount\\:* or system\\:node\\:*)\n  or kubernetes.audit.impersonatedUser.username:(system\\:serviceaccount\\:* or system\\:node\\:*))\n",
         "references": [
             "https://www.paloaltonetworks.com/apps/pan/public/downloadResource?pagePath=/content/pan/en_US/resources/whitepapers/kubernetes-privilege-escalation-excessive-permissions-in-popular-platforms",
             "https://kubernetes.io/docs/reference/access-authn-authz/authorization/#checking-api-access",
             "https://techcommunity.microsoft.com/t5/microsoft-defender-for-cloud/detecting-identity-attacks-in-kubernetes/ba-p/3232340"
         ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
         "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
             {
                 "ecs": false,
                 "name": "kubernetes.audit.impersonatedUser.username",
@@ -71,7 +87,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 100
+        "version": 201
     },
     "id": "12a2f15d-597e-4334-88ff-38a02cb1330b",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/12cbf709-69e8-4055-94f9-24314385c27e.json
+++ b/packages/security_detection_engine/kibana/security_rule/12cbf709-69e8-4055-94f9-24314385c27e.json
@@ -5,7 +5,7 @@
         ],
         "description": "This rules detects an attempt to create or modify a pod attached to the host network. HostNetwork allows a pod to use the node network namespace. Doing so gives the pod access to any service running on localhost of the host. An attacker could use this access to snoop on network activity of other pods on the same node or bypass restrictive network policies applied to its given namespace.",
         "false_positives": [
-            "An administrator or developer may want to use a pod that runs as root and shares the host\ufffds IPC, Network, and PID namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and network namespaces from the host's perspective."
+            "An administrator or developer may want to use a pod that runs as root and shares the hosts IPC, Network, and PID namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and network namespaces from the host's perspective. Add exceptions for trusted container images using the query field \"kubernetes.audit.requestObject.spec.container.image\""
         ],
         "index": [
             "logs-kubernetes.*"
@@ -14,16 +14,37 @@
         "license": "Elastic License v2",
         "name": "Kubernetes Pod Created With HostNetwork",
         "note": "",
-        "query": "kubernetes.audit.objectRef.resource:\"pods\" and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\") and kubernetes.audit.requestObject.spec.hostNetwork:true\n",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.objectRef.resource:\"pods\"\n  and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\")\n  and kubernetes.audit.requestObject.spec.hostNetwork:true\n  and not kubernetes.audit.requestObject.spec.containers.image: (\"docker.elastic.co/beats/elastic-agent:8.4.0\")\n",
         "references": [
             "https://research.nccgroup.com/2021/11/10/detection-engineering-for-kubernetes-clusters/#part3-kubernetes-detections",
             "https://kubernetes.io/docs/concepts/security/pod-security-policy/#host-namespaces",
             "https://bishopfox.com/blog/kubernetes-pod-privilege-escalation"
         ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
         "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
             {
                 "ecs": false,
                 "name": "kubernetes.audit.objectRef.resource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.requestObject.spec.containers.image",
                 "type": "unknown"
             },
             {
@@ -63,11 +84,26 @@
                         "reference": "https://attack.mitre.org/techniques/T1611/"
                     }
                 ]
+            },
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0002",
+                    "name": "Execution",
+                    "reference": "https://attack.mitre.org/tactics/TA0002/"
+                },
+                "technique": [
+                    {
+                        "id": "T1610",
+                        "name": "Deploy Container",
+                        "reference": "https://attack.mitre.org/techniques/T1610/"
+                    }
+                ]
             }
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 100
+        "version": 201
     },
     "id": "12cbf709-69e8-4055-94f9-24314385c27e",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/14de811c-d60f-11ec-9fd7-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/14de811c-d60f-11ec-9fd7-f661ea17fbce.json
@@ -14,12 +14,28 @@
         "license": "Elastic License v2",
         "name": "Kubernetes User Exec into Pod",
         "note": "",
-        "query": "kubernetes.audit.objectRef.resource:\"pods\"\n  and kubernetes.audit.objectRef.subresource:\"exec\"\n",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.verb:\"create\"\n  and kubernetes.audit.objectRef.resource:\"pods\"\n  and kubernetes.audit.objectRef.subresource:\"exec\"\n",
         "references": [
             "https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/",
             "https://kubernetes.io/docs/tasks/debug/debug-application/get-shell-running-container/"
         ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
         "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
             {
                 "ecs": false,
                 "name": "kubernetes.audit.objectRef.resource",
@@ -28,6 +44,11 @@
             {
                 "ecs": false,
                 "name": "kubernetes.audit.objectRef.subresource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.verb",
                 "type": "unknown"
             }
         ],
@@ -60,7 +81,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 100
+        "version": 201
     },
     "id": "14de811c-d60f-11ec-9fd7-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/2abda169-416b-4bb3-9a6b-f8d239fd78ba.json
+++ b/packages/security_detection_engine/kibana/security_rule/2abda169-416b-4bb3-9a6b-f8d239fd78ba.json
@@ -5,7 +5,7 @@
         ],
         "description": "This rule detects when a pod is created with a sensitive volume of type hostPath. A hostPath volume type mounts a sensitive file or folder from the node to the container. If the container gets compromised, the attacker can use this mount for gaining access to the node. There are many ways a container with unrestricted access to the host filesystem can escalate privileges, including reading data from other containers, and accessing tokens of more privileged pods.",
         "false_positives": [
-            "An administrator may need to attach a hostPath volume for a legitimate reason. This alert should be investigated for legitimacy by determining if the kuberenetes.audit.requestObject.spec.volumes.hostPath.path triggered is one needed by its target container/pod. For example, when the fleet managed elastic agent is deployed as a daemonset it creates several hostPath volume mounts, some of which are sensitive host directories like /proc, /etc/kubernetes, and /var/log."
+            "An administrator may need to attach a hostPath volume for a legitimate reason. This alert should be investigated for legitimacy by determining if the kuberenetes.audit.requestObject.spec.volumes.hostPath.path triggered is one needed by its target container/pod. For example, when the fleet managed elastic agent is deployed as a daemonset it creates several hostPath volume mounts, some of which are sensitive host directories like /proc, /etc/kubernetes, and /var/log. Add exceptions for trusted container images using the query field \"kubernetes.audit.requestObject.spec.container.image\""
         ],
         "index": [
             "logs-kubernetes.*"
@@ -14,15 +14,36 @@
         "license": "Elastic License v2",
         "name": "Kubernetes Pod created with a Sensitive hostPath Volume",
         "note": "",
-        "query": "kubernetes.audit.objectRef.resource:\"pods\"\n  and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\")\n  and kubernetes.audit.requestObject.spec.volumes.hostPath.path:(\"/\" or \"/proc\" or \"/root\" or \"/var\" or \"/var/run/docker.sock\" or \"/var/run/crio/crio.sock\" or \"/var/run/cri-dockerd.sock\" or \"/var/lib/kubelet\" or \"/var/lib/kubelet/pki\" or \"/var/lib/docker/overlay2\" or \"/etc\" or \"/etc/kubernetes\" or \"/etc/kubernetes/manifests\" or \"/home/admin\")\n",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.objectRef.resource:\"pods\"\n  and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\")\n  and kubernetes.audit.requestObject.spec.volumes.hostPath.path:\n  (\"/\" or\n  \"/proc\" or\n  \"/root\" or\n  \"/var\" or\n  \"/var/run\" or\n  \"/var/run/docker.sock\" or\n  \"/var/run/crio/crio.sock\" or\n  \"/var/run/cri-dockerd.sock\" or\n  \"/var/lib/kubelet\" or\n  \"/var/lib/kubelet/pki\" or\n  \"/var/lib/docker/overlay2\" or\n  \"/etc\" or\n  \"/etc/kubernetes\" or\n  \"/etc/kubernetes/manifests\" or\n  \"/etc/kubernetes/pki\" or\n  \"/home/admin\")\n  and not kubernetes.audit.requestObject.spec.containers.image: (\"docker.elastic.co/beats/elastic-agent:8.4.0\")\n",
         "references": [
             "https://blog.appsecco.com/kubernetes-namespace-breakout-using-insecure-host-path-volume-part-1-b382f2a6e216",
             "https://kubernetes.io/docs/concepts/storage/volumes/#hostpath"
         ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
         "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
             {
                 "ecs": false,
                 "name": "kubernetes.audit.objectRef.resource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.requestObject.spec.containers.image",
                 "type": "unknown"
             },
             {
@@ -62,11 +83,26 @@
                         "reference": "https://attack.mitre.org/techniques/T1611/"
                     }
                 ]
+            },
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0002",
+                    "name": "Execution",
+                    "reference": "https://attack.mitre.org/tactics/TA0002/"
+                },
+                "technique": [
+                    {
+                        "id": "T1610",
+                        "name": "Deploy Container",
+                        "reference": "https://attack.mitre.org/techniques/T1610/"
+                    }
+                ]
             }
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 100
+        "version": 201
     },
     "id": "2abda169-416b-4bb3-9a6b-f8d239fd78ba",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/495e5f2e-2480-11ed-bea8-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/495e5f2e-2480-11ed-bea8-f661ea17fbce.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -103,7 +103,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 4
+        "version": 104
     },
     "id": "495e5f2e-2480-11ed-bea8-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/5e161522-2545-11ed-ac47-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/5e161522-2545-11ed-ac47-f661ea17fbce.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -71,7 +71,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 4
+        "version": 104
     },
     "id": "5e161522-2545-11ed-ac47-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/63c05204-339a-11ed-a261-0242ac120002.json
+++ b/packages/security_detection_engine/kibana/security_rule/63c05204-339a-11ed-a261-0242ac120002.json
@@ -1,0 +1,100 @@
+{
+    "attributes": {
+        "author": [
+            "Elastic"
+        ],
+        "description": "This rule detects a request to attach a controller service account to an existing or new pod running in the kube-system namespace. By default, controllers running as part of the API Server utilize admin-equivalent service accounts hosted in the kube-system namespace. Controller service accounts aren't normally assigned to running pods and could indicate adversary behavior within the cluster. An attacker that can create or modify pods or pod controllers in the kube-system namespace, can assign one of these admin-equivalent service accounts to a pod and abuse their powerful token to escalate privileges and gain complete cluster control.",
+        "false_positives": [
+            "Controller service accounts aren't normally assigned to running pods, this is abnormal behavior with very few legitimate use-cases and should result in very few false positives."
+        ],
+        "index": [
+            "logs-kubernetes.*"
+        ],
+        "language": "kuery",
+        "license": "Elastic License v2",
+        "name": "Kubernetes Suspicious Assignment of Controller Service Account",
+        "note": "",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.verb : \"create\"\n  and kubernetes.audit.objectRef.resource : \"pods\"\n  and kubernetes.audit.objectRef.namespace : \"kube-system\"\n  and kubernetes.audit.requestObject.spec.serviceAccountName:*controller\n",
+        "references": [
+            "https://www.paloaltonetworks.com/apps/pan/public/downloadResource?pagePath=/content/pan/en_US/resources/whitepapers/kubernetes-privilege-escalation-excessive-permissions-in-popular-platforms"
+        ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
+        "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.objectRef.namespace",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.objectRef.resource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.requestObject.spec.serviceAccountName",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.verb",
+                "type": "unknown"
+            }
+        ],
+        "risk_score": 47,
+        "rule_id": "63c05204-339a-11ed-a261-0242ac120002",
+        "setup": "The Kubernetes Fleet integration with Audit Logs enabled or similarly structured data is required to be compatible with this rule.",
+        "severity": "medium",
+        "tags": [
+            "Elastic",
+            "Kubernetes",
+            "Continuous Monitoring",
+            "Execution",
+            "Privilege Escalation"
+        ],
+        "threat": [
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0004",
+                    "name": "Privilege Escalation",
+                    "reference": "https://attack.mitre.org/tactics/TA0004/"
+                },
+                "technique": [
+                    {
+                        "id": "T1078",
+                        "name": "Valid Accounts",
+                        "reference": "https://attack.mitre.org/techniques/T1078/",
+                        "subtechnique": [
+                            {
+                                "id": "T1078.001",
+                                "name": "Default Accounts",
+                                "reference": "https://attack.mitre.org/techniques/T1078/001/"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "timestamp_override": "event.ingested",
+        "type": "query",
+        "version": 4
+    },
+    "id": "63c05204-339a-11ed-a261-0242ac120002",
+    "type": "security-rule"
+}

--- a/packages/security_detection_engine/kibana/security_rule/63c056a0-339a-11ed-a261-0242ac120002.json
+++ b/packages/security_detection_engine/kibana/security_rule/63c056a0-339a-11ed-a261-0242ac120002.json
@@ -1,0 +1,78 @@
+{
+    "attributes": {
+        "author": [
+            "Elastic"
+        ],
+        "description": "This rule detects when a service account makes an unauthorized request for resources from the API server. Service accounts follow a very predictable pattern of behavior. A service account should never send an unauthorized request to the API server. This behavior is likely an indicator of compromise or of a problem within the cluster. An adversary may have gained access to credentials/tokens and this could be an attempt to access or create resources to facilitate further movement or execution within the cluster.",
+        "false_positives": [
+            "Unauthorized requests from service accounts are highly abnormal and more indicative of human behavior or a serious problem within the cluster. This behavior should be investigated further."
+        ],
+        "index": [
+            "logs-kubernetes.*"
+        ],
+        "language": "kuery",
+        "license": "Elastic License v2",
+        "name": "Kubernetes Denied Service Account Request",
+        "note": "",
+        "query": "event.dataset: \"kubernetes.audit_logs\"\n  and kubernetes.audit.user.username: system\\:serviceaccount\\:*\n  and kubernetes.audit.annotations.authorization_k8s_io/decision: \"forbid\"\n",
+        "references": [
+            "https://research.nccgroup.com/2021/11/10/detection-engineering-for-kubernetes-clusters/#part3-kubernetes-detections",
+            "https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens"
+        ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
+        "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.user.username",
+                "type": "unknown"
+            }
+        ],
+        "risk_score": 47,
+        "rule_id": "63c056a0-339a-11ed-a261-0242ac120002",
+        "setup": "The Kubernetes Fleet integration with Audit Logs enabled or similarly structured data is required to be compatible with this rule.",
+        "severity": "medium",
+        "tags": [
+            "Elastic",
+            "Kubernetes",
+            "Continuous Monitoring",
+            "Discovery"
+        ],
+        "threat": [
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0007",
+                    "name": "Discovery",
+                    "reference": "https://attack.mitre.org/tactics/TA0007/"
+                },
+                "technique": [
+                    {
+                        "id": "T1613",
+                        "name": "Container and Resource Discovery",
+                        "reference": "https://attack.mitre.org/techniques/T1613/"
+                    }
+                ]
+            }
+        ],
+        "timestamp_override": "event.ingested",
+        "type": "query",
+        "version": 3
+    },
+    "id": "63c056a0-339a-11ed-a261-0242ac120002",
+    "type": "security-rule"
+}

--- a/packages/security_detection_engine/kibana/security_rule/63c057cc-339a-11ed-a261-0242ac120002.json
+++ b/packages/security_detection_engine/kibana/security_rule/63c057cc-339a-11ed-a261-0242ac120002.json
@@ -1,0 +1,91 @@
+{
+    "attributes": {
+        "author": [
+            "Elastic"
+        ],
+        "description": "This rule detects when an unauthenticated user request is authorized within the cluster. Attackers may attempt to use anonymous accounts to gain initial access to the cluster or to avoid attribution of their activities within the cluster. This rule excludes the /healthz, /livez and /readyz endpoints which are commonly accessed anonymously.",
+        "false_positives": [
+            "Anonymous access to the API server is a dangerous setting enabled by default. Common anonymous connections (e.g., health checks) have been excluded from this rule. All other instances of authorized anonymous requests should be investigated."
+        ],
+        "index": [
+            "logs-kubernetes.*"
+        ],
+        "language": "kuery",
+        "license": "Elastic License v2",
+        "name": "Kubernetes Anonymous Request Authorized",
+        "note": "",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and (kubernetes.audit.user.username:(\"system:anonymous\" or \"system:unauthenticated\") or not kubernetes.audit.user.username:*)\n  and not kubernetes.audit.objectRef.resource:(\"healthz\" or \"livez\" or \"readyz\")\n",
+        "references": [
+            "https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF"
+        ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
+        "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.objectRef.resource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.user.username",
+                "type": "unknown"
+            }
+        ],
+        "risk_score": 47,
+        "rule_id": "63c057cc-339a-11ed-a261-0242ac120002",
+        "setup": "The Kubernetes Fleet integration with Audit Logs enabled or similarly structured data is required to be compatible with this rule.",
+        "severity": "medium",
+        "tags": [
+            "Elastic",
+            "Kubernetes",
+            "Continuous Monitoring",
+            "Execution",
+            "Initial Access",
+            "Defense Evasion"
+        ],
+        "threat": [
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0001",
+                    "name": "Initial Access",
+                    "reference": "https://attack.mitre.org/tactics/TA0001/"
+                },
+                "technique": [
+                    {
+                        "id": "T1078",
+                        "name": "Valid Accounts",
+                        "reference": "https://attack.mitre.org/techniques/T1078/",
+                        "subtechnique": [
+                            {
+                                "id": "T1078.001",
+                                "name": "Default Accounts",
+                                "reference": "https://attack.mitre.org/techniques/T1078/001/"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "timestamp_override": "event.ingested",
+        "type": "query",
+        "version": 3
+    },
+    "id": "63c057cc-339a-11ed-a261-0242ac120002",
+    "type": "security-rule"
+}

--- a/packages/security_detection_engine/kibana/security_rule/65f9bccd-510b-40df-8263-334f03174fed.json
+++ b/packages/security_detection_engine/kibana/security_rule/65f9bccd-510b-40df-8263-334f03174fed.json
@@ -14,13 +14,29 @@
         "license": "Elastic License v2",
         "name": "Kubernetes Exposed Service Created With Type NodePort",
         "note": "",
-        "query": "kubernetes.audit.objectRef.resource:\"services\" and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\") and kubernetes.audit.requestObject.spec.type:\"NodePort\"\n",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.objectRef.resource:\"services\"\n  and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\")\n  and kubernetes.audit.requestObject.spec.type:\"NodePort\"\n",
         "references": [
             "https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types",
             "https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
             "https://www.tigera.io/blog/new-vulnerability-exposes-kubernetes-to-man-in-the-middle-attacks-heres-how-to-mitigate/"
         ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
         "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
             {
                 "ecs": false,
                 "name": "kubernetes.audit.objectRef.resource",
@@ -67,7 +83,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 100
+        "version": 201
     },
     "id": "65f9bccd-510b-40df-8263-334f03174fed",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/68994a6c-c7ba-4e82-b476-26a26877adf6.json
+++ b/packages/security_detection_engine/kibana/security_rule/68994a6c-c7ba-4e82-b476-26a26877adf6.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -93,7 +93,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 104
+        "version": 204
     },
     "id": "68994a6c-c7ba-4e82-b476-26a26877adf6",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/6f435062-b7fc-4af9-acea-5b1ead65c5a5.json
+++ b/packages/security_detection_engine/kibana/security_rule/6f435062-b7fc-4af9-acea-5b1ead65c5a5.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -80,7 +80,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 103
+        "version": 203
     },
     "id": "6f435062-b7fc-4af9-acea-5b1ead65c5a5",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/7164081a-3930-11ed-a261-0242ac120002.json
+++ b/packages/security_detection_engine/kibana/security_rule/7164081a-3930-11ed-a261-0242ac120002.json
@@ -1,0 +1,111 @@
+{
+    "attributes": {
+        "author": [
+            "Elastic"
+        ],
+        "description": "This rule detects a container deployed with one or more dangerously permissive Linux capabilities. An attacker with the ability to deploy a container with added capabilities could use this for further execution, lateral movement, or privilege escalation within a cluster. The capabilities detected in this rule have been used in container escapes to the host machine.",
+        "false_positives": [
+            "Some container images require the addition of privileged capabilities. This rule leaves space for the exception of trusted container images. To add an exception, add the trusted container image name to the query field, kubernetes.audit.requestObject.spec.containers.image."
+        ],
+        "index": [
+            "logs-kubernetes.*"
+        ],
+        "language": "kuery",
+        "license": "Elastic License v2",
+        "name": "Kubernetes Container Created with Excessive Linux Capabilities",
+        "note": "## Triage and analysis\n\n### Investigating Kubernetes Container Created with Excessive Linux Capabilities\n\nLinux capabilities were designed to divide root privileges into smaller units. Each capability grants a thread just enough power to perform specific privileged tasks. In Kubernetes, containers are given a set of default capabilities that can be dropped or added to at the time of creation. Added capabilities entitle containers in a pod with additional privileges that can be used to change\ncore processes, change network settings of a cluster, or directly access the underlying host. The following have been used in container escape techniques:\n\nBPF - Allow creating BPF maps, loading BPF Type Format (BTF) data, retrieve JITed code of BPF programs, and more.\nDAC_READ_SEARCH - Bypass file read permission checks and directory read and execute permission checks.\nNET_ADMIN - Perform various network-related operations.\nSYS_ADMIN - Perform a range of system administration operations.\nSYS_BOOT - Use reboot(2) and kexec_load(2), reboot and load a new kernel for later execution.\nSYS_MODULE - Load and unload kernel modules.\nSYS_PTRACE - Trace arbitrary processes using ptrace(2).\nSYS_RAWIO - Perform I/O port operations (iopl(2) and ioperm(2)).\nSYSLOG - Perform privileged syslog(2) operations.\n\n### False positive analysis\n\n- While these capabilities are not included by default in containers, some legitimate images may need to add them. This rule leaves space for the exception of trusted container images. To add an exception, add the trusted container image name to the query field, kubernetes.audit.requestObject.spec.containers.image.",
+        "query": "event.dataset: kubernetes.audit_logs\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.verb: create\n  and kubernetes.audit.objectRef.resource: pods\n  and kubernetes.audit.requestObject.spec.containers.securityContext.capabilities.add: (\"BPF\" or \"DAC_READ_SEARCH\"  or \"NET_ADMIN\" or \"SYS_ADMIN\" or \"SYS_BOOT\" or \"SYS_MODULE\" or \"SYS_PTRACE\" or \"SYS_RAWIO\"  or \"SYSLOG\")\n  and not kubernetes.audit.requestObject.spec.containers.image : (\"docker.elastic.co/beats/elastic-agent:8.4.0\" or \"rancher/klipper-lb:v0.3.5\" or \"\")\n",
+        "references": [
+            "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container",
+            "https://0xn3va.gitbook.io/cheat-sheets/container/escaping/excessive-capabilities",
+            "https://man7.org/linux/man-pages/man7/capabilities.7.html",
+            "https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities"
+        ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
+        "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.objectRef.resource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.requestObject.spec.containers.image",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.requestObject.spec.containers.securityContext.capabilities.add",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.verb",
+                "type": "unknown"
+            }
+        ],
+        "risk_score": 47,
+        "rule_id": "7164081a-3930-11ed-a261-0242ac120002",
+        "setup": "The Kubernetes Fleet integration with Audit Logs enabled or similarly structured data is required to be compatible with this rule.",
+        "severity": "medium",
+        "tags": [
+            "Elastic",
+            "Kubernetes",
+            "Continuous Monitoring",
+            "Execution",
+            "Privilege Escalation"
+        ],
+        "threat": [
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0004",
+                    "name": "Privilege Escalation",
+                    "reference": "https://attack.mitre.org/tactics/TA0004/"
+                },
+                "technique": [
+                    {
+                        "id": "T1611",
+                        "name": "Escape to Host",
+                        "reference": "https://attack.mitre.org/techniques/T1611/"
+                    }
+                ]
+            },
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0002",
+                    "name": "Execution",
+                    "reference": "https://attack.mitre.org/tactics/TA0002/"
+                },
+                "technique": [
+                    {
+                        "id": "T1610",
+                        "name": "Deploy Container",
+                        "reference": "https://attack.mitre.org/techniques/T1610/"
+                    }
+                ]
+            }
+        ],
+        "timestamp_override": "event.ingested",
+        "type": "query",
+        "version": 2
+    },
+    "id": "7164081a-3930-11ed-a261-0242ac120002",
+    "type": "security-rule"
+}

--- a/packages/security_detection_engine/kibana/security_rule/764c8437-a581-4537-8060-1fdb0e92c92d.json
+++ b/packages/security_detection_engine/kibana/security_rule/764c8437-a581-4537-8060-1fdb0e92c92d.json
@@ -3,9 +3,9 @@
         "author": [
             "Elastic"
         ],
-        "description": "This rule detects an attempt to create or modify a pod using the host IPC namespace. This gives access to data used by any pod that also use the host\ufffds IPC namespace. If any process on the host or any processes in a pod uses the host\ufffds inter-process communication mechanisms (shared memory, semaphore arrays, message queues, etc.), an attacker can read/write to those same mechanisms. They may look for files in /dev/shm or use ipcs to check for any IPC facilities being used.",
+        "description": "This rule detects an attempt to create or modify a pod using the host IPC namespace. This gives access to data used by any pod that also use the hosts IPC namespace. If any process on the host or any processes in a pod uses the hosts inter-process communication mechanisms (shared memory, semaphore arrays, message queues, etc.), an attacker can read/write to those same mechanisms. They may look for files in /dev/shm or use ipcs to check for any IPC facilities being used.",
         "false_positives": [
-            "An administrator or developer may want to use a pod that runs as root and shares the host\ufffds IPC, Network, and PID namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and network namespaces from the host's perspective."
+            "An administrator or developer may want to use a pod that runs as root and shares the host's IPC, Network, and PID namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and network namespaces from the host's perspective. Add exceptions for trusted container images using the query field \"kubernetes.audit.requestObject.spec.container.image\""
         ],
         "index": [
             "logs-kubernetes.*"
@@ -14,16 +14,37 @@
         "license": "Elastic License v2",
         "name": "Kubernetes Pod Created With HostIPC",
         "note": "",
-        "query": "kubernetes.audit.objectRef.resource:\"pods\" and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\") and kubernetes.audit.requestObject.spec.hostIPC:true\n",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.objectRef.resource:\"pods\"\n  and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\")\n  and kubernetes.audit.requestObject.spec.hostIPC:true\n  and not kubernetes.audit.requestObject.spec.containers.image: (\"docker.elastic.co/beats/elastic-agent:8.4.0\")\n",
         "references": [
             "https://research.nccgroup.com/2021/11/10/detection-engineering-for-kubernetes-clusters/#part3-kubernetes-detections",
             "https://kubernetes.io/docs/concepts/security/pod-security-policy/#host-namespaces",
             "https://bishopfox.com/blog/kubernetes-pod-privilege-escalation"
         ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
         "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
             {
                 "ecs": false,
                 "name": "kubernetes.audit.objectRef.resource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.requestObject.spec.containers.image",
                 "type": "unknown"
             },
             {
@@ -63,11 +84,26 @@
                         "reference": "https://attack.mitre.org/techniques/T1611/"
                     }
                 ]
+            },
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0002",
+                    "name": "Execution",
+                    "reference": "https://attack.mitre.org/tactics/TA0002/"
+                },
+                "technique": [
+                    {
+                        "id": "T1610",
+                        "name": "Deploy Container",
+                        "reference": "https://attack.mitre.org/techniques/T1610/"
+                    }
+                ]
             }
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 100
+        "version": 201
     },
     "id": "764c8437-a581-4537-8060-1fdb0e92c92d",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/785a404b-75aa-4ffd-8be5-3334a5a544dd.json
+++ b/packages/security_detection_engine/kibana/security_rule/785a404b-75aa-4ffd-8be5-3334a5a544dd.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -75,7 +75,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 103
+        "version": 203
     },
     "id": "785a404b-75aa-4ffd-8be5-3334a5a544dd",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/7caa8e60-2df0-11ed-b814-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/7caa8e60-2df0-11ed-b814-f661ea17fbce.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -93,7 +93,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 4
+        "version": 104
     },
     "id": "7caa8e60-2df0-11ed-b814-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/93e63c3e-4154-4fc6-9f86-b411e0987bbf.json
+++ b/packages/security_detection_engine/kibana/security_rule/93e63c3e-4154-4fc6-9f86-b411e0987bbf.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -81,7 +81,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 103
+        "version": 203
     },
     "id": "93e63c3e-4154-4fc6-9f86-b411e0987bbf",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/9510add4-3392-11ed-bd01-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/9510add4-3392-11ed-bd01-f661ea17fbce.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -87,7 +87,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 4
+        "version": 104
     },
     "id": "9510add4-3392-11ed-bd01-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/9cf7a0ae-2404-11ed-ae7d-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/9cf7a0ae-2404-11ed-ae7d-f661ea17fbce.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -93,7 +93,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 4
+        "version": 104
     },
     "id": "9cf7a0ae-2404-11ed-ae7d-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/a2795334-2499-11ed-9e1a-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/a2795334-2499-11ed-9e1a-f661ea17fbce.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -103,7 +103,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 4
+        "version": 104
     },
     "id": "a2795334-2499-11ed-9e1a-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73.json
+++ b/packages/security_detection_engine/kibana/security_rule/a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73.json
@@ -21,7 +21,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -83,7 +83,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 103
+        "version": 203
     },
     "id": "a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/acbc8bb9-2486-49a8-8779-45fb5f9a93ee.json
+++ b/packages/security_detection_engine/kibana/security_rule/acbc8bb9-2486-49a8-8779-45fb5f9a93ee.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -80,7 +80,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 103
+        "version": 203
     },
     "id": "acbc8bb9-2486-49a8-8779-45fb5f9a93ee",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/ad3f2807-2b3e-47d7-b282-f84acbbe14be.json
+++ b/packages/security_detection_engine/kibana/security_rule/ad3f2807-2b3e-47d7-b282-f84acbbe14be.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -80,7 +80,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 103
+        "version": 203
     },
     "id": "ad3f2807-2b3e-47d7-b282-f84acbbe14be",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/c7908cac-337a-4f38-b50d-5eeb78bdb531.json
+++ b/packages/security_detection_engine/kibana/security_rule/c7908cac-337a-4f38-b50d-5eeb78bdb531.json
@@ -5,7 +5,7 @@
         ],
         "description": "This rule detects when a user creates a pod/container running in privileged mode. A highly privileged container has access to the node's resources and breaks the isolation between containers. If compromised, an attacker can use the privileged container to gain access to the underlying host. Gaining access to the host may provide the adversary with the opportunity to achieve follow-on objectives, such as establishing persistence, moving laterally within the environment, or setting up a command and control channel on the host.",
         "false_positives": [
-            "By default a container is not allowed to access any devices on the host, but a \"privileged\" container is given access to all devices on the host. This allows the container nearly all the same access as processes running on the host. An administrator may want to run a privileged container to use operating system administrative capabilities such as manipulating the network stack or accessing hardware devices from within the cluster."
+            "By default a container is not allowed to access any devices on the host, but a \"privileged\" container is given access to all devices on the host. This allows the container nearly all the same access as processes running on the host. An administrator may want to run a privileged container to use operating system administrative capabilities such as manipulating the network stack or accessing hardware devices from within the cluster. Add exceptions for trusted container images using the query field \"kubernetes.audit.requestObject.spec.container.image\""
         ],
         "index": [
             "logs-kubernetes.*"
@@ -14,15 +14,36 @@
         "license": "Elastic License v2",
         "name": "Kubernetes Privileged Pod Created",
         "note": "",
-        "query": "kubernetes.audit.objectRef.resource:pods and kubernetes.audit.verb:create and\n  kubernetes.audit.requestObject.spec.containers.securityContext.privileged:true\n",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.objectRef.resource:pods\n  and kubernetes.audit.verb:create\n  and kubernetes.audit.requestObject.spec.containers.securityContext.privileged:true\n  and not kubernetes.audit.requestObject.spec.containers.image: (\"docker.elastic.co/beats/elastic-agent:8.4.0\")\n",
         "references": [
             "https://media.defense.gov/2021/Aug/03/2002820425/-1/-1/1/CTR_KUBERNETES%20HARDENING%20GUIDANCE.PDF",
             "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
         ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
         "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
             {
                 "ecs": false,
                 "name": "kubernetes.audit.objectRef.resource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.requestObject.spec.containers.image",
                 "type": "unknown"
             },
             {
@@ -62,11 +83,26 @@
                         "reference": "https://attack.mitre.org/techniques/T1611/"
                     }
                 ]
+            },
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0002",
+                    "name": "Execution",
+                    "reference": "https://attack.mitre.org/tactics/TA0002/"
+                },
+                "technique": [
+                    {
+                        "id": "T1610",
+                        "name": "Deploy Container",
+                        "reference": "https://attack.mitre.org/techniques/T1610/"
+                    }
+                ]
             }
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 100
+        "version": 201
     },
     "id": "c7908cac-337a-4f38-b50d-5eeb78bdb531",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/cad4500a-abd7-4ef3-b5d3-95524de7cfe1.json
+++ b/packages/security_detection_engine/kibana/security_rule/cad4500a-abd7-4ef3-b5d3-95524de7cfe1.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -87,7 +87,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 106
+        "version": 206
     },
     "id": "cad4500a-abd7-4ef3-b5d3-95524de7cfe1",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/cc6a8a20-2df2-11ed-8378-f661ea17fbce.json
+++ b/packages/security_detection_engine/kibana/security_rule/cc6a8a20-2df2-11ed-8378-f661ea17fbce.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -93,7 +93,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 4
+        "version": 104
     },
     "id": "cc6a8a20-2df2-11ed-8378-f661ea17fbce",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/cf549724-c577-4fd6-8f9b-d1b8ec519ec0.json
+++ b/packages/security_detection_engine/kibana/security_rule/cf549724-c577-4fd6-8f9b-d1b8ec519ec0.json
@@ -24,7 +24,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -88,7 +88,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 103
+        "version": 203
     },
     "id": "cf549724-c577-4fd6-8f9b-d1b8ec519ec0",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/df7fda76-c92b-4943-bc68-04460a5ea5ba.json
+++ b/packages/security_detection_engine/kibana/security_rule/df7fda76-c92b-4943-bc68-04460a5ea5ba.json
@@ -5,7 +5,7 @@
         ],
         "description": "This rule detects an attempt to create or modify a pod attached to the host PID namespace. HostPID allows a pod to access all the processes running on the host and could allow an attacker to take malicious action. When paired with ptrace this can be used to escalate privileges outside of the container. When paired with a privileged container, the pod can see all of the processes on the host. An attacker can enter the init system (PID 1) on the host. From there, they could execute a shell and continue to escalate privileges to root.",
         "false_positives": [
-            "An administrator or developer may want to use a pod that runs as root and shares the host\ufffds IPC, Network, and PID namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and network namespaces from the host's perspective."
+            "An administrator or developer may want to use a pod that runs as root and shares the hosts IPC, Network, and PID namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and network namespaces from the host's perspective. Add exceptions for trusted container images using the query field \"kubernetes.audit.requestObject.spec.container.image\""
         ],
         "index": [
             "logs-kubernetes.*"
@@ -14,16 +14,37 @@
         "license": "Elastic License v2",
         "name": "Kubernetes Pod Created With HostPID",
         "note": "",
-        "query": "kubernetes.audit.objectRef.resource:\"pods\" and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\") and kubernetes.audit.requestObject.spec.hostPID:true\n",
+        "query": "event.dataset : \"kubernetes.audit_logs\"\n  and kubernetes.audit.annotations.authorization_k8s_io/decision:\"allow\"\n  and kubernetes.audit.objectRef.resource:\"pods\"\n  and kubernetes.audit.verb:(\"create\" or \"update\" or \"patch\")\n  and kubernetes.audit.requestObject.spec.hostPID:true\n  and not kubernetes.audit.requestObject.spec.containers.image: (\"docker.elastic.co/beats/elastic-agent:8.4.0\")\n",
         "references": [
             "https://research.nccgroup.com/2021/11/10/detection-engineering-for-kubernetes-clusters/#part3-kubernetes-detections",
             "https://kubernetes.io/docs/concepts/security/pod-security-policy/#host-namespaces",
             "https://bishopfox.com/blog/kubernetes-pod-privilege-escalation"
         ],
+        "related_integrations": [
+            {
+                "package": "kubernetes",
+                "version": "^1.4.1"
+            }
+        ],
         "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.dataset",
+                "type": "keyword"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.annotations.authorization_k8s_io/decision",
+                "type": "unknown"
+            },
             {
                 "ecs": false,
                 "name": "kubernetes.audit.objectRef.resource",
+                "type": "unknown"
+            },
+            {
+                "ecs": false,
+                "name": "kubernetes.audit.requestObject.spec.containers.image",
                 "type": "unknown"
             },
             {
@@ -63,11 +84,26 @@
                         "reference": "https://attack.mitre.org/techniques/T1611/"
                     }
                 ]
+            },
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0002",
+                    "name": "Execution",
+                    "reference": "https://attack.mitre.org/tactics/TA0002/"
+                },
+                "technique": [
+                    {
+                        "id": "T1610",
+                        "name": "Deploy Container",
+                        "reference": "https://attack.mitre.org/techniques/T1610/"
+                    }
+                ]
             }
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 100
+        "version": 201
     },
     "id": "df7fda76-c92b-4943-bc68-04460a5ea5ba",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/e555105c-ba6d-481f-82bb-9b633e7b4827.json
+++ b/packages/security_detection_engine/kibana/security_rule/e555105c-ba6d-481f-82bb-9b633e7b4827.json
@@ -21,7 +21,7 @@
         "related_integrations": [
             {
                 "package": "google_workspace",
-                "version": "^1.2.0"
+                "version": "^2.0.0"
             }
         ],
         "required_fields": [
@@ -83,7 +83,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "query",
-        "version": 103
+        "version": 203
     },
     "id": "e555105c-ba6d-481f-82bb-9b633e7b4827",
     "type": "security-rule"

--- a/packages/security_detection_engine/manifest.yml
+++ b/packages/security_detection_engine/manifest.yml
@@ -1,7 +1,7 @@
 categories:
   - security
 conditions:
-  kibana.version: ^8.3.0
+  kibana.version: ^8.4.0
 description: Prebuilt detection rules for Elastic Security
 format_version: 1.0.0
 icons:
@@ -15,4 +15,4 @@ owner:
 release: ga
 title: Prebuilt Security Detection Rules
 type: integration
-version: 8.3.4
+version: 8.4.2-beta.1


### PR DESCRIPTION
## What does this PR do?
Update the Security Rules package to version 8.4.2-beta.1.
Autogenerated from commit  https://github.com/elastic/detection-rules/tree/545122a6eac0cc7dcef9dfb0073edb4fd1033370

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist
- Install the most recently release security rules in the Detection Engine
- Install the package
- Confirm the update is available in Kibana. Click "Update X rules" or "Install X rules"
- Look at the changes made after the install and confirm they are consistent

## How to test this PR locally
- Perform the above checklist, and use `package-storage` to build EPR from source

## Related issues
* https://github.com/elastic/ia-trade-team/issues/91

## Screenshots
None
