### PR TITLE
[oracle,microsoft_sqlserver] - change owner to obs-service-integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -124,7 +124,7 @@
 /packages/microsoft_dhcp @elastic/security-external-integrations
 /packages/microsoft_exchange_online_message_trace @elastic/security-external-integrations
 /packages/microsoft @elastic/security-external-integrations
-/packages/microsoft_sqlserver @elastic/security-external-integrations @elastic/obs-service-integrations
+/packages/microsoft_sqlserver @elastic/obs-service-integrations
 /packages/mimecast @elastic/security-external-integrations
 /packages/modsecurity @elastic/security-external-integrations
 /packages/mongodb @elastic/obs-service-integrations
@@ -140,7 +140,7 @@
 /packages/nginx @elastic/obs-service-integrations
 /packages/o365 @elastic/security-external-integrations
 /packages/okta @elastic/security-external-integrations
-/packages/oracle @elastic/security-external-integrations
+/packages/oracle @elastic/obs-service-integrations
 /packages/oracle_weblogic @elastic/obs-service-integrations
 /packages/osquery_manager @elastic/security-asset-management
 /packages/osquery @elastic/security-external-integrations

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -73,4 +73,4 @@ policy_templates:
         title: Collect Microsoft SQL Server performance and transaction_log metrics
         description: Collecting performance and transaction_log metrics from Microsoft SQL Server instances
 owner:
-  github: elastic/security-external-integrations
+  github: elastic/obs-service-integrations

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -67,4 +67,4 @@ policy_templates:
         title: Collect Oracle database's performance metrics, tablespace metrics, sysmetrics and memory metrics
         description: Collecting performance metrics, tablespace metrics, sysmetrics, system statistics metrics and memory metrics from Oracle database instances
 owner:
-  github: elastic/security-external-integrations
+  github: elastic/obs-service-integrations


### PR DESCRIPTION
## What does this PR do?

The obs-service-integrations team will take ownership of the oracle and microsoft_sqlserver packages.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
