### PR TITLE
[fim] Fix for duplicate processor key

### DIFF
--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.4.2"
   changes:
     - description: fixed duplicate key issue in processors.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/5196
 - version: "1.4.1"
   changes:

--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.2"
+  changes:
+    - description: fixed duplicate key issue in processors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4900
 - version: "1.4.1"
   changes:
     - description: Add host metadata

--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: fixed duplicate key issue in processors.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4900
+      link: https://github.com/elastic/integrations/pull/5196
 - version: "1.4.1"
   changes:
     - description: Add host metadata

--- a/packages/fim/data_stream/event/agent/stream/file_integrity.yml.hbs
+++ b/packages/fim/data_stream/event/agent/stream/file_integrity.yml.hbs
@@ -31,6 +31,5 @@ processors:
 - add_host_metadata: 
     replace_fields: true
 {{#if processors}}
-processors:
 {{processors}}
 {{/if}}

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: fim
 title: "File Integrity Monitoring"
-version: "1.4.1"
+version: "1.4.2"
 license: basic
 release: ga
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."


### PR DESCRIPTION
## Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug

## What does this PR do?
Fixes for a SDH involving a duplicate key issue which prevented processors from being added in the config.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues
- Relates https://github.com/elastic/sdh-beats/issues/3018

