### PR TITLE
network_traffic: fix type of real_ip_header option for HTTP data stream

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Fix type of `real_ip_header` option for HTTP data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5362
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/network_traffic/data_stream/http/manifest.yml
+++ b/packages/network_traffic/data_stream/http/manifest.yml
@@ -111,8 +111,8 @@ streams:
         multi: false
         required: false
       - name: real_ip_header
-        type: bool
-        title: Real Ip Header
+        type: text
+        title: Real IP Header
         description: |-
           The header field to extract the real IP from. This setting is useful when
           you want to capture traffic behind a reverse proxy, but you want to get the

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.9.0"
+version: "1.9.1"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Fixes type of `real_ip_header` option for HTTP data stream.

The backing configuration expects a `string`, not a `bool`.

https://github.com/elastic/beats/blob/1f1868d6b1c98d9b9b995e6ffbb3772b8ee293b1/packetbeat/protos/http/config.go#L31

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

<img width="481" alt="Screenshot 2023-02-23 at 12 43 25" src="https://user-images.githubusercontent.com/90160302/220807270-04a81857-aa63-4092-a082-bc25e2f27431.png">
