### PR TITLE
[Security Rules] Update security rules package to v8.5.1

### DIFF
--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -1,167 +1,167 @@
 # newer versions go on top
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
-- changes:
+- version: 8.5.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5262
       type: enhancement
-  version: 8.5.1
-- changes:
+- version: 8.5.1-beta.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5261
       type: enhancement
-  version: 8.5.1-beta.1
-- changes:
+- version: 8.4.3
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5257
       type: enhancement
-  version: 8.4.3
-- changes:
+- version: 8.4.3-beta.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5238
       type: enhancement
-  version: 8.4.3-beta.1
-- changes:
+- version: 8.4.2
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5062
       type: enhancement
-  version: 8.4.2
-- changes:
+- version: 8.4.2-beta.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5027
       type: enhancement
-  version: 8.4.2-beta.1
-- changes:
+- version: 8.3.4
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5024
       type: enhancement
-  version: 8.3.4
-- changes:
+- version: 8.3.4-beta.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5000
       type: enhancement
-  version: 8.3.4-beta.1
-- changes:
+- version: 8.3.3
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4965
       type: enhancement
-  version: 8.3.3
-- changes:
+- version: 8.4.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4740
       type: enhancement
-  version: 8.4.1
-- changes:
+- version: 8.3.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4063
       type: enhancement
-  version: 8.3.1
-- changes:
+- version: 8.2.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4021
       type: enhancement
-  version: 8.2.1
-- changes:
+- version: 7.16.4
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4010
       type: enhancement
-  version: 7.16.4
-- changes:
+- version: 8.1.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/3565
       type: enhancement
-  version: 8.1.1
-- changes:
+- version: 7.16.3
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/3556
       type: enhancement
-  version: 7.16.3
-- changes:
+- version: 1.0.2
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/3238
       type: enhancement
-  version: 1.0.2
-- changes:
+- version: 0.16.2
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pulls/3191
       type: enhancement
-  version: 0.16.2
-- changes:
+- version: 0.16.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/2709
       type: enhancement
-  version: 0.16.1
-- changes:
+- version: 1.0.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/2605
       type: enhancement
-  version: 1.0.1
-- changes:
+- version: 0.14.3
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/2329
       type: enhancement
-  version: 0.14.3
-- changes:
+- version: 0.14.2
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/1924
       type: enhancement
-  version: 0.14.2
-- changes:
+- version: 0.14.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pulls/1591
       type: enhancement
-  version: 0.14.1
-- changes:
+- version: 0.13.3
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/1361
       type: enhancement
-  version: 0.13.3
-- changes:
+- version: 0.13.2
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/1297
       type: enhancement
-  version: 0.13.2
-- changes:
+- version: 0.13.1
+  changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/1177
       type: enhancement
-  version: 0.13.1
-- changes:
+- version: 0.13.1-dev.0
+  changes:
     - description: Pre-release for 0.13.1 security rules
       link: https://github.com/elastic/integrations/pull/1144
       type: bugfix
-  version: 0.13.1-dev.0
-- changes:
+- version: 0.13.0
+  changes:
     - description: Fix package for 7.13.0 from detection-rules
       link: https://github.com/elastic/integrations/pull/1127
       type: bugfix
-  version: 0.13.0
-- changes:
+- version: 0.13.0-dev.0
+  changes:
     - description: Publish package for 7.13.0 from detection-rules
       link: https://github.com/elastic/integrations/pull/1126
       type: enhancement
-  version: 0.13.0-dev.0
-- changes:
+- version: 0.0.3
+  changes:
     - description: Fix security rules naming
       link: https://github.com/elastic/integrations/pull/987
       type: bugfix
-  version: 0.0.3
-- changes:
+- version: 0.0.2
+  changes:
     - description: Change the rules to match Kibana 7.13 prepackaged
       link: https://github.com/elastic/integrations/pull/938
       type: enhancement
-  version: 0.0.2
-- changes:
+- version: 0.0.1-dev.3
+  changes:
     - description: Change the integration title
       link: https://github.com/elastic/integrations/pull/896
       type: enhancement
-  version: 0.0.1-dev.3
-- changes:
+- version: 0.0.1-dev.2
+  changes:
     - description: Change the saved object type to security-rule
       link: https://github.com/elastic/integrations/pull/797
       type: enhancement
-  version: 0.0.1-dev.2
-- changes:
+- version: 0.0.1-dev.1
+  changes:
     - description: Create package for security's detection engine
       link: https://github.com/elastic/integrations/pull/797
       type: enhancement
-  version: 0.0.1-dev.1

--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -2,7 +2,7 @@
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
 - changes:
     - description: Release security rules update
-      link: https://github.com/elastic/integrations/pulls/0000
+      link: https://github.com/elastic/integrations/pull/5262
       type: enhancement
   version: 8.5.1
 - changes:

--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -1,162 +1,167 @@
 # newer versions go on top
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
-- version: 8.5.1-beta.1
-  changes:
+- changes:
     - description: Release security rules update
+      link: https://github.com/elastic/integrations/pulls/0000
       type: enhancement
+  version: 8.5.1
+- changes:
+    - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5261
-- version: 8.4.3
-  changes:
+      type: enhancement
+  version: 8.5.1-beta.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5257
       type: enhancement
-- version: 8.4.3-beta.1
-  changes:
+  version: 8.4.3
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5238
       type: enhancement
-- version: 8.4.2
-  changes:
+  version: 8.4.3-beta.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5062
       type: enhancement
-- version: 8.4.2-beta.1
-  changes:
+  version: 8.4.2
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5027
       type: enhancement
-- version: 8.3.4
-  changes:
+  version: 8.4.2-beta.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5024
       type: enhancement
-- version: 8.3.4-beta.1
-  changes:
+  version: 8.3.4
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/5000
       type: enhancement
-- version: 8.3.3
-  changes:
+  version: 8.3.4-beta.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4965
       type: enhancement
-- version: 8.4.1
-  changes:
+  version: 8.3.3
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4740
       type: enhancement
-- version: 8.3.1
-  changes:
+  version: 8.4.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4063
       type: enhancement
-- version: 8.2.1
-  changes:
+  version: 8.3.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4021
       type: enhancement
-- version: 7.16.4
-  changes:
+  version: 8.2.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/4010
       type: enhancement
-- version: 8.1.1
-  changes:
+  version: 7.16.4
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/3565
       type: enhancement
-- version: 7.16.3
-  changes:
+  version: 8.1.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/3556
       type: enhancement
-- version: 1.0.2
-  changes:
+  version: 7.16.3
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/3238
       type: enhancement
-- version: 0.16.2
-  changes:
+  version: 1.0.2
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pulls/3191
       type: enhancement
-- version: 0.16.1
-  changes:
+  version: 0.16.2
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/2709
       type: enhancement
-- version: 1.0.1
-  changes:
+  version: 0.16.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/2605
       type: enhancement
-- version: 0.14.3
-  changes:
+  version: 1.0.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/2329
       type: enhancement
-- version: 0.14.2
-  changes:
+  version: 0.14.3
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/1924
       type: enhancement
-- version: 0.14.1
-  changes:
+  version: 0.14.2
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pulls/1591
       type: enhancement
-- version: 0.13.3
-  changes:
+  version: 0.14.1
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/1361
       type: enhancement
-- version: 0.13.2
-  changes:
+  version: 0.13.3
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/1297
       type: enhancement
-- version: 0.13.1
-  changes:
+  version: 0.13.2
+- changes:
     - description: Release security rules update
       link: https://github.com/elastic/integrations/pull/1177
       type: enhancement
-- version: 0.13.1-dev.0
-  changes:
+  version: 0.13.1
+- changes:
     - description: Pre-release for 0.13.1 security rules
       link: https://github.com/elastic/integrations/pull/1144
       type: bugfix
-- version: 0.13.0
-  changes:
+  version: 0.13.1-dev.0
+- changes:
     - description: Fix package for 7.13.0 from detection-rules
       link: https://github.com/elastic/integrations/pull/1127
       type: bugfix
-- version: 0.13.0-dev.0
-  changes:
+  version: 0.13.0
+- changes:
     - description: Publish package for 7.13.0 from detection-rules
       link: https://github.com/elastic/integrations/pull/1126
       type: enhancement
-- version: 0.0.3
-  changes:
+  version: 0.13.0-dev.0
+- changes:
     - description: Fix security rules naming
       link: https://github.com/elastic/integrations/pull/987
       type: bugfix
-- version: 0.0.2
-  changes:
+  version: 0.0.3
+- changes:
     - description: Change the rules to match Kibana 7.13 prepackaged
       link: https://github.com/elastic/integrations/pull/938
       type: enhancement
-- version: 0.0.1-dev.3
-  changes:
+  version: 0.0.2
+- changes:
     - description: Change the integration title
       link: https://github.com/elastic/integrations/pull/896
       type: enhancement
-- version: 0.0.1-dev.2
-  changes:
+  version: 0.0.1-dev.3
+- changes:
     - description: Change the saved object type to security-rule
       link: https://github.com/elastic/integrations/pull/797
       type: enhancement
-- version: 0.0.1-dev.1
-  changes:
+  version: 0.0.1-dev.2
+- changes:
     - description: Create package for security's detection engine
       link: https://github.com/elastic/integrations/pull/797
       type: enhancement
+  version: 0.0.1-dev.1

--- a/packages/security_detection_engine/manifest.yml
+++ b/packages/security_detection_engine/manifest.yml
@@ -15,4 +15,4 @@ owner:
 release: beta
 title: Prebuilt Security Detection Rules
 type: integration
-version: 8.5.1-beta.1
+version: 8.5.1


### PR DESCRIPTION
## What does this PR do?
Update the Security Rules package to version 8.5.1.
Autogenerated from commit  https://github.com/elastic/detection-rules/tree/d1a27608abc97fa517445ccc07ea05132cc00ade

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist
- Install the most recently release security rules in the Detection Engine
- Install the package
- Confirm the update is available in Kibana. Click "Update X rules" or "Install X rules"
- Look at the changes made after the install and confirm they are consistent

## How to test this PR locally
- Perform the above checklist, and use `package-storage` to build EPR from source

## Related issues
* https://github.com/elastic/ia-trade-team/issues/100

## Screenshots
None
