### PR TITLE
[winlog] Add a couple ECS fields for error checking/codes

### DIFF
--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Add ecs error fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5273
 - version: "1.11.0"
   changes:
     - description: Add agent fields

--- a/packages/winlog/data_stream/winlog/fields/ecs.yml
+++ b/packages/winlog/data_stream/winlog/fields/ecs.yml
@@ -1,8 +1,8 @@
 - name: ecs.version
   external: ecs
- - name: error.code
+- name: error.code
   external: ecs
- - name: error.message
+- name: error.message
   external: ecs
 - name: event.created
   external: ecs

--- a/packages/winlog/data_stream/winlog/fields/ecs.yml
+++ b/packages/winlog/data_stream/winlog/fields/ecs.yml
@@ -1,5 +1,9 @@
 - name: ecs.version
   external: ecs
+ - name: error.code
+  external: ecs
+ - name: error.message
+  external: ecs
 - name: event.created
   external: ecs
 - name: log.level

--- a/packages/winlog/docs/README.md
+++ b/packages/winlog/docs/README.md
@@ -43,6 +43,8 @@ To achieve this, `renderXml` needs to be set to `1` in your [inputs.conf](https:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| error.code | Error code describing the error. | keyword |
+| error.message | Error message. | match_only_text |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |

--- a/packages/winlog/manifest.yml
+++ b/packages/winlog/manifest.yml
@@ -3,7 +3,7 @@ name: winlog
 title: Custom Windows Event Logs
 description: Collect and parse logs from any Windows event log channel with Elastic Agent.
 type: integration
-version: "1.11.0"
+version: "1.12.0"
 release: ga
 conditions:
   kibana.version: '^7.16.0 || ^8.0.0'


### PR DESCRIPTION
- Bug

## What does this PR do?

Account for any ingest pipelines that might throw some error messages or event codes.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
