### PR TITLE
[NGINX] After 8.6.0, kubernetes pod labels used for condition matching are not dedoted

### DIFF
--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update ingress-nginx pod matching condition
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4855
+      link: https://github.com/elastic/integrations/pull/5099
 - version: "1.6.0"
   changes:
     - description: Work with logs from /var/log/containers

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Update ingress-nginx pod matching condition
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4855
 - version: "1.6.0"
   changes:
     - description: Work with logs from /var/log/containers

--- a/packages/nginx_ingress_controller/data_stream/access/manifest.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/manifest.yml
@@ -51,6 +51,6 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: ${kubernetes.labels.app_kubernetes_io/name} == 'ingress-nginx'
+        default: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'
     title: Nginx Ingress Controller access logs
     description: Collect Nginx Ingress Controller access logs

--- a/packages/nginx_ingress_controller/data_stream/error/manifest.yml
+++ b/packages/nginx_ingress_controller/data_stream/error/manifest.yml
@@ -51,6 +51,6 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: ${kubernetes.labels.app_kubernetes_io/name} == 'ingress-nginx'
+        default: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'
     title: Nginx Ingress Controller error logs
     description: Collect Nginx Ingress Controller error logs

--- a/packages/nginx_ingress_controller/manifest.yml
+++ b/packages/nginx_ingress_controller/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx_ingress_controller
 title: Nginx Ingress Controller Logs
-version: 1.6.0
+version: 1.7.0
 license: basic
 description: Collect Nginx Ingress Controller logs.
 type: integration
@@ -10,7 +10,7 @@ categories:
   - security
 release: ga
 conditions:
-  kibana.version: '^8.0.0'
+  kibana.version: '^8.6.0'
 screenshots:
   - src: /img/nginx-ingress-controller-overview.png
     title: Overview dashboard


### PR DESCRIPTION
## What does this PR do?

After 8.6.0, kubernetes pod labels used for condition matching are not dedoted. 
PR that introduced this is https://github.com/elastic/elastic-agent/pull/1398

So the `nginx_ingress_controller` integration needs to be updated with the correct defaults for conditions used to match the ingress-nginx pod.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Set up an elastic-stack of 8.6.0 version
2. Set up kubernetes cluster and  ingress-nginx following https://kind.sigs.k8s.io/docs/user/ingress/
3.  Install 1.7.0 versions of  nginx_ingress_controller package
4. Run agent with the correct policy
5. Check logs being collected