### PR TITLE
[mysql] Update ingest pipeline for performance datastream

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Update ingest pipeline for performance datastream.
       type: enhancement
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/5088
 - version: "1.4.0"
   changes:
     - description: Added infrastructure category.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.5.0"
+  changes:
+    - description: Update ingest pipeline for performance datastream.
+      type: enhancement
+      link: tbd
 - version: "1.4.0"
   changes:
     - description: Added infrastructure category.

--- a/packages/mysql/data_stream/performance/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mysql/data_stream/performance/elasticsearch/ingest_pipeline/default.yml
@@ -5,6 +5,7 @@ processors:
     field: mysql.performance.events_statements.last.seen
     pattern: ' '
     replacement: "T"
+    ignore_missing: true
 on_failure:
 - set:
     field: error.message

--- a/packages/mysql/data_stream/performance/sample_event.json
+++ b/packages/mysql/data_stream/performance/sample_event.json
@@ -1,42 +1,42 @@
 {
-    "@timestamp": "2022-09-08T07:57:58.755Z",
+    "@timestamp": "2023-01-25T14:23:17.060Z",
     "agent": {
-        "ephemeral_id": "d1d3bf8a-3d35-43bd-a99e-b4cd4817c335",
-        "id": "4f6e3559-2e06-4975-a37f-2abd678edefb",
         "name": "docker-fleet-agent",
+        "id": "39205dfa-169a-4567-a887-12b5974403f0",
         "type": "metricbeat",
-        "version": "8.4.0"
+        "ephemeral_id": "57fc2e5d-6672-4ed3-a0cf-b70093c1f0dc",
+        "version": "8.5.3"
     },
     "data_stream": {
-        "dataset": "mysql.performance",
-        "namespace": "ep",
-        "type": "metrics"
+        "namespace": "default",
+        "type": "metrics",
+        "dataset": "mysql.performance"
     },
     "ecs": {
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "4f6e3559-2e06-4975-a37f-2abd678edefb",
-        "snapshot": false,
-        "version": "8.4.0"
+        "id": "39205dfa-169a-4567-a887-12b5974403f0",
+        "version": "8.5.3",
+        "snapshot": false
     },
     "event": {
+        "duration": 2867042,
         "agent_id_status": "verified",
-        "dataset": "mysql.performance",
-        "duration": 35182375,
-        "ingested": "2022-09-08T07:58:00Z",
-        "module": "mysql"
+        "ingested": "2023-01-25T14:23:18Z",
+        "module": "mysql",
+        "dataset": "mysql.performance"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "5016511f0829451ea244f458eebf2212",
+        "id": "589e678e8f3f457d81e3a530d3ae6011",
         "ip": [
-            "192.168.240.7"
+            "172.24.0.7"
         ],
         "mac": [
-            "02:42:c0:a8:f0:07"
+            "02-42-AC-18-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -58,31 +58,31 @@
             "events_statements": {
                 "avg": {
                     "timer": {
-                        "wait": 11041070000
+                        "wait": 3722000000
                     }
                 },
                 "count": {
-                    "star": 23
+                    "star": 1
                 },
                 "digest": {
-                    "text": "SHOW STATUS"
+                    "text": "SELECT `digest_text` , `count_star` , `avg_timer_wait` , `max_timer_wait` , `last_seen` , `quantile_95` FROM `performance_schema` . `events_statements_summary_by_digest` ORDER BY `avg_timer_wait` DESC LIMIT ?"
                 },
                 "last": {
-                    "seen": "2022-09-08 07:57:58.737970"
+                    "seen": "2023-01-25T14:23:07.055308"
                 },
                 "max": {
                     "timer": {
-                        "wait": 174874458000
+                        "wait": 3722000000
                     }
                 },
                 "quantile": {
-                    "95": 10471285480
+                    "95": 3801893963
                 }
             }
         }
     },
     "service": {
-        "address": "tcp(elastic-package-service_mysql_1:3306)/?readTimeout=10s\u0026timeout=10s\u0026writeTimeout=10s",
+        "address": "tcp(host.docker.internal:52767)/?readTimeout=10s&timeout=10s&writeTimeout=10s",
         "type": "mysql"
     }
 }

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: 1.4.0
+version: 1.5.0
 license: basic
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement


## What does this PR do?

This PR is updating ingest pipeline for the performance data stream of mysql,
so that processor exits quietly when the field mysql.performance.events_statements.last.seen does not exist.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Add the mysql integration and ingest document without last.seen field for performance data stream and it should not give any error.

## Related issues


- Closes [17542](https://github.com/elastic/enhancements/issues/17542)



