### PR TITLE
Change default storage container name to avoid collision

### DIFF
--- a/packages/azure_frontdoor/changelog.yml
+++ b/packages/azure_frontdoor/changelog.yml
@@ -1,6 +1,13 @@
 # newer versions go on top
+
+- version: "0.0.2"
+  changes:
+    - description: Modify default storage container name to avoid collisions
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5329
 - version: "0.0.1"
   changes:
     - description: Initial draft of the package
       type: enhancement
       link: https://github.com/elastic/integrations/pull/2497
+

--- a/packages/azure_frontdoor/data_stream/access/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_frontdoor/data_stream/access/agent/stream/azure-eventhub.yml.hbs
@@ -5,7 +5,7 @@ connection_string: {{connection_string}}
 storage_account_container: {{storage_account_container}}
 {{else}}
 {{#if eventhub}}
-storage_account_container: filebeat-firewalllogs-{{eventhub}}
+storage_account_container: frontdoor-access-{{eventhub}}
 {{/if}}
 {{/if}}
 {{#if eventhub}}

--- a/packages/azure_frontdoor/data_stream/waf/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_frontdoor/data_stream/waf/agent/stream/azure-eventhub.yml.hbs
@@ -3,7 +3,7 @@ connection_string: {{connection_string}}
 {{/if}}
 {{#if eventhub}}
 eventhub: {{eventhub}}
-storage_account_container: filebeat-activitylogs-{{eventhub}}
+storage_account_container: frontdoor-waf-{{eventhub}}
 {{/if}}
 {{#if consumer_group}}
 consumer_group: {{consumer_group}}

--- a/packages/azure_frontdoor/manifest.yml
+++ b/packages/azure_frontdoor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: azure_frontdoor
 title: "Azure Frontdoor"
-version: 0.0.1
+version: 0.0.2
 license: basic
 description: "This Elastic integration collects logs from Azure Frontdoor."
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Changed the default storage container names for both streams to avoid collisions with the Azure Firewall Logs integration

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

The change can be seen by adding the integration and inspecting the corresponding agent policy (looking for `storage_account_container` under `inputs`).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
