### PR TITLE
Bumping version to 1.2.10 to include streams fix

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.10"
+  changes:
+    - description: Add GCP/Azure streams
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5267
 - version: "1.2.10-beta.3"
   changes:
     - description: Fix beta version

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management (CSPM/KSPM)"
-version: "1.2.10-beta.3"
+version: "1.2.10"
 source:
   license: "Elastic-2.0"
 description: "DO NOT USE MAIN TILE (WIP)"


### PR DESCRIPTION
## What does this PR do?

Bumping version of the integration to include the stream fix that was implemented in 1.2.10-beta2.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
