### PR TITLE
[Cloud Posture] Add cloud fields to mapping

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.8"
+  changes:
+    - description: Add cloud fields to mapping
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/####
 - version: "1.2.7"
   changes:
     - description: Add a cloudtrail fetcher to the aws cspm hbs file

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add cloud fields to mapping
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/####
+      link: https://github.com/elastic/integrations/pull/5101
 - version: "1.2.7"
   changes:
     - description: Add a cloudtrail fetcher to the aws cspm hbs file

--- a/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
@@ -202,3 +202,12 @@
 - name: orchestrator.cluster.name
   external: ecs
   type: keyword
+- name: cloud.account.id
+  external: ecs
+  type: keyword
+- name: cloud.account.name
+  external: ecs
+  type: keyword
+- name: cloud.provider
+  external: ecs
+  type: keyword

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Security Posture Management (CSPM/KSPM)"
-version: 1.2.7
+version: 1.2.8
 release: ga
 license: basic
 description: "DO NOT USE MAIN TILE (WIP)"


### PR DESCRIPTION
## What does this PR do?

Adds cloud fields to the cloud security posture event fields:
- `cloud.account.id`
- `cloud.account.name`
- `cloud.provider`

## Related issues

Related to https://github.com/elastic/cloudbeat/issues/586
