### PR TITLE
[atlassian-jira] Fix pagination for Jira Cloud

### DIFF
--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Fix pagination for Jira Cloud.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5377
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -44,12 +44,20 @@ response.split:
   ignore_empty_value: true
 response.pagination:
   - set:
-      target: url.value
-      value: '[[sprintf "%s/rest/api/3/auditing/record?from=%s&to=%s&offset=%d&limit=%s" "{{api_url}}" (.last_response.url.params.Get "from") (.last_response.url.params.Get "to") (add (toInt .last_response.body.offset) (toInt "{{ limit }}")) "{{ limit }}"]]'
+      target: url.params.offset
+      value: '[[if (eq (len .last_response.body.records) {{ limit }})]][[add (toInt (.last_response.url.params.Get "offset")) {{ limit }}]][[end]]'
+      fail_on_template_error: true
+  - set:
+      target: url.params.from
+      value: '[[.last_response.url.params.Get "from"]]'
+      fail_on_template_error: true
+  - set:
+      target: url.params.to
+      value: '[[.last_response.url.params.Get "to"]]'
       fail_on_template_error: true
 cursor:
   last_timestamp:
-    value: "[[.first_event.created]]"
+    value: '[[.last_response.url.params.Get "to"]]'
 {{else}}
 {{#unless username}}
 {{#unless password}}

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.7.0"
+version: "1.7.1"
 license: basic
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

The Jira Cloud integration produces an invalid date format where the timezone was appended to the end as `0000` (relates to #4391) and the pagination kept incrementing the offset and making infinite requests even when the current offset in the URL exceeded the total amount of records and the response array was empty.

By switching the cursor and changing how the pagination URL is calculated, the pagination stops once all records have been retrieved, and the date format sent is now correct. I've verified this working as intended against our Jira Cloud instance.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Related #4391