### PR TITLE
[Azure Logs] Fix `event.original` handling on Application Gateway and the generic Event Hub integration

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Check for 'event.original' already existing in Application Gateway and Event Hub ingest pipelines
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9999999999999
+      link: https://github.com/elastic/integrations/pull/5361
 - version: "1.5.9"
   changes:
     - description: Check for 'event.original' already existing in firewall logs ingest pipeline

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,8 +1,13 @@
+- version: "1.5.10"
+  changes:
+    - description: Check for 'event.original' already existing in Application Gateway and Event Hub ingest pipelines
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9999999999999
 - version: "1.5.9"
   changes:
-      - description: Check for 'event.original' already existing in firewall logs ingest pipeline
-        type: bugfix
-        link: https://github.com/elastic/integrations/pull/5334
+    - description: Check for 'event.original' already existing in firewall logs ingest pipeline
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5334
 - version: "1.5.8"
   changes:
     - description: Add `storage_account_container` option to the Application Gateway integration

--- a/packages/azure/data_stream/application_gateway/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/application_gateway/elasticsearch/ingest_pipeline/default.yml
@@ -17,6 +17,14 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
+
   - json:
       field: event.original
       target_field: json

--- a/packages/azure/data_stream/eventhub/elasticsearch/ingest_pipeline/parsed-message.yml
+++ b/packages/azure/data_stream/eventhub/elasticsearch/ingest_pipeline/parsed-message.yml
@@ -5,6 +5,13 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
+      description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: azure.eventhub

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 1.5.9
+version: 1.5.10
 release: ga
 description: This Elastic integration collects logs from Azure
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fix handling of the `event.original` in the last two Azure Logs that were missing it.

Some event forwarders (for example, Logstash) send both `message` and `event.original` fields, causing an error in the ingest pipeline.

With this change, the pipeline ensures there will only be the `event.original` field early in the pipeline.

<!-- Mandatory
Exp
lain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

## How to test this PR locally
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Open the Dev Tools and send the following request to simulate the pipeline execution:

```
POST _ingest/pipeline/logs-azure.application_gateway-1.5.10/_simulate
{
  "docs": [
    {
      "tags":
      "_source": {
        "event": {
          "original": "{\"resourceId\":\"/SUBSCRIPTIONS/23103928-B2CF-472A-8CDB-0146E2849129/RESOURCEGROUPS/PEERINGTEST/PROVIDERS/MICROSOFT.NETWORK/APPLICATIONGATEWAYS/Application-Gateway-Name\",\"operationName\":\"ApplicationGatewayAccess\",\"timestamp\":\"2017-04-26T19:27:38Z\",\"category\":\"ApplicationGatewayAccessLog\",\"properties\":{\"instanceId\":\"ApplicationGatewayRole_IN_0\",\"clientIP\":\"67.43.156.7\",\"clientPort\":46886,\"httpMethod\":\"GET\",\"requestUri\":\"/phpmyadmin/scripts/setup.php\",\"requestQuery\":\"X-AzureApplicationGateway-CACHE-HIT=0&SERVER-ROUTED=10.4.0.4&X-AzureApplicationGateway-LOG-ID=874f1f0f-6807-41c9-b7bc-f3cfa74aa0b1&SERVER-STATUS=404\",\"userAgent\":\"-\",\"httpStatus\":404,\"httpVersion\":\"HTTP/1.0\",\"receivedBytes\":65,\"sentBytes\":553,\"timeTaken\":205,\"sslEnabled\":\"off\",\"host\":\"www.contoso.com\",\"originalHost\":\"www.contoso.com\"}}"

        },
        "message": "{\"resourceId\":\"/SUBSCRIPTIONS/23103928-B2CF-472A-8CDB-0146E2849129/RESOURCEGROUPS/PEERINGTEST/PROVIDERS/MICROSOFT.NETWORK/APPLICATIONGATEWAYS/Application-Gateway-Name\",\"operationName\":\"ApplicationGatewayAccess\",\"timestamp\":\"2017-04-26T19:27:38Z\",\"category\":\"ApplicationGatewayAccessLog\",\"properties\":{\"instanceId\":\"ApplicationGatewayRole_IN_0\",\"clientIP\":\"67.43.156.7\",\"clientPort\":46886,\"httpMethod\":\"GET\",\"requestUri\":\"/phpmyadmin/scripts/setup.php\",\"requestQuery\":\"X-AzureApplicationGateway-CACHE-HIT=0&SERVER-ROUTED=10.4.0.4&X-AzureApplicationGateway-LOG-ID=874f1f0f-6807-41c9-b7bc-f3cfa74aa0b1&SERVER-STATUS=404\",\"userAgent\":\"-\",\"httpStatus\":404,\"httpVersion\":\"HTTP/1.0\",\"receivedBytes\":65,\"sentBytes\":553,\"timeTaken\":205,\"sslEnabled\":\"off\",\"host\":\"www.contoso.com\",\"originalHost\":\"www.contoso.com\"}}"

      }
    }
  ]
}
```

The pipeline will run with no error and return a document.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
Relates 
- #5334 
- #3639

<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
