### PR TITLE
Update the PR number in previour changelog

### DIFF
--- a/packages/vsphere/changelog.yml
+++ b/packages/vsphere/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Change the way host cpu and memory percentage is calculated.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4485
+      link: https://github.com/elastic/integrations/pull/4928
 - version: "1.2.0"
   changes:
     - description: Added infrastructure category.

--- a/packages/vsphere/manifest.yml
+++ b/packages/vsphere/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 1.0.0
+2format_version: 1.0.0
 name: vsphere
 title: VMware vSphere
-version: 1.2.1
+version: 1.2.2
 license: basic
 description: This Elastic integration collects metrics and logs from vSphere/vCenter servers
 type: integration


### PR DESCRIPTION

- Bug


## What does this PR do?

Updates the PR number for the previous changelog entry


## Related issues

- Closes https://github.com/elastic/integrations/issues/4985

