### PR TITLE
Fixing multiple for input streams

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Fixed multiple for input streams"
       type: bugfix
-      link: "https://github.com/elastic/integrations/pull/XXXX"
+      link: "https://github.com/elastic/integrations/pull/5308"
 - version: "1.2.11"
   changes:
     - description: "Fixed readme"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.11-next"
+  changes:
+    - description: "Fixed multiple for input streams"
+      type: bugfix
+      link: "https://github.com/elastic/integrations/pull/XXXX"
 - version: "1.2.11"
   changes:
     - description: "Fixed readme"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.2.11"
+version: "1.2.11-next"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -60,7 +60,6 @@ policy_templates:
   - name: kspm
     title: Kubernetes Security Posture Management (KSPM)
     description: Identify & remediate configuration risks in Kubernetes
-    multiple: false
     categories:
       - containers
       - kubernetes
@@ -92,7 +91,6 @@ policy_templates:
       - security
       - cloud
       - aws
-    multiple: false
     icons:
       - src: /img/logo_cspm.svg
         title: CSPM logo


### PR DESCRIPTION
## What does this PR do?
Due to `multiple` values being `false`, the fleet did not generate unique `ids` for the inputs.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues
- Relates https://github.com/elastic/cloudbeat/issues/755