### PR TITLE
[logstash] Add missing monitoring cpu aliases

### DIFF
--- a/packages/logstash/_dev/deploy/docker/docker-compose.yml
+++ b/packages/logstash/_dev/deploy/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.3"
 services:
   logstash:
     user: root
-    image: "docker.elastic.co/logstash/logstash:${ELASTIC_VERSION:-8.5.0}"
+    image: "docker.elastic.co/logstash/logstash:${ELASTIC_VERSION:-8.6.0}"
     volumes:
       - "./pipeline:/usr/share/logstash/pipeline"
       - "./config:/usr/share/logstash/config"

--- a/packages/logstash/_dev/deploy/docker/docker-compose.yml
+++ b/packages/logstash/_dev/deploy/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.3"
 services:
   logstash:
     user: root
-    image: "docker.elastic.co/logstash/logstash:${ELASTIC_VERSION:-8.5.0-SNAPSHOT}"
+    image: "docker.elastic.co/logstash/logstash:${ELASTIC_VERSION:-8.5.0}"
     volumes:
       - "./pipeline:/usr/share/logstash/pipeline"
       - "./config:/usr/share/logstash/config"

--- a/packages/logstash/_dev/deploy/variants.yml
+++ b/packages/logstash/_dev/deploy/variants.yml
@@ -1,4 +1,4 @@
 variants:
-  logstash_8.5.0:
-    ELASTIC_VERSION: 8.5.0-SNAPSHOT
-default: logstash_8.5.0
+  logstash_8.6.0:
+    ELASTIC_VERSION: 8.6.0
+default: logstash_8.6.0

--- a/packages/logstash/_dev/deploy/variants.yml
+++ b/packages/logstash/_dev/deploy/variants.yml
@@ -1,4 +1,4 @@
 variants:
-  logstash_8.5.0:
-    ELASTIC_VERSION: 8.5.0
-default: logstash_8.5.0
+  logstash_8.6.0:
+    ELASTIC_VERSION: 8.6.0
+default: logstash_8.6.0

--- a/packages/logstash/_dev/deploy/variants.yml
+++ b/packages/logstash/_dev/deploy/variants.yml
@@ -1,4 +1,4 @@
 variants:
-  logstash_8.6.0:
-    ELASTIC_VERSION: 8.6.0
-default: logstash_8.6.0
+  logstash_8.5.0:
+    ELASTIC_VERSION: 8.5.0
+default: logstash_8.5.0

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.2-preview1"
+  changes:
+    - description: Add missing node_stats cpu aliases
+      type: bugfix
+      link: tbd
 - version: "2.2.1-preview1"
   changes:
     - description: Add period variable to define polling frequency

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add missing node_stats cpu aliases
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/5431
 - version: "2.2.1-preview1"
   changes:
     - description: Add period variable to define polling frequency

--- a/packages/logstash/data_stream/log/sample_event.json
+++ b/packages/logstash/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-10-11T14:03:32.641Z",
+    "@timestamp": "2023-03-02T15:30:00.670Z",
     "agent": {
-        "ephemeral_id": "e1088945-f8e4-466b-83fd-f636ffbf9bdf",
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
+        "ephemeral_id": "5d10cac1-c84e-43b4-b79e-5658884bf24d",
+        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.0"
+        "version": "8.6.0"
     },
     "data_stream": {
         "dataset": "logstash.log",
@@ -16,34 +16,34 @@
         "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
-        "snapshot": true,
-        "version": "8.5.0"
+        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "snapshot": false,
+        "version": "8.6.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-10-11T14:03:32.641Z",
+        "created": "2023-03-02T15:30:00.670Z",
         "dataset": "logstash.log",
-        "ingested": "2022-10-11T14:03:44Z",
+        "ingested": "2023-03-02T15:30:11Z",
         "kind": "event",
         "type": "info"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "b6bc6723e51b43959ce07f0c3105c72d",
+        "id": "d38b554e341a476aaa15b74fbc11f03e",
         "ip": [
-            "192.168.0.7"
+            "192.168.112.7"
         ],
         "mac": [
-            "02-42-C0-A8-00-07"
+            "02-42-C0-A8-70-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.124-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -55,17 +55,17 @@
     },
     "log": {
         "file": {
-            "path": "/tmp/service_logs/logstash/logstash-json.log"
+            "path": "/tmp/service_logs/logstash-json.log"
         },
-        "level": "INFO",
+        "level": "WARN",
         "offset": 0
     },
     "logstash": {
         "log": {
             "log_event": {},
-            "module": "logstash.runner",
+            "module": "deprecation.logstash.runner",
             "thread": "main"
         }
     },
-    "message": "Log4j configuration path used is: /usr/share/logstash/config/log4j2.properties"
+    "message": "NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'allow_superuser' to 'false' to avoid startup errors in future releases."
 }

--- a/packages/logstash/data_stream/log/sample_event.json
+++ b/packages/logstash/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-03-02T15:30:00.670Z",
+    "@timestamp": "2023-03-02T15:56:09.250Z",
     "agent": {
-        "ephemeral_id": "5d10cac1-c84e-43b4-b79e-5658884bf24d",
-        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "ephemeral_id": "350b18f5-b2c5-44c2-9968-316905d2cfa0",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "logstash.log",
@@ -16,15 +16,15 @@
         "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "snapshot": false,
-        "version": "8.6.0"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-03-02T15:30:00.670Z",
+        "created": "2023-03-02T15:56:09.250Z",
         "dataset": "logstash.log",
-        "ingested": "2023-03-02T15:30:11Z",
+        "ingested": "2023-03-02T15:56:12Z",
         "kind": "event",
         "type": "info"
     },
@@ -32,12 +32,12 @@
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "d38b554e341a476aaa15b74fbc11f03e",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
-            "192.168.112.7"
+            "192.168.224.7"
         ],
         "mac": [
-            "02-42-C0-A8-70-07"
+            "02-42-C0-A8-E0-07"
         ],
         "name": "docker-fleet-agent",
         "os": {

--- a/packages/logstash/data_stream/node/sample_event.json
+++ b/packages/logstash/data_stream/node/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-10-11T14:04:44.089Z",
+    "@timestamp": "2023-03-02T15:30:52.717Z",
     "agent": {
-        "ephemeral_id": "1a1ca75b-a20f-4ae4-82a9-4e269c855a5d",
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
+        "ephemeral_id": "6b035224-77ee-4123-9cc3-504b6ed70712",
+        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.5.0"
+        "version": "8.6.0"
     },
     "data_stream": {
         "dataset": "logstash.stack_monitoring.node",
@@ -16,33 +16,33 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
-        "snapshot": true,
-        "version": "8.5.0"
+        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "snapshot": false,
+        "version": "8.6.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "logstash.stack_monitoring.node",
-        "duration": 131377542,
-        "ingested": "2022-10-11T14:04:45Z",
+        "duration": 101769000,
+        "ingested": "2023-03-02T15:30:53Z",
         "module": "logstash"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "b6bc6723e51b43959ce07f0c3105c72d",
+        "id": "d38b554e341a476aaa15b74fbc11f03e",
         "ip": [
-            "192.168.0.7"
+            "192.168.112.7"
         ],
         "mac": [
-            "02-42-C0-A8-00-07"
+            "02-42-C0-A8-70-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.124-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -51,44 +51,38 @@
     },
     "logstash": {
         "cluster": {
-            "id": "U8DCOXCFQHWlaKczNT4LNQ"
+            "id": "fu0AmqggQbiRa9-qF7-jcw"
         },
         "elasticsearch": {
             "cluster": {
-                "id": "U8DCOXCFQHWlaKczNT4LNQ"
+                "id": "fu0AmqggQbiRa9-qF7-jcw"
             }
         },
         "node": {
-            "host": "17a6005cfeaa",
-            "id": "7d7ee953-cf82-4d1d-91e0-1714346531de",
+            "host": "31b956d2ae73",
+            "id": "a99d33c1-13ce-46bd-820e-e785acdc2794",
             "jvm": {
-                "version": "17.0.4"
+                "version": "17.0.5"
             },
             "state": {
                 "pipeline": {
                     "batch_size": 125,
-                    "ephemeral_id": "3d2aff1f-dde1-4c56-9560-14f3b092f894",
-                    "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
-                    "id": "pipeline-with-persisted-queue",
+                    "ephemeral_id": "a5f2f3cb-f514-441e-88f7-4e28596d72d6",
+                    "hash": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
+                    "id": "pipeline-with-memory-queue",
                     "representation": {
                         "graph": {
                             "edges": [
                                 {
-                                    "from": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
-                                    "id": "9ed824e4f189b461c111ae27c17644c3c5f6d7c3c2bb213cbc7cc067cbd68fe6",
+                                    "from": "4c5941552cdaa72ebc285557c697a7150c359ee3eacf9b5664c4b1048e26153b",
+                                    "id": "dd5073edf88d34ebbedc42739631a437ac4f2ef073969e0099022a2fa8ab0dc4",
                                     "to": "__QUEUE__",
                                     "type": "plain"
                                 },
                                 {
                                     "from": "__QUEUE__",
-                                    "id": "cb33f8fb7611e31a2c1751b74cdedf5b8cdb96ea46b812a2541e2db4f13dca10",
-                                    "to": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
-                                    "type": "plain"
-                                },
-                                {
-                                    "from": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
-                                    "id": "63ef166c45b87a40f31e0a6def175f10460b6b0ed656e70968eb52b1c454ab16",
-                                    "to": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
+                                    "id": "cb9eedba9879b30496083a17bfae14f70695e887742ecd1564ac68861197cff3",
+                                    "to": "635a080aacc8700059852859da284a9cb92cb78a6d7112fbf55e441e51b6658a",
                                     "type": "plain"
                                 }
                             ],
@@ -96,11 +90,11 @@
                                 {
                                     "config_name": "java_generator",
                                     "explicit_id": false,
-                                    "id": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
+                                    "id": "4c5941552cdaa72ebc285557c697a7150c359ee3eacf9b5664c4b1048e26153b",
                                     "meta": {
                                         "source": {
                                             "column": 3,
-                                            "id": "/usr/share/logstash/pipeline/persisted-queue.conf",
+                                            "id": "/usr/share/logstash/pipeline/memory-queue.conf",
                                             "line": 2,
                                             "protocol": "file"
                                         }
@@ -115,29 +109,14 @@
                                     "type": "queue"
                                 },
                                 {
-                                    "config_name": "sleep",
-                                    "explicit_id": false,
-                                    "id": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
-                                    "meta": {
-                                        "source": {
-                                            "column": 3,
-                                            "id": "/usr/share/logstash/pipeline/persisted-queue.conf",
-                                            "line": 8,
-                                            "protocol": "file"
-                                        }
-                                    },
-                                    "plugin_type": "filter",
-                                    "type": "plugin"
-                                },
-                                {
                                     "config_name": "elasticsearch",
                                     "explicit_id": false,
-                                    "id": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
+                                    "id": "635a080aacc8700059852859da284a9cb92cb78a6d7112fbf55e441e51b6658a",
                                     "meta": {
                                         "source": {
                                             "column": 3,
-                                            "id": "/usr/share/logstash/pipeline/persisted-queue.conf",
-                                            "line": 15,
+                                            "id": "/usr/share/logstash/pipeline/memory-queue.conf",
+                                            "line": 8,
                                             "protocol": "file"
                                         }
                                     },
@@ -146,14 +125,14 @@
                                 }
                             ]
                         },
-                        "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
+                        "hash": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
                         "type": "lir",
                         "version": "0.0.0"
                     },
-                    "workers": 7
+                    "workers": 10
                 }
             },
-            "version": "8.5.0"
+            "version": "8.6.0"
         }
     },
     "metricset": {
@@ -164,11 +143,11 @@
         "pid": 1
     },
     "service": {
-        "address": "http://elastic-package-service-logstash-1:9600/_node",
-        "hostname": "17a6005cfeaa",
-        "id": "7d7ee953-cf82-4d1d-91e0-1714346531de",
+        "address": "http://elastic-package-service_logstash_1:9600/_node",
+        "hostname": "31b956d2ae73",
+        "id": "a99d33c1-13ce-46bd-820e-e785acdc2794",
         "name": "logstash",
         "type": "logstash",
-        "version": "8.5.0"
+        "version": "8.6.0"
     }
 }

--- a/packages/logstash/data_stream/node/sample_event.json
+++ b/packages/logstash/data_stream/node/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-03-02T15:30:52.717Z",
+    "@timestamp": "2023-03-02T15:57:03.999Z",
     "agent": {
-        "ephemeral_id": "6b035224-77ee-4123-9cc3-504b6ed70712",
-        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "ephemeral_id": "16f2dd63-454b-4699-a8c8-2a748bd044b8",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.6.0"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "logstash.stack_monitoring.node",
@@ -16,27 +16,27 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "snapshot": false,
-        "version": "8.6.0"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "logstash.stack_monitoring.node",
-        "duration": 101769000,
-        "ingested": "2023-03-02T15:30:53Z",
+        "duration": 69490100,
+        "ingested": "2023-03-02T15:57:05Z",
         "module": "logstash"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "d38b554e341a476aaa15b74fbc11f03e",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
-            "192.168.112.7"
+            "192.168.224.7"
         ],
         "mac": [
-            "02-42-C0-A8-70-07"
+            "02-42-C0-A8-E0-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -51,38 +51,44 @@
     },
     "logstash": {
         "cluster": {
-            "id": "fu0AmqggQbiRa9-qF7-jcw"
+            "id": "0toa26-cTzmqx0WD40-4XQ"
         },
         "elasticsearch": {
             "cluster": {
-                "id": "fu0AmqggQbiRa9-qF7-jcw"
+                "id": "0toa26-cTzmqx0WD40-4XQ"
             }
         },
         "node": {
-            "host": "31b956d2ae73",
-            "id": "a99d33c1-13ce-46bd-820e-e785acdc2794",
+            "host": "45730b5f8c3d",
+            "id": "2e17cd45-ecb8-4358-a420-b867f2e32b7a",
             "jvm": {
-                "version": "17.0.5"
+                "version": "17.0.4"
             },
             "state": {
                 "pipeline": {
                     "batch_size": 125,
-                    "ephemeral_id": "a5f2f3cb-f514-441e-88f7-4e28596d72d6",
-                    "hash": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
-                    "id": "pipeline-with-memory-queue",
+                    "ephemeral_id": "472cf082-aa15-41ca-9ed1-62d03afbadd0",
+                    "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
+                    "id": "pipeline-with-persisted-queue",
                     "representation": {
                         "graph": {
                             "edges": [
                                 {
-                                    "from": "4c5941552cdaa72ebc285557c697a7150c359ee3eacf9b5664c4b1048e26153b",
-                                    "id": "dd5073edf88d34ebbedc42739631a437ac4f2ef073969e0099022a2fa8ab0dc4",
+                                    "from": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
+                                    "id": "9ed824e4f189b461c111ae27c17644c3c5f6d7c3c2bb213cbc7cc067cbd68fe6",
                                     "to": "__QUEUE__",
                                     "type": "plain"
                                 },
                                 {
                                     "from": "__QUEUE__",
-                                    "id": "cb9eedba9879b30496083a17bfae14f70695e887742ecd1564ac68861197cff3",
-                                    "to": "635a080aacc8700059852859da284a9cb92cb78a6d7112fbf55e441e51b6658a",
+                                    "id": "cb33f8fb7611e31a2c1751b74cdedf5b8cdb96ea46b812a2541e2db4f13dca10",
+                                    "to": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
+                                    "type": "plain"
+                                },
+                                {
+                                    "from": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
+                                    "id": "63ef166c45b87a40f31e0a6def175f10460b6b0ed656e70968eb52b1c454ab16",
+                                    "to": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
                                     "type": "plain"
                                 }
                             ],
@@ -90,11 +96,11 @@
                                 {
                                     "config_name": "java_generator",
                                     "explicit_id": false,
-                                    "id": "4c5941552cdaa72ebc285557c697a7150c359ee3eacf9b5664c4b1048e26153b",
+                                    "id": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
                                     "meta": {
                                         "source": {
                                             "column": 3,
-                                            "id": "/usr/share/logstash/pipeline/memory-queue.conf",
+                                            "id": "/usr/share/logstash/pipeline/persisted-queue.conf",
                                             "line": 2,
                                             "protocol": "file"
                                         }
@@ -109,14 +115,29 @@
                                     "type": "queue"
                                 },
                                 {
-                                    "config_name": "elasticsearch",
+                                    "config_name": "sleep",
                                     "explicit_id": false,
-                                    "id": "635a080aacc8700059852859da284a9cb92cb78a6d7112fbf55e441e51b6658a",
+                                    "id": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
                                     "meta": {
                                         "source": {
                                             "column": 3,
-                                            "id": "/usr/share/logstash/pipeline/memory-queue.conf",
+                                            "id": "/usr/share/logstash/pipeline/persisted-queue.conf",
                                             "line": 8,
+                                            "protocol": "file"
+                                        }
+                                    },
+                                    "plugin_type": "filter",
+                                    "type": "plugin"
+                                },
+                                {
+                                    "config_name": "elasticsearch",
+                                    "explicit_id": false,
+                                    "id": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
+                                    "meta": {
+                                        "source": {
+                                            "column": 3,
+                                            "id": "/usr/share/logstash/pipeline/persisted-queue.conf",
+                                            "line": 15,
                                             "protocol": "file"
                                         }
                                     },
@@ -125,14 +146,14 @@
                                 }
                             ]
                         },
-                        "hash": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
+                        "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
                         "type": "lir",
                         "version": "0.0.0"
                     },
                     "workers": 10
                 }
             },
-            "version": "8.6.0"
+            "version": "8.5.0"
         }
     },
     "metricset": {
@@ -144,10 +165,10 @@
     },
     "service": {
         "address": "http://elastic-package-service_logstash_1:9600/_node",
-        "hostname": "31b956d2ae73",
-        "id": "a99d33c1-13ce-46bd-820e-e785acdc2794",
+        "hostname": "45730b5f8c3d",
+        "id": "2e17cd45-ecb8-4358-a420-b867f2e32b7a",
         "name": "logstash",
         "type": "logstash",
-        "version": "8.6.0"
+        "version": "8.5.0"
     }
 }

--- a/packages/logstash/data_stream/node_stats/fields/fields.yml
+++ b/packages/logstash/data_stream/node_stats/fields/fields.yml
@@ -123,7 +123,7 @@
                   type: group
                   fields:
                     - name: cpuacct
-                      type: object
+                      type: group
                       fields:
                         - name: control_group
                           type: text
@@ -137,7 +137,7 @@
                         - name: cfs_quota_micros
                           type: long
                         - name: stat
-                          type: object
+                          type: group
                           fields:
                             - name: number_of_elapsed_periods
                               type: long

--- a/packages/logstash/data_stream/node_stats/fields/package-fields.yml
+++ b/packages/logstash/data_stream/node_stats/fields/package-fields.yml
@@ -84,11 +84,29 @@
           type: group
           fields:
             - name: cpuacct
-              type: object
+              type: group
               fields:
                 - name: usage_nanos
                   type: alias
                   path: logstash.node.stats.os.cgroup.cpuacct.usage_nanos
+            - name: cpu
+              type: group
+              fields:
+                - name: cfs_quota_micros
+                  path: logstash.node.stats.os.cgroup.cpu.cfs_quota_micros
+                  type: alias
+                - name: stat
+                  type: group
+                  fields:
+                    - name: number_of_elapsed_periods
+                      path: logstash.node.stats.os.cgroup.cpu.stat.number_of_elapsed_periods
+                      type: alias
+                    - name: number_of_times_throttled
+                      path: logstash.node.stats.os.cgroup.cpu.stat.number_of_times_throttled
+                      type: alias
+                    - name: time_throttled_nanos
+                      path: logstash.node.stats.os.cgroup.cpu.stat.time_throttled_nanos
+                      type: alias
     - name: process.cpu.percent
       type: alias
       path: logstash.node.stats.process.cpu.percent

--- a/packages/logstash/data_stream/node_stats/manifest.yml
+++ b/packages/logstash/data_stream/node_stats/manifest.yml
@@ -8,8 +8,8 @@ elasticsearch:
       dynamic: false
 streams:
   - input: logstash/metrics
-    title: Logstash node stats
-    description: Collect Logstash node stats
+    title: Logstash node stats metrics
+    description: Collect Logstash node stats metrics
     vars:
       - name: period
         type: text

--- a/packages/logstash/data_stream/node_stats/sample_event.json
+++ b/packages/logstash/data_stream/node_stats/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-03-02T15:31:32.513Z",
+    "@timestamp": "2023-03-02T15:57:56.968Z",
     "agent": {
-        "ephemeral_id": "b0de3826-c2c4-49a2-8229-403c3e5fdcb6",
-        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "ephemeral_id": "16f2dd63-454b-4699-a8c8-2a748bd044b8",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.6.0"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "logstash.stack_monitoring.node_stats",
@@ -16,27 +16,27 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "snapshot": false,
-        "version": "8.6.0"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "logstash.stack_monitoring.node_stats",
-        "duration": 102120800,
-        "ingested": "2023-03-02T15:31:33Z",
+        "duration": 48419400,
+        "ingested": "2023-03-02T15:57:58Z",
         "module": "logstash"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "d38b554e341a476aaa15b74fbc11f03e",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
-            "192.168.112.7"
+            "192.168.224.7"
         ],
         "mac": [
-            "02-42-C0-A8-70-07"
+            "02-42-C0-A8-E0-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -51,20 +51,20 @@
     },
     "logstash": {
         "cluster": {
-            "id": "fu0AmqggQbiRa9-qF7-jcw"
+            "id": "0toa26-cTzmqx0WD40-4XQ"
         },
         "elasticsearch": {
             "cluster": {
-                "id": "fu0AmqggQbiRa9-qF7-jcw"
+                "id": "0toa26-cTzmqx0WD40-4XQ"
             }
         },
         "node": {
             "stats": {
                 "events": {
-                    "duration_in_millis": 16,
-                    "filtered": 3,
-                    "in": 43,
-                    "out": 3
+                    "duration_in_millis": 334,
+                    "filtered": 138,
+                    "in": 618,
+                    "out": 138
                 },
                 "jvm": {
                     "gc": {
@@ -74,31 +74,31 @@
                                 "collection_time_in_millis": 0
                             },
                             "young": {
-                                "collection_count": 10,
-                                "collection_time_in_millis": 152
+                                "collection_count": 13,
+                                "collection_time_in_millis": 177
                             }
                         }
                     },
                     "mem": {
                         "heap_max_in_bytes": 10527703038,
-                        "heap_used_in_bytes": 198153920,
-                        "heap_used_percent": 1
+                        "heap_used_in_bytes": 234688352,
+                        "heap_used_percent": 2
                     },
-                    "uptime_in_millis": 11569
+                    "uptime_in_millis": 21450
                 },
                 "logstash": {
-                    "ephemeral_id": "2ac12983-5d44-4c92-b380-988fa920597d",
-                    "host": "65b0ba135e8f",
+                    "ephemeral_id": "17681d23-bd67-4c40-b6b1-63e97b560856",
+                    "host": "170bc3698b89",
                     "http_address": "0.0.0.0:9600",
-                    "name": "65b0ba135e8f",
+                    "name": "170bc3698b89",
                     "pipeline": {
                         "batch_size": 125,
                         "workers": 10
                     },
                     "snapshot": false,
                     "status": "green",
-                    "uuid": "c36fc6ec-1df3-462b-b5c9-a10b7e3c9876",
-                    "version": "8.6.0"
+                    "uuid": "a4224a67-aae8-4bce-8660-079d068b2e72",
+                    "version": "8.5.0"
                 },
                 "os": {
                     "cgroup": {
@@ -113,27 +113,84 @@
                         },
                         "cpuacct": {
                             "control_group": "/",
-                            "usage_nanos": 41626767129
+                            "usage_nanos": 55911664431
                         }
                     },
                     "cpu": {
                         "load_average": {
-                            "15m": 1.82,
-                            "1m": 3.06,
-                            "5m": 2.13
+                            "15m": 2.28,
+                            "1m": 2.85,
+                            "5m": 2.62
                         },
                         "percent": 0
                     }
                 },
                 "pipelines": [
                     {
-                        "ephemeral_id": "09c8b004-3773-4247-9f95-36106536d0cf",
+                        "ephemeral_id": "453a2361-82d8-4d88-b7a4-063c3293cd4a",
                         "events": {
                             "duration_in_millis": 0,
                             "filtered": 0,
-                            "in": 7,
+                            "in": 476,
                             "out": 0,
-                            "queue_push_duration_in_millis": 7
+                            "queue_push_duration_in_millis": 59
+                        },
+                        "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
+                        "id": "pipeline-with-persisted-queue",
+                        "queue": {
+                            "capacity": {
+                                "max_queue_size_in_bytes": 1073741824,
+                                "max_unread_events": 0,
+                                "page_capacity_in_bytes": 67108864,
+                                "queue_size_in_bytes": 132880
+                            },
+                            "data": {
+                                "free_space_in_bytes": 51709984768,
+                                "path": "/usr/share/logstash/data/queue/pipeline-with-persisted-queue",
+                                "storage_type": "overlay"
+                            },
+                            "events": 0,
+                            "events_count": 0,
+                            "max_queue_size_in_bytes": 1073741824,
+                            "queue_size_in_bytes": 132880,
+                            "type": "persisted"
+                        },
+                        "reloads": {
+                            "failures": 0,
+                            "successes": 0
+                        },
+                        "vertices": [
+                            {
+                                "events_out": 475,
+                                "id": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
+                                "pipeline_ephemeral_id": "453a2361-82d8-4d88-b7a4-063c3293cd4a",
+                                "queue_push_duration_in_millis": 59
+                            },
+                            {
+                                "duration_in_millis": 0,
+                                "events_in": 375,
+                                "events_out": 0,
+                                "id": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
+                                "pipeline_ephemeral_id": "453a2361-82d8-4d88-b7a4-063c3293cd4a"
+                            },
+                            {
+                                "cluster_uuid": "0toa26-cTzmqx0WD40-4XQ",
+                                "duration_in_millis": 1,
+                                "events_in": 0,
+                                "events_out": 0,
+                                "id": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
+                                "pipeline_ephemeral_id": "453a2361-82d8-4d88-b7a4-063c3293cd4a"
+                            }
+                        ]
+                    },
+                    {
+                        "ephemeral_id": "7114cd7d-8d91-4afc-a986-32487c3edcbe",
+                        "events": {
+                            "duration_in_millis": 191,
+                            "filtered": 91,
+                            "in": 95,
+                            "out": 91,
+                            "queue_push_duration_in_millis": 4
                         },
                         "hash": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
                         "id": "pipeline-with-memory-queue",
@@ -149,85 +206,42 @@
                         },
                         "vertices": [
                             {
-                                "events_out": 7,
+                                "events_out": 95,
                                 "id": "4c5941552cdaa72ebc285557c697a7150c359ee3eacf9b5664c4b1048e26153b",
-                                "pipeline_ephemeral_id": "09c8b004-3773-4247-9f95-36106536d0cf",
-                                "queue_push_duration_in_millis": 7
+                                "pipeline_ephemeral_id": "7114cd7d-8d91-4afc-a986-32487c3edcbe",
+                                "queue_push_duration_in_millis": 4
                             },
                             {
-                                "cluster_uuid": "fu0AmqggQbiRa9-qF7-jcw",
-                                "duration_in_millis": 0,
-                                "events_in": 0,
-                                "events_out": 0,
+                                "cluster_uuid": "0toa26-cTzmqx0WD40-4XQ",
+                                "duration_in_millis": 193,
+                                "events_in": 91,
+                                "events_out": 91,
                                 "id": "635a080aacc8700059852859da284a9cb92cb78a6d7112fbf55e441e51b6658a",
-                                "pipeline_ephemeral_id": "09c8b004-3773-4247-9f95-36106536d0cf"
-                            }
-                        ]
-                    },
-                    {
-                        "ephemeral_id": "47c21ea6-1b83-4b59-ade0-487f1142dcdc",
-                        "events": {
-                            "duration_in_millis": 0,
-                            "filtered": 0,
-                            "in": 33,
-                            "out": 0,
-                            "queue_push_duration_in_millis": 40
-                        },
-                        "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
-                        "id": "pipeline-with-persisted-queue",
-                        "queue": {
-                            "capacity": {
-                                "max_queue_size_in_bytes": 1073741824,
-                                "max_unread_events": 0,
-                                "page_capacity_in_bytes": 67108864,
-                                "queue_size_in_bytes": 1
-                            },
-                            "data": {
-                                "free_space_in_bytes": 29465477120,
-                                "path": "/usr/share/logstash/data/queue/pipeline-with-persisted-queue",
-                                "storage_type": "overlay"
-                            },
-                            "events": 0,
-                            "events_count": 0,
-                            "max_queue_size_in_bytes": 1073741824,
-                            "queue_size_in_bytes": 1,
-                            "type": "persisted"
-                        },
-                        "reloads": {
-                            "failures": 0,
-                            "successes": 0
-                        },
-                        "vertices": [
-                            {
-                                "events_out": 32,
-                                "id": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
-                                "pipeline_ephemeral_id": "47c21ea6-1b83-4b59-ade0-487f1142dcdc",
-                                "queue_push_duration_in_millis": 40
-                            },
-                            {
-                                "duration_in_millis": 0,
-                                "events_in": 0,
-                                "events_out": 0,
-                                "id": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
-                                "pipeline_ephemeral_id": "47c21ea6-1b83-4b59-ade0-487f1142dcdc"
-                            },
-                            {
-                                "cluster_uuid": "fu0AmqggQbiRa9-qF7-jcw",
-                                "duration_in_millis": 0,
-                                "events_in": 0,
-                                "events_out": 0,
-                                "id": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
-                                "pipeline_ephemeral_id": "47c21ea6-1b83-4b59-ade0-487f1142dcdc"
+                                "long_counters": [
+                                    {
+                                        "name": "bulk_requests.successes",
+                                        "value": 12
+                                    },
+                                    {
+                                        "name": "bulk_requests.responses.200",
+                                        "value": 12
+                                    },
+                                    {
+                                        "name": "documents.successes",
+                                        "value": 91
+                                    }
+                                ],
+                                "pipeline_ephemeral_id": "7114cd7d-8d91-4afc-a986-32487c3edcbe"
                             }
                         ]
                     }
                 ],
                 "process": {
                     "cpu": {
-                        "percent": 0
+                        "percent": 4
                     },
                     "max_file_descriptors": 1048576,
-                    "open_file_descriptors": 73
+                    "open_file_descriptors": 89
                 },
                 "queue": {
                     "events_count": 0
@@ -236,7 +250,7 @@
                     "failures": 0,
                     "successes": 0
                 },
-                "timestamp": "2023-03-02T15:31:32.615Z"
+                "timestamp": "2023-03-02T15:57:57.016Z"
             }
         }
     },
@@ -246,10 +260,10 @@
     },
     "service": {
         "address": "http://elastic-package-service_logstash_1:9600/_node/stats",
-        "hostname": "65b0ba135e8f",
+        "hostname": "170bc3698b89",
         "id": "",
         "name": "logstash",
         "type": "logstash",
-        "version": "8.6.0"
+        "version": "8.5.0"
     }
 }

--- a/packages/logstash/data_stream/node_stats/sample_event.json
+++ b/packages/logstash/data_stream/node_stats/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-10-11T14:05:39.791Z",
+    "@timestamp": "2023-03-02T15:31:32.513Z",
     "agent": {
-        "ephemeral_id": "1a1ca75b-a20f-4ae4-82a9-4e269c855a5d",
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
+        "ephemeral_id": "b0de3826-c2c4-49a2-8229-403c3e5fdcb6",
+        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.5.0"
+        "version": "8.6.0"
     },
     "data_stream": {
         "dataset": "logstash.stack_monitoring.node_stats",
@@ -16,33 +16,33 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
-        "snapshot": true,
-        "version": "8.5.0"
+        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "snapshot": false,
+        "version": "8.6.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "logstash.stack_monitoring.node_stats",
-        "duration": 125822375,
-        "ingested": "2022-10-11T14:05:40Z",
+        "duration": 102120800,
+        "ingested": "2023-03-02T15:31:33Z",
         "module": "logstash"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "b6bc6723e51b43959ce07f0c3105c72d",
+        "id": "d38b554e341a476aaa15b74fbc11f03e",
         "ip": [
-            "192.168.0.7"
+            "192.168.112.7"
         ],
         "mac": [
-            "02-42-C0-A8-00-07"
+            "02-42-C0-A8-70-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.124-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -51,20 +51,20 @@
     },
     "logstash": {
         "cluster": {
-            "id": "U8DCOXCFQHWlaKczNT4LNQ"
+            "id": "fu0AmqggQbiRa9-qF7-jcw"
         },
         "elasticsearch": {
             "cluster": {
-                "id": "U8DCOXCFQHWlaKczNT4LNQ"
+                "id": "fu0AmqggQbiRa9-qF7-jcw"
             }
         },
         "node": {
             "stats": {
                 "events": {
-                    "duration_in_millis": 322,
-                    "filtered": 132,
-                    "in": 593,
-                    "out": 132
+                    "duration_in_millis": 16,
+                    "filtered": 3,
+                    "in": 43,
+                    "out": 3
                 },
                 "jvm": {
                     "gc": {
@@ -74,58 +74,66 @@
                                 "collection_time_in_millis": 0
                             },
                             "young": {
-                                "collection_count": 25,
-                                "collection_time_in_millis": 269
+                                "collection_count": 10,
+                                "collection_time_in_millis": 152
                             }
                         }
                     },
                     "mem": {
-                        "heap_max_in_bytes": 3137339390,
-                        "heap_used_in_bytes": 208271008,
-                        "heap_used_percent": 6
+                        "heap_max_in_bytes": 10527703038,
+                        "heap_used_in_bytes": 198153920,
+                        "heap_used_percent": 1
                     },
-                    "uptime_in_millis": 17121
+                    "uptime_in_millis": 11569
                 },
                 "logstash": {
-                    "ephemeral_id": "59ea6513-500d-4b0b-8d54-a32d94631b1f",
-                    "host": "ee237ad022ba",
+                    "ephemeral_id": "2ac12983-5d44-4c92-b380-988fa920597d",
+                    "host": "65b0ba135e8f",
                     "http_address": "0.0.0.0:9600",
-                    "name": "ee237ad022ba",
+                    "name": "65b0ba135e8f",
                     "pipeline": {
                         "batch_size": 125,
-                        "workers": 7
+                        "workers": 10
                     },
-                    "snapshot": true,
+                    "snapshot": false,
                     "status": "green",
-                    "uuid": "cb4f884e-d57b-43a3-bec6-7b3ec1adcbb9",
-                    "version": "8.5.0"
+                    "uuid": "c36fc6ec-1df3-462b-b5c9-a10b7e3c9876",
+                    "version": "8.6.0"
                 },
                 "os": {
                     "cgroup": {
                         "cpu": {
-                            "control_group": "",
-                            "stat": null
+                            "cfs_quota_micros": -1,
+                            "control_group": "/",
+                            "stat": {
+                                "number_of_elapsed_periods": 0,
+                                "number_of_times_throttled": 0,
+                                "time_throttled_nanos": 0
+                            }
                         },
-                        "cpuacct": null
+                        "cpuacct": {
+                            "control_group": "/",
+                            "usage_nanos": 41626767129
+                        }
                     },
                     "cpu": {
                         "load_average": {
-                            "15m": 2.17,
-                            "1m": 3.32,
-                            "5m": 2.32
+                            "15m": 1.82,
+                            "1m": 3.06,
+                            "5m": 2.13
                         },
                         "percent": 0
                     }
                 },
                 "pipelines": [
                     {
-                        "ephemeral_id": "0eff59ef-d130-4753-bd4e-289341a84c1a",
+                        "ephemeral_id": "09c8b004-3773-4247-9f95-36106536d0cf",
                         "events": {
-                            "duration_in_millis": 199,
-                            "filtered": 86,
-                            "in": 92,
-                            "out": 86,
-                            "queue_push_duration_in_millis": 4
+                            "duration_in_millis": 0,
+                            "filtered": 0,
+                            "in": 7,
+                            "out": 0,
+                            "queue_push_duration_in_millis": 7
                         },
                         "hash": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
                         "id": "pipeline-with-memory-queue",
@@ -141,43 +149,29 @@
                         },
                         "vertices": [
                             {
-                                "events_out": 92,
+                                "events_out": 7,
                                 "id": "4c5941552cdaa72ebc285557c697a7150c359ee3eacf9b5664c4b1048e26153b",
-                                "pipeline_ephemeral_id": "0eff59ef-d130-4753-bd4e-289341a84c1a",
-                                "queue_push_duration_in_millis": 4
+                                "pipeline_ephemeral_id": "09c8b004-3773-4247-9f95-36106536d0cf",
+                                "queue_push_duration_in_millis": 7
                             },
                             {
-                                "cluster_uuid": "U8DCOXCFQHWlaKczNT4LNQ",
-                                "duration_in_millis": 197,
-                                "events_in": 86,
-                                "events_out": 86,
+                                "cluster_uuid": "fu0AmqggQbiRa9-qF7-jcw",
+                                "duration_in_millis": 0,
+                                "events_in": 0,
+                                "events_out": 0,
                                 "id": "635a080aacc8700059852859da284a9cb92cb78a6d7112fbf55e441e51b6658a",
-                                "long_counters": [
-                                    {
-                                        "name": "bulk_requests.successes",
-                                        "value": 15
-                                    },
-                                    {
-                                        "name": "bulk_requests.responses.200",
-                                        "value": 15
-                                    },
-                                    {
-                                        "name": "documents.successes",
-                                        "value": 86
-                                    }
-                                ],
-                                "pipeline_ephemeral_id": "0eff59ef-d130-4753-bd4e-289341a84c1a"
+                                "pipeline_ephemeral_id": "09c8b004-3773-4247-9f95-36106536d0cf"
                             }
                         ]
                     },
                     {
-                        "ephemeral_id": "5ba3b3b3-4d82-4877-b96e-f327335bf1e1",
+                        "ephemeral_id": "47c21ea6-1b83-4b59-ade0-487f1142dcdc",
                         "events": {
                             "duration_in_millis": 0,
                             "filtered": 0,
-                            "in": 456,
+                            "in": 33,
                             "out": 0,
-                            "queue_push_duration_in_millis": 52
+                            "queue_push_duration_in_millis": 40
                         },
                         "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
                         "id": "pipeline-with-persisted-queue",
@@ -186,17 +180,17 @@
                                 "max_queue_size_in_bytes": 1073741824,
                                 "max_unread_events": 0,
                                 "page_capacity_in_bytes": 67108864,
-                                "queue_size_in_bytes": 139404
+                                "queue_size_in_bytes": 1
                             },
                             "data": {
-                                "free_space_in_bytes": 170819031040,
+                                "free_space_in_bytes": 29465477120,
                                 "path": "/usr/share/logstash/data/queue/pipeline-with-persisted-queue",
                                 "storage_type": "overlay"
                             },
                             "events": 0,
                             "events_count": 0,
                             "max_queue_size_in_bytes": 1073741824,
-                            "queue_size_in_bytes": 139404,
+                            "queue_size_in_bytes": 1,
                             "type": "persisted"
                         },
                         "reloads": {
@@ -205,35 +199,35 @@
                         },
                         "vertices": [
                             {
-                                "events_out": 456,
+                                "events_out": 32,
                                 "id": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
-                                "pipeline_ephemeral_id": "5ba3b3b3-4d82-4877-b96e-f327335bf1e1",
-                                "queue_push_duration_in_millis": 52
+                                "pipeline_ephemeral_id": "47c21ea6-1b83-4b59-ade0-487f1142dcdc",
+                                "queue_push_duration_in_millis": 40
                             },
                             {
                                 "duration_in_millis": 0,
-                                "events_in": 375,
+                                "events_in": 0,
                                 "events_out": 0,
                                 "id": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
-                                "pipeline_ephemeral_id": "5ba3b3b3-4d82-4877-b96e-f327335bf1e1"
+                                "pipeline_ephemeral_id": "47c21ea6-1b83-4b59-ade0-487f1142dcdc"
                             },
                             {
-                                "cluster_uuid": "U8DCOXCFQHWlaKczNT4LNQ",
+                                "cluster_uuid": "fu0AmqggQbiRa9-qF7-jcw",
                                 "duration_in_millis": 0,
                                 "events_in": 0,
                                 "events_out": 0,
                                 "id": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
-                                "pipeline_ephemeral_id": "5ba3b3b3-4d82-4877-b96e-f327335bf1e1"
+                                "pipeline_ephemeral_id": "47c21ea6-1b83-4b59-ade0-487f1142dcdc"
                             }
                         ]
                     }
                 ],
                 "process": {
                     "cpu": {
-                        "percent": 3
+                        "percent": 0
                     },
                     "max_file_descriptors": 1048576,
-                    "open_file_descriptors": 86
+                    "open_file_descriptors": 73
                 },
                 "queue": {
                     "events_count": 0
@@ -242,7 +236,7 @@
                     "failures": 0,
                     "successes": 0
                 },
-                "timestamp": "2022-10-11T14:05:39.916Z"
+                "timestamp": "2023-03-02T15:31:32.615Z"
             }
         }
     },
@@ -251,11 +245,11 @@
         "period": 10000
     },
     "service": {
-        "address": "http://elastic-package-service-logstash-1:9600/_node/stats",
-        "hostname": "ee237ad022ba",
+        "address": "http://elastic-package-service_logstash_1:9600/_node/stats",
+        "hostname": "65b0ba135e8f",
         "id": "",
         "name": "logstash",
         "type": "logstash",
-        "version": "8.5.0"
+        "version": "8.6.0"
     }
 }

--- a/packages/logstash/data_stream/slowlog/sample_event.json
+++ b/packages/logstash/data_stream/slowlog/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-03-02T15:32:15.572Z",
+    "@timestamp": "2023-03-02T15:58:44.848Z",
     "agent": {
-        "ephemeral_id": "0c288c7d-403a-4c4c-adae-47d96746ca38",
-        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "ephemeral_id": "e51615a5-198f-4173-a91c-08d7b6f299ca",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.5.0"
     },
     "data_stream": {
         "dataset": "logstash.slowlog",
@@ -16,16 +16,16 @@
         "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "snapshot": false,
-        "version": "8.6.0"
+        "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-03-02T15:32:15.572Z",
+        "created": "2023-03-02T15:58:44.848Z",
         "dataset": "logstash.slowlog",
-        "duration": 569000,
-        "ingested": "2023-03-02T15:32:19Z",
+        "duration": 867000,
+        "ingested": "2023-03-02T15:58:48Z",
         "kind": "event",
         "type": "info"
     },
@@ -33,12 +33,12 @@
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "d38b554e341a476aaa15b74fbc11f03e",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
-            "192.168.112.7"
+            "192.168.224.7"
         ],
         "mac": [
-            "02-42-C0-A8-70-07"
+            "02-42-C0-A8-E0-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
@@ -63,7 +63,7 @@
     },
     "logstash": {
         "slowlog": {
-            "event": "{\"sequence\":0,\"message\":\"Hello world!\",\"thread_number\":0,\"@timestamp\":\"2023-03-02T15:32:13.059412400Z\",\"hostname\":\"87434e8bc202\",\"@version\":\"1\"}",
+            "event": "{\"thread_number\":0,\"message\":\"Hello world!\",\"@timestamp\":\"2023-03-02T15:58:42.329587400Z\",\"sequence\":0,\"@version\":\"1\",\"hostname\":\"71227bcca86b\"}",
             "module": "slowlog.logstash.filters.sleep",
             "plugin_name": "sleep",
             "plugin_params_object": {
@@ -72,7 +72,7 @@
                 "time": 1
             },
             "plugin_type": "filters",
-            "thread": "[pipeline-with-persisted-queue]\u003eworker1",
+            "thread": "[pipeline-with-persisted-queue]\u003eworker9",
             "took_in_millis": 0
         }
     }

--- a/packages/logstash/data_stream/slowlog/sample_event.json
+++ b/packages/logstash/data_stream/slowlog/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-10-11T14:06:31.846Z",
+    "@timestamp": "2023-03-02T15:32:15.572Z",
     "agent": {
-        "ephemeral_id": "445bd68e-3789-4085-bf0a-0e871b82ce72",
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
+        "ephemeral_id": "0c288c7d-403a-4c4c-adae-47d96746ca38",
+        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.0"
+        "version": "8.6.0"
     },
     "data_stream": {
         "dataset": "logstash.slowlog",
@@ -16,35 +16,35 @@
         "version": "1.10.0"
     },
     "elastic_agent": {
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
-        "snapshot": true,
-        "version": "8.5.0"
+        "id": "16013041-48a1-4089-b313-ac8cf16e50b1",
+        "snapshot": false,
+        "version": "8.6.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2022-10-11T14:06:31.846Z",
+        "created": "2023-03-02T15:32:15.572Z",
         "dataset": "logstash.slowlog",
-        "duration": 287417,
-        "ingested": "2022-10-11T14:06:43Z",
+        "duration": 569000,
+        "ingested": "2023-03-02T15:32:19Z",
         "kind": "event",
         "type": "info"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "b6bc6723e51b43959ce07f0c3105c72d",
+        "id": "d38b554e341a476aaa15b74fbc11f03e",
         "ip": [
-            "192.168.0.7"
+            "192.168.112.7"
         ],
         "mac": [
-            "02-42-C0-A8-00-07"
+            "02-42-C0-A8-70-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.124-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -56,14 +56,14 @@
     },
     "log": {
         "file": {
-            "path": "/tmp/service_logs/logstash/logstash-slowlog-json.log"
+            "path": "/tmp/service_logs/logstash-slowlog-json.log"
         },
         "level": "WARN",
         "offset": 0
     },
     "logstash": {
         "slowlog": {
-            "event": "{\"message\":\"Hello world!\",\"sequence\":0,\"@version\":\"1\",\"@timestamp\":\"2022-10-11T14:06:29.325781334Z\",\"thread_number\":0,\"hostname\":\"da53f01a03cb\"}",
+            "event": "{\"sequence\":0,\"message\":\"Hello world!\",\"thread_number\":0,\"@timestamp\":\"2023-03-02T15:32:13.059412400Z\",\"hostname\":\"87434e8bc202\",\"@version\":\"1\"}",
             "module": "slowlog.logstash.filters.sleep",
             "plugin_name": "sleep",
             "plugin_params_object": {

--- a/packages/logstash/docs/README.md
+++ b/packages/logstash/docs/README.md
@@ -30,10 +30,10 @@ An example event for `node_stats` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-10-11T14:05:39.791Z",
+    "@timestamp": "2023-03-02T15:57:56.968Z",
     "agent": {
-        "ephemeral_id": "1a1ca75b-a20f-4ae4-82a9-4e269c855a5d",
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
+        "ephemeral_id": "16f2dd63-454b-4699-a8c8-2a748bd044b8",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
         "version": "8.5.0"
@@ -47,33 +47,33 @@ An example event for `node_stats` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
-        "snapshot": true,
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
+        "snapshot": false,
         "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "logstash.stack_monitoring.node_stats",
-        "duration": 125822375,
-        "ingested": "2022-10-11T14:05:40Z",
+        "duration": 48419400,
+        "ingested": "2023-03-02T15:57:58Z",
         "module": "logstash"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "b6bc6723e51b43959ce07f0c3105c72d",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
-            "192.168.0.7"
+            "192.168.224.7"
         ],
         "mac": [
-            "02-42-C0-A8-00-07"
+            "02-42-C0-A8-E0-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.124-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -82,20 +82,20 @@ An example event for `node_stats` looks as following:
     },
     "logstash": {
         "cluster": {
-            "id": "U8DCOXCFQHWlaKczNT4LNQ"
+            "id": "0toa26-cTzmqx0WD40-4XQ"
         },
         "elasticsearch": {
             "cluster": {
-                "id": "U8DCOXCFQHWlaKczNT4LNQ"
+                "id": "0toa26-cTzmqx0WD40-4XQ"
             }
         },
         "node": {
             "stats": {
                 "events": {
-                    "duration_in_millis": 322,
-                    "filtered": 132,
-                    "in": 593,
-                    "out": 132
+                    "duration_in_millis": 334,
+                    "filtered": 138,
+                    "in": 618,
+                    "out": 138
                 },
                 "jvm": {
                     "gc": {
@@ -105,57 +105,122 @@ An example event for `node_stats` looks as following:
                                 "collection_time_in_millis": 0
                             },
                             "young": {
-                                "collection_count": 25,
-                                "collection_time_in_millis": 269
+                                "collection_count": 13,
+                                "collection_time_in_millis": 177
                             }
                         }
                     },
                     "mem": {
-                        "heap_max_in_bytes": 3137339390,
-                        "heap_used_in_bytes": 208271008,
-                        "heap_used_percent": 6
+                        "heap_max_in_bytes": 10527703038,
+                        "heap_used_in_bytes": 234688352,
+                        "heap_used_percent": 2
                     },
-                    "uptime_in_millis": 17121
+                    "uptime_in_millis": 21450
                 },
                 "logstash": {
-                    "ephemeral_id": "59ea6513-500d-4b0b-8d54-a32d94631b1f",
-                    "host": "ee237ad022ba",
+                    "ephemeral_id": "17681d23-bd67-4c40-b6b1-63e97b560856",
+                    "host": "170bc3698b89",
                     "http_address": "0.0.0.0:9600",
-                    "name": "ee237ad022ba",
+                    "name": "170bc3698b89",
                     "pipeline": {
                         "batch_size": 125,
-                        "workers": 7
+                        "workers": 10
                     },
-                    "snapshot": true,
+                    "snapshot": false,
                     "status": "green",
-                    "uuid": "cb4f884e-d57b-43a3-bec6-7b3ec1adcbb9",
+                    "uuid": "a4224a67-aae8-4bce-8660-079d068b2e72",
                     "version": "8.5.0"
                 },
                 "os": {
                     "cgroup": {
                         "cpu": {
-                            "control_group": "",
-                            "stat": null
+                            "cfs_quota_micros": -1,
+                            "control_group": "/",
+                            "stat": {
+                                "number_of_elapsed_periods": 0,
+                                "number_of_times_throttled": 0,
+                                "time_throttled_nanos": 0
+                            }
                         },
-                        "cpuacct": null
+                        "cpuacct": {
+                            "control_group": "/",
+                            "usage_nanos": 55911664431
+                        }
                     },
                     "cpu": {
                         "load_average": {
-                            "15m": 2.17,
-                            "1m": 3.32,
-                            "5m": 2.32
+                            "15m": 2.28,
+                            "1m": 2.85,
+                            "5m": 2.62
                         },
                         "percent": 0
                     }
                 },
                 "pipelines": [
                     {
-                        "ephemeral_id": "0eff59ef-d130-4753-bd4e-289341a84c1a",
+                        "ephemeral_id": "453a2361-82d8-4d88-b7a4-063c3293cd4a",
                         "events": {
-                            "duration_in_millis": 199,
-                            "filtered": 86,
-                            "in": 92,
-                            "out": 86,
+                            "duration_in_millis": 0,
+                            "filtered": 0,
+                            "in": 476,
+                            "out": 0,
+                            "queue_push_duration_in_millis": 59
+                        },
+                        "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
+                        "id": "pipeline-with-persisted-queue",
+                        "queue": {
+                            "capacity": {
+                                "max_queue_size_in_bytes": 1073741824,
+                                "max_unread_events": 0,
+                                "page_capacity_in_bytes": 67108864,
+                                "queue_size_in_bytes": 132880
+                            },
+                            "data": {
+                                "free_space_in_bytes": 51709984768,
+                                "path": "/usr/share/logstash/data/queue/pipeline-with-persisted-queue",
+                                "storage_type": "overlay"
+                            },
+                            "events": 0,
+                            "events_count": 0,
+                            "max_queue_size_in_bytes": 1073741824,
+                            "queue_size_in_bytes": 132880,
+                            "type": "persisted"
+                        },
+                        "reloads": {
+                            "failures": 0,
+                            "successes": 0
+                        },
+                        "vertices": [
+                            {
+                                "events_out": 475,
+                                "id": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
+                                "pipeline_ephemeral_id": "453a2361-82d8-4d88-b7a4-063c3293cd4a",
+                                "queue_push_duration_in_millis": 59
+                            },
+                            {
+                                "duration_in_millis": 0,
+                                "events_in": 375,
+                                "events_out": 0,
+                                "id": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
+                                "pipeline_ephemeral_id": "453a2361-82d8-4d88-b7a4-063c3293cd4a"
+                            },
+                            {
+                                "cluster_uuid": "0toa26-cTzmqx0WD40-4XQ",
+                                "duration_in_millis": 1,
+                                "events_in": 0,
+                                "events_out": 0,
+                                "id": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
+                                "pipeline_ephemeral_id": "453a2361-82d8-4d88-b7a4-063c3293cd4a"
+                            }
+                        ]
+                    },
+                    {
+                        "ephemeral_id": "7114cd7d-8d91-4afc-a986-32487c3edcbe",
+                        "events": {
+                            "duration_in_millis": 191,
+                            "filtered": 91,
+                            "in": 95,
+                            "out": 91,
                             "queue_push_duration_in_millis": 4
                         },
                         "hash": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
@@ -172,99 +237,42 @@ An example event for `node_stats` looks as following:
                         },
                         "vertices": [
                             {
-                                "events_out": 92,
+                                "events_out": 95,
                                 "id": "4c5941552cdaa72ebc285557c697a7150c359ee3eacf9b5664c4b1048e26153b",
-                                "pipeline_ephemeral_id": "0eff59ef-d130-4753-bd4e-289341a84c1a",
+                                "pipeline_ephemeral_id": "7114cd7d-8d91-4afc-a986-32487c3edcbe",
                                 "queue_push_duration_in_millis": 4
                             },
                             {
-                                "cluster_uuid": "U8DCOXCFQHWlaKczNT4LNQ",
-                                "duration_in_millis": 197,
-                                "events_in": 86,
-                                "events_out": 86,
+                                "cluster_uuid": "0toa26-cTzmqx0WD40-4XQ",
+                                "duration_in_millis": 193,
+                                "events_in": 91,
+                                "events_out": 91,
                                 "id": "635a080aacc8700059852859da284a9cb92cb78a6d7112fbf55e441e51b6658a",
                                 "long_counters": [
                                     {
                                         "name": "bulk_requests.successes",
-                                        "value": 15
+                                        "value": 12
                                     },
                                     {
                                         "name": "bulk_requests.responses.200",
-                                        "value": 15
+                                        "value": 12
                                     },
                                     {
                                         "name": "documents.successes",
-                                        "value": 86
+                                        "value": 91
                                     }
                                 ],
-                                "pipeline_ephemeral_id": "0eff59ef-d130-4753-bd4e-289341a84c1a"
-                            }
-                        ]
-                    },
-                    {
-                        "ephemeral_id": "5ba3b3b3-4d82-4877-b96e-f327335bf1e1",
-                        "events": {
-                            "duration_in_millis": 0,
-                            "filtered": 0,
-                            "in": 456,
-                            "out": 0,
-                            "queue_push_duration_in_millis": 52
-                        },
-                        "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
-                        "id": "pipeline-with-persisted-queue",
-                        "queue": {
-                            "capacity": {
-                                "max_queue_size_in_bytes": 1073741824,
-                                "max_unread_events": 0,
-                                "page_capacity_in_bytes": 67108864,
-                                "queue_size_in_bytes": 139404
-                            },
-                            "data": {
-                                "free_space_in_bytes": 170819031040,
-                                "path": "/usr/share/logstash/data/queue/pipeline-with-persisted-queue",
-                                "storage_type": "overlay"
-                            },
-                            "events": 0,
-                            "events_count": 0,
-                            "max_queue_size_in_bytes": 1073741824,
-                            "queue_size_in_bytes": 139404,
-                            "type": "persisted"
-                        },
-                        "reloads": {
-                            "failures": 0,
-                            "successes": 0
-                        },
-                        "vertices": [
-                            {
-                                "events_out": 456,
-                                "id": "dfc132c40b9f5dbc970604f191cf87ee04b102b6f4be5a235436973dc7ea6368",
-                                "pipeline_ephemeral_id": "5ba3b3b3-4d82-4877-b96e-f327335bf1e1",
-                                "queue_push_duration_in_millis": 52
-                            },
-                            {
-                                "duration_in_millis": 0,
-                                "events_in": 375,
-                                "events_out": 0,
-                                "id": "e24d45cc4f3bb9981356480856120ed5f68127abbc3af7f47e7bca32460e5019",
-                                "pipeline_ephemeral_id": "5ba3b3b3-4d82-4877-b96e-f327335bf1e1"
-                            },
-                            {
-                                "cluster_uuid": "U8DCOXCFQHWlaKczNT4LNQ",
-                                "duration_in_millis": 0,
-                                "events_in": 0,
-                                "events_out": 0,
-                                "id": "9ba6577aa5c41a5ebcaae010b9a0ef44015ae68c624596ed924417d1701abc21",
-                                "pipeline_ephemeral_id": "5ba3b3b3-4d82-4877-b96e-f327335bf1e1"
+                                "pipeline_ephemeral_id": "7114cd7d-8d91-4afc-a986-32487c3edcbe"
                             }
                         ]
                     }
                 ],
                 "process": {
                     "cpu": {
-                        "percent": 3
+                        "percent": 4
                     },
                     "max_file_descriptors": 1048576,
-                    "open_file_descriptors": 86
+                    "open_file_descriptors": 89
                 },
                 "queue": {
                     "events_count": 0
@@ -273,7 +281,7 @@ An example event for `node_stats` looks as following:
                     "failures": 0,
                     "successes": 0
                 },
-                "timestamp": "2022-10-11T14:05:39.916Z"
+                "timestamp": "2023-03-02T15:57:57.016Z"
             }
         }
     },
@@ -282,8 +290,8 @@ An example event for `node_stats` looks as following:
         "period": 10000
     },
     "service": {
-        "address": "http://elastic-package-service-logstash-1:9600/_node/stats",
-        "hostname": "ee237ad022ba",
+        "address": "http://elastic-package-service_logstash_1:9600/_node/stats",
+        "hostname": "170bc3698b89",
         "id": "",
         "name": "logstash",
         "type": "logstash",
@@ -346,10 +354,10 @@ An example event for `node` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-10-11T14:04:44.089Z",
+    "@timestamp": "2023-03-02T15:57:03.999Z",
     "agent": {
-        "ephemeral_id": "1a1ca75b-a20f-4ae4-82a9-4e269c855a5d",
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
+        "ephemeral_id": "16f2dd63-454b-4699-a8c8-2a748bd044b8",
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
         "version": "8.5.0"
@@ -363,33 +371,33 @@ An example event for `node` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "79e48fe3-2ecd-4021-aed5-6e7e69d47606",
-        "snapshot": true,
+        "id": "3cc85092-54dc-4b58-8726-5e9458167f42",
+        "snapshot": false,
         "version": "8.5.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "logstash.stack_monitoring.node",
-        "duration": 131377542,
-        "ingested": "2022-10-11T14:04:45Z",
+        "duration": 69490100,
+        "ingested": "2023-03-02T15:57:05Z",
         "module": "logstash"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "b6bc6723e51b43959ce07f0c3105c72d",
+        "id": "66392b0697b84641af8006d87aeb89f1",
         "ip": [
-            "192.168.0.7"
+            "192.168.224.7"
         ],
         "mac": [
-            "02-42-C0-A8-00-07"
+            "02-42-C0-A8-E0-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.124-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -398,23 +406,23 @@ An example event for `node` looks as following:
     },
     "logstash": {
         "cluster": {
-            "id": "U8DCOXCFQHWlaKczNT4LNQ"
+            "id": "0toa26-cTzmqx0WD40-4XQ"
         },
         "elasticsearch": {
             "cluster": {
-                "id": "U8DCOXCFQHWlaKczNT4LNQ"
+                "id": "0toa26-cTzmqx0WD40-4XQ"
             }
         },
         "node": {
-            "host": "17a6005cfeaa",
-            "id": "7d7ee953-cf82-4d1d-91e0-1714346531de",
+            "host": "45730b5f8c3d",
+            "id": "2e17cd45-ecb8-4358-a420-b867f2e32b7a",
             "jvm": {
                 "version": "17.0.4"
             },
             "state": {
                 "pipeline": {
                     "batch_size": 125,
-                    "ephemeral_id": "3d2aff1f-dde1-4c56-9560-14f3b092f894",
+                    "ephemeral_id": "472cf082-aa15-41ca-9ed1-62d03afbadd0",
                     "hash": "d83c53e142e85177df0f039e5b9f4575b858e9cfdd51c2c60b1a9e8d5f9b1aaa",
                     "id": "pipeline-with-persisted-queue",
                     "representation": {
@@ -497,7 +505,7 @@ An example event for `node` looks as following:
                         "type": "lir",
                         "version": "0.0.0"
                     },
-                    "workers": 7
+                    "workers": 10
                 }
             },
             "version": "8.5.0"
@@ -511,9 +519,9 @@ An example event for `node` looks as following:
         "pid": 1
     },
     "service": {
-        "address": "http://elastic-package-service-logstash-1:9600/_node",
-        "hostname": "17a6005cfeaa",
-        "id": "7d7ee953-cf82-4d1d-91e0-1714346531de",
+        "address": "http://elastic-package-service_logstash_1:9600/_node",
+        "hostname": "45730b5f8c3d",
+        "id": "2e17cd45-ecb8-4358-a420-b867f2e32b7a",
         "name": "logstash",
         "type": "logstash",
         "version": "8.5.0"

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.2.1-preview1
+version: 2.2.2-preview1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -28,9 +28,11 @@ policy_templates:
     description: Collect logs and metrics from Logstash instances
     inputs:
       - type: logfile
-        title: "Collect Logstash application and slowlog logs"
-        description: "Collecting application and slowlog logs from Logstash instances"
+        title: Logstash logs
+        description: Collect application and slowlog logs from Logstash instances
       - type: logstash/metrics
+        title: Collect Logstash metrics for Stack Monitoring application
+        description: Collecting node and stats metrics from Logstash instances
         vars:
           - name: hosts
             type: text
@@ -54,13 +56,6 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-          - name: period
-            type: text
-            title: Period
-            multi: false
-            required: true
-            show_user: true
-            default: 10s
           - name: ssl
             type: yaml
             title: SSL Configuration
@@ -72,7 +67,5 @@ policy_templates:
               #certificate_authorities: ["/etc/ca.crt"]
               #certificate: "/etc/client.crt"
               #key: "/etc/client.key"
-        title: Collect Logstash node metrics and stats
-        description: Collecting node metrics and stats from Logstash instances
 owner:
   github: elastic/infra-monitoring-ui


### PR DESCRIPTION
Noticed empty graphs when implementing https://github.com/elastic/kibana/pull/152575 caused by missing aliases.
This change adds the mappings and updates wording about the metrics input.