### PR TITLE
[Security Rules] Update security rules package to v8.6.1-beta.1

### DIFF
--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
 # NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production
+- version: 8.6.1-beta.1
+  changes:
+    - description: Release security rules update
+      type: enhancement
+      link: https://github.com/elastic/integrations/pulls/0000
 - version: 8.5.1
   changes:
     - description: Release security rules update

--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -4,7 +4,7 @@
   changes:
     - description: Release security rules update
       type: enhancement
-      link: https://github.com/elastic/integrations/pulls/0000
+      link: https://github.com/elastic/integrations/pull/5263
 - version: 8.5.1
   changes:
     - description: Release security rules update

--- a/packages/security_detection_engine/kibana/security_rule/df0fd41e-5590-4965-ad5e-cd079ec22fa9.json
+++ b/packages/security_detection_engine/kibana/security_rule/df0fd41e-5590-4965-ad5e-cd079ec22fa9.json
@@ -1,0 +1,81 @@
+{
+    "attributes": {
+        "author": [
+            "Elastic"
+        ],
+        "description": "Identifies the load of a driver with an original file name and signature values that were observed for the first time during the last 30 days. This rule type can help baseline drivers installation within your environment.",
+        "from": "now-9m",
+        "history_window_start": "now-30d",
+        "index": [
+            "logs-endpoint.events.*"
+        ],
+        "language": "kuery",
+        "license": "Elastic License v2",
+        "name": "First Time Seen Driver Loaded",
+        "new_terms_fields": [
+            "dll.pe.original_file_name",
+            "dll.code_signature.subject_name"
+        ],
+        "query": "event.category : \"driver\" and event.action : \"load\"\n",
+        "references": [
+            "https://www.elastic.co/kr/security-labs/stopping-vulnerable-driver-attacks"
+        ],
+        "related_integrations": [
+            {
+                "package": "endpoint",
+                "version": "^8.2.0"
+            }
+        ],
+        "required_fields": [
+            {
+                "ecs": true,
+                "name": "event.action",
+                "type": "keyword"
+            },
+            {
+                "ecs": true,
+                "name": "event.category",
+                "type": "keyword"
+            }
+        ],
+        "risk_score": 47,
+        "rule_id": "df0fd41e-5590-4965-ad5e-cd079ec22fa9",
+        "severity": "medium",
+        "tags": [
+            "Elastic",
+            "Host",
+            "Windows",
+            "Threat Detection",
+            "Persistence"
+        ],
+        "threat": [
+            {
+                "framework": "MITRE ATT\u0026CK",
+                "tactic": {
+                    "id": "TA0003",
+                    "name": "Persistence",
+                    "reference": "https://attack.mitre.org/tactics/TA0003/"
+                },
+                "technique": [
+                    {
+                        "id": "T1543",
+                        "name": "Create or Modify System Process",
+                        "reference": "https://attack.mitre.org/techniques/T1543/",
+                        "subtechnique": [
+                            {
+                                "id": "T1543.003",
+                                "name": "Windows Service",
+                                "reference": "https://attack.mitre.org/techniques/T1543/003/"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "timestamp_override": "event.ingested",
+        "type": "new_terms",
+        "version": 1
+    },
+    "id": "df0fd41e-5590-4965-ad5e-cd079ec22fa9",
+    "type": "security-rule"
+}

--- a/packages/security_detection_engine/manifest.yml
+++ b/packages/security_detection_engine/manifest.yml
@@ -1,7 +1,7 @@
 categories:
   - security
 conditions:
-  kibana.version: ^8.5.0
+  kibana.version: ^8.6.0
 description: Prebuilt detection rules for Elastic Security
 format_version: 1.0.0
 icons:
@@ -12,7 +12,7 @@ license: basic
 name: security_detection_engine
 owner:
   github: elastic/protections
-release: beta
+release: ga
 title: Prebuilt Security Detection Rules
 type: integration
-version: 8.5.1
+version: 8.6.1-beta.1

--- a/packages/security_detection_engine/manifest.yml
+++ b/packages/security_detection_engine/manifest.yml
@@ -12,7 +12,7 @@ license: basic
 name: security_detection_engine
 owner:
   github: elastic/protections
-release: ga
+release: beta
 title: Prebuilt Security Detection Rules
 type: integration
 version: 8.6.1-beta.1


### PR DESCRIPTION

## What does this PR do?
Update the Security Rules package to version 8.6.1-beta.1.
Autogenerated from commit  https://github.com/elastic/detection-rules/tree/8e283cea844bfebbac9d63ad4d622148b7383e75

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/master/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] If I'm introducing a new feature, I have modified the Kibana version constraint in my package's `manifest.yml` file to point to the latest Elastic stack release (e.g. `^7.13.0`).

## Author's Checklist
- Install the most recently release security rules in the Detection Engine
- Install the package
- Confirm the update is available in Kibana. Click "Update X rules" or "Install X rules"
- Look at the changes made after the install and confirm they are consistent

## How to test this PR locally
- Perform the above checklist, and use `package-storage` to build EPR from source

## Related issues
None

## Screenshots
None
