### PR TITLE
[System] Add processing for event ID's 4797, 5379, 5380, 5381, and 5382

### DIFF
--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -609,6 +609,13 @@ processors:
             - user
             - change
           action: renamed-user-account
+        "4797":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: query-existence-of-blank-password
         "4798":
           category:
             - iam
@@ -752,6 +759,34 @@ processors:
             - info
             - access
           action: network-share-object-access-checked
+        "5379":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: credential-manager-credentials-were-read
+        "5380":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: vault-credential-find
+        "5381":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: vault-credentials-were-read
+        "5382":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: vault-credentials-were-read
       source: |-
         if (ctx?.event?.code == null || params.get(ctx.event.code) == null) {
           return;
@@ -2395,7 +2430,7 @@ processors:
       source: |-
         if (ctx?.event?.code == null ||
             !["4624", "4625", "4634", "4647", "4648", "4768", "4769", "4770",
-              "4771", "4776", "4964"].contains(ctx.event.code)) {
+              "4771", "4776", "4964", "4797"].contains(ctx.event.code)) {
           return;
         }
 
@@ -2604,8 +2639,8 @@ processors:
               "4742", "4743", "4744", "4745", "4746", "4747", "4748", "4749",
               "4750", "4751", "4752", "4753", "4754", "4755", "4756", "4757",
               "4758", "4759", "4760", "4761", "4762", "4763", "4764", "4767",
-              "4781", "4798", "4799", "4817", "4904", "4905", "4907", "4912",
-              "4648", "5140", "5145"].contains(ctx.event.code)) {
+              "4781", "4797", "4798", "4799", "4817", "4904", "4905", "4907",
+              "4912", "4648", "5140", "5145", "5379", "5380", "5381", "5382"].contains(ctx.event.code)) {
           return;
         }
         if (ctx?.winlog?.event_data?.SubjectUserSid != null) {


### PR DESCRIPTION
# Type of change

- Enhancement

## What does this PR do?

This PR adds event parsing to the `System` Integration's Security Ingest Pipeline for Event ID's 4797, 5379, 5380, 5381, and 5382. This PR is mirroring recent changes to Winlogbeat parsing in PR [#34294](https://github.com/elastic/beats/pull/34294#issuecomment-1400784075)

## Why is it important?

These Event ID's are quite common in our environment, so ensuring the correct `event.action` is populated will help identify the nature of the event at a quick glance. 

## Related issues

- Relates [#34293](https://github.com/elastic/beats/issues/34293)
