### PR TITLE
Bump lyve_cloud version

### DIFF
--- a/packages/lyve_cloud/changelog.yml
+++ b/packages/lyve_cloud/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix changelog link
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/5177
 - version: "1.0.0"
   changes:
     - description: Initial implementation

--- a/packages/lyve_cloud/changelog.yml
+++ b/packages/lyve_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Fix changelog link
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.0.0"
   changes:
     - description: Initial implementation

--- a/packages/lyve_cloud/manifest.yml
+++ b/packages/lyve_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: lyve_cloud
 title: Lyve Cloud
-version: "1.0.0"
+version: "1.0.1"
 license: basic
 description: Collect S3 API audit log from Lyve Cloud with Elastic Agent .
 type: integration


### PR DESCRIPTION
The Lyve Cloud changelog was fixed in https://github.com/elastic/integrations/pull/4991. I didn't know that you also have to bump the version for changes to make it into EPR. The PR bumps the version to 1.0.1.