### PR TITLE
[Google Workspace] Fix timestamp value in Rules data stream

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.2"
+  changes:
+    - description: Fix @timestamp value in Rules data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/5301
 - version: "2.2.1"
   changes:
     - description: Fix pagination and filters for Report API data streams.

--- a/packages/google_workspace/data_stream/rules/_dev/test/pipeline/test-rules.log-expected.json
+++ b/packages/google_workspace/data_stream/rules/_dev/test/pipeline/test-rules.log-expected.json
@@ -1,6 +1,7 @@
 {
     "expected": [
         {
+            "@timestamp": "2020-10-02T15:00:00.000Z",
             "ecs": {
                 "version": "8.5.0"
             },

--- a/packages/google_workspace/data_stream/rules/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/rules/elasticsearch/ingest_pipeline/default.yml
@@ -14,7 +14,7 @@ processors:
       ignore_failure: true
   - date:
       field: json.id.time
-      target_field: google_workspace.id.time
+      target_field: '@timestamp'
       if: ctx.json?.id?.time != null && ctx.json.id.time != ''
       formats:
         - UNIX
@@ -27,6 +27,10 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
+  - set:
+      field: google_workspace.id.time
+      copy_from: '@timestamp'
+      ignore_empty_value: true
   - rename:
       field: json.events.name
       target_field: event.action
@@ -467,6 +471,7 @@ processors:
         - google_workspace.actor.email
         - google_workspace.rules.id
         - google_workspace.rules.name
+        - google_workspace.id.time
       ignore_failure: true
       ignore_missing: true
   - remove:

--- a/packages/google_workspace/data_stream/rules/sample_event.json
+++ b/packages/google_workspace/data_stream/rules/sample_event.json
@@ -1,8 +1,8 @@
 {
-    "@timestamp": "2022-11-09T20:20:24.760Z",
+    "@timestamp": "2020-10-02T15:00:00.000Z",
     "agent": {
-        "ephemeral_id": "3dc6d078-b3ef-4a6f-b157-653c84fc2200",
-        "id": "028e4d41-c14a-49b1-90be-56ac7eeebf3c",
+        "ephemeral_id": "c785c636-8726-43d8-88b0-f4250d19316e",
+        "id": "fac63989-e363-4de3-97f9-5aed6227ea5d",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.4.0"
@@ -16,17 +16,17 @@
         "version": "8.5.0"
     },
     "elastic_agent": {
-        "id": "028e4d41-c14a-49b1-90be-56ac7eeebf3c",
+        "id": "fac63989-e363-4de3-97f9-5aed6227ea5d",
         "snapshot": false,
         "version": "8.4.0"
     },
     "event": {
         "action": "rule_match",
         "agent_id_status": "verified",
-        "created": "2022-11-09T20:20:24.760Z",
+        "created": "2023-02-16T13:17:03.574Z",
         "dataset": "google_workspace.rules",
         "id": "1",
-        "ingested": "2022-11-09T20:20:28Z",
+        "ingested": "2023-02-16T13:17:06Z",
         "kind": "event",
         "original": "{\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"events\":{\"name\":\"rule_match\",\"parameters\":[{\"boolValue\":\"true\",\"name\":\"has_alert\"},{\"name\":\"actor_ip_address\",\"value\":\"127.0.0.0\"},{\"intValue\":\"1234\",\"name\":\"resource_recipients_omitted_count\"},{\"multiValue\":[\"managers\"],\"name\":\"rule_name\"},{\"multiIntValue\":[\"12\"],\"name\":\"rule_id\"}],\"type\":\"rule_match_type\"},\"id\":{\"applicationName\":\"rules\",\"customerId\":\"1\",\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1},\"ipAddress\":\"67.43.156.13\",\"kind\":\"admin#reports#activity\",\"ownerDomain\":\"elastic.com\"}",
         "provider": "rules"

--- a/packages/google_workspace/docs/README.md
+++ b/packages/google_workspace/docs/README.md
@@ -780,10 +780,10 @@ An example event for `rules` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-11-09T20:20:24.760Z",
+    "@timestamp": "2020-10-02T15:00:00.000Z",
     "agent": {
-        "ephemeral_id": "3dc6d078-b3ef-4a6f-b157-653c84fc2200",
-        "id": "028e4d41-c14a-49b1-90be-56ac7eeebf3c",
+        "ephemeral_id": "c785c636-8726-43d8-88b0-f4250d19316e",
+        "id": "fac63989-e363-4de3-97f9-5aed6227ea5d",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.4.0"
@@ -797,17 +797,17 @@ An example event for `rules` looks as following:
         "version": "8.5.0"
     },
     "elastic_agent": {
-        "id": "028e4d41-c14a-49b1-90be-56ac7eeebf3c",
+        "id": "fac63989-e363-4de3-97f9-5aed6227ea5d",
         "snapshot": false,
         "version": "8.4.0"
     },
     "event": {
         "action": "rule_match",
         "agent_id_status": "verified",
-        "created": "2022-11-09T20:20:24.760Z",
+        "created": "2023-02-16T13:17:03.574Z",
         "dataset": "google_workspace.rules",
         "id": "1",
-        "ingested": "2022-11-09T20:20:28Z",
+        "ingested": "2023-02-16T13:17:06Z",
         "kind": "event",
         "original": "{\"actor\":{\"callerType\":\"USER\",\"email\":\"foo@bar.com\",\"profileId\":1},\"events\":{\"name\":\"rule_match\",\"parameters\":[{\"boolValue\":\"true\",\"name\":\"has_alert\"},{\"name\":\"actor_ip_address\",\"value\":\"127.0.0.0\"},{\"intValue\":\"1234\",\"name\":\"resource_recipients_omitted_count\"},{\"multiValue\":[\"managers\"],\"name\":\"rule_name\"},{\"multiIntValue\":[\"12\"],\"name\":\"rule_id\"}],\"type\":\"rule_match_type\"},\"id\":{\"applicationName\":\"rules\",\"customerId\":\"1\",\"time\":\"2020-10-02T15:00:00Z\",\"uniqueQualifier\":1},\"ipAddress\":\"67.43.156.13\",\"kind\":\"admin#reports#activity\",\"ownerDomain\":\"elastic.com\"}",
         "provider": "rules"

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.2.1"
+version: "2.2.2"
 release: ga
 description: Collect logs from Google Workspace with Elastic Agent.
 type: integration


### PR DESCRIPTION
Type of change
- Bug
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
- Fix `@timestamp` field value by mapping `google_workspace.id.time` in the Google Workspace Rules data stream.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's changelog.yml file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/google_workspace directory.
- Run the following command to run tests.
> elastic-package test 
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes #5301  
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->


## Screenshots
![static](https://user-images.githubusercontent.com/123942796/219378434-7bfa251a-8596-4078-a1f9-7c97ee9e8ad7.PNG)
![asset](https://user-images.githubusercontent.com/123942796/219378466-57bdecc5-bbdc-483f-9cfb-6d4f623b0eee.PNG)
![system](https://user-images.githubusercontent.com/123942796/219378483-8695149b-7455-49c8-852b-5bb66d2c5919.PNG)
![pipeline](https://user-images.githubusercontent.com/123942796/219378493-b9191241-fccb-44d3-bb71-c2a765450750.PNG)


<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->