### PR TITLE
[O365] Add fingerprint processor to prevent ingestion of duplicate events

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Add fingerprint processor to prevent ingestion of duplicate events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0001 # FIXME: Change to real PR
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add fingerprint processor to prevent ingestion of duplicate events.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0001 # FIXME: Change to real PR
+      link: https://github.com/elastic/integrations/pull/5047
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -16,7 +16,7 @@ processors:
       value: web
   - fingerprint:
       fields:
-        - o365audit
+        - o365audit.Id
       target_field: "_id"
       ignore_missing: true
   # General Schema

--- a/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -14,6 +14,11 @@ processors:
   - append:
       field: event.category
       value: web
+  - fingerprint:
+      fields:
+        - o365audit
+      target_field: "_id"
+      ignore_missing: true
   # General Schema
   - date:
       field: o365audit.CreationTime

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.10.0"
+version: "1.10.1"
 release: ga
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

- Added a fingerprint processor to prevent duplicate events from being ingested. It generates a hash based on the o365audit field.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #5046 
