### PR TITLE
[System] Update cpu, load, memory dataset with dimensions

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.23.2"
+- version: "1.24.0"
   changes:
     - description: Add basic dimension fields for cpu, load and memory
       type: enhancement

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.2"
+  changes:
+    - description: Add basic dimension fields for cpu, load and memory
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.23.1"
   changes:
     - description: Mark datasets as ga

--- a/packages/system/data_stream/cpu/fields/agent.yml
+++ b/packages/system/data_stream/cpu/fields/agent.yml
@@ -25,6 +25,7 @@
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
+      dimension: true
     - name: instance.name
       level: extended
       type: keyword
@@ -67,6 +68,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+      dimension: true
     - name: image.name
       level: extended
       type: keyword
@@ -134,6 +136,7 @@
       level: core
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: 'Name of the host.
 
         It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
@@ -196,9 +199,11 @@
       description: >
         OS codename, if any.
 
-    - name: cpu.pct
-      type: scaled_float
-      format: percent
-      description: >
-        Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1.
-
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/system/data_stream/cpu/fields/agent.yml
+++ b/packages/system/data_stream/cpu/fields/agent.yml
@@ -43,6 +43,7 @@
       ignore_above: 1024
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
+      dimension: true
     - name: region
       level: extended
       type: keyword
@@ -52,6 +53,7 @@
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
+      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/system/data_stream/load/fields/agent.yml
+++ b/packages/system/data_stream/load/fields/agent.yml
@@ -43,6 +43,7 @@
       ignore_above: 1024
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
+      dimension: true
     - name: region
       level: extended
       type: keyword
@@ -52,6 +53,7 @@
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
+      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/system/data_stream/load/fields/agent.yml
+++ b/packages/system/data_stream/load/fields/agent.yml
@@ -25,6 +25,7 @@
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
+      dimension: true
     - name: instance.name
       level: extended
       type: keyword
@@ -67,6 +68,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+      dimension: true
     - name: image.name
       level: extended
       type: keyword
@@ -134,6 +136,7 @@
       level: core
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: 'Name of the host.
 
         It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
@@ -196,3 +199,11 @@
       description: >
         OS codename, if any.
 
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/system/data_stream/memory/fields/agent.yml
+++ b/packages/system/data_stream/memory/fields/agent.yml
@@ -43,6 +43,7 @@
       ignore_above: 1024
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
+      dimension: true
     - name: region
       level: extended
       type: keyword
@@ -52,6 +53,7 @@
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
+      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/system/data_stream/memory/fields/agent.yml
+++ b/packages/system/data_stream/memory/fields/agent.yml
@@ -25,6 +25,7 @@
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
+      dimension: true
     - name: instance.name
       level: extended
       type: keyword
@@ -67,6 +68,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+      dimension: true
     - name: image.name
       level: extended
       type: keyword
@@ -134,6 +136,7 @@
       level: core
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: 'Name of the host.
 
         It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
@@ -196,3 +199,11 @@
       description: >
         OS codename, if any.
 
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -1202,6 +1202,7 @@ This data should be available without elevated permissions.
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| agent.id |  | keyword |  |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
 | cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
 | cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
@@ -1223,7 +1224,7 @@ This data should be available without elevated permissions.
 | host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |  |  |
 | host.architecture | Operating system architecture. | keyword |  |  |
 | host.containerized | If the host is a container. | boolean |  |  |
-| host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float |  |  |
+| host.cpu.pct | Percent CPU used. This value is normalized by the number of CPU cores and it ranges from 0 to 1. | scaled_float | percent | gauge |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
@@ -1510,6 +1511,7 @@ This data should be available without elevated permissions.
 | Field | Description | Type | Metric Type |
 |---|---|---|---|
 | @timestamp | Event timestamp. | date |  |
+| agent.id |  | keyword |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
 | cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
 | cloud.image.id | Image ID for the cloud instance. | keyword |  |
@@ -1578,6 +1580,7 @@ This data should be available without elevated permissions.
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| agent.id |  | keyword |  |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
 | cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
 | cloud.image.id | Image ID for the cloud instance. | keyword |  |  |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.23.1
+version: 1.23.2
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.23.2
+version: 1.24.0
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
We are in the progress of starting to adopt TSDB. To enabled TSDB, dimension fields are required. In this PR, dimensions are added to the following dataset:

* system.cpu
* system.load
* system.memory

The dimensions that were selected are:

* agent.id
* container.id
* host.name
* cloud.instance.id

These 4 dimensions should set a good foundation for the dataset selected above. It should make it work well in host, cloud and container environments. Not all dimensions always have to exist. We still need to define a more generic set of dimensions for integrations.

The goal of this PR is to enable us testing TSDB on common dataset. It also allows Kibana developers to have dataset ready for testing.

As long as TSDB is not enabled and on older versions of the stack, this change will not have any effect.