### PR TITLE
MS Exchange - Add missing ECS mappings & ability to configure request timeout

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,4 @@
-- version: "0.3.1"
+- version: "0.4.0"
   changes:
     - description: Added the ability to configure request.timeout
       type: enhancement

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,3 +1,11 @@
+- version: "0.3.1"
+  changes:
+    - description: Added the ability to configure request.timeout
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5318
+    - description: Add Missing event.created and event.start ECS mappings
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5318
 - version: "0.3.0"
   changes:
     - description: Retain original data in structured format.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -10,7 +10,7 @@ request.transforms:
   - set:
       target: url.params.$skiptoken
       value: 0
-request.timeout: 60s
+request.timeout: {{request_timeout}}
 {{#if proxy_url }}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/fields/ecs.yml
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/fields/ecs.yml
@@ -65,6 +65,10 @@
 - external: ecs
   name: source.ip
 - external: ecs
+  name: event.created
+- external: ecs
+  name: event.start
+- external: ecs
   name: event.end
 - external: ecs
   name: destination.domain

--- a/packages/microsoft_exchange_online_message_trace/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/docs/README.md
@@ -239,8 +239,10 @@ An example event for `log` looks as following:
 | email.subject | A brief summary of the topic of the message. | keyword |
 | email.subject.text | Multi-field of `email.subject`. | match_only_text |
 | email.to.address | The email address of recipient | keyword |
+| event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Event dataset | constant_keyword |
 | event.end | event.end contains the date when the event ended or when the activity was last observed. | date |
+| event.start | event.start contains the date when the event started or when the activity was first observed. | date |
 | input.type |  | keyword |
 | log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.offset |  | long |

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "0.3.0"
+version: "0.3.1"
 license: basic
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
@@ -69,6 +69,14 @@ policy_templates:
             title: Initial Interval
             description: How far back to pull the initial log from Exchange Online
             default: 1h
+            multi: false
+            required: true
+            show_user: true
+          - name: request_timeout
+            type: text
+            title: Request Timeout
+            description: How long to wait for the request to timeout.
+            default: 60s
             multi: false
             required: true
             show_user: true

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "0.3.1"
+version: "0.4.0"
 license: basic
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

Enhancement & Bug

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Two changes were made:

1. Added missing `event.start` and `event.created` ECS mappings
2. Added the ability to configure the `request.timeout` field

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

I made this a single PR and only bumped by patch as both of these things are relatively small changes. I can split into 2 different PRs if desired.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Spin up stack install old version of package
2. Update to new version of package
3. Observe that the missing field mappings are now present in the component template
4. Observe that you can now configure the request.timeout value. Confirm that the default value is 60s and that it is set when adding the integration to a policy. Confirm that changing the timeout value also changes it in the policy.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5291

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
