### PR TITLE
Fix image source in Jumpcloud readme

### DIFF
--- a/packages/jumpcloud/_dev/build/docs/README.md
+++ b/packages/jumpcloud/_dev/build/docs/README.md
@@ -35,7 +35,7 @@ Ensure you have created a JumpCloud admin API key that you have access to, refer
 5. Configure the integration as appropriate
 6. Assign the integration to a new Elastic Agent host, or an existing Elastic Agent host
 
-![Example of Add JumpCloud Integration](./img/sample-add-integration.png)
+![Example of Add JumpCloud Integration](../img/sample-add-integration.png)
 
 ## Events
 

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -2,7 +2,7 @@
 - version: "0.0.2"
   changes:
     - description: Fix img links in readme
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/5414
 - version: "0.0.1"
   changes:

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix img links in readme
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5031
+      link: https://github.com/elastic/integrations/pull/5414
 - version: "0.0.1"
   changes:
     - description: Initial draft of the package

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.2"
+  changes:
+    - description: Fix img links in readme
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5031
 - version: "0.0.1"
   changes:
     - description: Initial draft of the package

--- a/packages/jumpcloud/docs/README.md
+++ b/packages/jumpcloud/docs/README.md
@@ -35,7 +35,7 @@ Ensure you have created a JumpCloud admin API key that you have access to, refer
 5. Configure the integration as appropriate
 6. Assign the integration to a new Elastic Agent host, or an existing Elastic Agent host
 
-![Example of Add JumpCloud Integration](./img/sample-add-integration.png)
+![Example of Add JumpCloud Integration](../img/sample-add-integration.png)
 
 ## Events
 

--- a/packages/jumpcloud/manifest.yml
+++ b/packages/jumpcloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: jumpcloud
 title: "JumpCloud"
-version: 0.0.1
+version: 0.0.2
 description: "Collect logs from JumpCloud Directory as a Service"
 type: integration
 categories:


### PR DESCRIPTION
The Jumpcloud integration screenshot source is incorrect. This PR fixes it so that the screenshot will correctly render in Kibana and our documentation.