### PR TITLE
tines: make email address optional and add note

### DIFF
--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.3"
+  changes:
+    - description: Make email address optional for configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5441
 - version: "0.0.2"
   changes:
     - description: Fix img link in readme

--- a/packages/tines/manifest.yml
+++ b/packages/tines/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: tines
 title: "Tines"
-version: 0.0.2
+version: 0.0.3
 description: "Tines Logs & Time Saved Reports"
 type: integration
 categories:
@@ -42,8 +42,9 @@ policy_templates:
           - name: auth_email
             type: text
             title: Tines User Account Email
+            description: For all Tines cloud tenants, and self hosted tenants using v13+ an email address is [no longer required for authentication](https://www.tines.com/api/authentication#using-an-api-key).
             show_user: true
-            required: true
+            required: false
           - name: auth_token
             type: text
             title: Tines API User Account API Key


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Makes the email address configuration field optional; v13+ of self-hosted instances and all cloud instances do not require it and so it would be confusing. Do leave it though since there may be pre v13 users, but add a note with a link to the Tines auth documentation.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5421

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

<img width="840" alt="Screenshot 2023-03-06 at 15 50 23" src="https://user-images.githubusercontent.com/90160302/223025837-a3d3243d-c35d-4c91-981b-6c81eb7a8f1c.png">
