### PR TITLE
Promote Elasticsearch 1.4.0 to GA

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.4.0-beta1"
+- version: "1.4.0"
   changes:
     - description: Add ingest pipeline monitoring dataset and dashboard (experimental)
       type: enhancement

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.4.0-beta1
+version: 1.4.0
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Promotes the changes from 1.4.0-beta1 to GA, including support for Ingest Pipeline metrics added in https://github.com/elastic/integrations/pull/4597. This will bump the minimum required Kibana version to 8.7.0.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Test 1.4.0-beta1 on 8.7.0 BC cluster

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates to https://github.com/elastic/integrations/pull/4597

## Screenshots

Here's what it looks like when I have Logs & Metrics enabled on a 8.7 cluster in Cloud + an agent running the system integration to ingest data.

<img width="1613" alt="image" src="https://user-images.githubusercontent.com/1813008/221537364-b8b8126e-04ea-418f-aa54-713b5d1845be.png">
