### PR TITLE
o365: retain file, directory and URL details for SharePointSharingOperation

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Retain file, directory and URL details for `SharePointSharingOperation`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5146
 - version: "1.10.1"
   changes:
     - description: Add fingerprint processor to prevent ingestion of duplicate events.

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-sharepointfileop-events.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-sharepointfileop-events.json
@@ -342,6 +342,37 @@
                 "WebId": "8c5c94bb-8396-470c-87d7-8999f440cd30",
                 "Workload": "OneDrive"
             }
+        },
+        {
+            "event": {
+                "original": "{\"CreationTime\":\"2023-01-30T07:39:56\",\"Id\":\"xxxxxxxxx-832d-4e6a-868b-yyyyyyyyyyyyy\",\"Operation\":\"SecureLinkUsed\",\"OrganizationId\":\"xxxxxxxxxxx-9e16-4286-9a69-yyyyyyyyyy\",\"RecordType\":14,\"UserKey\":\"i:0h.f|membership|xxxxxxxxxc@live.com\",\"UserType\":0,\"Version\":1,\"Workload\":\"SharePoint\",\"ClientIP\":\"67.43.156.15\",\"ObjectId\":\"https://dummydomain.sharepoint.com/sites/msteams_067dce/Shared Documents/General/Trainings/Train The Trainer (TTT)/Day 1 - CSRDesktop/HL Agenda.pdf\",\"UserId\":\"user@dummydomain.com\",\"CorrelationId\":\"xxxxxxx-e021-6000-1d2d-yyyyyyyy\",\"EventSource\":\"SharePoint\",\"ItemType\":\"File\",\"ListId\":\"xxxxxxxxxx-e1db-4a04-ab81-zzzzzzzzzzz\",\"ListItemUniqueId\":\"zzzzzzzz-1872-4e5c-8db1-yyyyyyyyyyyy\",\"Site\":\"xxxxxxxxxxx-6723-456f-994c-yyyyyyyyyyy\",\"UserAgent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.70\",\"WebId\":\"xxxxxxxxxxxxx-d881-418c-89dd-yyyyyyyy\",\"SourceFileExtension\":\"pdf\",\"SiteUrl\":\"https://dummydomain.sharepoint.com/sites/msteams_067dce\",\"SourceFileName\":\"HL Agenda.pdf\",\"SourceRelativeUrl\":\"Shared Documents/General/Trainings/Train The Trainer (TTT)/Day 1 - CSRDesktop/HL Agenda.pdf\"}"
+            },
+            "o365audit": {
+                "CreationTime": "2023-01-30T07:39:56",
+                "Id": "xxxxxxxxx-832d-4e6a-868b-yyyyyyyyyyyyy",
+                "Operation": "SecureLinkUsed",
+                "OrganizationId": "xxxxxxxxxxx-9e16-4286-9a69-yyyyyyyyyy",
+                "RecordType": 14,
+                "UserKey": "i:0h.f|membership|xxxxxxxxxc@live.com",
+                "UserType": 0,
+                "Version": 1,
+                "Workload": "SharePoint",
+                "ClientIP": "67.43.156.15",
+                "ObjectId": "https://dummydomain.sharepoint.com/sites/msteams_067dce/Shared Documents/General/Trainings/Train The Trainer (TTT)/Day 1 - CSRDesktop/HL Agenda.pdf",
+                "UserId": "user@dummydomain.com",
+                "CorrelationId": "xxxxxxx-e021-6000-1d2d-yyyyyyyy",
+                "EventSource": "SharePoint",
+                "ItemType": "File",
+                "ListId": "xxxxxxxxxx-e1db-4a04-ab81-zzzzzzzzzzz",
+                "ListItemUniqueId": "zzzzzzzz-1872-4e5c-8db1-yyyyyyyyyyyy",
+                "Site": "xxxxxxxxxxx-6723-456f-994c-yyyyyyyyyyy",
+                "UserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.70",
+                "WebId": "xxxxxxxxxxxxx-d881-418c-89dd-yyyyyyyy",
+                "SourceFileExtension": "pdf",
+                "SiteUrl": "https://dummydomain.sharepoint.com/sites/msteams_067dce",
+                "SourceFileName": "HL Agenda.pdf",
+                "SourceRelativeUrl": "Shared Documents/General/Trainings/Train The Trainer (TTT)/Day 1 - CSRDesktop/HL Agenda.pdf"
+            }
         }
     ]
 }

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-sharepointfileop-events.json-expected.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-sharepointfileop-events.json-expected.json
@@ -1200,6 +1200,112 @@
                 },
                 "version": "72.0."
             }
+        },
+        {
+            "@timestamp": "2023-01-30T07:39:56.000Z",
+            "client": {
+                "address": "67.43.156.15",
+                "ip": "67.43.156.15"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "SecureLinkUsed",
+                "category": [
+                    "web"
+                ],
+                "code": "SharePointSharingOperation",
+                "id": "xxxxxxxxx-832d-4e6a-868b-yyyyyyyyyyyyy",
+                "kind": "event",
+                "original": "{\"CreationTime\":\"2023-01-30T07:39:56\",\"Id\":\"xxxxxxxxx-832d-4e6a-868b-yyyyyyyyyyyyy\",\"Operation\":\"SecureLinkUsed\",\"OrganizationId\":\"xxxxxxxxxxx-9e16-4286-9a69-yyyyyyyyyy\",\"RecordType\":14,\"UserKey\":\"i:0h.f|membership|xxxxxxxxxc@live.com\",\"UserType\":0,\"Version\":1,\"Workload\":\"SharePoint\",\"ClientIP\":\"67.43.156.15\",\"ObjectId\":\"https://dummydomain.sharepoint.com/sites/msteams_067dce/Shared Documents/General/Trainings/Train The Trainer (TTT)/Day 1 - CSRDesktop/HL Agenda.pdf\",\"UserId\":\"user@dummydomain.com\",\"CorrelationId\":\"xxxxxxx-e021-6000-1d2d-yyyyyyyy\",\"EventSource\":\"SharePoint\",\"ItemType\":\"File\",\"ListId\":\"xxxxxxxxxx-e1db-4a04-ab81-zzzzzzzzzzz\",\"ListItemUniqueId\":\"zzzzzzzz-1872-4e5c-8db1-yyyyyyyyyyyy\",\"Site\":\"xxxxxxxxxxx-6723-456f-994c-yyyyyyyyyyy\",\"UserAgent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.70\",\"WebId\":\"xxxxxxxxxxxxx-d881-418c-89dd-yyyyyyyy\",\"SourceFileExtension\":\"pdf\",\"SiteUrl\":\"https://dummydomain.sharepoint.com/sites/msteams_067dce\",\"SourceFileName\":\"HL Agenda.pdf\",\"SourceRelativeUrl\":\"Shared Documents/General/Trainings/Train The Trainer (TTT)/Day 1 - CSRDesktop/HL Agenda.pdf\"}",
+                "outcome": "success",
+                "provider": "SharePoint",
+                "type": [
+                    "info"
+                ]
+            },
+            "file": {
+                "directory": "Shared Documents/General/Trainings/Train The Trainer (TTT)/Day 1 - CSRDesktop/HL Agenda.pdf",
+                "extension": "pdf",
+                "name": "HL Agenda.pdf"
+            },
+            "host": {
+                "id": "xxxxxxxxxxx-9e16-4286-9a69-yyyyyyyyyy",
+                "name": "dummydomain.com"
+            },
+            "network": {
+                "type": "ipv4"
+            },
+            "o365": {
+                "audit": {
+                    "CorrelationId": "xxxxxxx-e021-6000-1d2d-yyyyyyyy",
+                    "CreationTime": "2023-01-30T07:39:56",
+                    "EventSource": "SharePoint",
+                    "ItemType": "File",
+                    "ListId": "xxxxxxxxxx-e1db-4a04-ab81-zzzzzzzzzzz",
+                    "ListItemUniqueId": "zzzzzzzz-1872-4e5c-8db1-yyyyyyyyyyyy",
+                    "RecordType": "14",
+                    "Site": "xxxxxxxxxxx-6723-456f-994c-yyyyyyyyyyy",
+                    "SiteUrl": "https://dummydomain.sharepoint.com/sites/msteams_067dce",
+                    "UserId": "user@dummydomain.com",
+                    "UserKey": "i:0h.f|membership|xxxxxxxxxc@live.com",
+                    "UserType": "0",
+                    "Version": "1",
+                    "WebId": "xxxxxxxxxxxxx-d881-418c-89dd-yyyyyyyy"
+                }
+            },
+            "organization": {
+                "id": "xxxxxxxxxxx-9e16-4286-9a69-yyyyyyyyyy"
+            },
+            "related": {
+                "ip": [
+                    "67.43.156.15"
+                ],
+                "user": [
+                    "user"
+                ]
+            },
+            "source": {
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.15"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "original": "https://dummydomain.sharepoint.com/sites/msteams_067dce/Shared Documents/General/Trainings/Train The Trainer (TTT)/Day 1 - CSRDesktop/HL Agenda.pdf"
+            },
+            "user": {
+                "domain": "dummydomain.com",
+                "email": "user@dummydomain.com",
+                "id": "user@dummydomain.com",
+                "name": "user"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Other"
+                },
+                "name": "Edge",
+                "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.70",
+                "os": {
+                    "full": "Windows 10",
+                    "name": "Windows",
+                    "version": "10"
+                },
+                "version": "109.0.1518.70"
+            }
         }
     ]
 }

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-sp-sharing-op-events.json-expected.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-sp-sharing-op-events.json-expected.json
@@ -32,7 +32,6 @@
                     "EventData": "\u003cGroup\u003eSite Members\u003c/Group\u003e",
                     "EventSource": "SharePoint",
                     "ItemType": "Web",
-                    "ObjectId": "https://testsiem.sharepoint.com/sites/SIEMTest",
                     "RecordType": "14",
                     "Site": "9d58b52e-2adb-4976-8c1f-9932c32a8bd2",
                     "SiteUrl": "https://testsiem.sharepoint.com/sites/SIEMTest",
@@ -57,6 +56,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem.sharepoint.com/sites/SIEMTest"
+            },
             "user": {
                 "domain": "sharepoint",
                 "email": "app@sharepoint",
@@ -103,7 +105,6 @@
                     "EventData": "\u003cGroup\u003eSite Owners\u003c/Group\u003e",
                     "EventSource": "SharePoint",
                     "ItemType": "Web",
-                    "ObjectId": "https://testsiem.sharepoint.com/sites/SIEMTest",
                     "RecordType": "14",
                     "Site": "9d58b52e-2adb-4976-8c1f-9932c32a8bd2",
                     "SiteUrl": "https://testsiem.sharepoint.com/sites/SIEMTest",
@@ -128,6 +129,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem.sharepoint.com/sites/SIEMTest"
+            },
             "user": {
                 "domain": "sharepoint",
                 "email": "app@sharepoint",
@@ -174,7 +178,6 @@
                     "EventData": "\u003cGroup\u003eSite Owners\u003c/Group\u003e",
                     "EventSource": "SharePoint",
                     "ItemType": "Web",
-                    "ObjectId": "https://testsiem.sharepoint.com/sites/SIEMTest",
                     "RecordType": "14",
                     "Site": "9d58b52e-2adb-4976-8c1f-9932c32a8bd2",
                     "SiteUrl": "https://testsiem.sharepoint.com/sites/SIEMTest",
@@ -199,6 +202,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem.sharepoint.com/sites/SIEMTest"
+            },
             "user": {
                 "domain": "sharepoint",
                 "email": "app@sharepoint",
@@ -245,7 +251,6 @@
                     "EventData": "\u003cGroup\u003eSite Members\u003c/Group\u003e",
                     "EventSource": "SharePoint",
                     "ItemType": "Web",
-                    "ObjectId": "https://testsiem.sharepoint.com/sites/SIEMTest",
                     "RecordType": "14",
                     "Site": "9d58b52e-2adb-4976-8c1f-9932c32a8bd2",
                     "SiteUrl": "https://testsiem.sharepoint.com/sites/SIEMTest",
@@ -270,6 +275,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem.sharepoint.com/sites/SIEMTest"
+            },
             "user": {
                 "domain": "sharepoint",
                 "email": "app@sharepoint",
@@ -316,7 +324,6 @@
                     "EventData": "\u003cGroup\u003eSite Owners\u003c/Group\u003e",
                     "EventSource": "SharePoint",
                     "ItemType": "Web",
-                    "ObjectId": "https://testsiem.sharepoint.com/sites/SIEMTest",
                     "RecordType": "14",
                     "Site": "9d58b52e-2adb-4976-8c1f-9932c32a8bd2",
                     "SiteUrl": "https://testsiem.sharepoint.com/sites/SIEMTest",
@@ -341,6 +348,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem.sharepoint.com/sites/SIEMTest"
+            },
             "user": {
                 "domain": "sharepoint",
                 "email": "app@sharepoint",
@@ -379,6 +389,9 @@
                     "info"
                 ]
             },
+            "file": {
+                "directory": "Sharing Links"
+            },
             "host": {
                 "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
                 "name": "mytenant.onmicrosoft.com"
@@ -394,11 +407,9 @@
                     "EventSource": "SharePoint",
                     "ItemType": "List",
                     "ListId": "b108938d-3546-4359-925d-a1b54b4db8c2",
-                    "ObjectId": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com//personal/asr_testsiem_onmicrosoft_com/Sharing Links",
                     "RecordType": "14",
                     "Site": "d5180cfc-3479-44d6-b410-8c985ac894e3",
                     "SiteUrl": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com",
-                    "SourceRelativeUrl": "Sharing Links",
                     "UserId": "asr@testsiem.onmicrosoft.com",
                     "UserKey": "i:0h.f|membership|1003200096971f55@live.com",
                     "UserType": "0",
@@ -436,6 +447,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com//personal/asr_testsiem_onmicrosoft_com/Sharing Links"
+            },
             "user": {
                 "domain": "testsiem.onmicrosoft.com",
                 "email": "asr@testsiem.onmicrosoft.com",
@@ -480,6 +494,11 @@
                     "info"
                 ]
             },
+            "file": {
+                "directory": "Documents/Screenshot.png",
+                "extension": "png",
+                "name": "Screenshot.png"
+            },
             "host": {
                 "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
                 "name": "mytenant.onmicrosoft.com"
@@ -496,13 +515,9 @@
                     "ItemType": "File",
                     "ListId": "2b6ad2bd-0fd7-4556-9c89-a97847085b85",
                     "ListItemUniqueId": "7f06ab3a-bd98-41d3-a0b2-ad270d71e4d8",
-                    "ObjectId": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/Documents/Screenshot.png",
                     "RecordType": "14",
                     "Site": "d5180cfc-3479-44d6-b410-8c985ac894e3",
                     "SiteUrl": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com",
-                    "SourceFileExtension": "png",
-                    "SourceFileName": "Screenshot.png",
-                    "SourceRelativeUrl": "Documents/Screenshot.png",
                     "UniqueSharingId": "d323b5ea-ceca-4d65-a628-e22ca9296a76",
                     "UserId": "asr@testsiem.onmicrosoft.com",
                     "UserKey": "i:0h.f|membership|1003200096971f55@live.com",
@@ -541,6 +556,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/Documents/Screenshot.png"
+            },
             "user": {
                 "domain": "testsiem.onmicrosoft.com",
                 "email": "asr@testsiem.onmicrosoft.com",
@@ -585,6 +603,11 @@
                     "info"
                 ]
             },
+            "file": {
+                "directory": "Documents/Screenshot.png",
+                "extension": "png",
+                "name": "Screenshot.png"
+            },
             "host": {
                 "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
                 "name": "mytenant.onmicrosoft.com"
@@ -601,13 +624,9 @@
                     "ItemType": "File",
                     "ListId": "2b6ad2bd-0fd7-4556-9c89-a97847085b85",
                     "ListItemUniqueId": "7f06ab3a-bd98-41d3-a0b2-ad270d71e4d8",
-                    "ObjectId": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/Documents/Screenshot.png",
                     "RecordType": "14",
                     "Site": "d5180cfc-3479-44d6-b410-8c985ac894e3",
                     "SiteUrl": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com",
-                    "SourceFileExtension": "png",
-                    "SourceFileName": "Screenshot.png",
-                    "SourceRelativeUrl": "Documents/Screenshot.png",
                     "TargetUserOrGroupName": "SharingLinks.7f06ab3a-bd98-41d3-a0b2-ad270d71e4d8.AnonymousEdit.d323b5ea-ceca-4d65-a628-e22ca9296a76",
                     "TargetUserOrGroupType": "SharePointGroup",
                     "UserId": "asr@testsiem.onmicrosoft.com",
@@ -647,6 +666,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/Documents/Screenshot.png"
+            },
             "user": {
                 "domain": "testsiem.onmicrosoft.com",
                 "email": "asr@testsiem.onmicrosoft.com",
@@ -691,6 +713,11 @@
                     "info"
                 ]
             },
+            "file": {
+                "directory": "Documents/Screenshot.png",
+                "extension": "png",
+                "name": "Screenshot.png"
+            },
             "host": {
                 "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
                 "name": "mytenant.onmicrosoft.com"
@@ -707,13 +734,9 @@
                     "ItemType": "File",
                     "ListId": "2b6ad2bd-0fd7-4556-9c89-a97847085b85",
                     "ListItemUniqueId": "7f06ab3a-bd98-41d3-a0b2-ad270d71e4d8",
-                    "ObjectId": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/Documents/Screenshot.png",
                     "RecordType": "14",
                     "Site": "d5180cfc-3479-44d6-b410-8c985ac894e3",
                     "SiteUrl": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com",
-                    "SourceFileExtension": "png",
-                    "SourceFileName": "Screenshot.png",
-                    "SourceRelativeUrl": "Documents/Screenshot.png",
                     "TargetUserOrGroupName": "Limited Access System Group",
                     "TargetUserOrGroupType": "SharePointGroup",
                     "UserId": "asr@testsiem.onmicrosoft.com",
@@ -753,6 +776,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/Documents/Screenshot.png"
+            },
             "user": {
                 "domain": "testsiem.onmicrosoft.com",
                 "email": "asr@testsiem.onmicrosoft.com",
@@ -797,6 +823,11 @@
                     "info"
                 ]
             },
+            "file": {
+                "directory": "Documents/Screenshot.png",
+                "extension": "png",
+                "name": "Screenshot.png"
+            },
             "host": {
                 "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
                 "name": "mytenant.onmicrosoft.com"
@@ -813,13 +844,9 @@
                     "ItemType": "File",
                     "ListId": "2b6ad2bd-0fd7-4556-9c89-a97847085b85",
                     "ListItemUniqueId": "7f06ab3a-bd98-41d3-a0b2-ad270d71e4d8",
-                    "ObjectId": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/Documents/Screenshot.png",
                     "RecordType": "14",
                     "Site": "d5180cfc-3479-44d6-b410-8c985ac894e3",
                     "SiteUrl": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com",
-                    "SourceFileExtension": "png",
-                    "SourceFileName": "Screenshot.png",
-                    "SourceRelativeUrl": "Documents/Screenshot.png",
                     "TargetUserOrGroupName": "4da1e7f54501bb99b6e0ab2ff8749842152ac02ff8c0c8017b0e40e6b67fecdd",
                     "TargetUserOrGroupType": "SecurityGroup",
                     "UserId": "asr@testsiem.onmicrosoft.com",
@@ -859,6 +886,9 @@
             "tags": [
                 "preserve_original_event"
             ],
+            "url": {
+                "original": "https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/Documents/Screenshot.png"
+            },
             "user": {
                 "domain": "testsiem.onmicrosoft.com",
                 "email": "asr@testsiem.onmicrosoft.com",

--- a/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -400,27 +400,27 @@ processors:
       field: event.type
       value: access
       if: 'ctx.event?.code == "AzureActiveDirectoryStsLogon"'
-  # SharePointFileOperation Schema
+  # SharePointFileOperation and SharePointSharingOperation Schemas
   - rename:
       field: o365audit.ObjectId
       target_field: url.original
       ignore_missing: true
-      if: ctx.event?.code == "SharePointFileOperation"
+      if: ctx.event?.code != null && ["SharePointFileOperation", "SharePointSharingOperation"].contains(ctx.event.code)
   - rename:
       field: o365audit.SourceRelativeUrl
       target_field: file.directory
       ignore_missing: true
-      if: ctx.event?.code == "SharePointFileOperation"
+      if: ctx.event?.code != null && ["SharePointFileOperation", "SharePointSharingOperation"].contains(ctx.event.code)
   - rename:
       field: o365audit.SourceFileName
       target_field: file.name
       ignore_missing: true
-      if: ctx.event?.code == "SharePointFileOperation"
+      if: ctx.event?.code != null && ["SharePointFileOperation", "SharePointSharingOperation"].contains(ctx.event.code)
   - rename:
       field: o365audit.SourceFileExtension
       target_field: file.extension
       ignore_missing: true
-      if: ctx.event?.code == "SharePointFileOperation"
+      if: ctx.event?.code != null && ["SharePointFileOperation", "SharePointSharingOperation"].contains(ctx.event.code)
   - append: 
       field: event.category
       value: file

--- a/packages/o365/data_stream/audit/sample_event.json
+++ b/packages/o365/data_stream/audit/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-02-07T16:43:53.000Z",
     "agent": {
-        "ephemeral_id": "2bdc8c46-c1e5-40ff-b8a4-249988bae0a1",
-        "id": "e7303a60-a051-4b51-bba8-b13f8f1a47ca",
+        "ephemeral_id": "d8eff6cd-2ba5-4930-9630-5f70e7bae64a",
+        "id": "daae9b35-e01e-4afc-a59d-da75f9702aa7",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.0"
+        "version": "8.5.1"
     },
     "client": {
         "address": "213.97.47.133",
@@ -20,9 +20,9 @@
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "e7303a60-a051-4b51-bba8-b13f8f1a47ca",
+        "id": "daae9b35-e01e-4afc-a59d-da75f9702aa7",
         "snapshot": false,
-        "version": "8.1.0"
+        "version": "8.5.1"
     },
     "event": {
         "action": "PageViewed",
@@ -33,7 +33,7 @@
         "code": "SharePoint",
         "dataset": "o365.audit",
         "id": "99d005e6-a4c6-46fd-117c-08d7abeceab5",
-        "ingested": "2022-11-14T19:23:46Z",
+        "ingested": "2023-01-29T22:48:55Z",
         "kind": "event",
         "original": "{\"ListItemUniqueId\": \"59a8433d-9bb8-cfef-6edc-4c0fc8b86875\", \"ItemType\": \"Page\", \"Workload\": \"OneDrive\", \"OrganizationId\": \"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\", \"UserId\": \"asr@testsiem.onmicrosoft.com\", \"CreationTime\": \"2020-02-07T16:43:53\", \"Site\": \"d5180cfc-3479-44d6-b410-8c985ac894e3\", \"ClientIP\": \"213.97.47.133\", \"WebId\": \"8c5c94bb-8396-470c-87d7-8999f440cd30\", \"UserType\": 0, \"Version\": 1, \"EventSource\": \"SharePoint\", \"UserAgent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0\", \"UserKey\": \"i:0h.f|membership|1003200096971f55@live.com\", \"CustomUniqueId\": true, \"Operation\": \"PageViewed\", \"ObjectId\": \"https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/_layouts/15/onedrive.aspx\", \"Id\": \"99d005e6-a4c6-46fd-117c-08d7abeceab5\", \"CorrelationId\": \"622b339f-4000-a000-f25f-92b3478c7a25\", \"RecordType\": 4}",
         "outcome": "success",

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -33,11 +33,11 @@ An example event for `audit` looks as following:
 {
     "@timestamp": "2020-02-07T16:43:53.000Z",
     "agent": {
-        "ephemeral_id": "2bdc8c46-c1e5-40ff-b8a4-249988bae0a1",
-        "id": "e7303a60-a051-4b51-bba8-b13f8f1a47ca",
+        "ephemeral_id": "d8eff6cd-2ba5-4930-9630-5f70e7bae64a",
+        "id": "daae9b35-e01e-4afc-a59d-da75f9702aa7",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.0"
+        "version": "8.5.1"
     },
     "client": {
         "address": "213.97.47.133",
@@ -52,9 +52,9 @@ An example event for `audit` looks as following:
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "e7303a60-a051-4b51-bba8-b13f8f1a47ca",
+        "id": "daae9b35-e01e-4afc-a59d-da75f9702aa7",
         "snapshot": false,
-        "version": "8.1.0"
+        "version": "8.5.1"
     },
     "event": {
         "action": "PageViewed",
@@ -65,7 +65,7 @@ An example event for `audit` looks as following:
         "code": "SharePoint",
         "dataset": "o365.audit",
         "id": "99d005e6-a4c6-46fd-117c-08d7abeceab5",
-        "ingested": "2022-11-14T19:23:46Z",
+        "ingested": "2023-01-29T22:48:55Z",
         "kind": "event",
         "original": "{\"ListItemUniqueId\": \"59a8433d-9bb8-cfef-6edc-4c0fc8b86875\", \"ItemType\": \"Page\", \"Workload\": \"OneDrive\", \"OrganizationId\": \"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\", \"UserId\": \"asr@testsiem.onmicrosoft.com\", \"CreationTime\": \"2020-02-07T16:43:53\", \"Site\": \"d5180cfc-3479-44d6-b410-8c985ac894e3\", \"ClientIP\": \"213.97.47.133\", \"WebId\": \"8c5c94bb-8396-470c-87d7-8999f440cd30\", \"UserType\": 0, \"Version\": 1, \"EventSource\": \"SharePoint\", \"UserAgent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0\", \"UserKey\": \"i:0h.f|membership|1003200096971f55@live.com\", \"CustomUniqueId\": true, \"Operation\": \"PageViewed\", \"ObjectId\": \"https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/_layouts/15/onedrive.aspx\", \"Id\": \"99d005e6-a4c6-46fd-117c-08d7abeceab5\", \"CorrelationId\": \"622b339f-4000-a000-f25f-92b3478c7a25\", \"RecordType\": 4}",
         "outcome": "success",

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.10.1"
+version: "1.11.0"
 release: ga
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds "SharePointSharingOperation" to event codes that have file, directory and URL details retained in ECS fields.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5064 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
