### PR TITLE
[o365] Fixing correct mapping for ListBaseType

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add ListBaseType field to o365.audit.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5115
+      link: https://github.com/elastic/integrations/pull/5428
 - version: "1.12.0"
   changes:
     - description: Add NewValue field to o365.audit.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Add ListBaseType field to o365.audit.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5115
 - version: "1.12.0"
   changes:
     - description: Add NewValue field to o365.audit.

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -94,6 +94,8 @@
       type: keyword
     - name: ItemType
       type: keyword
+    - name: ListBaseType
+      type: keyword
     - name: ListId
       type: keyword
     - name: ListItemUniqueId

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -259,6 +259,7 @@ An example event for `audit` looks as following:
 | o365.audit.Item.\*.\* |  | object |
 | o365.audit.ItemName |  | keyword |
 | o365.audit.ItemType |  | keyword |
+| o365.audit.ListBaseType |  | keyword |
 | o365.audit.ListId |  | keyword |
 | o365.audit.ListItemUniqueId |  | keyword |
 | o365.audit.LogonError |  | keyword |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.12.0"
+version: 1.13.0
 release: ga
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

New field has been introduced, for some reason the dynamic mapping added it as a numerical field (long), however according to the documentation (and current incoming data) this field is supposed to be a keyword.

This halts ingestion in the meantime, so we would like to ensure the field type is correct.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



