### PR TITLE
Add additional checks for event.original already existing into Azure firewall logs integration ingest pipeline

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,4 +1,4 @@
-- version: "1.5.0"
+- version: "1.5.9"
   changes:
       - description: Check for 'event.original' already existing in firewall logs ingest pipeline
         type: bugfix

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.5.0"
+  changes:
+      - description: Check for 'event.original' already existing in firewall logs ingest pipeline
+        type: bugfix
+        link: https://github.com/elastic/integrations/pull/5334
 - version: "1.5.8"
   changes:
     - description: Add `storage_account_container` option to the Application Gateway integration

--- a/packages/azure/data_stream/firewall_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/firewall_logs/elasticsearch/ingest_pipeline/default.yml
@@ -17,6 +17,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 1.5.8
+version: 1.5.9
 release: ga
 description: This Elastic integration collects logs from Azure
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add additional checks for event.original already existing into Azure firewall logs integration ingest pipeline

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

