### PR TITLE
[beat] Add new apm_server fields

### DIFF
--- a/packages/beat/data_stream/stats/fields/fields.yml
+++ b/packages/beat/data_stream/stats/fields/fields.yml
@@ -484,6 +484,32 @@
                   type: long
                 - name: overflowed
                   type: long
+        - name: agentcfg
+          type: group
+          fields:
+            - name: elasticsearch
+              type: group
+              fields:
+                - name: cache
+                  type: group
+                  fields:
+                    - name: entries.count
+                      type: long
+                    - name: refresh.failures
+                      type: long
+                    - name: refresh.successes
+                      type: long
+                - name: fetch
+                  type: group
+                  fields:
+                    - name: es
+                      type: long
+                    - name: fallback
+                      type: long
+                    - name: invalid
+                      type: long
+                    - name: unavailable
+                      type: long
         - name: acm.request.count
           type: long
         - name: acm.unset

--- a/packages/beat/docs/README.md
+++ b/packages/beat/docs/README.md
@@ -277,6 +277,13 @@ An example event for `stats` looks as following:
 | beat.stats.apm_server.acm.response.valid.notmodified |  | long |
 | beat.stats.apm_server.acm.response.valid.ok |  | long |
 | beat.stats.apm_server.acm.unset |  | long |
+| beat.stats.apm_server.agentcfg.elasticsearch.cache.entries.count |  | long |
+| beat.stats.apm_server.agentcfg.elasticsearch.cache.refresh.failures |  | long |
+| beat.stats.apm_server.agentcfg.elasticsearch.cache.refresh.successes |  | long |
+| beat.stats.apm_server.agentcfg.elasticsearch.fetch.es |  | long |
+| beat.stats.apm_server.agentcfg.elasticsearch.fetch.fallback |  | long |
+| beat.stats.apm_server.agentcfg.elasticsearch.fetch.invalid |  | long |
+| beat.stats.apm_server.agentcfg.elasticsearch.fetch.unavailable |  | long |
 | beat.stats.apm_server.aggregation.txmetrics.active_groups |  | long |
 | beat.stats.apm_server.aggregation.txmetrics.overflowed |  | long |
 | beat.stats.apm_server.decoder.deflate.content-length |  | long |


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Adds recently created [APM server fields](https://github.com/elastic/apm-server/commit/2e58ae3ad343b6520a5aef047b50e2bc019ddab1#diff-20f700df6ec50fcbecb398cba4104ea382244cc68006978dcde3a107b5e12b7cR254) to the mappings

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Closes [#5225](https://github.com/elastic/integrations/issues/5225)
