### PR TITLE
[kibana] Mention elasticsearch data dependency in readme 

### DIFF
--- a/packages/kibana/docs/README.md
+++ b/packages/kibana/docs/README.md
@@ -15,6 +15,8 @@ The `kibana` package works with Kibana 8.5.0 and later.
 The `kibana` package can be used to collect metrics shown in our Stack Monitoring
 UI in Kibana. To enable this usage, set `xpack.enabled: true` on the package config.
 
+**Note**: Using this integration package will require elasticsearch to be monitored as well in order to see the data in Stack Monitoring UI. If the elasticsearch data is not collected and only Kibana is monitored the Stack monitoring UI won't show the Kibana data.
+
 ## Logs
 
 ### Audit


### PR DESCRIPTION
## What does this PR do?

This PR adds an explanation to the readme file that the elasticsearch data should be monitored in order to see Kibana data in Stack monitoring UI 

## Related issues

- Closes #3974


## Screenshots

<img width="640" alt="image" src="https://user-images.githubusercontent.com/14139027/217575217-b7437aa0-632c-433c-971e-87853e95f1df.png">

