### PR TITLE
[System] Add proper PR instead of filler text "1234"

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -8,7 +8,7 @@
   changes:
     - description: Add basic dimension fields for cpu, load and memory
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/5160
 - version: "1.23.1"
   changes:
     - description: Mark datasets as ga


### PR DESCRIPTION
- Bug

## What does this PR do?

Link to correct documentation. The PR was set to 1234 not the actual PR so documentation led you to an NGINX PR.
<!-- Mandatory
Fix docs.
-->

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
