### PR TITLE
[system] Change winlogbeat to Elastic agent integration in visualization

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.4"
+  changes:
+    - description: Fix visualization to reference Elastic Agent integrations, not Winlogbeat
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5403
 - version: "1.24.3"
   changes:
     - description: Fix mapping for winlog.time_created by setting to date instead of keyword

--- a/packages/system/kibana/visualization/system-2dc6b820-b9e8-11e9-b6a2-c9b4015c4baf.json
+++ b/packages/system/kibana/visualization/system-2dc6b820-b9e8-11e9-b6a2-c9b4015c4baf.json
@@ -17,7 +17,7 @@
             "aggs": [],
             "params": {
                 "fontSize": 10,
-                "markdown": "# **User Management Events**\n\n#### This dashboard shows information about User Management Events collected by winlogbeat\n",
+                "markdown": "# **User Management Events**\n\n#### This dashboard shows information about User Management Events collected by the Elastic Agent Windows integrations (System, Windows, Custom Windows Event Logs).\n",
                 "openLinksInNewTab": false
             },
             "title": "User  Management Events - Description [Windows System Security]",

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.24.3
+version: 1.24.4
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug

## What does this PR do?
The dashboards that reference this visualization comes bundled with the Windows Integrations not Winlogbeat.

## Checklist
- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

