### PR TITLE
Assign streams to inputs

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.2.10-beta2"
   changes:
     - description: Add GCP/Azure streams
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/5267
 - version: "1.2.10-beta1"
   changes:

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.10-beta2"
+  changes:
+    - description: Add GCP/Azure streams
+      type: bug
+      link: https://github.com/elastic/integrations/pull/5267
 - version: "1.2.10-beta1"
   changes:
     - description: Add CSPM/KSPM icons

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/azure.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/azure.yml.hbs
@@ -1,0 +1,6 @@
+fetchers:
+config:
+  v1:
+    posture: {{posture}}
+    deployment: {{deployment}}
+    benchmark: cis_azure

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
@@ -1,0 +1,6 @@
+fetchers:
+config:
+  v1:
+    posture: {{posture}}
+    deployment: {{deployment}}
+    benchmark: cis_gcp

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -110,6 +110,8 @@ streams:
   - input: cloudbeat/cis_gcp
     title: CIS GCP Benchmark
     description: CIS Benchmark for Google Cloud Platform Foundation
+    template_path: gcp.yml.hbs
   - input: cloudbeat/cis_azure
     title: CIS Azure Benchmark
     description: CIS Benchmark for Microsoft Azure Foundations
+    template_path: azure.yml.hbs

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management (CSPM/KSPM)"
-version: "1.2.10-beta1"
+version: "1.2.10-beta2"
 source:
   license: "Elastic-2.0"
 description: "DO NOT USE MAIN TILE (WIP)"


### PR DESCRIPTION
## What does this PR do?

GCP and Azure inputs weren't mapped to any stream.
This caused the fleet to crash due to it being unable to find `stream.yml.hbs` that it assigns by default in such cases.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/kibana/issues/151062