### PR TITLE
[IIS] Accept multiple application_pool name

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Accept multiple application pool names
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5140
 - version: "1.4.0"
   changes:
     - description: Updated ECS version to 8.5.1

--- a/packages/iis/data_stream/application_pool/agent/stream/stream.yml.hbs
+++ b/packages/iis/data_stream/application_pool/agent/stream/stream.yml.hbs
@@ -1,3 +1,8 @@
 metricsets: ["application_pool"]
 period: {{period}}
-application_pool.name: {{name}}
+{{#if name}}
+application_pool.name::
+{{#each name as |app_pool_name i|}}
+  - {{app_pool_name}}
+{{/each}}
+{{/if}}

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 1.4.0
+version: 1.5.0
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 1.5.0
+version: 1.4.1
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION

- Bug

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.


## How to test this PR locally

Create multiple application pools in IIS Manager
Verify all the application pool metrics are getting captured.
Specify names in the application pool configuration and verify whether only those metrics are being captured.

## Related issues

- Closes #4445 

## Screenshots

