### PR TITLE
[Tomcat] - change owner to obs service integrations team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -189,7 +189,7 @@
 /packages/ti_recordedfuture @elastic/security-external-integrations
 /packages/ti_threatq @elastic/security-external-integrations
 /packages/ti_util @elastic/security-external-integrations
-/packages/tomcat @elastic/security-external-integrations
+/packages/tomcat @elastic/obs-service-integrations
 /packages/traefik @elastic/obs-service-integrations
 /packages/trend_micro_vision_one @elastic/security-external-integrations
 /packages/udp @elastic/security-external-integrations

--- a/packages/tomcat/manifest.yml
+++ b/packages/tomcat/manifest.yml
@@ -29,4 +29,4 @@ icons:
     size: 32x32
     type: image/svg+xml
 owner:
-  github: elastic/security-external-integrations
+  github: elastic/obs-service-integrations


### PR DESCRIPTION
## What does this PR do?

With the agreement of the service integrations team, they will take ownership of the Apache Tomcat package.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
