### PR TITLE
Enable setting condition on Prometheus Collector

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,8 @@
-# newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Enable setting condition on Prometheus Collector
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5317
 - version: "1.1.0"
   changes:
     - description: Remove "integration" from the package name

--- a/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
@@ -26,9 +26,7 @@ ssl.certificate_authorities:
 use_types: {{use_types}}
 username: {{username}}
 password: {{password}}
-{{#if leaderelection}}
-condition: ${kubernetes_leaderelection.leader} == true
-{{/if}}
+condition: {{ condition }}
 {{#if query}}
 {{query}}
 {{/if}}

--- a/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
@@ -26,7 +26,9 @@ ssl.certificate_authorities:
 use_types: {{use_types}}
 username: {{username}}
 password: {{password}}
+{{#if condition }}
 condition: {{ condition }}
+{{/if}}
 {{#if query}}
 {{query}}
 {{/if}}

--- a/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
@@ -26,8 +26,16 @@ ssl.certificate_authorities:
 use_types: {{use_types}}
 username: {{username}}
 password: {{password}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
 {{#if condition }}
 condition: {{ condition }}
+{{/if}}
 {{/if}}
 {{#if query}}
 {{query}}

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -44,7 +44,7 @@ streams:
         title: Leader Election
         description: Enable leaderelection between a set of Elastic Agents running on Kubernetes
         multi: false
-        required: false
+        required: true
         show_user: true
         default: false
       - name: condition

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -39,6 +39,14 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: leaderelection
+        type: bool
+        title: Leader Election
+        description: Enable leaderelection between a set of Elastic Agents running on Kubernetes
+        multi: false
+        required: false
+        show_user: true
+        default: false
       - name: condition
         title: Condition
         description: Condition to filter when to apply this datastream

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -39,14 +39,13 @@ streams:
         required: true
         show_user: true
         default: true
-      - name: leaderelection
-        type: bool
-        title: Leader Election
-        description: Enable leaderelection between a set of Elastic Agents running on Kubernetes
+      - name: condition
+        title: Condition
+        description: Condition to filter when to apply this datastream
+        type: text
         multi: false
         required: true
         show_user: true
-        default: false
       - name: bearer_token_file
         type: text
         title: 'HTTP config options: bearer_token_file'

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -44,7 +44,7 @@ streams:
         description: Condition to filter when to apply this datastream
         type: text
         multi: false
-        required: true
+        required: false
         show_user: true
       - name: bearer_token_file
         type: text

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus
-version: 1.1.0
+version: 1.2.0
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

Enhancement

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

In the Prometheus Collector, switch from `condition` being a toggle for Leader Election only, to a text field.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

I'm not sure what the policy for this type of change is, but when upgrading existing Integrations via this change, it will blank out an existing leader election condition, if one was previously set:

![image](https://user-images.githubusercontent.com/8277432/219877528-6eb673a5-775c-4ca2-9fa5-72113721555d.png)

<details>
<summary>Integration Before Upgrade</summary>

```yaml
inputs:
  - id: prometheus/metrics-prometheus-eb767fbc-1e20-47da-b85d-973f5b4195f2
    name: prometheus-1
    revision: 1
    type: prometheus/metrics
    use_output: default
    meta:
      package:
        name: prometheus
        version: 1.2.0
    data_stream:
      namespace: default
    package_policy_id: eb767fbc-1e20-47da-b85d-973f5b4195f2
    streams:
      - id: >-
          prometheus/metrics-prometheus.collector-eb767fbc-1e20-47da-b85d-973f5b4195f2
        data_stream:
          dataset: prometheus.collector
          type: metrics
        metricsets:
          - collector
        hosts:
          - 'localhost:9090'
        metrics_filters.exclude: null
        metrics_filters.include: null
        metrics_path: /metrics
        period: 10s
        rate_counters: true
        use_types: true
        username: user
        password: secret
        condition: '${kubernetes_leaderelection.leader} == true'
```

</details>

<details>
<summary>Integration After Upgrade (with no user intervention)</summary>

```yaml
inputs:
  - id: prometheus/metrics-prometheus-eb767fbc-1e20-47da-b85d-973f5b4195f2
    name: prometheus-1
    revision: 2
    type: prometheus/metrics
    use_output: default
    meta:
      package:
        name: prometheus
        version: 1.2.2
    data_stream:
      namespace: default
    package_policy_id: eb767fbc-1e20-47da-b85d-973f5b4195f2
    streams:
      - id: >-
          prometheus/metrics-prometheus.collector-eb767fbc-1e20-47da-b85d-973f5b4195f2
        data_stream:
          dataset: prometheus.collector
          type: metrics
        metrics_filters.exclude: null
        period: 10s
        password: secret
        condition: null
        hosts:
          - 'localhost:9090'
        metricsets:
          - collector
        use_types: true
        metrics_filters.include: null
        rate_counters: true
        metrics_path: /metrics
        username: user
```

</details>

<details>
<summary>Integration After Upgrade (with user manually re-adding Leader Election condition)</summary>

```yaml
inputs:
  - id: prometheus/metrics-prometheus-eb767fbc-1e20-47da-b85d-973f5b4195f2
    name: prometheus-1
    revision: 3
    type: prometheus/metrics
    use_output: default
    meta:
      package:
        name: prometheus
        version: 1.2.2
    data_stream:
      namespace: default
    package_policy_id: eb767fbc-1e20-47da-b85d-973f5b4195f2
    streams:
      - id: >-
          prometheus/metrics-prometheus.collector-eb767fbc-1e20-47da-b85d-973f5b4195f2
        data_stream:
          dataset: prometheus.collector
          type: metrics
        metrics_filters.exclude: null
        period: 10s
        password: secret
        condition: '${kubernetes_leaderelection.leader} == true'
        hosts:
          - 'localhost:9090'
        metricsets:
          - collector
        use_types: true
        metrics_filters.include: null
        rate_counters: true
        metrics_path: /metrics
        username: user
```

</details>

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Spin up test stack and install Prometheus 1.1.0, enabling Leader Election
2. Upgrade to 1.2.0.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5259

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
