### PR TITLE
[Cloud Posture] Add posture_type field to mapping

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add posture_type field to mapping
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4968
+      link: https://github.com/elastic/integrations/pull/5035
 - version: "1.2.5"
   changes:
     - description: Add S3 fetcher to the AWS CSPM hbs file

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.6"
+  changes:
+    - description: Add posture_type field to mapping
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4968
 - version: "1.2.5"
   changes:
     - description: Add S3 fetcher to the AWS CSPM hbs file

--- a/packages/cloud_security_posture/data_stream/findings/fields/rule.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/rule.yml
@@ -30,6 +30,12 @@
       ignore_above: 1024
       description: Version of the compliance benchmark.
       default_field: false
+    - name: benchmark.posture_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Type of the compliance benchmark.
+      default_field: false
     - name: description
       level: extended
       type: keyword

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Security Posture Management (CSPM/KSPM)"
-version: 1.2.5
+version: 1.2.6
 release: ga
 license: basic
 description: "DO NOT USE MAIN TILE (WIP)"


### PR DESCRIPTION
## What does this PR do?

Adds a new `rule.benchmark.posture_type` field to the mapping.