### PR TITLE
Update system integration data streams to beta

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.1"
+  changes:
+    - description: Mark datasets as beta
+      type: bugfix
+      link: TBD
 - version: "1.22.0"
   changes:
     - description: Improve handling of user name and event outcome in auth dataset.

--- a/packages/system/data_stream/application/manifest.yml
+++ b/packages/system/data_stream/application/manifest.yml
@@ -1,6 +1,6 @@
 type: logs
 title: Windows Application Events
-release: experimental
+release: beta
 streams:
   - input: winlog
     template_path: winlog.yml.hbs

--- a/packages/system/data_stream/auth/manifest.yml
+++ b/packages/system/data_stream/auth/manifest.yml
@@ -1,5 +1,5 @@
 title: System auth logs
-release: experimental
+release: beta
 type: logs
 streams:
   - input: logfile

--- a/packages/system/data_stream/core/manifest.yml
+++ b/packages/system/data_stream/core/manifest.yml
@@ -1,5 +1,5 @@
 title: System core metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/cpu/manifest.yml
+++ b/packages/system/data_stream/cpu/manifest.yml
@@ -1,5 +1,5 @@
 title: System cpu metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/diskio/manifest.yml
+++ b/packages/system/data_stream/diskio/manifest.yml
@@ -1,5 +1,5 @@
 title: System diskio metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/filesystem/manifest.yml
+++ b/packages/system/data_stream/filesystem/manifest.yml
@@ -1,5 +1,5 @@
 title: System filesystem metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/fsstat/manifest.yml
+++ b/packages/system/data_stream/fsstat/manifest.yml
@@ -1,5 +1,5 @@
 title: System fsstat metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/load/manifest.yml
+++ b/packages/system/data_stream/load/manifest.yml
@@ -1,5 +1,5 @@
 title: System load metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/memory/manifest.yml
+++ b/packages/system/data_stream/memory/manifest.yml
@@ -1,5 +1,5 @@
 title: System memory metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/network/manifest.yml
+++ b/packages/system/data_stream/network/manifest.yml
@@ -1,5 +1,5 @@
 title: System network metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/process/manifest.yml
+++ b/packages/system/data_stream/process/manifest.yml
@@ -1,5 +1,5 @@
 title: System process metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/process_summary/manifest.yml
+++ b/packages/system/data_stream/process_summary/manifest.yml
@@ -1,6 +1,6 @@
 title: System process_summary metrics
 dataset: system.process.summary
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/security/manifest.yml
+++ b/packages/system/data_stream/security/manifest.yml
@@ -1,6 +1,6 @@
 type: logs
 title: Security logs
-release: experimental
+release: beta
 streams:
   - input: winlog
     template_path: winlog.yml.hbs

--- a/packages/system/data_stream/socket_summary/manifest.yml
+++ b/packages/system/data_stream/socket_summary/manifest.yml
@@ -1,5 +1,5 @@
 title: System socket_summary metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/data_stream/syslog/manifest.yml
+++ b/packages/system/data_stream/syslog/manifest.yml
@@ -1,5 +1,5 @@
 title: System syslog logs
-release: experimental
+release: beta
 type: logs
 streams:
   - input: logfile

--- a/packages/system/data_stream/system/manifest.yml
+++ b/packages/system/data_stream/system/manifest.yml
@@ -1,6 +1,6 @@
 type: logs
 title: Windows System Events
-release: experimental
+release: beta
 streams:
   - input: winlog
     template_path: winlog.yml.hbs

--- a/packages/system/data_stream/uptime/manifest.yml
+++ b/packages/system/data_stream/uptime/manifest.yml
@@ -1,5 +1,5 @@
 title: System uptime metrics
-release: experimental
+release: beta
 type: metrics
 streams:
   - input: system/metrics

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.22.0
+version: 1.22.1
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/elastic/integrations/issues/5116

cc @mukeshelastic @cmacknz 

This updates all the system integrations from `experimental` to `beta`. 

For reasons I don't quite understand, the `elastic-package` linter doesn't allow you to mark data streams as `ga`, only integrations themselves.

There was some discussion over marking certain data streams as GA based on gaps in the OS support, but if we're just marking them as `beta`, I'm not sure if that still applies. 