### PR TITLE
Fix image sources in Tines readme

### DIFF
--- a/packages/tines/_dev/build/docs/README.md
+++ b/packages/tines/_dev/build/docs/README.md
@@ -42,7 +42,7 @@ The API key can be either a Personal or Tenant API key.
 6. Insert your Tines API user email address
 7. Insert the Tines API key created associated with the API user email address
 
-![Example Integration Configuration](./img/tines-integration-configuration.png)
+![Example Integration Configuration](../img/tines-integration-configuration.png)
 
 ## Dashboards
 
@@ -50,11 +50,11 @@ There are two dashboards immediately available as part of the integration.
 
 The Tines Audit Logs summary dashboard,
 
-![Tines Audit Logs](./img/tines-audit-logs-dashboard.png)
+![Tines Audit Logs](../img/tines-audit-logs-dashboard.png)
 
 And the Tines Time Saved dashboard,
 
-![Tines Time Saved](./img/tines-time-saved-dashboard.png)
+![Tines Time Saved](../img/tines-time-saved-dashboard.png)
 
 ## Data Stream
 

--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix img link in readme
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5076
+      link: https://github.com/elastic/integrations/pull/5415
 - version: "0.0.1"
   changes:
     - description: Initial draft of the package

--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.2"
+  changes:
+    - description: Fix img link in readme
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5076
 - version: "0.0.1"
   changes:
     - description: Initial draft of the package

--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -2,7 +2,7 @@
 - version: "0.0.2"
   changes:
     - description: Fix img link in readme
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/5415
 - version: "0.0.1"
   changes:

--- a/packages/tines/docs/README.md
+++ b/packages/tines/docs/README.md
@@ -42,7 +42,7 @@ The API key can be either a Personal or Tenant API key.
 6. Insert your Tines API user email address
 7. Insert the Tines API key created associated with the API user email address
 
-![Example Integration Configuration](./img/tines-integration-configuration.png)
+![Example Integration Configuration](../img/tines-integration-configuration.png)
 
 ## Dashboards
 
@@ -50,11 +50,11 @@ There are two dashboards immediately available as part of the integration.
 
 The Tines Audit Logs summary dashboard,
 
-![Tines Audit Logs](./img/tines-audit-logs-dashboard.png)
+![Tines Audit Logs](../img/tines-audit-logs-dashboard.png)
 
 And the Tines Time Saved dashboard,
 
-![Tines Time Saved](./img/tines-time-saved-dashboard.png)
+![Tines Time Saved](../img/tines-time-saved-dashboard.png)
 
 ## Data Stream
 

--- a/packages/tines/manifest.yml
+++ b/packages/tines/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: tines
 title: "Tines"
-version: 0.0.1
+version: 0.0.2
 description: "Tines Logs & Time Saved Reports"
 type: integration
 categories:


### PR DESCRIPTION
The Tines integration screenshot sources are incorrect. This PR fixes them so the screenshots will correctly render in Kibana and our documentation.