### PR TITLE
Add filters to elastic agent visualizations

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Add dataset filters for agent metrics
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5186
 - version: "1.5.0"
   changes:
     - description: Add filebeat input metrics

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -60,7 +60,8 @@
                         "title": "",
                         "type": "input_control_vis",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 6,
@@ -72,7 +73,7 @@
                 "panelIndex": "8e715e81-4077-4e7d-9c67-af1d1c98af00",
                 "title": "Host name",
                 "type": "visualization",
-                "version": "7.15.0-SNAPSHOT"
+                "version": "7.16.0"
             },
             {
                 "embeddableConfig": {
@@ -230,10 +231,10 @@
         "title": "[Elastic Agent] Agent metrics",
         "version": 1
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "migrationVersion": {
-        "dashboard": "7.14.0"
+        "dashboard": "7.16.0"
     },
     "references": [
         {

--- a/packages/elastic_agent/kibana/lens/elastic_agent-27798780-0037-11ec-af6c-1740f74b2d73.json
+++ b/packages/elastic_agent/kibana/lens/elastic_agent-27798780-0037-11ec-af6c-1740f74b2d73.json
@@ -72,7 +72,29 @@
                     }
                 }
             },
-            "filters": [],
+            "filters": [
+                {
+                    "$state": {
+                        "store": "appState"
+                    },
+                    "meta": {
+                        "alias": null,
+                        "disabled": false,
+                        "indexRefName": "filter-index-pattern-0",
+                        "key": "data_stream.dataset",
+                        "negate": false,
+                        "params": {
+                            "query": "elastic_agent.*"
+                        },
+                        "type": "phrase"
+                    },
+                    "query": {
+                        "match_phrase": {
+                            "data_stream.dataset": "elastic_agent.*"
+                        }
+                    }
+                }
+            ],
             "query": {
                 "language": "kuery",
                 "query": ""
@@ -100,6 +122,7 @@
                             "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
                         ],
                         "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                        "layerType": "data",
                         "position": "top",
                         "seriesType": "line",
                         "showGridlines": false,
@@ -129,10 +152,10 @@
         "title": "[Elastic Agent] Total events rate /s",
         "visualizationType": "lnsXY"
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-27798780-0037-11ec-af6c-1740f74b2d73",
     "migrationVersion": {
-        "lens": "7.14.0"
+        "lens": "7.16.0"
     },
     "references": [
         {
@@ -143,6 +166,11 @@
         {
             "id": "metrics-*",
             "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "filter-index-pattern-0",
             "type": "index-pattern"
         }
     ],

--- a/packages/elastic_agent/kibana/lens/elastic_agent-409f5d70-0037-11ec-af6c-1740f74b2d73.json
+++ b/packages/elastic_agent/kibana/lens/elastic_agent-409f5d70-0037-11ec-af6c-1740f74b2d73.json
@@ -72,7 +72,29 @@
                     }
                 }
             },
-            "filters": [],
+            "filters": [
+                {
+                    "$state": {
+                        "store": "appState"
+                    },
+                    "meta": {
+                        "alias": null,
+                        "disabled": false,
+                        "indexRefName": "filter-index-pattern-0",
+                        "key": "data_stream.dataset",
+                        "negate": false,
+                        "params": {
+                            "query": "elastic_agent.*"
+                        },
+                        "type": "phrase"
+                    },
+                    "query": {
+                        "match_phrase": {
+                            "data_stream.dataset": "elastic_agent.*"
+                        }
+                    }
+                }
+            ],
             "query": {
                 "language": "kuery",
                 "query": ""
@@ -100,6 +122,7 @@
                             "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
                         ],
                         "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                        "layerType": "data",
                         "position": "top",
                         "seriesType": "line",
                         "showGridlines": false,
@@ -129,10 +152,10 @@
         "title": "[Elastic Agent] Events acknowledged rate /s",
         "visualizationType": "lnsXY"
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-409f5d70-0037-11ec-af6c-1740f74b2d73",
     "migrationVersion": {
-        "lens": "7.14.0"
+        "lens": "7.16.0"
     },
     "references": [
         {
@@ -143,6 +166,11 @@
         {
             "id": "metrics-*",
             "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "filter-index-pattern-0",
             "type": "index-pattern"
         }
     ],

--- a/packages/elastic_agent/kibana/lens/elastic_agent-58677820-0037-11ec-af6c-1740f74b2d73.json
+++ b/packages/elastic_agent/kibana/lens/elastic_agent-58677820-0037-11ec-af6c-1740f74b2d73.json
@@ -73,7 +73,29 @@
                     }
                 }
             },
-            "filters": [],
+            "filters": [
+                {
+                    "$state": {
+                        "store": "appState"
+                    },
+                    "meta": {
+                        "alias": null,
+                        "disabled": false,
+                        "indexRefName": "filter-index-pattern-0",
+                        "key": "data_stream.dataset",
+                        "negate": false,
+                        "params": {
+                            "query": "elastic_agent.*"
+                        },
+                        "type": "phrase"
+                    },
+                    "query": {
+                        "match_phrase": {
+                            "data_stream.dataset": "elastic_agent.*"
+                        }
+                    }
+                }
+            ],
             "query": {
                 "language": "kuery",
                 "query": ""
@@ -101,6 +123,7 @@
                             "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
                         ],
                         "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                        "layerType": "data",
                         "position": "top",
                         "seriesType": "line",
                         "showGridlines": false,
@@ -130,10 +153,10 @@
         "title": "[Elastic Agent] Output write errors",
         "visualizationType": "lnsXY"
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-58677820-0037-11ec-af6c-1740f74b2d73",
     "migrationVersion": {
-        "lens": "7.14.0"
+        "lens": "7.16.0"
     },
     "references": [
         {
@@ -144,6 +167,11 @@
         {
             "id": "metrics-*",
             "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "filter-index-pattern-0",
             "type": "index-pattern"
         }
     ],

--- a/packages/elastic_agent/kibana/lens/elastic_agent-6e88c0a0-0037-11ec-af6c-1740f74b2d73.json
+++ b/packages/elastic_agent/kibana/lens/elastic_agent-6e88c0a0-0037-11ec-af6c-1740f74b2d73.json
@@ -80,7 +80,29 @@
                     }
                 }
             },
-            "filters": [],
+            "filters": [
+                {
+                    "$state": {
+                        "store": "appState"
+                    },
+                    "meta": {
+                        "alias": null,
+                        "disabled": false,
+                        "indexRefName": "filter-index-pattern-0",
+                        "key": "data_stream.dataset",
+                        "negate": false,
+                        "params": {
+                            "query": "elastic_agent.*"
+                        },
+                        "type": "phrase"
+                    },
+                    "query": {
+                        "match_phrase": {
+                            "data_stream.dataset": "elastic_agent.*"
+                        }
+                    }
+                }
+            ],
             "query": {
                 "language": "kuery",
                 "query": ""
@@ -108,6 +130,7 @@
                             "c601246c-06f3-4f94-9d2a-a950eb4d499e"
                         ],
                         "layerId": "47363713-6910-43c5-9f85-328b9ee18f0d",
+                        "layerType": "data",
                         "position": "top",
                         "seriesType": "line",
                         "showGridlines": false,
@@ -137,10 +160,10 @@
         "title": "[Elastic Agent] Output write throughput",
         "visualizationType": "lnsXY"
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-6e88c0a0-0037-11ec-af6c-1740f74b2d73",
     "migrationVersion": {
-        "lens": "7.14.0"
+        "lens": "7.16.0"
     },
     "references": [
         {
@@ -151,6 +174,11 @@
         {
             "id": "metrics-*",
             "name": "indexpattern-datasource-layer-47363713-6910-43c5-9f85-328b9ee18f0d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "filter-index-pattern-0",
             "type": "index-pattern"
         }
     ],

--- a/packages/elastic_agent/kibana/visualization/elastic_agent-47d87552-8421-4cfc-bc5d-4a7205f5b007.json
+++ b/packages/elastic_agent/kibana/visualization/elastic_agent-47d87552-8421-4cfc-bc5d-4a7205f5b007.json
@@ -1,8 +1,31 @@
 {
     "attributes": {
+        "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "elastic_agent.elastic_agent"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "elastic_agent.elastic_agent"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -18,10 +41,12 @@
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "axis_scale": "normal",
+                "drop_last_bucket": 0,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "",
                 "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -30,7 +55,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"elastic_agent.elastic_agent\" "
+                            "query": ""
                         },
                         "formatter": "number",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
@@ -45,17 +70,21 @@
                         ],
                         "point_size": 1,
                         "separate_axis": 0,
+                        "series_index_pattern": "",
                         "split_color_mode": "kibana",
                         "split_mode": "terms",
                         "stacked": "stacked",
                         "terms_field": "elastic_agent.process",
+                        "time_range_mode": "entire_time_range",
                         "type": "timeseries"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "",
+                "time_range_mode": "entire_time_range",
                 "tooltip_mode": "show_all",
+                "truncate_legend": 1,
                 "type": "timeseries",
                 "use_kibana_indexes": false
             },
@@ -63,11 +92,17 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-47d87552-8421-4cfc-bc5d-4a7205f5b007",
     "migrationVersion": {
         "visualization": "7.14.0"
     },
-    "references": [],
+    "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        }
+    ],
     "type": "visualization"
 }

--- a/packages/elastic_agent/kibana/visualization/elastic_agent-69219f50-febc-11eb-9a5b-19cc90b68e55.json
+++ b/packages/elastic_agent/kibana/visualization/elastic_agent-69219f50-febc-11eb-9a5b-19cc90b68e55.json
@@ -3,7 +3,29 @@
         "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "elastic_agent.elastic_agent"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "elastic_agent.elastic_agent"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -24,6 +46,7 @@
                 "index_pattern": "metrics-*",
                 "interval": "",
                 "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -32,7 +55,7 @@
                         "fill": "0.5",
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"elastic_agent.elastic_agent\"    "
+                            "query": ""
                         },
                         "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
@@ -53,6 +76,7 @@
                         "split_mode": "terms",
                         "stacked": "stacked",
                         "terms_field": "elastic_agent.process",
+                        "time_range_mode": "entire_time_range",
                         "type": "timeseries"
                     },
                     {
@@ -96,6 +120,7 @@
                         "series_index_pattern": "",
                         "split_mode": "everything",
                         "stacked": "none",
+                        "time_range_mode": "entire_time_range",
                         "type": "timeseries"
                     }
                 ],
@@ -104,6 +129,7 @@
                 "time_field": "",
                 "time_range_mode": "entire_time_range",
                 "tooltip_mode": "show_all",
+                "truncate_legend": 1,
                 "type": "timeseries",
                 "use_kibana_indexes": false
             },
@@ -111,11 +137,17 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-69219f50-febc-11eb-9a5b-19cc90b68e55",
     "migrationVersion": {
         "visualization": "7.14.0"
     },
-    "references": [],
+    "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        }
+    ],
     "type": "visualization"
 }

--- a/packages/elastic_agent/kibana/visualization/elastic_agent-819241d0-0037-11ec-af6c-1740f74b2d73.json
+++ b/packages/elastic_agent/kibana/visualization/elastic_agent-819241d0-0037-11ec-af6c-1740f74b2d73.json
@@ -3,7 +3,29 @@
         "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "elastic_agent.elastic_agent"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "elastic_agent.elastic_agent"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -28,6 +50,7 @@
                 "index_pattern_ref_name": "metrics_0_index_pattern",
                 "interval": "",
                 "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -36,7 +59,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"elastic_agent.elastic_agent\"   "
+                            "query": ""
                         },
                         "formatter": "number",
                         "id": "a35c4256-5cee-4b6a-ae21-bdd0f0f6d4a2",
@@ -102,6 +125,7 @@
                         "split_mode": "terms",
                         "stacked": "stacked",
                         "terms_field": "elastic_agent.process",
+                        "time_range_mode": "entire_time_range",
                         "type": "timeseries",
                         "value_template": "{{value}}%"
                     }
@@ -111,6 +135,7 @@
                 "time_field": "@timestamp",
                 "time_range_mode": "entire_time_range",
                 "tooltip_mode": "show_all",
+                "truncate_legend": 1,
                 "type": "timeseries",
                 "use_kibana_indexes": true
             },
@@ -118,12 +143,17 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-819241d0-0037-11ec-af6c-1740f74b2d73",
     "migrationVersion": {
         "visualization": "7.14.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "metrics_0_index_pattern",

--- a/packages/elastic_agent/kibana/visualization/elastic_agent-93a8a11d-b2da-4ef3-81dc-c7040560ffde.json
+++ b/packages/elastic_agent/kibana/visualization/elastic_agent-93a8a11d-b2da-4ef3-81dc-c7040560ffde.json
@@ -3,7 +3,29 @@
         "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "elastic_agent.elastic_agent"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "elastic_agent.elastic_agent"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -19,10 +41,12 @@
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "axis_scale": "normal",
+                "drop_last_bucket": 0,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "",
                 "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -31,7 +55,7 @@
                         "fill": "0.5",
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"elastic_agent.elastic_agent\" "
+                            "query": ""
                         },
                         "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
@@ -46,17 +70,21 @@
                         ],
                         "point_size": 1,
                         "separate_axis": 0,
+                        "series_index_pattern": "",
                         "split_color_mode": "kibana",
                         "split_mode": "terms",
                         "stacked": "stacked",
                         "terms_field": "elastic_agent.process",
+                        "time_range_mode": "entire_time_range",
                         "type": "timeseries"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "",
+                "time_range_mode": "entire_time_range",
                 "tooltip_mode": "show_all",
+                "truncate_legend": 1,
                 "type": "timeseries",
                 "use_kibana_indexes": false
             },
@@ -64,11 +92,17 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-93a8a11d-b2da-4ef3-81dc-c7040560ffde",
     "migrationVersion": {
         "visualization": "7.14.0"
     },
-    "references": [],
+    "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        }
+    ],
     "type": "visualization"
 }

--- a/packages/elastic_agent/kibana/visualization/elastic_agent-a11c250a-865f-4eb2-9441-882d229313be.json
+++ b/packages/elastic_agent/kibana/visualization/elastic_agent-a11c250a-865f-4eb2-9441-882d229313be.json
@@ -3,7 +3,29 @@
         "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "elastic_agent.elastic_agent"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "elastic_agent.elastic_agent"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -24,6 +46,7 @@
                 "index_pattern": "metrics-*",
                 "interval": "",
                 "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -32,7 +55,7 @@
                         "fill": 0.5,
                         "filter": {
                             "language": "kuery",
-                            "query": "data_stream.dataset : \"elastic_agent.elastic_agent\" "
+                            "query": ""
                         },
                         "formatter": "percent",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
@@ -65,10 +88,12 @@
                         ],
                         "point_size": 1,
                         "separate_axis": 0,
+                        "series_index_pattern": "",
                         "split_color_mode": "kibana",
                         "split_mode": "terms",
                         "stacked": "stacked",
                         "terms_field": "elastic_agent.process",
+                        "time_range_mode": "entire_time_range",
                         "type": "timeseries"
                     }
                 ],
@@ -77,6 +102,7 @@
                 "time_field": "@timestamp",
                 "time_range_mode": "entire_time_range",
                 "tooltip_mode": "show_all",
+                "truncate_legend": 1,
                 "type": "timeseries",
                 "use_kibana_indexes": false
             },
@@ -84,11 +110,17 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "7.15.0",
+    "coreMigrationVersion": "7.16.0",
     "id": "elastic_agent-a11c250a-865f-4eb2-9441-882d229313be",
     "migrationVersion": {
         "visualization": "7.14.0"
     },
-    "references": [],
+    "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        }
+    ],
     "type": "visualization"
 }

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.5.0
+version: 1.5.1
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
Add data_stream.dataset=elastic_agent.elastic agent for agent visualizations in elastic agent metrics dashboard and data_stream.dataset=elastic_agent.* for beats visualizations.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
Add filters to visualizations on elastic agent metrics dashboard.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Build the elastic agent extension and bring up the integration stack with 
`elastic-package build && elastic-package stack up -d -v` 
and go to [Elastic agent dashboard](https://localhost:5601/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395) 

Click edit and notice like all the panels have a filter icon on the top right corner
![image](https://user-images.githubusercontent.com/96178987/216995650-27689709-1838-4841-8926-f8dbe313cc11.png)


If we edit a graph we can see the filter applied on dataset (it's the same for all panels of this type)
![image](https://user-images.githubusercontent.com/96178987/216995809-81aa6442-b8e9-4bfa-88e0-835575b29d64.png)

Beat Lens visualization are slightly different, for example:
![image](https://user-images.githubusercontent.com/96178987/216996024-a7bc024c-3204-4c67-8882-973ade5f56c4.png)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #4936 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
