### PR TITLE
[Kubernetes] Add system testing for state service

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.2"
+  changes:
+    - description: Add system testing for state service datastream
+      type: testing
+      link: https://github.com/elastic/integrations/pull/5161
 - version: "1.31.1"
   changes:
     - description: Update controller manager, proxy and scheduler metrics and dashboards

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.31.2"
   changes:
     - description: Add system testing for state service datastream
-      type: testing
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/5161
 - version: "1.31.1"
   changes:

--- a/packages/kubernetes/data_stream/state_service/_dev/test/system/test-default-config.yml
+++ b/packages/kubernetes/data_stream/state_service/_dev/test/system/test-default-config.yml
@@ -1,0 +1,6 @@
+service: kubernetes
+data_stream:
+  vars:
+    hosts:
+      # this is the DNS name of the k8s service for kube-state-metrics deployment
+      - http://kube-state-metrics:8080

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.31.1
+version: 1.31.2
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add system testing for state service datastream.

Unlike the other `state_*` datastreams, the `_dev` folder needed for that test was missing.
