### PR TITLE
[system + winlog] Fix mapping for time_created to date

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.4"
+  changes:
+    - description: Fix mapping for winlog.time_created by setting to date instead of keyword
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5350
 - version: "1.24.2"
   changes:
     - description: Remove redundant regular expression quantifier.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.24.4"
+- version: "1.24.3"
   changes:
     - description: Fix mapping for winlog.time_created by setting to date instead of keyword
       type: bugfix

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -59,7 +59,7 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
-      tag: parsing winlog.time_created as date for @timestamp
+      tag: time_created_date
       formats:
         - ISO8601
       ignore_missing: true

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -59,6 +59,7 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
+      tag: parsing winlog.time_created as date for @timestamp
       formats:
         - ISO8601
       ignore_missing: true

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -73,7 +73,7 @@ processors:
         - fail:
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 on_failure:
-  - set:
+  - append:
       field: error.message
       value: |-
         Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -70,7 +70,10 @@ processors:
         - append:
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
+        - set:
+            field: event.kind
+            value: pipeline_error
+        - append:
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 on_failure:
   - set:

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -70,10 +70,7 @@ processors:
         - append:
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - set:
-            field: event.kind
-            value: pipeline_error
-        - append:
+        - fail:
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 on_failure:
   - set:

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -73,6 +73,9 @@ processors:
         - fail:
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: |-

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -61,8 +61,17 @@ processors:
       field: winlog.time_created
       formats:
         - ISO8601
-      ignore_failure: true
+      ignore_missing: true
       if: ctx?.winlog?.time_created != null
+      on_failure:
+        - remove:
+            field: winlog.time_created
+            ignore_failure: true
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 on_failure:
   - set:
       field: error.message

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -59,7 +59,7 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
-      tag: time_created_date
+      tag: "time_created_date"
       formats:
         - ISO8601
       ignore_missing: true

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -78,5 +78,4 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: |-
-        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -62,8 +62,7 @@ processors:
       tag: "time_created_date"
       formats:
         - ISO8601
-      ignore_missing: true
-      if: ctx?.winlog?.time_created != null
+      if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
             field: winlog.time_created

--- a/packages/system/data_stream/security/fields/winlog.yml
+++ b/packages/system/data_stream/security/fields/winlog.yml
@@ -586,7 +586,7 @@
         The task defined in the event. Task and opcode are typically used to identify the location in the application from where the event was logged. The category used by the Event Logging API (on pre Windows Vista operating systems) is written to this field.
 
     - name: time_created
-      type: keyword
+      type: date
       required: false
       description: >
         Time event was created

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -910,7 +910,7 @@ An example event for `security` looks as following:
 | winlog.record_id | The record ID of the event log record. The first record written to an event log is record number 1, and other records are numbered sequentially. If the record number reaches the maximum value (2^32^ for the Event Logging API and 2^64^ for the Windows Event Log API), the next record number will be 0. | keyword |
 | winlog.related_activity_id | A globally unique identifier that identifies the activity to which control was transferred to. The related events would then have this identifier as their `activity_id` identifier. | keyword |
 | winlog.task | The task defined in the event. Task and opcode are typically used to identify the location in the application from where the event was logged. The category used by the Event Logging API (on pre Windows Vista operating systems) is written to this field. | keyword |
-| winlog.time_created | Time event was created | keyword |
+| winlog.time_created | Time event was created | date |
 | winlog.trustAttribute |  | keyword |
 | winlog.trustDirection |  | keyword |
 | winlog.trustType |  | keyword |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.24.2
+version: 1.24.4
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.24.4
+version: 1.24.3
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration

--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.2"
+  changes:
+    - description: Fix mapping for winlog.time_created by setting to date instead of keyword
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5350
 - version: "1.12.1"
   changes:
     - description: Fix event.dataset to allow for custom datasets and conform to ECS.

--- a/packages/winlog/data_stream/winlog/fields/winlog.yml
+++ b/packages/winlog/data_stream/winlog/fields/winlog.yml
@@ -536,7 +536,7 @@
         The task defined in the event. Task and opcode are typically used to identify the location in the application from where the event was logged. The category used by the Event Logging API (on pre Windows Vista operating systems) is written to this field.
 
     - name: time_created
-      type: keyword
+      type: date
       required: false
       description: >
         Time event was created

--- a/packages/winlog/docs/README.md
+++ b/packages/winlog/docs/README.md
@@ -296,7 +296,7 @@ To achieve this, `renderXml` needs to be set to `1` in your [inputs.conf](https:
 | winlog.record_id | The record ID of the event log record. The first record written to an event log is record number 1, and other records are numbered sequentially. If the record number reaches the maximum value (2^32^ for the Event Logging API and 2^64^ for the Windows Event Log API), the next record number will be 0. | keyword |
 | winlog.related_activity_id | A globally unique identifier that identifies the activity to which control was transferred to. The related events would then have this identifier as their `activity_id` identifier. | keyword |
 | winlog.task | The task defined in the event. Task and opcode are typically used to identify the location in the application from where the event was logged. The category used by the Event Logging API (on pre Windows Vista operating systems) is written to this field. | keyword |
-| winlog.time_created | Time event was created | keyword |
+| winlog.time_created | Time event was created | date |
 | winlog.trustAttribute |  | keyword |
 | winlog.trustDirection |  | keyword |
 | winlog.trustType |  | keyword |

--- a/packages/winlog/manifest.yml
+++ b/packages/winlog/manifest.yml
@@ -3,7 +3,7 @@ name: winlog
 title: Custom Windows Event Logs
 description: Collect and parse logs from any Windows event log channel with Elastic Agent.
 type: integration
-version: "1.12.1"
+version: "1.12.2"
 release: ga
 conditions:
   kibana.version: '^7.16.0 || ^8.0.0'


### PR DESCRIPTION
- Bug

## What does this PR do?

This sets the winlog.time_created field (currently keyword) to a date type. Even though that I have no data that has this field any longer (in Winlogbeat or Elastic Agent System or Custom Windows event log integrations), I see that it exists in the sample json files provided in the pipelines directory for testing, so instead of removing it, I am updating to a date as it should be.


## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).