### PR TITLE
[IIS] Replace deprecated control filter

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Update control filter
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5242
 - version: "1.4.1"
   changes:
     - description: Accept multiple application pool names

--- a/packages/iis/kibana/dashboard/iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7.json
@@ -1,5 +1,11 @@
 {
     "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"e64d858e-86d6-4060-843a-3cc4ca4dde4e\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"iis.website.name\",\"title\":\"Website\",\"id\":\"e64d858e-86d6-4060-843a-3cc4ca4dde4e\",\"enhancements\":{}}}}"
+        },
         "description": "This dashboard shows metrics for the websites running on IIS.",
         "hits": 0,
         "kibanaSavedObjectMeta": {
@@ -41,7 +47,7 @@
                     }
                 },
                 "gridData": {
-                    "h": 6,
+                    "h": 12,
                     "i": "7dffa44e-5ac7-46a6-9301-6952beedbee5",
                     "w": 9,
                     "x": 0,
@@ -50,60 +56,7 @@
                 "panelIndex": "7dffa44e-5ac7-46a6-9301-6952beedbee5",
                 "title": "Navigation Website Overview",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "controls": [
-                                {
-                                    "fieldName": "iis.website.name",
-                                    "id": "1549397251041",
-                                    "indexPatternRefName": "control_d551bd38-1391-43b9-9a1e-8190819338f8_0_index_pattern",
-                                    "label": "Website",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
-                                }
-                            ],
-                            "pinFilters": false,
-                            "updateFiltersOnChange": true,
-                            "useTimeFilter": false
-                        },
-                        "type": "input_control_vis",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "d551bd38-1391-43b9-9a1e-8190819338f8",
-                    "w": 9,
-                    "x": 0,
-                    "y": 6
-                },
-                "panelIndex": "d551bd38-1391-43b9-9a1e-8190819338f8",
-                "title": "Filters",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -214,7 +167,7 @@
                 "panelIndex": "d366a32e-1ed5-4089-82b4-e9e34b674c43",
                 "title": "Current Connections",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -325,7 +278,7 @@
                 "panelIndex": "ba537347-2422-4e09-931e-c0ff3ad24ca3",
                 "title": "Maximum Connections",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -436,7 +389,7 @@
                 "panelIndex": "3ca8af17-0bbf-4697-a193-6f0db4bfeeb8",
                 "title": "Total Connection Attempts",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -548,7 +501,7 @@
                 "panelIndex": "7dbfdcf7-2742-4a48-8520-170afa068e2c",
                 "title": "Service Uptime",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -623,7 +576,7 @@
                 "panelIndex": "5c01ce6f-2b93-439a-b5a0-d911da07af9b",
                 "title": "Bytes Sent/sec",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -698,7 +651,7 @@
                 "panelIndex": "6bac7104-6ff4-480a-9987-ce2e92628053",
                 "title": "Bytes Received/sec",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -773,82 +726,7 @@
                 "panelIndex": "97dd63e6-2e3c-45af-bab2-7b8c2ec485ce",
                 "title": "GET Requests/sec",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
-                            "index_pattern": "metrics-*",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(104,188,0,1)",
-                                    "fill": "0",
-                                    "formatter": "number",
-                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
-                                    "label": "Total GET Requests ",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "iis.website.network.total_get_requests",
-                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "iis.website.name",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "f0a4e232-26f6-4b33-b728-62f73cd74f08",
-                    "w": 12,
-                    "x": 0,
-                    "y": 36
-                },
-                "panelIndex": "f0a4e232-26f6-4b33-b728-62f73cd74f08",
-                "title": "Total GET Requests",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -923,82 +801,7 @@
                 "panelIndex": "4f05e422-f1be-4856-be21-9be206b34834",
                 "title": "POST Requests/sec",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
-                            "index_pattern": "metrics-*",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(104,188,0,1)",
-                                    "fill": "0",
-                                    "formatter": "number",
-                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
-                                    "label": "Total POST Requests ",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "iis.website.network.total_post_requests",
-                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "iis.website.name",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "49524a34-1a10-49bf-842f-20d2606380a4",
-                    "w": 12,
-                    "x": 12,
-                    "y": 36
-                },
-                "panelIndex": "49524a34-1a10-49bf-842f-20d2606380a4",
-                "title": "Total POST Requests",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -1073,82 +876,7 @@
                 "panelIndex": "2cfab1f4-89e9-4548-b6c0-2533bf6b536b",
                 "title": "PUT Requests/sec",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
-                            "index_pattern": "metrics-*",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(22,165,165,1)",
-                                    "fill": "0",
-                                    "formatter": "number",
-                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
-                                    "label": "Total PUT Requests ",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "iis.website.network.total_put_requests",
-                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "iis.website.name",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "fc2ce632-ac12-4835-bceb-6ae9deeaf4c4",
-                    "w": 12,
-                    "x": 24,
-                    "y": 36
-                },
-                "panelIndex": "fc2ce632-ac12-4835-bceb-6ae9deeaf4c4",
-                "title": "Total PUT Requests",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -1223,7 +951,232 @@
                 "panelIndex": "7ae0e0fd-c4b0-4836-8d7d-15c601312bc0",
                 "title": "DELETE Requests/sec",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {}
+                        },
+                        "description": "",
+                        "params": {
+                            "axis_formatter": "number",
+                            "axis_min": 0,
+                            "axis_position": "left",
+                            "axis_scale": "normal",
+                            "drop_last_bucket": 1,
+                            "filter": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
+                            "index_pattern": "metrics-*",
+                            "interval": "",
+                            "isModelInvalid": false,
+                            "max_lines_legend": 1,
+                            "series": [
+                                {
+                                    "axis_position": "right",
+                                    "chart_type": "line",
+                                    "color": "rgba(104,188,0,1)",
+                                    "fill": "0",
+                                    "formatter": "number",
+                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
+                                    "label": "Total GET Requests ",
+                                    "line_width": "2",
+                                    "metrics": [
+                                        {
+                                            "field": "iis.website.network.total_get_requests",
+                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
+                                            "type": "avg"
+                                        }
+                                    ],
+                                    "point_size": 0,
+                                    "separate_axis": 0,
+                                    "split_color_mode": "rainbow",
+                                    "split_mode": "terms",
+                                    "stacked": "none",
+                                    "terms_field": "iis.website.name",
+                                    "type": "timeseries",
+                                    "value_template": "{{value}}"
+                                }
+                            ],
+                            "show_grid": 1,
+                            "show_legend": 1,
+                            "time_field": "@timestamp",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
+                            "type": "timeseries",
+                            "use_kibana_indexes": false
+                        },
+                        "type": "metrics",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "f0a4e232-26f6-4b33-b728-62f73cd74f08",
+                    "w": 12,
+                    "x": 0,
+                    "y": 36
+                },
+                "panelIndex": "f0a4e232-26f6-4b33-b728-62f73cd74f08",
+                "title": "Total GET Requests",
+                "type": "visualization",
+                "version": "8.5.0"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {}
+                        },
+                        "description": "",
+                        "params": {
+                            "axis_formatter": "number",
+                            "axis_min": 0,
+                            "axis_position": "left",
+                            "axis_scale": "normal",
+                            "drop_last_bucket": 1,
+                            "filter": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
+                            "index_pattern": "metrics-*",
+                            "interval": "",
+                            "isModelInvalid": false,
+                            "max_lines_legend": 1,
+                            "series": [
+                                {
+                                    "axis_position": "right",
+                                    "chart_type": "line",
+                                    "color": "rgba(104,188,0,1)",
+                                    "fill": "0",
+                                    "formatter": "number",
+                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
+                                    "label": "Total POST Requests ",
+                                    "line_width": "2",
+                                    "metrics": [
+                                        {
+                                            "field": "iis.website.network.total_post_requests",
+                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
+                                            "type": "avg"
+                                        }
+                                    ],
+                                    "point_size": 0,
+                                    "separate_axis": 0,
+                                    "split_color_mode": "rainbow",
+                                    "split_mode": "terms",
+                                    "stacked": "none",
+                                    "terms_field": "iis.website.name",
+                                    "type": "timeseries",
+                                    "value_template": "{{value}}"
+                                }
+                            ],
+                            "show_grid": 1,
+                            "show_legend": 1,
+                            "time_field": "@timestamp",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
+                            "type": "timeseries",
+                            "use_kibana_indexes": false
+                        },
+                        "type": "metrics",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "49524a34-1a10-49bf-842f-20d2606380a4",
+                    "w": 12,
+                    "x": 12,
+                    "y": 36
+                },
+                "panelIndex": "49524a34-1a10-49bf-842f-20d2606380a4",
+                "title": "Total POST Requests",
+                "type": "visualization",
+                "version": "8.5.0"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {}
+                        },
+                        "description": "",
+                        "params": {
+                            "axis_formatter": "number",
+                            "axis_min": 0,
+                            "axis_position": "left",
+                            "axis_scale": "normal",
+                            "drop_last_bucket": 1,
+                            "filter": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
+                            "index_pattern": "metrics-*",
+                            "interval": "",
+                            "isModelInvalid": false,
+                            "max_lines_legend": 1,
+                            "series": [
+                                {
+                                    "axis_position": "right",
+                                    "chart_type": "line",
+                                    "color": "rgba(22,165,165,1)",
+                                    "fill": "0",
+                                    "formatter": "number",
+                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
+                                    "label": "Total PUT Requests ",
+                                    "line_width": "2",
+                                    "metrics": [
+                                        {
+                                            "field": "iis.website.network.total_put_requests",
+                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
+                                            "type": "avg"
+                                        }
+                                    ],
+                                    "point_size": 0,
+                                    "separate_axis": 0,
+                                    "split_color_mode": "rainbow",
+                                    "split_mode": "terms",
+                                    "stacked": "none",
+                                    "terms_field": "iis.website.name",
+                                    "type": "timeseries",
+                                    "value_template": "{{value}}"
+                                }
+                            ],
+                            "show_grid": 1,
+                            "show_legend": 1,
+                            "time_field": "@timestamp",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
+                            "type": "timeseries",
+                            "use_kibana_indexes": false
+                        },
+                        "type": "metrics",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "fc2ce632-ac12-4835-bceb-6ae9deeaf4c4",
+                    "w": 12,
+                    "x": 24,
+                    "y": 36
+                },
+                "panelIndex": "fc2ce632-ac12-4835-bceb-6ae9deeaf4c4",
+                "title": "Total PUT Requests",
+                "type": "visualization",
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -1298,23 +1251,33 @@
                 "panelIndex": "d9d3a2fc-a39e-40c2-9260-69eb70a2114e",
                 "title": "Total DELETE Requests",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics IIS] Website Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.5.0",
     "id": "iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.5.0"
     },
     "references": [
         {
             "id": "metrics-*",
-            "name": "d551bd38-1391-43b9-9a1e-8190819338f8:control_d551bd38-1391-43b9-9a1e-8190819338f8_0_index_pattern",
+            "name": "controlGroup_e64d858e-86d6-4060-843a-3cc4ca4dde4e:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "id": "iis-managed",
+            "name": "tag-managed",
+            "type": "tag"
+        },
+        {
+            "id": "iis-iis",
+            "name": "tag-iis",
+            "type": "tag"
         }
     ],
     "type": "dashboard"

--- a/packages/iis/kibana/dashboard/iis-b4108810-861c-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-b4108810-861c-11ea-91bc-ab084c7ec0e7.json
@@ -1,5 +1,11 @@
 {
     "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"e4128dd2-623d-4352-94dd-048e5884c879\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"iis.application_pool.name\",\"title\":\"Application Pools\",\"id\":\"e4128dd2-623d-4352-94dd-048e5884c879\",\"selectedOptions\":[],\"enhancements\":{}}}}"
+        },
         "description": "This dashboard shows application pools metrics for the IIS server.",
         "hits": 0,
         "kibanaSavedObjectMeta": {
@@ -41,7 +47,7 @@
                     }
                 },
                 "gridData": {
-                    "h": 5,
+                    "h": 11,
                     "i": "bbb20379-e68e-42c9-aa22-23eec29e026d",
                     "w": 9,
                     "x": 0,
@@ -50,60 +56,7 @@
                 "panelIndex": "bbb20379-e68e-42c9-aa22-23eec29e026d",
                 "title": "Navigation Application Pool Overview",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "controls": [
-                                {
-                                    "fieldName": "iis.application_pool.name",
-                                    "id": "1549397251041",
-                                    "indexPatternRefName": "control_b39222ac-8bd3-4106-8a84-bc49d8bea8a7_0_index_pattern",
-                                    "label": "Application Pools",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
-                                }
-                            ],
-                            "pinFilters": false,
-                            "updateFiltersOnChange": true,
-                            "useTimeFilter": false
-                        },
-                        "type": "input_control_vis",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "b39222ac-8bd3-4106-8a84-bc49d8bea8a7",
-                    "w": 9,
-                    "x": 0,
-                    "y": 5
-                },
-                "panelIndex": "b39222ac-8bd3-4106-8a84-bc49d8bea8a7",
-                "title": "Filters",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -214,7 +167,7 @@
                 "panelIndex": "ced1390c-3b38-40a6-a612-3599310fc00c",
                 "title": "Thread Count",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -325,7 +278,7 @@
                 "panelIndex": "d1d8f9cc-ed70-431d-aa06-ee7dd9114d20",
                 "title": "Handle Count",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -400,7 +353,7 @@
                 "panelIndex": "fd7434f4-2b36-496a-acd0-e2769c287097",
                 "title": "IO Write Operations",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -475,7 +428,7 @@
                 "panelIndex": "88924e40-5355-4910-b7d3-c9ad92176cdf",
                 "title": "IO Read Operations",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -550,7 +503,7 @@
                 "panelIndex": "e202ea3a-7511-4c0a-80c4-68e99f05c214",
                 "title": "Working Set",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -625,7 +578,7 @@
                 "panelIndex": "8d577f96-e997-4b58-976c-f063554d216e",
                 "title": "CPU Usage",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -700,7 +653,7 @@
                 "panelIndex": "00b25a4c-5ef4-46bc-9275-127d4007499f",
                 "title": "Private Bytes",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             },
             {
                 "embeddableConfig": {
@@ -775,23 +728,43 @@
                 "panelIndex": "0c1a3c6e-31c5-4be9-94de-10f7dfb368c3",
                 "title": "Virtual Bytes",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.5.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics IIS] Application Pool Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.5.0",
     "id": "iis-b4108810-861c-11ea-91bc-ab084c7ec0e7",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.5.0"
     },
     "references": [
         {
             "id": "metrics-*",
-            "name": "b39222ac-8bd3-4106-8a84-bc49d8bea8a7:control_b39222ac-8bd3-4106-8a84-bc49d8bea8a7_0_index_pattern",
+            "name": "controlGroup_e4128dd2-623d-4352-94dd-048e5884c879:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "id": "iis-managed",
+            "name": "tag-ref-iis-managed",
+            "type": "tag"
+        },
+        {
+            "id": "iis-iis",
+            "name": "tag-ref-iis-iis",
+            "type": "tag"
+        },
+        {
+            "id": "iis-managed",
+            "name": "tag-ref-managed",
+            "type": "tag"
+        },
+        {
+            "id": "iis-iis",
+            "name": "tag-ref-iis",
+            "type": "tag"
         }
     ],
     "type": "dashboard"

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 1.4.1
+version: 1.5.0
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION

- Enhancement

## What does this PR do?

Replaces the deprecated control filter and adds the newer filter.

## Checklist

- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

- Install IIS integration 
- Import the new dashboards manually to verify the control filter changes.

## Related issues


- Closes #4302 
