### PR TITLE
feat: add monitoring fetcher

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.9"
+  changes:
+    - description: Add monitoring fetcher to the aws cspm hbs file
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5163
 - version: "1.2.8"
   changes:
     - description: Add cloud fields to mapping

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -3,6 +3,7 @@ fetchers:
   - name: aws-ec2-network
   - name: aws-s3
   - name: aws-trail
+  - name: aws-monitoring
 config:
   v1:
     posture: {{posture}}

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Security Posture Management (CSPM/KSPM)"
-version: 1.2.8
+version: 1.2.9
 release: ga
 license: basic
 description: "DO NOT USE MAIN TILE (WIP)"


### PR DESCRIPTION
## What does this PR do?

Add `aws-monitoring` fetcher to aws hbs file

Related https://github.com/elastic/csp-security-policies/issues/148

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

