### PR TITLE
cef: allow user configuration of datastream name

### DIFF
--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.0"
+  changes:
+    - description: Allow user configuration of datatream.dataset.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5391
 - version: "2.6.1"
   changes:
     - description: Ensure numeric timezones are correctly interpreted.

--- a/packages/cef/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/cef/data_stream/log/agent/stream/log.yml.hbs
@@ -1,3 +1,5 @@
+data_stream:
+  dataset: {{data_stream.dataset}}
 paths:
   {{#each paths as |path i|}}
 - {{path}}

--- a/packages/cef/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cef/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,3 +1,5 @@
+data_stream:
+  dataset: {{data_stream.dataset}}
 host: "{{syslog_host}}:{{syslog_port}}"
 {{#if udp_options}}
 {{udp_options}}

--- a/packages/cef/data_stream/log/manifest.yml
+++ b/packages/cef/data_stream/log/manifest.yml
@@ -21,6 +21,13 @@ streams:
         required: false
         show_user: false
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting timestamps without a time zone in the CEF message.
+      - name: data_stream.dataset
+        type: text
+        title: Dataset name
+        description: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+        default: cef.log
+        required: true
+        show_user: true
       - name: tags
         type: text
         title: Tags
@@ -76,6 +83,13 @@ streams:
         required: false
         show_user: false
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting timestamps without a time zone in the CEF message.
+      - name: data_stream.dataset
+        type: text
+        title: Dataset name
+        description: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+        default: cef.log
+        required: true
+        show_user: true
       - name: tags
         type: text
         title: Tags

--- a/packages/cef/manifest.yml
+++ b/packages/cef/manifest.yml
@@ -1,6 +1,6 @@
 name: cef
 title: Common Event Format (CEF)
-version: "2.6.1"
+version: "2.7.0"
 release: ga
 description: Collect logs from CEF Logs with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Allows user configuration of datastream name.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #5379

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
<img width="830" alt="Screenshot 2023-02-27 at 14 22 52" src="https://user-images.githubusercontent.com/90160302/221470422-8fb9c72d-6f3d-49f5-aa04-524927b6fb5a.png">

