### PR TITLE
[Google Workspace ] Fix order of processes in ingest pipeline

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.3.0"
+- version: "2.2.2"
   changes:
     - description: Fix ingest pipeline to rename event name after fingerprint
       type: bugfix

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix ingest pipeline to rename event name after fingerprint
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/4982
+      link: https://github.com/elastic/integrations/pull/5300
 - version: "2.2.1"
   changes:
     - description: Fix pagination and filters for Report API data streams.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Fix ingest pipeline to rename event name after fingerprint
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4982
 - version: "2.2.1"
   changes:
     - description: Fix pagination and filters for Report API data streams.

--- a/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -27,10 +27,6 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
-  - rename: 
-      field: json.events.name
-      target_field: event.action
-      ignore_missing: true
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
@@ -39,6 +35,10 @@ processors:
       target_field: _id
       ignore_missing: true
       ignore_failure: true
+  - rename: 
+      field: json.events.name
+      target_field: event.action
+      ignore_missing: true
   - rename: 
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
@@ -27,10 +27,6 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
-  - rename:
-      field: json.events.name
-      target_field: event.action
-      ignore_missing: true
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
@@ -39,6 +35,10 @@ processors:
       target_field: _id
       ignore_missing: true
       ignore_failure: true
+  - rename:
+      field: json.events.name
+      target_field: event.action
+      ignore_missing: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
@@ -30,10 +30,6 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
-  - rename:
-      field: json.events.name
-      target_field: event.action
-      ignore_missing: true
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
@@ -42,6 +38,10 @@ processors:
       target_field: _id
       ignore_missing: true
       ignore_failure: true
+  - rename:
+      field: json.events.name
+      target_field: event.action
+      ignore_missing: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
@@ -27,10 +27,6 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
-  - rename:
-      field: json.events.name
-      target_field: event.action
-      ignore_missing: true
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
@@ -39,6 +35,10 @@ processors:
       target_field: _id
       ignore_missing: true
       ignore_failure: true
+  - rename:
+      field: json.events.name
+      target_field: event.action
+      ignore_missing: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/rules/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/rules/elasticsearch/ingest_pipeline/default.yml
@@ -27,14 +27,6 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
-  - rename:
-      field: json.events.name
-      target_field: event.action
-      ignore_missing: true
-  - set:
-      field: google_workspace.event.name
-      copy_from: event.action
-      ignore_failure: true
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
@@ -42,6 +34,14 @@ processors:
         - json.events
       target_field: _id
       ignore_missing: true
+      ignore_failure: true
+  - rename:
+      field: json.events.name
+      target_field: event.action
+      ignore_missing: true
+  - set:
+      field: google_workspace.event.name
+      copy_from: event.action
       ignore_failure: true
   - rename:
       field: json.id.applicationName

--- a/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
@@ -33,10 +33,6 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
-  - rename:
-      field: json.events.name
-      target_field: event.action
-      ignore_missing: true
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
@@ -45,6 +41,10 @@ processors:
       target_field: _id
       ignore_missing: true
       ignore_failure: true
+  - rename:
+      field: json.events.name
+      target_field: event.action
+      ignore_missing: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
@@ -33,10 +33,6 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
-  - rename:
-      field: json.events.name
-      target_field: event.action
-      ignore_missing: true
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:
@@ -45,6 +41,10 @@ processors:
       target_field: _id
       ignore_missing: true
       ignore_failure: true
+  - rename:
+      field: json.events.name
+      target_field: event.action
+      ignore_missing: true
   - rename:
       field: json.id.applicationName
       target_field: event.provider

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.2.1"
+version: "2.3.0"
 release: ga
 description: Collect logs from Google Workspace with Elastic Agent.
 type: integration

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.3.0"
+version: "2.2.2"
 release: ga
 description: Collect logs from Google Workspace with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fixes the order of `processes` in ingest-pipeline. The `fingerprint` process had colliding documents because `rename` process ran first and changed the value of `json.events.name` which potentially could create same fingerprint for documents with different name but other matching fields.

Found this bug as part of system testing in https://github.com/elastic/security-team/issues/5869

## Checklist

- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

- Build elastic-package locally - `make build`
- Navigate to `google_workspace` package
- Add `assert: hit_count : 22` to `admin` data_stream's System test [config](https://github.com/elastic/integrations/blob/main/packages/google_workspace/data_stream/admin/_dev/test/system/test-default-config.yml)
- The system test fails without this PR as the number of documents ingested are less than expected , reason being duplicate fingerprint created for multiple documents.

## Related issues

- Closes #5274 
