### PR TITLE
[network_traffic] Fix field type for send_headers from bool to text

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.2"
+  changes:
+    - description: Fix type of `send_headers` option for HTTP data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5362
 - version: "1.9.1"
   changes:
     - description: Fix type of `real_ip_header` option for HTTP data stream.

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix type of `send_headers` option for HTTP data stream.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/5362
+      link: https://github.com/elastic/integrations/pull/5433
 - version: "1.9.1"
   changes:
     - description: Fix type of `real_ip_header` option for HTTP data stream.

--- a/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
@@ -16,7 +16,10 @@ hide_keywords:
 {{/each}}
 {{/if}}
 {{#if send_headers}}
-send_headers: {{send_headers}}
+send_headers:
+{{#each send_headers as |send_header|}}
+  - {{send_header}}
+{{/each}}
 {{/if}}
 {{#if send_all_headers}}
 send_all_headers: {{send_all_headers}}

--- a/packages/network_traffic/data_stream/http/manifest.yml
+++ b/packages/network_traffic/data_stream/http/manifest.yml
@@ -43,7 +43,7 @@ streams:
           A list of header names to capture and send to Elasticsearch. These headers
           are placed under the `headers` dictionary in the resulting JSON.
         show_user: false
-        multi: false
+        multi: true
         required: false
       - name: send_all_headers
         type: bool

--- a/packages/network_traffic/data_stream/http/manifest.yml
+++ b/packages/network_traffic/data_stream/http/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: true
         required: false
       - name: send_headers
-        type: bool
+        type: text
         title: Send Headers
         description: |-
           A list of header names to capture and send to Elasticsearch. These headers

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.9.1"
+version: "1.9.2"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Manifest.yml defined the send_headers UI option as the wrong type (bool not text), this PR fixes that.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


