### PR TITLE
[System Audit] Change Asciidoc attribute/variable to plain text

### DIFF
--- a/packages/system_audit/_dev/build/docs/README.md
+++ b/packages/system_audit/_dev/build/docs/README.md
@@ -27,7 +27,7 @@ The frequency of these polls is controlled by the `period` configuration paramet
 ### Entity IDs
 
 This module populates `entity_id` fields to uniquely identify entities (packages) within a host. 
-This requires {beatname_uc} to obtain a unique identifier for the host:
+This requires the module to obtain a unique identifier for the host:
 
 - Windows: Uses the `HKLM\Software\Microsoft\Cryptography\MachineGuid` registry
 key.

--- a/packages/system_audit/docs/README.md
+++ b/packages/system_audit/docs/README.md
@@ -27,7 +27,7 @@ The frequency of these polls is controlled by the `period` configuration paramet
 ### Entity IDs
 
 This module populates `entity_id` fields to uniquely identify entities (packages) within a host. 
-This requires {beatname_uc} to obtain a unique identifier for the host:
+This requires the module to obtain a unique identifier for the host:
 
 - Windows: Uses the `HKLM\Software\Microsoft\Cryptography\MachineGuid` registry
 key.


### PR DESCRIPTION
## What does this PR do?

This PR fixes an integration docs build error originating in the description for the System Audit integration. Currently the description contains an errant Asciidoc attribute/variable (`{beatname_uc}`), which was likely copied over from legacy Beats docs. The `{beatname_uc}` attribute isn't defined for integration docs, however, so this PR replaces it with hard-written plain text ("the module").

## Checklist

(Not applicable for docs fix?)

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm that the suggested replacement text is appropriate for this integration.

## How to test this PR locally

Probably no testing required for the integration itself, since this shouldn't affect any functionality. Docs testing will be done in https://github.com/elastic/wordlake/pull/72 to ensure that downstream docs build errors no longer occur.

## Related issues

- Relates https://github.com/elastic/wordlake/pull/72
- Relates https://github.com/elastic/integrations/pull/4862