### PR TITLE
[windows] Fix mapping/pipelines for time_created

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Fix mapping/pipelines for winlog.time_created
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.17.0"
   changes:
     - description: Add CallTrace, GrantedAccess, TargetImage, TargetProcessGUID, fields to sysmon_operational fields

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix mapping/pipelines for winlog.time_created
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/5384
 - version: "1.17.0"
   changes:
     - description: Add CallTrace, GrantedAccess, TargetImage, TargetProcessGUID, fields to sysmon_operational fields

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
@@ -31,7 +31,7 @@ processors:
       ignore_empty_value: true
       ignore_failure: true
       if: ctx?.winlog?.level != ""
-- date:
+  - date:
       field: winlog.time_created
       tag: "time_created_date"
       formats:

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
@@ -31,13 +31,21 @@ processors:
       ignore_empty_value: true
       ignore_failure: true
       if: ctx?.winlog?.level != ""
-  - date:
+- date:
       field: winlog.time_created
+      tag: "time_created_date"
       formats:
         - ISO8601
-      ignore_failure: true
-      if: ctx?.winlog?.time_created != null
-
+      if: ctx.winlog?.time_created != null
+      on_failure:
+        - remove:
+            field: winlog.time_created
+            ignore_failure: true
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - set:
       field: event.kind
       value: event

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
@@ -434,5 +434,8 @@ processors:
 
 on_failure:
   - set:
-      field: "error.message"
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
@@ -35,11 +35,19 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
+      tag: "time_created_date"
       formats:
         - ISO8601
-      ignore_failure: true
-      if: ctx?.winlog?.time_created != null
-
+      if: ctx.winlog?.time_created != null
+      on_failure:
+        - remove:
+            field: winlog.time_created
+            ignore_failure: true
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - set:
       field: event.kind
       value: event
@@ -485,5 +493,8 @@ processors:
 
 on_failure:
   - set:
-      field: "error.message"
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security.yml
@@ -3251,13 +3251,24 @@ processors:
 
   - date:
       field: winlog.time_created
+      tag: "time_created_date"
       formats:
         - ISO8601
-      ignore_failure: true
-      if: ctx?.winlog?.time_created != null
+      if: ctx.winlog?.time_created != null
+      on_failure:
+        - remove:
+            field: winlog.time_created
+            ignore_failure: true
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: |-
-        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -14,11 +14,19 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
-      target_field: event.created
+      tag: "time_created_date"
       formats:
         - ISO8601
-      ignore_failure: true
-      if: ctx?.winlog?.time_created != null
+      if: ctx.winlog?.time_created != null
+      on_failure:
+        - remove:
+            field: winlog.time_created
+            ignore_failure: true
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - date:
       field: winlog.event_data.UtcTime
       formats:
@@ -1249,6 +1257,8 @@ processors:
 
 on_failure:
   - set:
-      field: "error.message"
-      value: |-
-        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -14,6 +14,7 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
+      target_field: event.created
       tag: "time_created_date"
       formats:
         - ISO8601

--- a/packages/windows/data_stream/forwarded/fields/winlog.yml
+++ b/packages/windows/data_stream/forwarded/fields/winlog.yml
@@ -37,7 +37,7 @@
         Success or Failure of the event.
 
     - name: time_created
-      type: keyword
+      type: date
       required: false
       description: >
         Time event was created

--- a/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
@@ -33,10 +33,19 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
+      tag: "time_created_date"
       formats:
         - ISO8601
-      ignore_failure: true
-      if: ctx?.winlog?.time_created != null
+      if: ctx.winlog?.time_created != null
+      on_failure:
+        - remove:
+            field: winlog.time_created
+            ignore_failure: true
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   - set:
       field: event.kind
@@ -449,5 +458,8 @@ processors:
 
 on_failure:
   - set:
-      field: "error.message"
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
@@ -35,10 +35,19 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
+      tag: "time_created_date"
       formats:
         - ISO8601
-      ignore_failure: true
-      if: ctx?.winlog?.time_created != null
+      if: ctx.winlog?.time_created != null
+      on_failure:
+        - remove:
+            field: winlog.time_created
+            ignore_failure: true
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   - set:
       field: event.kind
@@ -508,5 +517,8 @@ processors:
 
 on_failure:
   - set:
-      field: "error.message"
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,7 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
+      target_field: event.created
       tag: "time_created_date"
       formats:
         - ISO8601

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -18,11 +18,19 @@ processors:
       if: ctx?.winlog?.level != ""
   - date:
       field: winlog.time_created
-      target_field: event.created
+      tag: "time_created_date"
       formats:
         - ISO8601
-      ignore_failure: true
-      if: ctx?.winlog?.time_created != null
+      if: ctx.winlog?.time_created != null
+      on_failure:
+        - remove:
+            field: winlog.time_created
+            ignore_failure: true
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - date:
       field: winlog.event_data.UtcTime
       formats:
@@ -1259,6 +1267,8 @@ processors:
 
 on_failure:
   - set:
-      field: "error.message"
-      value: |-
-        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.17.0
+version: 1.18.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Bug
- Enhancement


## What does this PR do?

Align with other Windows integrations and the winlog.time_created improper mapping and adjusting the error handling for said pipelines.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Relates #5350 