### PR TITLE
cisco_asa: allow user to retain searchable log message

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.14.0"
+  changes:
+    - description: Allow retention of a searchable log message.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5393
 - version: "2.13.2"
   changes:
     - description: Support additional patterns in 113012, 113004, and 716039 messages

--- a/packages/cisco_asa/data_stream/log/_dev/test/system/test-logfile-config.yml
+++ b/packages/cisco_asa/data_stream/log/_dev/test/system/test-logfile-config.yml
@@ -5,4 +5,5 @@ data_stream:
     paths:
       - "{{SERVICE_LOGS_DIR}}/*asa*.log"
     preserve_original_event: true
+    keep_message: true
     tz_offset: "+0500"

--- a/packages/cisco_asa/data_stream/log/_dev/test/system/test-tcp-config.yml
+++ b/packages/cisco_asa/data_stream/log/_dev/test/system/test-tcp-config.yml
@@ -6,4 +6,5 @@ data_stream:
     tcp_host: 0.0.0.0
     tcp_port: 9514
     preserve_original_event: true
+    keep_message: true
     tz_offset: "+0500"

--- a/packages/cisco_asa/data_stream/log/_dev/test/system/test-tls-config.yml
+++ b/packages/cisco_asa/data_stream/log/_dev/test/system/test-tls-config.yml
@@ -6,6 +6,7 @@ data_stream:
     tcp_host: 0.0.0.0
     tcp_port: 9515
     preserve_original_event: true
+    keep_message: true
     ssl: |
       key: |
         -----BEGIN PRIVATE KEY-----

--- a/packages/cisco_asa/data_stream/log/_dev/test/system/test-udp-config.yml
+++ b/packages/cisco_asa/data_stream/log/_dev/test/system/test-udp-config.yml
@@ -6,3 +6,4 @@ data_stream:
     udp_host: 0.0.0.0
     udp_port: 9514
     preserve_original_event: true
+    keep_message: true

--- a/packages/cisco_asa/data_stream/log/agent/stream/stream.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/stream.yml.hbs
@@ -7,6 +7,9 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
+{{#if keep_message}}
+  - keep_message
+{{/if}}
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}

--- a/packages/cisco_asa/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/tcp.yml.hbs
@@ -3,6 +3,9 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
+{{#if keep_message}}
+  - keep_message
+{{/if}}
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}

--- a/packages/cisco_asa/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cisco_asa/data_stream/log/agent/stream/udp.yml.hbs
@@ -6,6 +6,9 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
+{{#if keep_message}}
+  - keep_message
+{{/if}}
 {{#each tags as |tag i|}}
   - {{tag}}
 {{/each}}

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1114,6 +1114,12 @@ processors:
   # The field has been used as temporary buffer while decoding. The full message
   # is kept under event.original. Processors below can still add a message field, as some
   # security events contain an explanatory Message field.
+  - rename:
+      description: Retain full log message without the Cisco codes for later search.
+      if: ctx.tags != null && ctx.tags.contains('keep_message')
+      field: message
+      target_field: _temp_.cisco.full_message
+      ignore_failure: true
   - remove:
       field:
         - message

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1116,10 +1116,9 @@ processors:
   # security events contain an explanatory Message field.
   - rename:
       description: Retain full log message without the Cisco codes for later search.
-      if: ctx.tags != null && ctx.tags.contains('keep_message')
+      if: ctx.tags != null && ctx.tags.contains('keep_message') && ctx._temp_?.cisco?.full_message == null
       field: message
       target_field: _temp_.cisco.full_message
-      ignore_failure: true
   - remove:
       field:
         - message

--- a/packages/cisco_asa/data_stream/log/fields/fields.yml
+++ b/packages/cisco_asa/data_stream/log/fields/fields.yml
@@ -216,3 +216,9 @@
       type: keyword
       description: >-
         The message associated with SIP and Skinny VoIP events
+
+    - name: full_message
+      default_field: false
+      type: keyword
+      description: >-
+        The Cisco log message text.

--- a/packages/cisco_asa/data_stream/log/manifest.yml
+++ b/packages/cisco_asa/data_stream/log/manifest.yml
@@ -51,6 +51,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: keep_message
+        required: true
+        show_user: true
+        title: Preserve searchable message text.
+        description: Preserves the log message in a searchable field, `cisco.asa.full_message`
+        type: bool
+        multi: false
+        default: false
       - name: udp_options
         type: yaml
         title: Custom UDP Options
@@ -126,6 +134,14 @@ streams:
         show_user: true
         title: Preserve original event
         description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
+      - name: keep_message
+        required: true
+        show_user: true
+        title: Preserve searchable message text.
+        description: Preserves the log message in a searchable field, `cisco.asa.full_message`
         type: bool
         multi: false
         default: false
@@ -210,6 +226,14 @@ streams:
         show_user: true
         title: Preserve original event
         description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false
+      - name: keep_message
+        required: true
+        show_user: true
+        title: Preserve searchable message text.
+        description: Preserves the log message in a searchable field, `cisco.asa.full_message`
         type: bool
         multi: false
         default: false

--- a/packages/cisco_asa/data_stream/log/sample_event.json
+++ b/packages/cisco_asa/data_stream/log/sample_event.json
@@ -1,15 +1,16 @@
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "3531225b-f1f1-4313-8769-3c60fbf048a3",
-        "id": "cef48eaa-95bc-48e2-955a-d5c41d508b84",
+        "ephemeral_id": "ca988d63-3269-4129-84a2-fe0a0723829f",
+        "id": "07815f3b-703a-41bd-802e-d773e9f55819",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.6.1"
     },
     "cisco": {
         "asa": {
             "destination_interface": "outside",
+            "full_message": "Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
             "source_interface": "inside"
         }
     },
@@ -27,9 +28,9 @@
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "cef48eaa-95bc-48e2-955a-d5c41d508b84",
+        "id": "07815f3b-703a-41bd-802e-d773e9f55819",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.6.1"
     },
     "event": {
         "action": "firewall-rule",
@@ -39,7 +40,7 @@
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2023-01-30T06:56:43Z",
+        "ingested": "2023-02-27T06:06:31Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
         "severity": 6,
@@ -57,7 +58,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.20.0.4:53092"
+            "address": "172.20.0.4:51426"
         }
     },
     "network": {
@@ -101,6 +102,7 @@
     },
     "tags": [
         "preserve_original_event",
+        "keep_message",
         "cisco-asa",
         "forwarded"
     ]

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -17,15 +17,16 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "3531225b-f1f1-4313-8769-3c60fbf048a3",
-        "id": "cef48eaa-95bc-48e2-955a-d5c41d508b84",
+        "ephemeral_id": "ca988d63-3269-4129-84a2-fe0a0723829f",
+        "id": "07815f3b-703a-41bd-802e-d773e9f55819",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.6.1"
     },
     "cisco": {
         "asa": {
             "destination_interface": "outside",
+            "full_message": "Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
             "source_interface": "inside"
         }
     },
@@ -43,9 +44,9 @@ An example event for `log` looks as following:
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "cef48eaa-95bc-48e2-955a-d5c41d508b84",
+        "id": "07815f3b-703a-41bd-802e-d773e9f55819",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.6.1"
     },
     "event": {
         "action": "firewall-rule",
@@ -55,7 +56,7 @@ An example event for `log` looks as following:
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2023-01-30T06:56:43Z",
+        "ingested": "2023-02-27T06:06:31Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
         "severity": 6,
@@ -73,7 +74,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.20.0.4:53092"
+            "address": "172.20.0.4:51426"
         }
     },
     "network": {
@@ -117,6 +118,7 @@ An example event for `log` looks as following:
     },
     "tags": [
         "preserve_original_event",
+        "keep_message",
         "cisco-asa",
         "forwarded"
     ]
@@ -144,6 +146,7 @@ An example event for `log` looks as following:
 | cisco.asa.destination_interface | Destination interface for the flow or event. | keyword |
 | cisco.asa.destination_user_security_group_tag | The Security Group Tag for the destination user. Security Group Tag are 16-bit identifiers used to represent logical group privilege. | long |
 | cisco.asa.destination_username | Name of the user that is the destination for this event. | keyword |
+| cisco.asa.full_message | The Cisco log message text. | keyword |
 | cisco.asa.icmp_code | ICMP code. | short |
 | cisco.asa.icmp_type | ICMP type. | short |
 | cisco.asa.mapped_destination_host |  | keyword |

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.13.2"
+version: "2.14.0"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Provides an option to allow the user to retain a searchable copy of the log message.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5249

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
