### PR TITLE
[o365] Update fields.yml with new ListBaseType field

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Add NewValue field to o365.audit.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5314
 - version: "1.12.0"
   changes:
     - description: Add NewValue field to o365.audit.

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -94,6 +94,8 @@
       type: keyword
     - name: ItemType
       type: keyword
+    - name: ListBaseType
+      type: keyword
     - name: ListId
       type: keyword
     - name: ListItemUniqueId

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -259,6 +259,7 @@ An example event for `audit` looks as following:
 | o365.audit.Item.\*.\* |  | object |
 | o365.audit.ItemName |  | keyword |
 | o365.audit.ItemType |  | keyword |
+| o365.audit.ListBaseType |  | keyword |
 | o365.audit.ListId |  | keyword |
 | o365.audit.ListItemUniqueId |  | keyword |
 | o365.audit.LogonError |  | keyword |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.12.0"
+version: "1.13.0"
 release: ga
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration


### PR DESCRIPTION
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement


## What does this PR do?
This PR adds the new o365.audit.ListBaseType that could be categorized as a long on a rollover or new index creation. Previously this was a keyword but could be mapped to a long which does not fit since the value could be either null, 1, 2, or some small integer.


## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
