### PR TITLE
[ IIS ] - Replace deprecated control filter with new control

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Remove deprecated controls and added new control panel
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5041
 - version: "1.4.1"
   changes:
     - description: Accept multiple application pool names

--- a/packages/iis/kibana/dashboard/iis-2c171500-858b-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-2c171500-858b-11ea-91bc-ab084c7ec0e7.json
@@ -38,7 +38,8 @@
                         },
                         "type": "markdown",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 5,
@@ -50,7 +51,7 @@
                 "panelIndex": "814bba79-ccef-4523-a1dd-ebf561e5c6a1",
                 "title": "Navigation Webserver Process Overview",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -149,7 +150,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 11,
@@ -161,7 +163,7 @@
                 "panelIndex": "ed54f5fc-2831-4966-b6d1-d280fb281294",
                 "title": "Output Cache Current Memory Usage",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -260,7 +262,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 11,
@@ -272,7 +275,7 @@
                 "panelIndex": "51daa2b9-38a3-4296-b067-163d86458ca0",
                 "title": "Worker Process Count",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -371,7 +374,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 11,
@@ -383,7 +387,7 @@
                 "panelIndex": "a26144c0-b9e0-4911-9993-62e9c9a69247",
                 "title": "Thread Count",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -482,7 +486,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 11,
@@ -494,7 +499,7 @@
                 "panelIndex": "1ad60aae-4dc8-4320-80ad-cfee5fa8aabd",
                 "title": "Handle Count",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -593,7 +598,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 9,
@@ -605,7 +611,7 @@
                 "panelIndex": "bd6cc2bb-eb25-4b8b-8222-4cfb1dff901c",
                 "title": "Current Files Cached",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -704,7 +710,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 9,
@@ -716,7 +723,7 @@
                 "panelIndex": "a9dc3618-6388-4ad8-aae4-b915464b9368",
                 "title": "Total Files Cached",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -815,7 +822,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 9,
@@ -827,7 +835,7 @@
                 "panelIndex": "8411faec-c5f7-45e1-a45a-076b8468ac98",
                 "title": "Current Uris Cached",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -926,7 +934,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 9,
@@ -938,7 +947,7 @@
                 "panelIndex": "ad9ebba2-880d-40df-af03-71e01a240ab6",
                 "title": "Total Uris Cached",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1025,7 +1034,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 12,
@@ -1037,7 +1047,7 @@
                 "panelIndex": "c805cba0-cce2-4c3a-8626-492958427932",
                 "title": "IO Operations",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1100,7 +1110,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 15,
@@ -1112,7 +1123,7 @@
                 "panelIndex": "73429e76-7391-4cb0-94d4-6a7f0eae0803",
                 "title": "CPU Usage",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1221,7 +1232,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 15,
@@ -1233,17 +1245,17 @@
                 "panelIndex": "049042c8-335a-4a0f-834b-97d2fa0efc62",
                 "title": "Memory Usage",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics IIS] Webserver Process Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.3.0",
     "id": "iis-2c171500-858b-11ea-91bc-ab084c7ec0e7",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.3.0"
     },
     "references": [],
     "type": "dashboard"

--- a/packages/iis/kibana/dashboard/iis-4278ad30-fe16-11e7-a3b0-d13028918f9f.json
+++ b/packages/iis/kibana/dashboard/iis-4278ad30-fe16-11e7-a3b0-d13028918f9f.json
@@ -113,6 +113,7 @@
                                 "show": false
                             },
                             "legendPosition": "right",
+                            "legendSize": "auto",
                             "maxLegendLines": 1,
                             "palette": {
                                 "name": "kibana_palette",
@@ -170,7 +171,8 @@
                         },
                         "type": "histogram",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 12,
@@ -182,7 +184,7 @@
                 "panelIndex": "0ffe2208-412f-4190-9899-2a51d13d2d3e",
                 "title": "Response codes over time",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -278,6 +280,7 @@
                                 "show": false
                             },
                             "legendPosition": "right",
+                            "legendSize": "auto",
                             "maxLegendLines": 1,
                             "palette": {
                                 "name": "kibana_palette",
@@ -335,7 +338,8 @@
                         },
                         "type": "histogram",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 12,
@@ -347,7 +351,7 @@
                 "panelIndex": "8e8adaa8-b942-479a-b1fd-7946a9dd48ae",
                 "title": "Error logs over time",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -407,7 +411,6 @@
                         },
                         "description": "",
                         "params": {
-                            "addLegend": true,
                             "addTooltip": true,
                             "distinctColors": true,
                             "isDonut": false,
@@ -417,7 +420,9 @@
                                 "truncate": 100,
                                 "values": true
                             },
+                            "legendDisplay": "show",
                             "legendPosition": "right",
+                            "legendSize": "auto",
                             "maxLegendLines": 1,
                             "nestedLegend": false,
                             "palette": {
@@ -430,7 +435,8 @@
                         },
                         "type": "pie",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 12,
@@ -442,7 +448,7 @@
                 "panelIndex": "f5b7af45-a5fc-4d79-ace3-cd9a195031ee",
                 "title": "Top URLs by response code",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -501,7 +507,6 @@
                         },
                         "description": "",
                         "params": {
-                            "addLegend": true,
                             "addTooltip": true,
                             "distinctColors": true,
                             "isDonut": true,
@@ -511,7 +516,9 @@
                                 "truncate": 100,
                                 "values": true
                             },
+                            "legendDisplay": "show",
                             "legendPosition": "right",
+                            "legendSize": "auto",
                             "maxLegendLines": 1,
                             "nestedLegend": false,
                             "palette": {
@@ -523,7 +530,8 @@
                         },
                         "type": "pie",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 12,
@@ -535,7 +543,7 @@
                 "panelIndex": "89fc83de-2e69-4fba-aea1-80afe19d3540",
                 "title": "Operating systems breakdown",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -594,7 +602,6 @@
                         },
                         "description": "",
                         "params": {
-                            "addLegend": true,
                             "addTooltip": true,
                             "distinctColors": true,
                             "isDonut": true,
@@ -604,7 +611,9 @@
                                 "truncate": 100,
                                 "values": true
                             },
+                            "legendDisplay": "show",
                             "legendPosition": "right",
+                            "legendSize": "auto",
                             "maxLegendLines": 1,
                             "nestedLegend": false,
                             "palette": {
@@ -616,7 +625,8 @@
                         },
                         "type": "pie",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 12,
@@ -628,7 +638,7 @@
                 "panelIndex": "6addedd8-6910-47ea-8006-ce3fc3c342ec",
                 "title": "Browsers breakdown",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -665,10 +675,10 @@
         "title": "[Logs IIS] Access and error logs",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.3.0",
     "id": "iis-4278ad30-fe16-11e7-a3b0-d13028918f9f",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.3.0"
     },
     "references": [
         {

--- a/packages/iis/kibana/dashboard/iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7.json
@@ -1,5 +1,11 @@
 {
     "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"668fb881-e69e-4967-90d8-866139ef2bcf\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"iis.website.name\",\"title\":\"Website\",\"id\":\"668fb881-e69e-4967-90d8-866139ef2bcf\",\"enhancements\":{}}}}"
+        },
         "description": "This dashboard shows metrics for the websites running on IIS.",
         "hits": 0,
         "kibanaSavedObjectMeta": {
@@ -41,7 +47,7 @@
                     }
                 },
                 "gridData": {
-                    "h": 6,
+                    "h": 12,
                     "i": "7dffa44e-5ac7-46a6-9301-6952beedbee5",
                     "w": 9,
                     "x": 0,
@@ -50,60 +56,7 @@
                 "panelIndex": "7dffa44e-5ac7-46a6-9301-6952beedbee5",
                 "title": "Navigation Website Overview",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "controls": [
-                                {
-                                    "fieldName": "iis.website.name",
-                                    "id": "1549397251041",
-                                    "indexPatternRefName": "control_d551bd38-1391-43b9-9a1e-8190819338f8_0_index_pattern",
-                                    "label": "Website",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
-                                }
-                            ],
-                            "pinFilters": false,
-                            "updateFiltersOnChange": true,
-                            "useTimeFilter": false
-                        },
-                        "type": "input_control_vis",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "d551bd38-1391-43b9-9a1e-8190819338f8",
-                    "w": 9,
-                    "x": 0,
-                    "y": 6
-                },
-                "panelIndex": "d551bd38-1391-43b9-9a1e-8190819338f8",
-                "title": "Filters",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -214,7 +167,7 @@
                 "panelIndex": "d366a32e-1ed5-4089-82b4-e9e34b674c43",
                 "title": "Current Connections",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -325,7 +278,7 @@
                 "panelIndex": "ba537347-2422-4e09-931e-c0ff3ad24ca3",
                 "title": "Maximum Connections",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -436,7 +389,7 @@
                 "panelIndex": "3ca8af17-0bbf-4697-a193-6f0db4bfeeb8",
                 "title": "Total Connection Attempts",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -548,7 +501,7 @@
                 "panelIndex": "7dbfdcf7-2742-4a48-8520-170afa068e2c",
                 "title": "Service Uptime",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -623,7 +576,7 @@
                 "panelIndex": "5c01ce6f-2b93-439a-b5a0-d911da07af9b",
                 "title": "Bytes Sent/sec",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -698,7 +651,7 @@
                 "panelIndex": "6bac7104-6ff4-480a-9987-ce2e92628053",
                 "title": "Bytes Received/sec",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -773,82 +726,7 @@
                 "panelIndex": "97dd63e6-2e3c-45af-bab2-7b8c2ec485ce",
                 "title": "GET Requests/sec",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
-                            "index_pattern": "metrics-*",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(104,188,0,1)",
-                                    "fill": "0",
-                                    "formatter": "number",
-                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
-                                    "label": "Total GET Requests ",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "iis.website.network.total_get_requests",
-                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "iis.website.name",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "f0a4e232-26f6-4b33-b728-62f73cd74f08",
-                    "w": 12,
-                    "x": 0,
-                    "y": 36
-                },
-                "panelIndex": "f0a4e232-26f6-4b33-b728-62f73cd74f08",
-                "title": "Total GET Requests",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -923,82 +801,7 @@
                 "panelIndex": "4f05e422-f1be-4856-be21-9be206b34834",
                 "title": "POST Requests/sec",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
-                            "index_pattern": "metrics-*",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(104,188,0,1)",
-                                    "fill": "0",
-                                    "formatter": "number",
-                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
-                                    "label": "Total POST Requests ",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "iis.website.network.total_post_requests",
-                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "iis.website.name",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "49524a34-1a10-49bf-842f-20d2606380a4",
-                    "w": 12,
-                    "x": 12,
-                    "y": 36
-                },
-                "panelIndex": "49524a34-1a10-49bf-842f-20d2606380a4",
-                "title": "Total POST Requests",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1073,82 +876,7 @@
                 "panelIndex": "2cfab1f4-89e9-4548-b6c0-2533bf6b536b",
                 "title": "PUT Requests/sec",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
-                            "index_pattern": "metrics-*",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(22,165,165,1)",
-                                    "fill": "0",
-                                    "formatter": "number",
-                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
-                                    "label": "Total PUT Requests ",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "iis.website.network.total_put_requests",
-                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "iis.website.name",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "fc2ce632-ac12-4835-bceb-6ae9deeaf4c4",
-                    "w": 12,
-                    "x": 24,
-                    "y": 36
-                },
-                "panelIndex": "fc2ce632-ac12-4835-bceb-6ae9deeaf4c4",
-                "title": "Total PUT Requests",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1223,7 +951,232 @@
                 "panelIndex": "7ae0e0fd-c4b0-4836-8d7d-15c601312bc0",
                 "title": "DELETE Requests/sec",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {}
+                        },
+                        "description": "",
+                        "params": {
+                            "axis_formatter": "number",
+                            "axis_min": 0,
+                            "axis_position": "left",
+                            "axis_scale": "normal",
+                            "drop_last_bucket": 1,
+                            "filter": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
+                            "index_pattern": "metrics-*",
+                            "interval": "",
+                            "isModelInvalid": false,
+                            "max_lines_legend": 1,
+                            "series": [
+                                {
+                                    "axis_position": "right",
+                                    "chart_type": "line",
+                                    "color": "rgba(104,188,0,1)",
+                                    "fill": "0",
+                                    "formatter": "number",
+                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
+                                    "label": "Total GET Requests ",
+                                    "line_width": "2",
+                                    "metrics": [
+                                        {
+                                            "field": "iis.website.network.total_get_requests",
+                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
+                                            "type": "avg"
+                                        }
+                                    ],
+                                    "point_size": 0,
+                                    "separate_axis": 0,
+                                    "split_color_mode": "rainbow",
+                                    "split_mode": "terms",
+                                    "stacked": "none",
+                                    "terms_field": "iis.website.name",
+                                    "type": "timeseries",
+                                    "value_template": "{{value}}"
+                                }
+                            ],
+                            "show_grid": 1,
+                            "show_legend": 1,
+                            "time_field": "@timestamp",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
+                            "type": "timeseries",
+                            "use_kibana_indexes": false
+                        },
+                        "type": "metrics",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "f0a4e232-26f6-4b33-b728-62f73cd74f08",
+                    "w": 12,
+                    "x": 0,
+                    "y": 36
+                },
+                "panelIndex": "f0a4e232-26f6-4b33-b728-62f73cd74f08",
+                "title": "Total GET Requests",
+                "type": "visualization",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {}
+                        },
+                        "description": "",
+                        "params": {
+                            "axis_formatter": "number",
+                            "axis_min": 0,
+                            "axis_position": "left",
+                            "axis_scale": "normal",
+                            "drop_last_bucket": 1,
+                            "filter": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
+                            "index_pattern": "metrics-*",
+                            "interval": "",
+                            "isModelInvalid": false,
+                            "max_lines_legend": 1,
+                            "series": [
+                                {
+                                    "axis_position": "right",
+                                    "chart_type": "line",
+                                    "color": "rgba(104,188,0,1)",
+                                    "fill": "0",
+                                    "formatter": "number",
+                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
+                                    "label": "Total POST Requests ",
+                                    "line_width": "2",
+                                    "metrics": [
+                                        {
+                                            "field": "iis.website.network.total_post_requests",
+                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
+                                            "type": "avg"
+                                        }
+                                    ],
+                                    "point_size": 0,
+                                    "separate_axis": 0,
+                                    "split_color_mode": "rainbow",
+                                    "split_mode": "terms",
+                                    "stacked": "none",
+                                    "terms_field": "iis.website.name",
+                                    "type": "timeseries",
+                                    "value_template": "{{value}}"
+                                }
+                            ],
+                            "show_grid": 1,
+                            "show_legend": 1,
+                            "time_field": "@timestamp",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
+                            "type": "timeseries",
+                            "use_kibana_indexes": false
+                        },
+                        "type": "metrics",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "49524a34-1a10-49bf-842f-20d2606380a4",
+                    "w": 12,
+                    "x": 12,
+                    "y": 36
+                },
+                "panelIndex": "49524a34-1a10-49bf-842f-20d2606380a4",
+                "title": "Total POST Requests",
+                "type": "visualization",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {}
+                        },
+                        "description": "",
+                        "params": {
+                            "axis_formatter": "number",
+                            "axis_min": 0,
+                            "axis_position": "left",
+                            "axis_scale": "normal",
+                            "drop_last_bucket": 1,
+                            "filter": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
+                            "index_pattern": "metrics-*",
+                            "interval": "",
+                            "isModelInvalid": false,
+                            "max_lines_legend": 1,
+                            "series": [
+                                {
+                                    "axis_position": "right",
+                                    "chart_type": "line",
+                                    "color": "rgba(22,165,165,1)",
+                                    "fill": "0",
+                                    "formatter": "number",
+                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
+                                    "label": "Total PUT Requests ",
+                                    "line_width": "2",
+                                    "metrics": [
+                                        {
+                                            "field": "iis.website.network.total_put_requests",
+                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
+                                            "type": "avg"
+                                        }
+                                    ],
+                                    "point_size": 0,
+                                    "separate_axis": 0,
+                                    "split_color_mode": "rainbow",
+                                    "split_mode": "terms",
+                                    "stacked": "none",
+                                    "terms_field": "iis.website.name",
+                                    "type": "timeseries",
+                                    "value_template": "{{value}}"
+                                }
+                            ],
+                            "show_grid": 1,
+                            "show_legend": 1,
+                            "time_field": "@timestamp",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
+                            "type": "timeseries",
+                            "use_kibana_indexes": false
+                        },
+                        "type": "metrics",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "fc2ce632-ac12-4835-bceb-6ae9deeaf4c4",
+                    "w": 12,
+                    "x": 24,
+                    "y": 36
+                },
+                "panelIndex": "fc2ce632-ac12-4835-bceb-6ae9deeaf4c4",
+                "title": "Total PUT Requests",
+                "type": "visualization",
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1298,22 +1251,22 @@
                 "panelIndex": "d9d3a2fc-a39e-40c2-9260-69eb70a2114e",
                 "title": "Total DELETE Requests",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics IIS] Website Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.3.0",
     "id": "iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.3.0"
     },
     "references": [
         {
             "id": "metrics-*",
-            "name": "d551bd38-1391-43b9-9a1e-8190819338f8:control_d551bd38-1391-43b9-9a1e-8190819338f8_0_index_pattern",
+            "name": "controlGroup_668fb881-e69e-4967-90d8-866139ef2bcf:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/iis/kibana/dashboard/iis-b4108810-861c-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-b4108810-861c-11ea-91bc-ab084c7ec0e7.json
@@ -1,5 +1,11 @@
 {
     "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"f279b45c-d41b-4daf-aaba-30b57fdebad3\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"iis.application_pool.name\",\"title\":\"Application Pools\",\"id\":\"f279b45c-d41b-4daf-aaba-30b57fdebad3\",\"enhancements\":{}}}}"
+        },
         "description": "This dashboard shows application pools metrics for the IIS server.",
         "hits": 0,
         "kibanaSavedObjectMeta": {
@@ -41,7 +47,7 @@
                     }
                 },
                 "gridData": {
-                    "h": 5,
+                    "h": 11,
                     "i": "bbb20379-e68e-42c9-aa22-23eec29e026d",
                     "w": 9,
                     "x": 0,
@@ -50,60 +56,7 @@
                 "panelIndex": "bbb20379-e68e-42c9-aa22-23eec29e026d",
                 "title": "Navigation Application Pool Overview",
                 "type": "visualization",
-                "version": "8.0.0"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "controls": [
-                                {
-                                    "fieldName": "iis.application_pool.name",
-                                    "id": "1549397251041",
-                                    "indexPatternRefName": "control_b39222ac-8bd3-4106-8a84-bc49d8bea8a7_0_index_pattern",
-                                    "label": "Application Pools",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
-                                }
-                            ],
-                            "pinFilters": false,
-                            "updateFiltersOnChange": true,
-                            "useTimeFilter": false
-                        },
-                        "type": "input_control_vis",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "b39222ac-8bd3-4106-8a84-bc49d8bea8a7",
-                    "w": 9,
-                    "x": 0,
-                    "y": 5
-                },
-                "panelIndex": "b39222ac-8bd3-4106-8a84-bc49d8bea8a7",
-                "title": "Filters",
-                "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -214,7 +167,7 @@
                 "panelIndex": "ced1390c-3b38-40a6-a612-3599310fc00c",
                 "title": "Thread Count",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -325,7 +278,7 @@
                 "panelIndex": "d1d8f9cc-ed70-431d-aa06-ee7dd9114d20",
                 "title": "Handle Count",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -400,7 +353,7 @@
                 "panelIndex": "fd7434f4-2b36-496a-acd0-e2769c287097",
                 "title": "IO Write Operations",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -475,7 +428,7 @@
                 "panelIndex": "88924e40-5355-4910-b7d3-c9ad92176cdf",
                 "title": "IO Read Operations",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -550,7 +503,7 @@
                 "panelIndex": "e202ea3a-7511-4c0a-80c4-68e99f05c214",
                 "title": "Working Set",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -625,7 +578,7 @@
                 "panelIndex": "8d577f96-e997-4b58-976c-f063554d216e",
                 "title": "CPU Usage",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -700,7 +653,7 @@
                 "panelIndex": "00b25a4c-5ef4-46bc-9275-127d4007499f",
                 "title": "Private Bytes",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -775,22 +728,22 @@
                 "panelIndex": "0c1a3c6e-31c5-4be9-94de-10f7dfb368c3",
                 "title": "Virtual Bytes",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics IIS] Application Pool Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.3.0",
     "id": "iis-b4108810-861c-11ea-91bc-ab084c7ec0e7",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.3.0"
     },
     "references": [
         {
             "id": "metrics-*",
-            "name": "b39222ac-8bd3-4106-8a84-bc49d8bea8a7:control_b39222ac-8bd3-4106-8a84-bc49d8bea8a7_0_index_pattern",
+            "name": "controlGroup_f279b45c-d41b-4daf-aaba-30b57fdebad3:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/iis/kibana/dashboard/iis-ebc23240-8572-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-ebc23240-8572-11ea-91bc-ab084c7ec0e7.json
@@ -38,7 +38,8 @@
                         },
                         "type": "markdown",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 5,
@@ -50,7 +51,7 @@
                 "panelIndex": "22d47dab-cb90-4eda-8b2c-c309a42e85d0",
                 "title": "Navigation Webserver Overview",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -149,7 +150,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 8,
@@ -161,7 +163,7 @@
                 "panelIndex": "c5a3e065-8ea8-49c2-a226-d050e3b72e24",
                 "title": "Total Anonymous Users",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -260,7 +262,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 8,
@@ -272,7 +275,7 @@
                 "panelIndex": "7912bd2e-a28f-4685-81f2-d26de1a382be",
                 "title": "Current Anonymous Users",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -371,7 +374,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 8,
@@ -383,7 +387,7 @@
                 "panelIndex": "1355d5ca-3e97-4474-ad3e-e24fbb57d3f6",
                 "title": "Current Non Anonymous Users",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -482,7 +486,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 8,
@@ -494,7 +499,7 @@
                 "panelIndex": "05fe70a6-cde7-4e32-81c4-37cd416c09ac",
                 "title": "Total Non Anonymous Users",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -593,7 +598,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 9,
@@ -605,7 +611,7 @@
                 "panelIndex": "43f3aba6-bf62-40fd-9101-6ba15fe18a0d",
                 "title": "Service Uptime",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -704,7 +710,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 9,
@@ -716,7 +723,7 @@
                 "panelIndex": "9b0b7732-7e8a-4239-8e8d-2b0552e2eff3",
                 "title": "Current Connections",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -815,7 +822,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 9,
@@ -827,7 +835,7 @@
                 "panelIndex": "b8410749-25bc-466b-85d1-0e24745912a6",
                 "title": "Maximum Connections",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -926,7 +934,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 9,
@@ -938,7 +947,7 @@
                 "panelIndex": "e130755f-5c7a-4972-ab79-853d8de25d51",
                 "title": "Total Connection Attempts",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1047,7 +1056,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 12,
@@ -1059,7 +1069,7 @@
                 "panelIndex": "89279953-dda3-4340-b049-bb52c2cbbeb8",
                 "title": "Total Requests",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1181,7 +1191,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 14,
@@ -1193,7 +1204,7 @@
                 "panelIndex": "6df3b202-cc19-43fe-8832-499d8e22ac22",
                 "title": "Bytes Transferred/sec",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             },
             {
                 "embeddableConfig": {
@@ -1314,7 +1325,8 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    }
+                    },
+                    "type": "visualization"
                 },
                 "gridData": {
                     "h": 14,
@@ -1326,17 +1338,17 @@
                 "panelIndex": "a3c9d1bc-611b-45aa-a3de-3750399f11e2",
                 "title": "Total Bytes Transferred",
                 "type": "visualization",
-                "version": "8.0.0"
+                "version": "8.3.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics IIS] Webserver Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.3.0",
     "id": "iis-ebc23240-8572-11ea-91bc-ab084c7ec0e7",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.3.0"
     },
     "references": [],
     "type": "dashboard"

--- a/packages/iis/kibana/map/iis-0ac17980-e1d8-11ec-baf0-970634a1784d.json
+++ b/packages/iis/kibana/map/iis-0ac17980-e1d8-11ec-baf0-970634a1784d.json
@@ -17,7 +17,7 @@
                 "style": {
                     "type": "TILE"
                 },
-                "type": "VECTOR_TILE",
+                "type": "EMS_VECTOR_TILE",
                 "visible": true
             },
             {
@@ -139,7 +139,7 @@
                     },
                     "type": "VECTOR"
                 },
-                "type": "VECTOR",
+                "type": "GEOJSON_VECTOR",
                 "visible": true
             }
         ],
@@ -195,10 +195,10 @@
             "openTOCDetails": []
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.3.0",
     "id": "iis-0ac17980-e1d8-11ec-baf0-970634a1784d",
     "migrationVersion": {
-        "map": "8.0.0"
+        "map": "8.1.0"
     },
     "references": [
         {

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 1.4.1
+version: 1.5.0
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:
@@ -15,7 +15,7 @@ categories:
   - infrastructure
 release: ga
 conditions:
-  kibana.version: "^8.0.0"
+  kibana.version: "^8.3.0"
 screenshots:
   - src: /img/kibana-iis.png
     title: kibana iis


### PR DESCRIPTION

- Enhancement

## What does this PR do?

Replaces the older deprecated control filter with new control panel. The old filter doesn't respect the selected time range in Kibana to load the data.

The Kibana version has been updated to `8.3.0` as the new control panel is introduced in 8.3.0

## Checklist

- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Verify the control filter is replaced with the new one.
Check the dashboards loading data.

## Related issues


- Closes #4302 