### PR TITLE
[Security Rules] Update security rules package to v8.4.2

### DIFF
--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -2,6 +2,11 @@
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
 - changes:
     - description: Release security rules update
+      link: https://github.com/elastic/integrations/pulls/0000
+      type: enhancement
+  version: 8.4.2
+- changes:
+    - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5027
       type: enhancement
   version: 8.4.2-beta.1

--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -2,7 +2,7 @@
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
 - changes:
     - description: Release security rules update
-      link: https://github.com/elastic/integrations/pulls/0000
+      link: https://github.com/elastic/integrations/pull/5062
       type: enhancement
   version: 8.4.2
 - changes:

--- a/packages/security_detection_engine/manifest.yml
+++ b/packages/security_detection_engine/manifest.yml
@@ -15,4 +15,4 @@ owner:
 release: ga
 title: Prebuilt Security Detection Rules
 type: integration
-version: 8.4.2-beta.1
+version: 8.4.2


### PR DESCRIPTION
## What does this PR do?
Update the Security Rules package to version 8.4.2.
Autogenerated from commit  https://github.com/elastic/detection-rules/tree/545122a6eac0cc7dcef9dfb0073edb4fd1033370

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist
- Install the most recently release security rules in the Detection Engine
- Install the package
- Confirm the update is available in Kibana. Click "Update X rules" or "Install X rules"
- Look at the changes made after the install and confirm they are consistent

## How to test this PR locally
- Perform the above checklist, and use `package-storage` to build EPR from source

## Related issues
* https://github.com/elastic/ia-trade-team/issues/91

## Screenshots
None
