### PR TITLE
[Cloud Security] Add backward compatibility for cloudbeat < 8.7

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,14 +1,12 @@
 # newer versions go on top
-- version: "1.2.12-next"
-  changes:
-    - description: "Fix next version"
-      type: bugfix
-      link: "https://github.com/elastic/integrations/pull/5327"
-- version: "1.2.11-next"
+- version: "1.2.13-preview"
   changes:
     - description: "Fixed multiple for input streams"
       type: bugfix
       link: "https://github.com/elastic/integrations/pull/5308"
+    - description: "Fixed commit time formatting and 8.6 BC"
+      type: bugfix
+      link: "https://github.com/elastic/integrations/pull/123"
 - version: "1.2.11"
   changes:
     - description: "Fixed readme"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -6,7 +6,7 @@
       link: "https://github.com/elastic/integrations/pull/5308"
     - description: "Fixed commit time formatting and 8.6 BC"
       type: bugfix
-      link: "https://github.com/elastic/integrations/pull/123"
+      link: "https://github.com/elastic/integrations/pull/5357"
 - version: "1.2.11"
   changes:
     - description: "Fixed readme"

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,11 @@ processors:
 - set:
     field: ecs.version
     value: '8.6.0'
+- set:
+    field: rule.benchmark.posture_type
+    value: 'kspm'
+    description: 'Backward compatibility cloudbeat version < 8.7'
+    if: ctx.rule?.benchmark?.posture_type == null
 on_failure:
 - set:
     field: error.message

--- a/packages/cloud_security_posture/data_stream/findings/fields/cloudbeat.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/cloudbeat.yml
@@ -23,12 +23,13 @@
       ignore_above: 1024
       description: The commit SHA of the Cloudbeat.
       default_field: false
-    - name: commit_time
-      level: extended
-      type: date
-      description: The commit time of the Cloudbeat.
-      format: "yyyy-MM-dd HH:mm:ss Z z||strict_date_optional_time||epoch_millis"
-      default_field: false
+# Currently we can't map commit_time, epm doesn't support format for field type date (see: https://github.com/elastic/kibana/pull/151871)
+#    - name: commit_time
+#      level: extended
+#      type: date
+#      description: The commit time of the Cloudbeat.
+#      format: "yyyy-MM-dd HH:mm:ss Z z||strict_date_optional_time||epoch_millis"
+#      default_field: false
     - name: kubernetes.version
       level: extended
       type: keyword

--- a/packages/cloud_security_posture/data_stream/findings/fields/cloudbeat.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/cloudbeat.yml
@@ -27,6 +27,7 @@
       level: extended
       type: date
       description: The commit time of the Cloudbeat.
+      format: "yyyy-MM-dd HH:mm:ss Z z||strict_date_optional_time||epoch_millis"
       default_field: false
     - name: kubernetes.version
       level: extended

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.2.12-next"
+version: "1.2.13-preview"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

fixes https://github.com/elastic/cloudbeat/issues/768, https://github.com/elastic/kibana/issues/150608

- Added `rule.benchmark.posture_type: kspm` when it's missing
- Added commit_time format support (requires a fix on kibana as well: https://github.com/elastic/kibana/pull/151871)

<!-- Mandatory
Explain here the changes you made on the PR.
-->
