### PR TITLE
[Elasticsearch] Add condition and leader election to Elasticsearch integration

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Add conditional support to Elasticsearch log and metrics inputs
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/5141
+      link: https://github.com/elastic/integrations/issues/5353
     - description: Add leader election support to Elasticsearch inputs metrics inputs
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/5141
+      link: https://github.com/elastic/integrations/issues/5353
 - version: "1.2.0"
   changes:
     - description: Add period variable to define polling frequency

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Add conditional support to Elasticsearch log and metrics inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/5141
+    - description: Add leader election support to Elasticsearch inputs metrics inputs
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/5141
 - version: "1.2.0"
   changes:
     - description: Add period variable to define polling frequency

--- a/packages/elasticsearch/data_stream/audit/agent/stream/log.yml.hbs
+++ b/packages/elasticsearch/data_stream/audit/agent/stream/log.yml.hbs
@@ -2,6 +2,9 @@ paths:
 {{#each paths as |path i|}}
  - {{path}}
 {{/each}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 exclude_files: [".gz$"]
 processors:
   - add_locale: ~

--- a/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/deprecation/agent/stream/log.yml.hbs
+++ b/packages/elasticsearch/data_stream/deprecation/agent/stream/log.yml.hbs
@@ -2,4 +2,7 @@ paths:
 {{#each paths as |path i|}}
  - {{path}}
 {{/each}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 exclude_files: [".gz$","_slowlog.log$","_access.log$"]

--- a/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/gc/agent/stream/log.yml.hbs
+++ b/packages/elasticsearch/data_stream/gc/agent/stream/log.yml.hbs
@@ -2,6 +2,9 @@ paths:
 {{#each paths as |path i|}}
  - {{path}}
 {{/each}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 exclude_files: [".gz$"]
 exclude_lines: ["^(OpenJDK|Java HotSpot).* Server VM ", "^CommandLine flags: ", "^Memory: ", "^{"] # exclude JVM8 banner and JSON
 multiline:

--- a/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/server/agent/stream/log.yml.hbs
+++ b/packages/elasticsearch/data_stream/server/agent/stream/log.yml.hbs
@@ -2,4 +2,7 @@ paths:
 {{#each paths as |path i|}}
  - {{path}}
 {{/each}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 exclude_files: [".gz$","_slowlog.log$","_access.log$","_deprecation.log$"]

--- a/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
@@ -14,3 +14,14 @@ period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}
+{{#if leaderelection }}
+{{#if condition }}
+condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}
+{{ else }}
+condition: ${kubernetes_leaderelection.leader} == true
+{{/if}}
+{{ else }}
+{{#if condition }}
+condition: {{ condition }}
+{{/if}}
+{{/if}}

--- a/packages/elasticsearch/data_stream/slowlog/agent/stream/log.yml.hbs
+++ b/packages/elasticsearch/data_stream/slowlog/agent/stream/log.yml.hbs
@@ -2,4 +2,7 @@ paths:
 {{#each paths as |path i|}}
  - {{path}}
 {{/each}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 exclude_files: [".gz$"]

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.2.0
+version: 1.3.0
 description: Elasticsearch Integration
 type: integration
 icons:
@@ -21,6 +21,14 @@ policy_templates:
       - type: logfile
         title: Collect Elasticsearch logs
         description: "Collecting audit, deprecation, gc, server and slowlog logs from Elasticsearch instances (input: logfile)"
+        vars:
+          - name: condition
+            title: Condition
+            description: Condition to filter when to apply this datastream
+            type: text
+            multi: false
+            required: false
+            show_user: false
       - type: elasticsearch/metrics
         title: Collect Elasticsearch metrics
         description: Collect Elasticsearch metrics about indices, CCR, cluster stats, machine learning or node statistics
@@ -67,5 +75,20 @@ policy_templates:
               #certificate_authorities: ["/etc/ca.crt"]
               #certificate: "/etc/client.crt"
               #key: "/etc/client.key"
+          - name: leaderelection
+            type: bool
+            title: Leader Election
+            description: Enable leaderelection between a set of Elastic Agents running on Kubernetes. Useful for when scope is `cluster`.
+            multi: false
+            required: true
+            show_user: false
+            default: false
+          - name: condition
+            title: Condition
+            description: Condition to filter when to apply this datastream
+            type: text
+            multi: false
+            required: false
+            show_user: false
 owner:
   github: elastic/infra-monitoring-ui

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -24,7 +24,7 @@ policy_templates:
         vars:
           - name: condition
             title: Condition
-            description: Condition to filter when to apply this datastream
+            description: Condition to filter when to collect this input
             type: text
             multi: false
             required: false
@@ -85,7 +85,7 @@ policy_templates:
             default: false
           - name: condition
             title: Condition
-            description: Condition to filter when to apply this datastream
+            description: Condition to filter when to collect this input
             type: text
             multi: false
             required: false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

Enhancement

## What does this PR do?

1. Add the ability to set condition to both the Logs and Metrics sections
2. Add the ability to set leader election on the Metrics section

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- `condition` is a top level of both inputs as I couldn't think of a reason where a user would want conditions to be different based on what is being collected within an input, and this greatly simplifies things for users.
- `leaderelection` was added to the metrics input, because if you want to use the `cluster` scope, you'd want only one Elastic Agent performing the collection
- `condition` and `leaderelection` are both under the advanced sections, as I'm not sure how many people would actually use this (I don't know how many users actually run Elasticsearch on Kubernetes)

<details>
<summary>Integration Policy Before Upgrade</summary>

```yaml
inputs:
  - id: logfile-elasticsearch-3bed89b0-3bff-40e6-95c2-43f6d203d7db
    name: elasticsearch-1
    revision: 1
    type: logfile
    use_output: default
    meta:
      package:
        name: elasticsearch
        version: 1.2.0
    data_stream:
      namespace: default
    package_policy_id: 3bed89b0-3bff-40e6-95c2-43f6d203d7db
    streams:
      - id: logfile-elasticsearch.audit-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.audit
          type: logs
        paths:
          - /var/log/elasticsearch/*_audit.json
        exclude_files:
          - .gz$
        processors:
          - add_locale: null
          - add_fields:
              target: ''
              fields:
                ecs.version: 1.10.0
          - decode_json_fields:
              fields:
                - message
              target: _json
          - rename:
              fields:
                - from: _json.request.body
                  to: _request
              ignore_missing: true
          - drop_fields:
              fields:
                - _json
          - detect_mime_type:
              field: _request
              target: http.request.mime_type
          - drop_fields:
              fields:
                - _request
              ignore_missing: true
      - id: logfile-elasticsearch.deprecation-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.deprecation
          type: logs
        paths:
          - /var/log/elasticsearch/*_deprecation.json
        exclude_files:
          - .gz$
          - _slowlog.log$
          - _access.log$
      - id: logfile-elasticsearch.gc-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.gc
          type: logs
        paths:
          - '/var/log/elasticsearch/gc.log.[0-9]*'
          - /var/log/elasticsearch/gc.log
        exclude_files:
          - .gz$
        exclude_lines:
          - '^(OpenJDK|Java HotSpot).* Server VM '
          - '^CommandLine flags: '
          - '^Memory: '
          - '^{'
        multiline:
          pattern: '^(\[?[0-9]{4}-[0-9]{2}-[0-9]{2}|{)'
          negate: true
          match: after
        processors:
          - add_fields:
              target: ''
              fields:
                ecs.version: 1.10.0
      - id: logfile-elasticsearch.server-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.server
          type: logs
        paths:
          - /var/log/elasticsearch/*_server.json
        exclude_files:
          - .gz$
          - _slowlog.log$
          - _access.log$
          - _deprecation.log$
      - id: logfile-elasticsearch.slowlog-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.slowlog
          type: logs
        paths:
          - /var/log/elasticsearch/*_index_search_slowlog.json
          - /var/log/elasticsearch/*_index_indexing_slowlog.json
        exclude_files:
          - .gz$
  - id: elasticsearch/metrics-elasticsearch-3bed89b0-3bff-40e6-95c2-43f6d203d7db
    name: elasticsearch-1
    revision: 1
    type: elasticsearch/metrics
    use_output: default
    meta:
      package:
        name: elasticsearch
        version: 1.2.0
    data_stream:
      namespace: default
    package_policy_id: 3bed89b0-3bff-40e6-95c2-43f6d203d7db
    streams:
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.ccr-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.ccr
          type: metrics
        metricsets:
          - ccr
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.cluster_stats-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.cluster_stats
          type: metrics
        metricsets:
          - cluster_stats
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.enrich-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.enrich
          type: metrics
        metricsets:
          - enrich
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index
          type: metrics
        metricsets:
          - index
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index_recovery-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index_recovery
          type: metrics
        metricsets:
          - index_recovery
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index_summary-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index_summary
          type: metrics
        metricsets:
          - index_summary
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.ml_job-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.ml_job
          type: metrics
        metricsets:
          - ml_job
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.node-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.node
          type: metrics
        metricsets:
          - node
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.node_stats-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.node_stats
          type: metrics
        metricsets:
          - node_stats
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.pending_tasks-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.pending_tasks
          type: metrics
        metricsets:
          - pending_tasks
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.shard-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.shard
          type: metrics
        metricsets:
          - shard
        hosts:
          - 'http://localhost:9200'
        scope: node
        period: 10s
        ssl: null
```

</details>

<details>
<summary>Integration Policy After Upgrade</summary>

```yaml
inputs:
  - id: logfile-elasticsearch-3bed89b0-3bff-40e6-95c2-43f6d203d7db
    name: elasticsearch-1
    revision: 2
    type: logfile
    use_output: default
    meta:
      package:
        name: elasticsearch
        version: 1.3.0
    data_stream:
      namespace: default
    package_policy_id: 3bed89b0-3bff-40e6-95c2-43f6d203d7db
    streams:
      - id: logfile-elasticsearch.audit-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.audit
          type: logs
        exclude_files:
          - .gz$
        paths:
          - /var/log/elasticsearch/*_audit.json
        processors:
          - add_locale: null
          - add_fields:
              fields:
                ecs.version: 1.10.0
              target: ''
          - decode_json_fields:
              fields:
                - message
              target: _json
          - rename:
              ignore_missing: true
              fields:
                - from: _json.request.body
                  to: _request
          - drop_fields:
              fields:
                - _json
          - detect_mime_type:
              field: _request
              target: http.request.mime_type
          - drop_fields:
              ignore_missing: true
              fields:
                - _request
      - id: logfile-elasticsearch.deprecation-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.deprecation
          type: logs
        exclude_files:
          - .gz$
          - _slowlog.log$
          - _access.log$
        paths:
          - /var/log/elasticsearch/*_deprecation.json
      - id: logfile-elasticsearch.gc-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.gc
          type: logs
        exclude_files:
          - .gz$
        paths:
          - '/var/log/elasticsearch/gc.log.[0-9]*'
          - /var/log/elasticsearch/gc.log
        multiline:
          negate: true
          pattern: '^(\[?[0-9]{4}-[0-9]{2}-[0-9]{2}|{)'
          match: after
        processors:
          - add_fields:
              fields:
                ecs.version: 1.10.0
              target: ''
        exclude_lines:
          - '^(OpenJDK|Java HotSpot).* Server VM '
          - '^CommandLine flags: '
          - '^Memory: '
          - '^{'
      - id: logfile-elasticsearch.server-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.server
          type: logs
        exclude_files:
          - .gz$
          - _slowlog.log$
          - _access.log$
          - _deprecation.log$
        paths:
          - /var/log/elasticsearch/*_server.json
      - id: logfile-elasticsearch.slowlog-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.slowlog
          type: logs
        exclude_files:
          - .gz$
        paths:
          - /var/log/elasticsearch/*_index_search_slowlog.json
          - /var/log/elasticsearch/*_index_indexing_slowlog.json
  - id: elasticsearch/metrics-elasticsearch-3bed89b0-3bff-40e6-95c2-43f6d203d7db
    name: elasticsearch-1
    revision: 2
    type: elasticsearch/metrics
    use_output: default
    meta:
      package:
        name: elasticsearch
        version: 1.3.0
    data_stream:
      namespace: default
    package_policy_id: 3bed89b0-3bff-40e6-95c2-43f6d203d7db
    streams:
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.ccr-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.ccr
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - ccr
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.cluster_stats-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.cluster_stats
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - cluster_stats
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.enrich-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.enrich
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - enrich
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - index
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index_recovery-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index_recovery
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - index_recovery
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index_summary-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index_summary
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - index_summary
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.ml_job-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.ml_job
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - ml_job
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.node-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.node
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - node
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.node_stats-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.node_stats
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - node_stats
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.pending_tasks-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.pending_tasks
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - pending_tasks
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.shard-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.shard
          type: metrics
        period: 10s
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - shard
        ssl: null
```

</details>

<details>
<summary>Integration Policy After Upgrade & Adding Conditions/Leader Election</summary>

```yaml
inputs:
  - id: logfile-elasticsearch-3bed89b0-3bff-40e6-95c2-43f6d203d7db
    name: elasticsearch-1
    revision: 3
    type: logfile
    use_output: default
    meta:
      package:
        name: elasticsearch
        version: 1.3.0
    data_stream:
      namespace: default
    package_policy_id: 3bed89b0-3bff-40e6-95c2-43f6d203d7db
    streams:
      - id: logfile-elasticsearch.audit-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.audit
          type: logs
        condition: k8s.labels == abc
        exclude_files:
          - .gz$
        paths:
          - /var/log/elasticsearch/*_audit.json
        processors:
          - add_locale: null
          - add_fields:
              fields:
                ecs.version: 1.10.0
              target: ''
          - decode_json_fields:
              fields:
                - message
              target: _json
          - rename:
              ignore_missing: true
              fields:
                - from: _json.request.body
                  to: _request
          - drop_fields:
              fields:
                - _json
          - detect_mime_type:
              field: _request
              target: http.request.mime_type
          - drop_fields:
              ignore_missing: true
              fields:
                - _request
      - id: logfile-elasticsearch.deprecation-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.deprecation
          type: logs
        condition: k8s.labels == abc
        exclude_files:
          - .gz$
          - _slowlog.log$
          - _access.log$
        paths:
          - /var/log/elasticsearch/*_deprecation.json
      - id: logfile-elasticsearch.gc-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.gc
          type: logs
        condition: k8s.labels == abc
        exclude_files:
          - .gz$
        paths:
          - '/var/log/elasticsearch/gc.log.[0-9]*'
          - /var/log/elasticsearch/gc.log
        multiline:
          negate: true
          pattern: '^(\[?[0-9]{4}-[0-9]{2}-[0-9]{2}|{)'
          match: after
        processors:
          - add_fields:
              fields:
                ecs.version: 1.10.0
              target: ''
        exclude_lines:
          - '^(OpenJDK|Java HotSpot).* Server VM '
          - '^CommandLine flags: '
          - '^Memory: '
          - '^{'
      - id: logfile-elasticsearch.server-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.server
          type: logs
        condition: k8s.labels == abc
        exclude_files:
          - .gz$
          - _slowlog.log$
          - _access.log$
          - _deprecation.log$
        paths:
          - /var/log/elasticsearch/*_server.json
      - id: logfile-elasticsearch.slowlog-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.slowlog
          type: logs
        condition: k8s.labels == abc
        exclude_files:
          - .gz$
        paths:
          - /var/log/elasticsearch/*_index_search_slowlog.json
          - /var/log/elasticsearch/*_index_indexing_slowlog.json
  - id: elasticsearch/metrics-elasticsearch-3bed89b0-3bff-40e6-95c2-43f6d203d7db
    name: elasticsearch-1
    revision: 3
    type: elasticsearch/metrics
    use_output: default
    meta:
      package:
        name: elasticsearch
        version: 1.3.0
    data_stream:
      namespace: default
    package_policy_id: 3bed89b0-3bff-40e6-95c2-43f6d203d7db
    streams:
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.ccr-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.ccr
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - ccr
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.cluster_stats-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.cluster_stats
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - cluster_stats
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.enrich-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.enrich
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - enrich
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - index
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index_recovery-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index_recovery
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - index_recovery
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.index_summary-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.index_summary
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - index_summary
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.ml_job-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.ml_job
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - ml_job
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.node-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.node
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - node
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.node_stats-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.node_stats
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - node_stats
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.pending_tasks-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.pending_tasks
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - pending_tasks
        ssl: null
      - id: >-
          elasticsearch/metrics-elasticsearch.stack_monitoring.shard-3bed89b0-3bff-40e6-95c2-43f6d203d7db
        data_stream:
          dataset: elasticsearch.stack_monitoring.shard
          type: metrics
        period: 10s
        condition: '${kubernetes_leaderelection.leader} == true and k8s.label == abc'
        hosts:
          - 'http://localhost:9200'
        scope: node
        metricsets:
          - shard
        ssl: null
```

</details>


## How to test this PR locally

1. Install currently released Elasticsearch integration (1.2.0 as of writing this PR)
2. Upgrade to 1.3.0
3. Observe new fields
4. Test adding & removing contents from the fields

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5319

## Screenshots

![image](https://user-images.githubusercontent.com/8277432/220499155-7d35a791-749d-4625-8765-1493ba63641d.png)

![image](https://user-images.githubusercontent.com/8277432/220499193-686a93cd-c5a8-4df3-b9bd-f1a129af02cc.png)
