### PR TITLE
cisco_secure_email_gateway: allow configuration of time zones

### DIFF
--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Allow configuration of time zones.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5192
 - version: "1.5.1"
   changes:
     - description: Add trim processor to remove white spaces in message.

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-amp.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-amp.log-expected.json
@@ -25,7 +25,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: File reputation query initiating. File Name = 'mod-6.exe', MID = 5, File Size = 1673216 bytes, File Type = application/x-dosexec"
+                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: File reputation query initiating. File Name = 'mod-6.exe', MID = 5, File Size = 1673216 bytes, File Type = application/x-dosexec",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -69,7 +70,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: Response received for file reputation query from Cloud. FileName = 'mod-6.exe', MID = 5, Disposition = MALICIOUS, Malware = W32.061DEF69B5-100.SBX.TG,Reputation Score = 73, sha256 =061def69b5c100e9979610fa5675bd19258b19a7ff538b5c2d230b467c312f19, upload_action = 2"
+                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: Response received for file reputation query from Cloud. FileName = 'mod-6.exe', MID = 5, Disposition = MALICIOUS, Malware = W32.061DEF69B5-100.SBX.TG,Reputation Score = 73, sha256 =061def69b5c100e9979610fa5675bd19258b19a7ff538b5c2d230b467c312f19, upload_action = 2",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -121,7 +123,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: File Analysis complete. SHA256: 16454aff5082c2e9df43f3e3b9cdba3c6ae1766416e548c30a971786db570bfc, Submit Timestamp: 1475825466, Update Timestamp: 1475825953, Disposition: 3 Score: 100, run_id: 194926004 Details: Analysis is completed for the File SHA256[16454aff5082c2e9df43f3e3b9cdba3c6ae1766416e548c30a971786db570bfc] Spyname:[W32.16454AFF50-100.SBX.TG]"
+                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: File Analysis complete. SHA256: 16454aff5082c2e9df43f3e3b9cdba3c6ae1766416e548c30a971786db570bfc, Submit Timestamp: 1475825466, Update Timestamp: 1475825953, Disposition: 3 Score: 100, run_id: 194926004 Details: Analysis is completed for the File SHA256[16454aff5082c2e9df43f3e3b9cdba3c6ae1766416e548c30a971786db570bfc] Spyname:[W32.16454AFF50-100.SBX.TG]",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -165,7 +168,8 @@
             "event": {
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: File not uploaded for analysis. MID = 0 File SHA256[a5f28f1fed7c2fe88bcdf403710098977fa12c32d13bfbd78bbe27e95b245f82] file mime[text/plain] Reason: No active/dynamic contents exists",
-                "reason": "No active/dynamic contents exists"
+                "reason": "No active/dynamic contents exists",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -216,7 +220,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: File analysis upload skipped. SHA256: b5c7e26491983baa713c9a2910ee868efd891661c6a0553b28f17b8fdc8cc3ef,Timestamp[1454782976] details[File SHA256[b5c7e26491983baa713c9a2910ee868efd891661c6a0553b28f17b8fdc8cc3ef] file mime[application/pdf], upload priority[Low] not uploaded, re-tries[3], backoff[986] discarding ...]"
+                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: File analysis upload skipped. SHA256: b5c7e26491983baa713c9a2910ee868efd891661c6a0553b28f17b8fdc8cc3ef,Timestamp[1454782976] details[File SHA256[b5c7e26491983baa713c9a2910ee868efd891661c6a0553b28f17b8fdc8cc3ef] file mime[application/pdf], upload priority[Low] not uploaded, re-tries[3], backoff[986] discarding ...]",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -261,7 +266,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: SHA256: 69e17e213732da0d0cbc48ae7030a4a18e0c1289f510e8b139945787f67692a5,Timestamp[1454959409] details[Server Response HTTP code:[502]]"
+                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: SHA256: 69e17e213732da0d0cbc48ae7030a4a18e0c1289f510e8b139945787f67692a5,Timestamp[1454959409] details[Server Response HTTP code:[502]]",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -308,7 +314,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: Retrospective verdict received. SHA256: 16454aff5082c2e9df43f3e3b9cdba3c6ae1766416e548c30a971786db570bfc, Timestamp: 1475832815.7, Verdict: MALICIOUS, Reputation Score: 0, Spyname: W32.16454AFF50-100.SBX."
+                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info: Retrospective verdict received. SHA256: 16454aff5082c2e9df43f3e3b9cdba3c6ae1766416e548c30a971786db570bfc, Timestamp: 1475832815.7, Verdict: MALICIOUS, Reputation Score: 0, Spyname: W32.16454AFF50-100.SBX.",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -355,7 +362,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info:   Retrospective verdict received. SHA256: 16454aff5082c2e9df43f3e3b9cdba3c6ae1766416e548c30a971786db570bfc, Timestamp: 1475832815.7, Verdict: MALICIOUS, Reputation Score: 0, Spyname: W32.16454AFF50-100.SBX."
+                "original": "\u003c166\u003eMar 17 18:24:37 amp: Info:   Retrospective verdict received. SHA256: 16454aff5082c2e9df43f3e3b9cdba3c6ae1766416e548c30a971786db570bfc, Timestamp: 1475832815.7, Verdict: MALICIOUS, Reputation Score: 0, Spyname: W32.16454AFF50-100.SBX.",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-anti-spam.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-anti-spam.log-expected.json
@@ -18,7 +18,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 antispam: Info: case antispam - engine (72324) : case-daemon: Initializing Child"
+                "original": "\u003c166\u003eMar 17 18:24:37 antispam: Info: case antispam - engine (72324) : case-daemon: Initializing Child",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -49,7 +50,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 antispam: Info: case antispam - engine (15703) : case-daemon: all children killed, exitting"
+                "original": "\u003c166\u003eMar 17 18:24:37 antispam: Info: case antispam - engine (15703) : case-daemon: all children killed, exitting",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -81,7 +83,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 antispam: Info: case antispam - engine (15703) : case-daemon: server killed by SIGHUP, shutting down"
+                "original": "\u003c166\u003eMar 17 18:24:37 antispam: Info: case antispam - engine (15703) : case-daemon: server killed by SIGHUP, shutting down",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-consolidated-event.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-consolidated-event.log-expected.json
@@ -78,7 +78,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.0.0-657|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=42127C7DDEE76852677B-F80CE8074CD3 ESAMID=1053 ESAICID=134 ESAAMPVerdict=UNKNOWN ESAASVerdict=NEGATIVE ESAAVVerdict=NEGATIVE  ESACFVerdict=MATCH endTime=Thu Mar 18 08:04:46 2021 ESADLPVerdict=NOT_EVALUATED dvc=1.128.3.4 ESAAttachmentDetails={'test.txt': {'AMP': {'Verdict': 'FILE UNKNOWN', 'fileHash': '7f843d263304fb0516d6210e9de4fa7f01f2f623074aab6e3ee7051f7b785cfa'}, 'BodyScanner': {'fsize': 10059}}} ESAFriendlyFrom=example.com ESAGMVerdict=NEGATIVE startTime=Thu Mar 18 08:04:29 2021 deviceInboundInterface=Incomingmail deviceDirection=0 ESAMailFlowPolicy=ACCEPT suser=example.com cs1Label=MailPolicy cs1=DEFAULT ESAMFVerdict=NOT_EVALUATED act=QUARANTINED ESAFinalActionDetails=To POLICY cs4Label=ExternalMsgID cs4='\u003cexample.com\u003e' ESAMsgSize=11873 ESAOFVerdict=POSITIVE duser=example.com ESAHeloIP=1.128.3.4 cfp1Label=SBRSScore cfp1=None ESASDRDomainAge=27 years 2 months 15 days cs3Label=SDRThreatCategory cs3=N/A cs6Label=SDRRepScore cs6=Weak ESASPFVerdict={'mailfrom': {'result': 'None', 'sender': 'example.com'}, 'helo': {'result': 'None', 'sender': 'postmaster'}, 'pra': {'result': 'None', 'sender': 'example.com'}} sourceHostName=unknown ESASenderGroup=UNKNOWNLIST sourceAddress=1.128.3.4 msg='Testing'",
                 "severity": "5",
-                "start": "Thu Mar 18 08:04:29 2021"
+                "start": "Thu Mar 18 08:04:29 2021",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "42127C7DDEE76852677B-F80CE8074CD3"
@@ -180,7 +181,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.0.0-657|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=42127C7DDEE76852677B-F80CE8074CD3 ESAMID=1053 ESAICID=134 ESAAMPVerdict=UNKNOWN ESAASVerdict=NEGATIVE ESAAVVerdict=NEGATIVE  ESACFVerdict=MATCH endTime=Thu Mar 18 08:04:46 2021 ESADLPVerdict=NOT_EVALUATED dvc=1.128.3.4 ESAAttachmentDetails={'test.txt': {'AMP': {'Verdict': 'FILE UNKNOWN', 'fileHash': '7f843d263304fb0516d6210e9de4fa7f01f2f623074aab6e3ee7051f7b785cfa'}, 'BodyScanner': {'fsize': 10059}}} ESAFriendlyFrom=example.com ESAGMVerdict=NEGATIVE startTime=Thu Mar 18 08:04:29 2021 deviceInboundInterface=Incomingmail deviceDirection=0 ESAMailFlowPolicy=ACCEPT suser=example.com cs1Label=MailPolicy cs1=DEFAULT ESAMFVerdict=NOT_EVALUATED act=QUARANTINED ESAFinalActionDetails=To POLICY cs4Label=ExternalMsgID cs4='\u003cexample.com\u003e' ESAMsgSize=11873 ESAOFVerdict=POSITIVE duser=example.com ESAHeloIP=1.128.3.4 cfp1Label=SBRSScore cfp1=95.2 ESASDRDomainAge=27 years 2 months 15 days cs3Label=SDRThreatCategory cs3=N/A cs6Label=SDRRepScore cs6=Weak ESASPFVerdict={'mailfrom': {'result': 'None', 'sender': 'example.com'}, 'helo': {'result': 'None', 'sender': 'postmaster'}, 'pra': {'result': 'None', 'sender': 'example.com'}} sourceHostName=unknown ESASenderGroup=UNKNOWNLIST sourceAddress=1.128.3.4 msg='Testing'",
                 "severity": "5",
-                "start": "Thu Mar 18 08:04:29 2021"
+                "start": "Thu Mar 18 08:04:29 2021",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "42127C7DDEE76852677B-F80CE8074CD3"
@@ -278,7 +280,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.0.2-020|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=422084EE64B1B0454D49-AAFBF6B55869 ESAMID=153634 ESAICID=55854 ESADCID=41512 ESAAMPVerdict=NOT_EVALUATED ESAASVerdict=NOT_EVALUATED ESAAVVerdict=NEGATIVE ESACFVerdict=NO_MATCH endTime=Thu Nov  3 14:05:44 2022 ESADLPVerdict=NO_TRIGGER dvc=1.128.3.4 ESAFriendlyFrom=example.com ESAGMVerdict=NEGATIVE startTime=Thu Nov  3 14:05:43 2022 deviceOutboundInterface=OutList deviceDirection=1 ESAMailFlowPolicy=RELAY suser=example.com cs1Label=MailPolicy cs1=DEFAULT cs2Label=SenderCountry cs2=not enabled ESAMFVerdict=NOT_EVALUATED act=DELIVERED cs4Label=ExternalMsgID cs4='\u003cexample.com\u003e' ESAMsgSize=8893 ESAOFVerdict=NEGATIVE duser=example.com ESAHeloDomain=example.cisco.com ESAHeloIP=1.128.3.4 ESAReplyTo=example.com cfp1Label=SBRSScore cfp1=not enabled sourceHostName=unknown ESASenderGroup=RELAYLIST sourceAddress=1.128.3.4 msg='[SUSPICIOUS MESSAGE] Everycloud Mailflow Monitor guid: 12312314123' ESAURLDetails={'https://secure-web.cisco.com/213weqs123eqwdasrwqe12rf3efd-dasarfgsaddasdasfdas13rdsdw1e1w31rswd...': {'ExpandedUrl': 'https://www.example.com/example-monitor'}}",
                 "severity": "5",
-                "start": "Thu Nov  3 14:05:43 2022"
+                "start": "Thu Nov  3 14:05:43 2022",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "422084EE64B1B0454D49-AAFBF6B55869"
@@ -364,7 +367,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.0.2-020|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=422084EE64B1B0454D49-AAFBF6B55869 ESAMID=164226 ESAICID=62905 ESAAMPVerdict=NOT_EVALUATED ESAASVerdict=NOT_EVALUATED ESAAVVerdict=NOT_EVALUATED ESACFVerdict=NOT_EVALUATED endTime=Mon Nov 14 15:32:05 2022 ESADLPVerdict=NOT_EVALUATED dvc=1.128.3.4 ESAGMVerdict=NOT_EVALUATED startTime=Mon Nov 14 15:32:05 2022 deviceInboundInterface=IncList ESAMailFlowPolicy=ACCEPT suser=example.com cs2Label=SenderCountry cs2=United States ESAMFVerdict=NOT_EVALUATED act=ABORTED ESAFinalActionDetails=Receiving aborted by sender ESAOFVerdict=NOT_EVALUATED ESAHeloDomain=GHYU-TRY-AIMV ESAHeloIP=1.128.3.4 cfp1Label=SBRSScore cfp1=-2.3 sourceHostName=example.cisco.com ESASenderGroup=SUSPECTLIST sourceAddress=1.128.3.4 msg=''",
                 "severity": "5",
-                "start": "Mon Nov 14 15:32:05 2022"
+                "start": "Mon Nov 14 15:32:05 2022",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "422084EE64B1B0454D49-AAFBF6B55869"
@@ -461,7 +465,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.0.2-020|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=422084EE64B1B0454D49-AAFBF6B55869 ESAMID=164230 ESAICID=62909 ESADCID=47846 ESAAMPVerdict=NOT_EVALUATED ESAASVerdict=NOT_EVALUATED ESAAVVerdict=NEGATIVE ESACFVerdict=NO_MATCH endTime=Mon Nov 14 15:40:49 2022 ESADLPVerdict=NO_TRIGGER dvc=1.128.3.4 ESAFriendlyFrom=example.com ESAGMVerdict=NEGATIVE startTime=Mon Nov 14 15:40:49 2022 deviceOutboundInterface=OutList deviceDirection=1 ESAMailFlowPolicy=RELAY suser=example.com cs1Label=MailPolicy cs1=DEFAULT cs2Label=SenderCountry cs2=not enabled ESAMFVerdict=NOT_EVALUATED act=DELIVERED cs4Label=ExternalMsgID cs4='\u003cexample.com\u003e' ESAMsgSize=7360 ESAOFVerdict=NEGATIVE duser=example.com ESAHeloDomain=example.cisco.com ESAHeloIP=1.128.3.4 ESAReplyTo=example.com cfp1Label=SBRSScore cfp1=not enabled sourceHostName=unknown ESASenderGroup=RELAYLIST sourceAddress=1.128.3.4 msg='Everycloud Mailflow Monitor guid: 34214234232'",
                 "severity": "5",
-                "start": "Mon Nov 14 15:40:49 2022"
+                "start": "Mon Nov 14 15:40:49 2022",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "422084EE64B1B0454D49-AAFBF6B55869"
@@ -564,7 +569,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.0.2-020|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=422084EE64B1B0454D49-AAFBF6B55869 ESAMID=164229 ESAICID=62908 ESADCID=47845 ESAAMPVerdict=SKIPPED ESAASVerdict=NEGATIVE ESAAVVerdict=NEGATIVE ESACFVerdict=NO_MATCH endTime=Mon Nov 14 15:40:48 2022 ESADLPVerdict=NOT_EVALUATED dvc=1.128.3.4 ESAFriendlyFrom=example.com ESAGMVerdict=NEGATIVE startTime=Mon Nov 14 15:40:47 2022 deviceInboundInterface=IncList deviceDirection=0 ESAMailFlowPolicy=ACCEPT suser=example.com cs1Label=MailPolicy cs1=DEFAULT cs2Label=SenderCountry cs2=United States ESAMFVerdict=NOT_EVALUATED act=DELIVERED cs4Label=ExternalMsgID cs4='\u003cexample.com\u003e' ESAMsgSize=1411 ESAOFVerdict=NEGATIVE duser=example.com ESAHeloDomain=example.cisco.com ESAHeloIP=1.128.3.4 ESAReplyTo=example.com cfp1Label=SBRSScore cfp1=5.2 ESASDRDomainAge=1 month cs3Label=SDRThreatCategory cs3=N/A cs6Label=SDRRepScore cs6=Neutral sourceHostName=example.cisco.com ESASenderGroup=UNKNOWNLIST sourceAddress=1.128.3.4 msg='Everycloud Mailflow Monitor guid: 321514231213'",
                 "severity": "5",
-                "start": "Mon Nov 14 15:40:47 2022"
+                "start": "Mon Nov 14 15:40:47 2022",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "422084EE64B1B0454D49-AAFBF6B55869"
@@ -667,7 +673,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.0.2-020|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=422084EE64B1B0454D49-AAFBF6B55869 ESAMID=164231 ESAICID=62910 ESADCID=47847 ESAAMPVerdict=UNKNOWN ESAASVerdict=NEGATIVE ESAAVVerdict=NEGATIVE ESACFVerdict=NO_MATCH endTime=Mon Nov 14 15:43:36 2022 ESADLPVerdict=NOT_EVALUATED dvc=1.128.3.4 ESAAttachmentDetails={'image003.png': {'AMP': {'Verdict': 'FILE UNKNOWN', 'fileHash': '7de9d8514c142887d11821fd30faddc693d192efdd19dfb6459872a1be63dcfa'}, 'BodyScanner': {}}} ESAFriendlyFrom=example.com ESAGMVerdict=NEGATIVE startTime=Mon Nov 14 15:43:29 2022 deviceInboundInterface=IncList deviceDirection=0 ESAMailFlowPolicy=ACCEPT suser=example.com cs1Label=MailPolicy cs1=DEFAULT cs2Label=SenderCountry cs2=United States ESAMFVerdict=NOT_EVALUATED act=DELIVERED cs4Label=ExternalMsgID cs4='\u003cexample.com\u003e' ESAMsgSize=352844 ESAOFVerdict=NEGATIVE duser=example.com ESAHeloDomain=example.cisco.com ESAHeloIP=1.128.3.4 cfp1Label=SBRSScore cfp1=5.1 ESASDRDomainAge=1 month cs3Label=SDRThreatCategory cs3=N/A cs6Label=SDRRepScore cs6=Neutral sourceHostName=example.cisco.com ESASenderGroup=UNKNOWNLIST sourceAddress=1.128.3.4 msg='TEST'",
                 "severity": "5",
-                "start": "Mon Nov 14 15:43:29 2022"
+                "start": "Mon Nov 14 15:43:29 2022",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "422084EE64B1B0454D49-AAFBF6B55869"
@@ -783,7 +790,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.3.0-023|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=423A4DF759243122B64F-7941F28E57A4 ESAMID=4086421 ESAICID=13956459 ESADCID=2522340 ESAAMPVerdict=UNKNOWN ESAASVerdict=NEGATIVE ESAAVVerdict=NOT_EVALUATED ESACFVerdict=NO_MATCH endTime=Thu Nov 24 13:39:24 2022 ESADKIMVerdict=pass ESADLPVerdict=NOT_EVALUATED dvc=1.128.3.4 ESAAttachmentDetails={'image002.png': {'AMP': {'Verdict': 'FILE UNKNOWN', 'fileHash': '30bf618599d8784ebcf38769f8b524b40dc20d2ba262a1e4052d24711abcd064'}, 'BodyScanner': {}}, 'image001.png': {'AMP': {'Verdict': 'FILE UNKNOWN', 'fileHash': '7de9d8514c142887d11821fd30faddc693d192efdd19dfb6459872a1be63dcfa'}, 'BodyScanner': {}}} ESAFriendlyFrom=example.com ESAGMVerdict=NEGATIVE startTime=Thu Nov 24 13:39:16 2022 deviceInboundInterface=IncomingMail deviceDirection=0 ESAMailFlowPolicy=ACCEPT suser=example.com cs1Label=MailPolicy cs1=DEFAULT cs2Label=SenderCountry cs2=United States ESAMFVerdict=MATCH act=DELIVERED cs4Label=ExternalMsgID cs4='\u003cexample.com\u003e' ESAMsgSize=716707 ESAOFVerdict=NEGATIVE duser=example.com ESAHeloDomain=example.cisco.com ESAHeloIP=1.128.3.4 cfp1Label=SBRSScore cfp1=3.5 ESASDRDomainAge=30 days (or greater) cs3Label=SDRThreatCategory cs3=N/A cs6Label=SDRRepScore cs6=Favorable sourceHostName=example.cisco.com ESASenderGroup=ACCEPTLIST sourceAddress=1.128.3.4 msg='RE: SR 312312 : consolidate event log' ESATLSInCipher=KWLDS-RSA-AES256-GCM-SHA384 ESATLSInConnStatus=Success ESATLSInProtocol=TLSv1.2 ESATLSOutCipher=HDKWA-RSA-AES256-JMB-SHA384 ESATLSOutConnStatus=Success ESATLSOutProtocol=TLSv1.2",
                 "severity": "5",
-                "start": "Thu Nov 24 13:39:16 2022"
+                "start": "Thu Nov 24 13:39:16 2022",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "423A4DF759243122B64F-7941F28E57A4"
@@ -910,7 +918,8 @@
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 consolidated_event: CEF:0|Cisco|C100V Email Security Virtual Appliance|14.3.0-023|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=423A4DF759243122B64F-7941F28E57A4 ESAMID=4086421 ESAICID=13956459 ESADCID=2522340 ESAAMPVerdict=UNKNOWN ESAASVerdict=NEGATIVE ESAAVVerdict=NOT_EVALUATED ESACFVerdict=NO_MATCH endTime=Thu Nov 24 13:39:24 2022 ESADKIMVerdict=pass ESADLPVerdict=NOT_EVALUATED dvc=1.128.3.4 ESAAttachmentDetails={'image002.png': {'AMP': {'Verdict': 'FILE UNKNOWN', 'fileHash': '30bf618599d8784ebcf38769f8b524b40dc20d2ba262a1e4052d24711abcd064'}, 'BodyScanner': {}}, 'image001.png': {'AMP': {'Verdict': 'FILE UNKNOWN', 'fileHash': '7de9d8514c142887d11821fd30faddc693d192efdd19dfb6459872a1be63dcfa'}, 'BodyScanner': {}}} ESAFriendlyFrom=example.com ESAGMVerdict=NEGATIVE startTime=Thu Nov 24 13:39:16 2022 deviceInboundInterface=IncomingMail deviceDirection=0 ESAMailFlowPolicy=ACCEPT suser=example.com cs1Label=MailPolicy cs1=DEFAULT cs2Label=SenderCountry cs2=United States ESAMFVerdict=MATCH act=DELIVERED cs4Label=ExternalMsgID cs4='\u003cexample.com\u003e' ESAMsgSize=716707 ESAOFVerdict=NEGATIVE duser=example.com ESAHeloDomain=example.cisco.com ESAHeloIP=1.128.3.4 cfp1Label=SBRSScore cfp1=3.5 ESASDRDomainAge=30 days (or greater) cs3Label=SDRThreatCategory cs3=N/A cs6Label=SDRRepScore cs6=Favorable sourceHostName=example.cisco.com ESASenderGroup=ACCEPTLIST sourceAddress=1.128.3.4 msg='RE: SR 312312 : consolidate event log' ESATLSInCipher=KWLDS-RSA-AES256-GCM-SHA384 ESATLSInConnStatus=Success ESATLSInProtocol=TLSv1.2 ESATLSOutCipher=HDKWA-RSA-AES256-JMB-SHA384 ESATLSOutConnStatus=Success ESATLSOutProtocol=TLSv1.2 ESADaneHost=testdomain.com ESADaneStatus=success ESADHASource=1.128.3.4 ESADMARCVerdict=TempFailure cs5Label=ESAMsgLanguage cs5=English ESAMARAction={'action':'\u003c\u003e';'succesful_rcpts'='\u003c\u003e';'failed_recipients'='\u003c\u003e';'filename'='\u003c\u003e'} ESAMsgTooBigFromSender=true ESARateLimitedIP=1.128.3.4",
                 "severity": "5",
-                "start": "Thu Nov 24 13:39:16 2022"
+                "start": "Thu Nov 24 13:39:16 2022",
+                "timezone": "UTC"
             },
             "host": {
                 "id": "423A4DF759243122B64F-7941F28E57A4"

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-content-scanner.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-content-scanner.log-expected.json
@@ -17,7 +17,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 content_scanner: Info: PF: Starting multi-threaded Perceptive server (pid=17729)"
+                "original": "\u003c166\u003eMar 17 18:31:14 content_scanner: Info: PF: Starting multi-threaded Perceptive server (pid=17729)",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -50,7 +51,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 content_scanner: Info: PF: Restarting content_scanner service."
+                "original": "\u003c166\u003eMar 17 18:31:14 content_scanner: Info: PF: Restarting content_scanner service.",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-error.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-error.log-expected.json
@@ -18,6 +18,7 @@
             "event": {
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:31:14 error_logs: Info: Quarantine: Failed to connect to quarantine",
+                "timezone": "UTC",
                 "type": [
                     "error"
                 ]
@@ -54,6 +55,7 @@
             "event": {
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:31:14 error_logs: Info: Internal SMTP giving up on message to example.com with subject 'Warning \u003cSystem\u003e example.com: Your \"IronPort Email Encryption\" key will expire in under 60...': Unrecoverable error.",
+                "timezone": "UTC",
                 "type": [
                     "error"
                 ]
@@ -94,6 +96,7 @@
             "event": {
                 "kind": "alert",
                 "original": "\u003c166\u003eMar 17 18:31:14 error_logs: Critical: Error while sending alert: Unable to send System/Warning alert to example.com with subject \"Warning \u003cSystem\u003e example.com: Your \"IronPort Email Encryption\" key will expire in under 60...\".",
+                "timezone": "UTC",
                 "type": [
                     "error"
                 ]
@@ -130,6 +133,7 @@
             "event": {
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:31:14 error_logs: Info: Internal SMTP system attempting to send a message to example.com with subject 'Critical \u003cSystem\u003e example.com: Log Error: Subscription error_logs: Failed to connect to 10....' (attempt #0).",
+                "timezone": "UTC",
                 "type": [
                     "error"
                 ]

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-gui-log.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-gui-log.log-expected.json
@@ -23,6 +23,7 @@
                 "id": "2v10z5fEuDsvhdbVE6Ck",
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: req:1.128.3.4 user:admin id:2v10z5fEuDsvhdbVE6Ck 200 GET xxx.png HTTP/1.1 Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
+                "timezone": "UTC",
                 "type": [
                     "access"
                 ]
@@ -96,6 +97,7 @@
                 "id": "2v10z5fEuDsvhdbVE6Ck",
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: req:1.128.3.4 user:- id:2v10z5fEuDsvhdbVE6Ck 200 GET xxx.png HTTP/1.1 -",
+                "timezone": "UTC",
                 "type": [
                     "access"
                 ]
@@ -148,6 +150,7 @@
                 ],
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: Action: User admin logged out from session 5GPz0QDlfxUYQ0Y3PgYN beacuse of inactivity timeout",
+                "timezone": "UTC",
                 "type": [
                     "end"
                 ]
@@ -191,6 +194,7 @@
                 ],
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: Session fRK3TSjzhHhoI9CV5Kvt user:admin expired",
+                "timezone": "UTC",
                 "type": [
                     "end"
                 ]
@@ -230,7 +234,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: Session fRK3TSjzhHhoI9CV5Kvt from 1.128.3.4 not found Destination:/mail_policies/email_security_manager/incoming_mail_policies"
+                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: Session fRK3TSjzhHhoI9CV5Kvt from 1.128.3.4 not found Destination:/mail_policies/email_security_manager/incoming_mail_policies",
+                "timezone": "UTC"
             },
             "host": {
                 "ip": "1.128.3.4"
@@ -269,7 +274,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: SourceIP:1.128.3.4 Destination:/login Username:admin Privilege:admin session:5GPz0QDlfxUYQ0Y3PgYN Action: The HTTPS session has been established successfully."
+                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: SourceIP:1.128.3.4 Destination:/login Username:admin Privilege:admin session:5GPz0QDlfxUYQ0Y3PgYN Action: The HTTPS session has been established successfully.",
+                "timezone": "UTC"
             },
             "host": {
                 "ip": "1.128.3.4"
@@ -312,7 +318,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: PERIODIC REPORTS: No root directory for Periodic Reports Archive. Probably, running first time..."
+                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: PERIODIC REPORTS: No root directory for Periodic Reports Archive. Probably, running first time...",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -341,7 +348,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Warning: Could not fetch current Virus Threat Level: OS error opening URL 'http://example.com/xxxxx/xxxxx.txt'"
+                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Warning: Could not fetch current Virus Threat Level: OS error opening URL 'http://example.com/xxxxx/xxxxx.txt'",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "warning",
@@ -370,7 +378,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Warning: SSL error with client 1.128.3.4:000 - (336151574, 'error:14094416:SSL routines:ssl3_read_bytes:sslv3 alert certificate unknown')"
+                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Warning: SSL error with client 1.128.3.4:000 - (336151574, 'error:14094416:SSL routines:ssl3_read_bytes:sslv3 alert certificate unknown')",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "warning",
@@ -408,7 +417,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: Error in https connection from host 1.128.3.4 port 000 - [Errno 54] Connection reset by peer"
+                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: Error in https connection from host 1.128.3.4 port 000 - [Errno 54] Connection reset by peer",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -446,7 +456,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: Passphrase has been changed for user admin"
+                "original": "\u003c166\u003eMar 17 18:31:14 gui_logs: Info: Passphrase has been changed for user admin",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-status.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-status.log-expected.json
@@ -103,7 +103,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c182\u003eMar 30 15:12:26 status: Info: Status: CPULd 0 DskIO 0 RAMUtil 1 QKUsd 0 QKFre 8388608 CrtMID 0 CrtICID 0 CrtDCID 1 InjMsg 0 InjRcp 0 GenBncRcp 0 RejRcp 0 DrpMsg 0 SftBncEvnt 0 CmpRcp 0 HrdBncRcp 0 DnsHrdBnc 0 5XXHrdBnc 0 FltrHrdBnc 0 ExpHrdBnc 0 OtrHrdBnc 0 DlvRcp 0 DelRcp 0 GlbUnsbHt 0 ActvRcp 0 UnatmptRcp 0 AtmptRcp 0 CrtCncIn 0 CrtCncOut 0 DnsReq 0 NetReq 0 CchHit 0 CchMis 0 CchEct 0 CchExp 0 CPUTTm 91 CPUETm 32182 MaxIO 487 RAMUsd 125195690 MMLen 0 DstInMem 3 ResCon 0 WorkQ 0 QuarMsgs 0 QuarQKUsd 0 LogUsd 5 SophLd 99 BMLd 0 CASELd 0 TotalLd 47 LogAvail 148G EuQ 0 EuqRls 0 CmrkLd 0 McafLd 0 SwIn 338 SwOut 681 SwPgIn 2123 SwPgOut 7156 SwapUsage 0% RptLd 0 QtnLd 0 EncrQ 0 InjBytes 0"
+                "original": "\u003c182\u003eMar 30 15:12:26 status: Info: Status: CPULd 0 DskIO 0 RAMUtil 1 QKUsd 0 QKFre 8388608 CrtMID 0 CrtICID 0 CrtDCID 1 InjMsg 0 InjRcp 0 GenBncRcp 0 RejRcp 0 DrpMsg 0 SftBncEvnt 0 CmpRcp 0 HrdBncRcp 0 DnsHrdBnc 0 5XXHrdBnc 0 FltrHrdBnc 0 ExpHrdBnc 0 OtrHrdBnc 0 DlvRcp 0 DelRcp 0 GlbUnsbHt 0 ActvRcp 0 UnatmptRcp 0 AtmptRcp 0 CrtCncIn 0 CrtCncOut 0 DnsReq 0 NetReq 0 CchHit 0 CchMis 0 CchEct 0 CchExp 0 CPUTTm 91 CPUETm 32182 MaxIO 487 RAMUsd 125195690 MMLen 0 DstInMem 3 ResCon 0 WorkQ 0 QuarMsgs 0 QuarQKUsd 0 LogUsd 5 SophLd 99 BMLd 0 CASELd 0 TotalLd 47 LogAvail 148G EuQ 0 EuqRls 0 CmrkLd 0 McafLd 0 SwIn 338 SwOut 681 SwPgIn 2123 SwPgOut 7156 SwapUsage 0% RptLd 0 QtnLd 0 EncrQ 0 InjBytes 0",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-system.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-system.log-expected.json
@@ -16,7 +16,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 system: Info: PID 1237: User admin commit changes: Added a second CLI log for examples"
+                "original": "\u003c166\u003eMar 17 18:31:14 system: Info: PID 1237: User admin commit changes: Added a second CLI log for examples",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -60,7 +61,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 system: Info: lame DNS referral: qname:example.net ns_name:example.net zone:example.net ref_zone:example.net referrals:[(524666183436709L, 0, 'insecure', 'example.net'), (524666183436709L, 0, 'insecure', 'example.net')]"
+                "original": "\u003c166\u003eMar 17 18:31:14 system: Info: lame DNS referral: qname:example.net ns_name:example.net zone:example.net ref_zone:example.net referrals:[(524666183436709L, 0, 'insecure', 'example.net'), (524666183436709L, 0, 'insecure', 'example.net')]",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -89,7 +91,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 system: Warning: Failed to bootstrap the DNS resolver. Unable to contact root servers."
+                "original": "\u003c166\u003eMar 17 18:31:14 system: Warning: Failed to bootstrap the DNS resolver. Unable to contact root servers.",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "warning",
@@ -118,7 +121,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 system: Warning: DNS query network error '[Errno 51] Network is unreachable' to 'dummy_ip' looking up ' '"
+                "original": "\u003c166\u003eMar 17 18:31:14 system: Warning: DNS query network error '[Errno 51] Network is unreachable' to 'dummy_ip' looking up ' '",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "warning",
@@ -147,7 +151,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:31:14 system: Warning: Received an invalid DNS Response: '' to IP dummy_ip looking up example.de"
+                "original": "\u003c166\u003eMar 17 18:31:14 system: Warning: Received an invalid DNS Response: '' to IP dummy_ip looking up example.de",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "warning",

--- a/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-text-mail.log-expected.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/_dev/test/pipeline/test-common-text-mail.log-expected.json
@@ -22,7 +22,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: MID 111 DLP violation. Severity: LOW (Risk Factor: 15). DLP policy match: 'PCI-DSS (Payment Card Industry Data Security Standard)'."
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: MID 111 DLP violation. Severity: LOW (Risk Factor: 15). DLP policy match: 'PCI-DSS (Payment Card Industry Data Security Standard)'.",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -51,7 +52,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: graymail [CONFIG] Starting graymail configuration handler"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: graymail [CONFIG] Starting graymail configuration handler",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -83,6 +85,7 @@
             "event": {
                 "kind": "event",
                 "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: URL_REP_CLIENT: Configuration changed. Triggering restart of URL Reputation client service.",
+                "timezone": "UTC",
                 "type": "change"
             },
             "log": {
@@ -116,7 +119,8 @@
             },
             "event": {
                 "kind": "alert",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: A System/Warning alert was sent to example.com with subject \"Warning \u003cSystem\u003e cisco.esa: URL category definitions have changed.; Added new category '...\"."
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: A System/Warning alert was sent to example.com with subject \"Warning \u003cSystem\u003e cisco.esa: URL category definitions have changed.; Added new category '...\".",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -153,7 +157,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: New SMTP ICID 5 interface Management (1.128.3.4) address 1.128.3.4 reverse dns host http://example.com/example/example.txt.com verified yes"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: New SMTP ICID 5 interface Management (1.128.3.4) address 1.128.3.4 reverse dns host http://example.com/example/example.txt.com verified yes",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -193,7 +198,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: Start MID 6 ICID 5"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: Start MID 6 ICID 5",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -227,7 +233,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: MID 6 ICID 5 From: \u003cexample.com\u003e"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: MID 6 ICID 5 From: \u003cexample.com\u003e",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -262,7 +269,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: MID 6 ICID 5 RID 0 To: \u003cexample.com\u003e"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: MID 6 ICID 5 RID 0 To: \u003cexample.com\u003e",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -296,7 +304,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: MID 6 ready 100 bytes from \u003cexample.com\u003e"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: MID 6 ready 100 bytes from \u003cexample.com\u003e",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -325,7 +334,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: ICID 5 close"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: ICID 5 close",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -356,7 +366,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: New SMTP DCID 8 interface 1.128.3.4 address 1.128.3.4"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: New SMTP DCID 8 interface 1.128.3.4 address 1.128.3.4",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -397,7 +408,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: Delivery start DCID 8 MID 6 to RID [0]"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: Delivery start DCID 8 MID 6 to RID [0]",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -430,7 +442,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: Message done DCID 8 MID 6 to RID [0]"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: Message done DCID 8 MID 6 to RID [0]",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -459,7 +472,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: DCID 8 close"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: DCID 8 close",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -488,7 +502,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Warning: URL category definitions have changed. Please check and update your filters to use the new definitions"
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Warning: URL category definitions have changed. Please check and update your filters to use the new definitions",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "warning",
@@ -522,7 +537,8 @@
             },
             "event": {
                 "kind": "alert",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Critical: Error while sending alert: Unable to send System/Warning alert to example.com with subject \"Warning \u003cSystem\u003e example.com: Your \"IronPort Email Encryption\" key will expire in under 60...\"."
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Critical: Error while sending alert: Unable to send System/Warning alert to example.com with subject \"Warning \u003cSystem\u003e example.com: Your \"IronPort Email Encryption\" key will expire in under 60...\".",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "critical",
@@ -551,7 +567,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Warning: Your \"IronPort Anti-Spam\" key will expire in under 60 day(s). Please contact your authorized Cisco sales representative."
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Warning: Your \"IronPort Anti-Spam\" key will expire in under 60 day(s). Please contact your authorized Cisco sales representative.",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "warning",
@@ -584,7 +601,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: Internal SMTP system successfully sent a message to example.com with subject 'Warning \u003cSystem\u003e cisco.esa: Your \"Sophos Anti-Virus\" key will expire in under 60 day(s)....'."
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Info: Internal SMTP system successfully sent a message to example.com with subject 'Warning \u003cSystem\u003e cisco.esa: Your \"Sophos Anti-Virus\" key will expire in under 60 day(s)....'.",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "info",
@@ -620,7 +638,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Critical: Internal SMTP giving up on message to example.com with subject 'Warning \u003cSystem\u003e example.com: Your \"IronPort Email Encryption\" key will expire in under 60...': Unrecoverable error."
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Critical: Internal SMTP giving up on message to example.com with subject 'Warning \u003cSystem\u003e example.com: Your \"IronPort Email Encryption\" key will expire in under 60...': Unrecoverable error.",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "critical",
@@ -661,7 +680,8 @@
             },
             "event": {
                 "kind": "event",
-                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Warning: Internal SMTP Error: Failed to send message to host 1.128.3.4:000 for recipient example: Unexpected SMTP response \"553\", expecting code starting with \"2\", response was ['#5.1.8 Domain of sender address \u003cexample.com\u003e does not exist']."
+                "original": "\u003c166\u003eMar 17 18:24:37 mail_logs: Warning: Internal SMTP Error: Failed to send message to host 1.128.3.4:000 for recipient example: Unexpected SMTP response \"553\", expecting code starting with \"2\", response was ['#5.1.8 Domain of sender address \u003cexample.com\u003e does not exist'].",
+                "timezone": "UTC"
             },
             "log": {
                 "level": "warning",

--- a/packages/cisco_secure_email_gateway/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/cisco_secure_email_gateway/data_stream/log/agent/stream/stream.yml.hbs
@@ -13,7 +13,14 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 exclude_files: [".gz$"]
-{{#if processors}}
+{{#if tz_offset}}
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: "{{tz_offset}}"
+{{/if}}
 processors:
+- add_locale: ~
+{{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/cisco_secure_email_gateway/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/cisco_secure_email_gateway/data_stream/log/agent/stream/tcp.yml.hbs
@@ -12,7 +12,14 @@ publisher_pipeline.disable_host: true
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
-{{#if processors}}
+{{#if tz_offset}}
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: "{{tz_offset}}"
+{{/if}}
 processors:
+- add_locale: ~
+{{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/cisco_secure_email_gateway/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_secure_email_gateway/data_stream/log/agent/stream/udp.yml.hbs
@@ -12,7 +12,14 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if processors}}
+{{#if tz_offset}}
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: "{{tz_offset}}"
+{{/if}}
 processors:
+- add_locale: ~
+{{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -30,8 +30,28 @@ processors:
   - lowercase:
       field: log.level
       ignore_failure: true
+
+  # Time zone can come from two sources, choose in order: config, locale, default to UTC.
+  - set:
+      field: _tmp.tz
+      copy_from: _conf.tz_offset
+      if: ctx._conf?.tz_offset != null && ctx._conf?.tz_offset != 'local'
+  - set:
+      field: _tmp.tz
+      copy_from: event.timezone
+      override: false
+      if: ctx.event?.timezone != null
+  - set:
+      field: _tmp.tz
+      value: UTC
+      override: false
+  - set:
+      field: event.timezone
+      copy_from: _tmp.tz
+
   - date:
       field: _tmp.timestamp
+      timezone: "{{{ event.timezone }}}"
       if: ctx._tmp?.timestamp != null
       formats:
         - E MMM dd HH:mm:ss yyyy
@@ -41,9 +61,21 @@ processors:
         - MMM dd HH:mm:ss
         - MMM d HH:mm:ss
       on_failure:
-        - append:
-            field: error.message
-            value: '{{{_ingest.on_failure_message}}}'
+        # Try to re-parse as UTC to catch when TZ is invalid or unknown.
+        - remove:
+            field: event.timezone
+            ignore_missing: true
+        - date:
+            field: _tmp.timestamp
+            if: ctx._tmp?.timestamp != null
+            formats:
+              - E MMM dd HH:mm:ss yyyy
+              - E MMM  d HH:mm:ss yyyy
+              - E MMM d HH:mm:ss yyyy
+              - MMM  d HH:mm:ss
+              - MMM dd HH:mm:ss
+              - MMM d HH:mm:ss
+
   - pipeline:
       name: '{{ IngestPipeline "pipeline_authentication" }}'
       if: ctx.cisco_secure_email_gateway?.log?.category?.name == 'authentication'
@@ -80,6 +112,7 @@ processors:
   - remove:
       field:
         - _tmp
+        - _conf
       ignore_missing: true
   - remove:
       field: event.original
@@ -88,7 +121,7 @@ processors:
       ignore_missing: true
   - script:
       lang: painless
-      source:
+      source: |
         boolean dropEmptyFields(Object object) {
           if (object == null || object == '') {
             return true;

--- a/packages/cisco_secure_email_gateway/data_stream/log/manifest.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/manifest.yml
@@ -57,6 +57,14 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: false
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
   - input: udp
     template_path: udp.yml.hbs
     title: Cisco Secure Email Gateway logs
@@ -114,6 +122,14 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: false
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
   - input: logfile
     template_path: stream.yml.hbs
     title: Cisco Secure Email Gateway logs
@@ -150,3 +166,11 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: false
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.

--- a/packages/cisco_secure_email_gateway/data_stream/log/sample_event.json
+++ b/packages/cisco_secure_email_gateway/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2023-03-17T18:24:37.000Z",
     "agent": {
-        "ephemeral_id": "4e9fd9b0-5de2-40cd-83b6-9f71ce5aa238",
-        "id": "ffb5b53a-4f77-4103-afe1-2d02bcc1a0cb",
+        "ephemeral_id": "d6ca6527-2f8f-4784-853c-27069d4ac2e6",
+        "id": "610726cd-f180-4f66-aada-78088db0abce",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.5.1"
     },
     "cisco_secure_email_gateway": {
         "log": {
@@ -24,9 +24,9 @@
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "ffb5b53a-4f77-4103-afe1-2d02bcc1a0cb",
+        "id": "610726cd-f180-4f66-aada-78088db0abce",
         "snapshot": false,
-        "version": "8.6.0"
+        "version": "8.5.1"
     },
     "email": {
         "attachments": {
@@ -41,8 +41,9 @@
     "event": {
         "agent_id_status": "verified",
         "dataset": "cisco_secure_email_gateway.log",
-        "ingested": "2023-01-31T06:32:29Z",
-        "kind": "event"
+        "ingested": "2023-02-07T03:41:26Z",
+        "kind": "event",
+        "timezone": "UTC"
     },
     "input": {
         "type": "udp"
@@ -50,7 +51,7 @@
     "log": {
         "level": "info",
         "source": {
-            "address": "192.168.144.1:59695"
+            "address": "192.168.176.4:37393"
         },
         "syslog": {
             "priority": 166

--- a/packages/cisco_secure_email_gateway/docs/README.md
+++ b/packages/cisco_secure_email_gateway/docs/README.md
@@ -202,11 +202,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2023-03-17T18:24:37.000Z",
     "agent": {
-        "ephemeral_id": "4e9fd9b0-5de2-40cd-83b6-9f71ce5aa238",
-        "id": "ffb5b53a-4f77-4103-afe1-2d02bcc1a0cb",
+        "ephemeral_id": "d6ca6527-2f8f-4784-853c-27069d4ac2e6",
+        "id": "610726cd-f180-4f66-aada-78088db0abce",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.5.1"
     },
     "cisco_secure_email_gateway": {
         "log": {
@@ -225,9 +225,9 @@ An example event for `log` looks as following:
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "ffb5b53a-4f77-4103-afe1-2d02bcc1a0cb",
+        "id": "610726cd-f180-4f66-aada-78088db0abce",
         "snapshot": false,
-        "version": "8.6.0"
+        "version": "8.5.1"
     },
     "email": {
         "attachments": {
@@ -242,8 +242,9 @@ An example event for `log` looks as following:
     "event": {
         "agent_id_status": "verified",
         "dataset": "cisco_secure_email_gateway.log",
-        "ingested": "2023-01-31T06:32:29Z",
-        "kind": "event"
+        "ingested": "2023-02-07T03:41:26Z",
+        "kind": "event",
+        "timezone": "UTC"
     },
     "input": {
         "type": "udp"
@@ -251,7 +252,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "info",
         "source": {
-            "address": "192.168.144.1:59695"
+            "address": "192.168.176.4:37393"
         },
         "syslog": {
             "priority": 166

--- a/packages/cisco_secure_email_gateway/manifest.yml
+++ b/packages/cisco_secure_email_gateway/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_secure_email_gateway
 title: Cisco Secure Email Gateway
-version: "1.5.1"
+version: "1.6.0"
 license: basic
 description: Collect logs from Cisco Secure Email Gateway with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Allow user configuration of timezones via config dash or locale.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Updates #5094

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
