### PR TITLE
[winlog] Add agent fields to align with Windows integration

### DIFF
--- a/packages/winlog/data_stream/winlog/fields/agent.yml
+++ b/packages/winlog/data_stream/winlog/fields/agent.yml
@@ -1,0 +1,197 @@
+- name: cloud
+  title: Cloud
+  group: 2
+  description: Fields related to the cloud or infrastructure the events are coming from.
+  footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.'
+  type: group
+  fields:
+    - name: account.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+    - name: availability_zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Availability zone in which this host is running.
+      example: us-east-1c
+    - name: instance.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+    - name: instance.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance name of the host machine.
+    - name: machine.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the host machine.
+      example: t2.medium
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
+      example: aws
+    - name: region
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Region in which this host is running.
+      example: us-east-1
+    - name: project.id
+      type: keyword
+      description: Name of the project in Google Cloud.
+    - name: image.id
+      type: keyword
+      description: Image ID for the cloud instance.
+- name: container
+  title: Container
+  group: 2
+  description: 'Container fields are used for meta information about the specific container that is the source of information.
+
+    These fields help correlate data based containers from any runtime.'
+  type: group
+  fields:
+    - name: id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique container id.
+    - name: image.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the image the container was built on.
+    - name: labels
+      level: extended
+      type: object
+      object_type: keyword
+      description: Image labels.
+    - name: name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Container name.
+- name: host
+  title: Host
+  group: 2
+  description: 'A host is defined as a general computing instance.
+
+    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.'
+  type: group
+  fields:
+    - name: architecture
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Operating system architecture.
+      example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the domain of which the host is a member.
+
+        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      example: CONTOSO
+      default_field: false
+    - name: hostname
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Hostname of the host.
+
+        It normally contains what the `hostname` command returns on the host machine.'
+    - name: id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique host id.
+
+        As hostname is not always unique, use values that are meaningful in your environment.
+
+        Example: The current usage of `beat.name`.'
+    - name: ip
+      level: core
+      type: ip
+      description: Host ip addresses.
+    - name: mac
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Host mac addresses.
+    - name: name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the host.
+
+        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+    - name: os.family
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: OS family (such as redhat, debian, freebsd, windows).
+      example: debian
+    - name: os.kernel
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Operating system kernel version as a raw string.
+      example: 4.4.0-112-generic
+    - name: os.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: Operating system name, without the version.
+      example: Mac OS X
+    - name: os.platform
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Operating system platform (such centos, ubuntu, windows).
+      example: darwin
+    - name: os.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Operating system version as a raw string.
+      example: 10.14.1
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of host.
+
+        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+    - name: containerized
+      type: boolean
+      description: >
+        If the host is a container.
+
+    - name: os.build
+      type: keyword
+      example: "18D109"
+      description: >
+        OS build information.
+
+    - name: os.codename
+      type: keyword
+      example: "stretch"
+      description: >
+        OS codename, if any.


### PR DESCRIPTION
There is no mapping to the agent/host.* fields which causes conflicts in the data views. These fields should probably be mapped for consistency and usability.

This file was copied directly from: https://github.com/elastic/integrations/blob/main/packages/windows/data_stream/sysmon_operational/fields/agent.yml

Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement


## What does this PR do?

This PR makes the Custom Windows Event log integration more consistent with the other Windows Event ingestion. By default, for example, the host.ip field will get mapped as a keyword which is not ideal and causes a field conflict. This seems to be the logical way to get this implemented unless this integration is being overhauled or deprecated. This is all predicated on having the agent.yml fields actually does what I think it does which is adding these fields to the logs-winlog.winlog@pacakge template.

Using version 1.10.0 of the integration you can see that that host.* fields don't exist:

![image](https://user-images.githubusercontent.com/5582679/215292352-ac97cf8c-29c8-4e2e-9c34-f078699f6fce.png)


## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

