### PR TITLE
Microsoft Exchange Message Trace: fix httpjson cursor template

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.2.1"
+  changes:
+    - description: Fix issue #5180
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5181
 - version: "0.2.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -56,7 +56,7 @@ response.pagination:
       value: '[[ (add (toInt (index .last_response.url.params "$skiptoken")) 2000) ]]'
 cursor:
   last_execution_datetime:
-    value: '[[(formatDate (now (parseDuration)) "RFC3339")]]'
+    value: '[[(formatDate (now) "RFC3339")]]'
 
 {{#if processors}}
 processors:

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/sample_event.json
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-10-21T17:25:36.969376Z",
+    "@timestamp": "2022-09-05T18:10:13.4907658",
     "agent": {
-        "ephemeral_id": "2e812a1b-8325-40ec-b03f-94d26ef6cf76",
-        "id": "4d88038c-4b3b-4bb4-95f4-cc5789c88852",
+        "ephemeral_id": "8dd8df52-8178-4bf2-aaaa-6e0428159010",
+        "id": "50b8c42c-b98d-4ac5-9c3e-d5cde54083d3",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.6.1"
     },
     "data_stream": {
         "dataset": "microsoft_exchange_online_message_trace.log",
@@ -13,7 +13,23 @@
         "type": "logs"
     },
     "destination": {
+        "as": {
+            "number": 209
+        },
         "domain": "contoso.com",
+        "geo": {
+            "city_name": "Milton",
+            "continent_name": "North America",
+            "country_iso_code": "US",
+            "country_name": "United States",
+            "location": {
+                "lat": 47.2513,
+                "lon": -122.3149
+            },
+            "region_iso_code": "US-WA",
+            "region_name": "Washington"
+        },
+        "ip": "216.160.83.56",
         "registered_domain": "contoso.com",
         "top_level_domain": "com"
     },
@@ -21,54 +37,59 @@
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "4d88038c-4b3b-4bb4-95f4-cc5789c88852",
+        "id": "50b8c42c-b98d-4ac5-9c3e-d5cde54083d3",
         "snapshot": false,
-        "version": "8.0.0"
+        "version": "8.6.1"
     },
     "email": {
         "attachments": {
             "file": {
-                "size": 22761
+                "size": 87891
             }
         },
-        "delivery_timestamp": "2022-10-21T17:25:36.969376Z",
+        "delivery_timestamp": "2022-09-05T18:10:13.4907658",
         "from": {
-            "address": "noreply@azure.microsoft.com"
+            "address": "azure-noreply@microsoft.com"
         },
-        "local_id": "a5e6dc0f-23df-4b20-d240-08dab38944a1",
-        "message_id": "\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\u003e",
-        "subject": "testmail 2",
+        "local_id": "cf7a249a-5edd-4350-130a-08da8f69e0f6",
+        "message_id": "\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\u003e",
+        "subject": "PIM: A privileged directory role was assigned outside of PIM",
         "to": {
             "address": "linus@contoso.com"
         }
     },
     "event": {
         "agent_id_status": "verified",
+        "created": "2023-02-04T08:25:54.054Z",
         "dataset": "microsoft_exchange_online_message_trace.log",
-        "end": "2022-10-22T09:40:10.000Z",
-        "ingested": "2022-10-25T10:21:12Z",
-        "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:36.969376Z\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 2\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"40.107.23.54\",\"Size\":22761,\"MessageTraceId\":\"a5e6dc0f-23df-4b20-d240-08dab38944a1\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":0}",
+        "end": "2022-09-06T09:01:46.036Z",
+        "ingested": "2023-02-04T08:25:58Z",
+        "original": "{\"EndDate\":\"2022-09-06T09:01:46.0369423Z\",\"FromIP\":\"81.2.69.144\",\"Index\":0,\"MessageId\":\"\\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\\u003e\",\"MessageTraceId\":\"cf7a249a-5edd-4350-130a-08da8f69e0f6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-09-05T18:10:13.4907658\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"azure-noreply@microsoft.com\",\"Size\":87891,\"StartDate\":\"2022-09-04T09:01:46.0369423Z\",\"Status\":\"Delivered\",\"Subject\":\"PIM: A privileged directory role was assigned outside of PIM\",\"ToIP\":\"216.160.83.56\"}",
         "outcome": "Delivered"
     },
     "input": {
-        "type": "log"
-    },
-    "log": {
-        "file": {
-            "path": "/tmp/service_logs/microsoft_exchange_online_message_trace_test.ndjson.log"
-        },
-        "offset": 0
+        "type": "httpjson"
     },
     "source": {
-        "domain": "azure.microsoft.com",
-        "ip": "40.107.23.54",
+        "domain": "microsoft.com",
+        "geo": {
+            "city_name": "London",
+            "continent_name": "Europe",
+            "country_iso_code": "GB",
+            "country_name": "United Kingdom",
+            "location": {
+                "lat": 51.5142,
+                "lon": -0.0931
+            },
+            "region_iso_code": "GB-ENG",
+            "region_name": "England"
+        },
+        "ip": "81.2.69.144",
         "registered_domain": "microsoft.com",
-        "subdomain": "azure",
         "top_level_domain": "com"
     },
     "tags": [
         "preserve_original_event",
-        "microsoft-defender-endpoint",
         "forwarded"
     ]
 }

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "0.2.0"
+version: "0.2.1"
 license: basic
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration


### PR DESCRIPTION
Bug Fix

## What does this PR do?

Fix incorrect use of parseDuration with zero arguments when setting cursor value for httpjson input.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

Make not broke.

## How to test this PR locally

Test against a Microsoft Exchange Online tenant.

## Related issues

- Closes #5180

## Screenshots

Not applicable.