### PR TITLE
[Cloud Security] - Updating readme documentation with the supported namespace - backporting Kibana 8.6

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.3"
+  changes:
+    - description: Documentation update - backport documentation update for Kibana 8.6
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4885
 - version: "1.1.1"
   changes:
     - description: CSPM support spaces for 8.6 - fix

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Documentation update - backport documentation update for Kibana 8.6
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/4885
+      link: https://github.com/elastic/integrations/pull/5211
 - version: "1.1.1"
   changes:
     - description: CSPM support spaces for 8.6 - fix

--- a/packages/cloud_security_posture/docs/README.md
+++ b/packages/cloud_security_posture/docs/README.md
@@ -40,7 +40,12 @@ This integration does not currently support the security posture assessment of t
 
 The integration supports **elastic agent** version 8.5 and above.
 
-## Integration Requirments 
+## Namespace support
+KSPM is currently only supported with the default namespace configuration.
+
+Failing to install the integration using the default namespace will result in an invalid integration state.
+
+## Integration Requirements 
 
 The KSPM integration requires access to node files, node processes, and the Kubernetes api-server therefore, it assumes the agent will be installed as a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) with the proper [Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) and [RoleBindings](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) attached.
 

--- a/packages/cloud_security_posture/docs/README.md
+++ b/packages/cloud_security_posture/docs/README.md
@@ -41,9 +41,7 @@ This integration does not currently support the security posture assessment of t
 The integration supports **elastic agent** version 8.5 and above.
 
 ## Namespace support
-KSPM is currently only supported with the default namespace configuration.
-
-Failing to install the integration using the default namespace will result in an invalid integration state.
+KSPM is currently only supported with the default namespace configuration in fleet. Changing the default namespace will result in the integration not working.
 
 ## Integration Requirements 
 

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Kubernetes Security Posture Management (KSPM)"
-version: 1.1.1
+version: 1.1.3
 release: ga
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."


### PR DESCRIPTION
## What does this PR do?
This PR is adding a paragraph in our integration README, that the cloud security posture plugin support installation only using the `default` namespace.
 
This PR will be back-ported to our CSP integration on Kibana 8.6. 

### What does this PR include?
Only readme changes.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues
- Relates https://github.com/elastic/security-team/issues/5831
- https://github.com/elastic/integrations/pull/5209