### PR TITLE
[Cisco ASA] Support additional patterns for 113012, 113004, and 716039 message ids

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.13.2"
+  changes:
+    - description: Support additional patterns in 113012, 113004, and 716039 messages
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/5443
 - version: "2.13.1"
   changes:
     - description: Remove `ignore_failure` causing performance bottleneck

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -100,3 +100,6 @@ May  5 19:02:25 dev01: %ASA-6-716039: Authentication: rejected, group = malcorp 
 May  5 19:02:25 dev01: %ASA-6-716039: Authentication: rejected, group = malcorp user = malory , Session Type: WebVPN
 May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp> User <eve> IP <172.31.98.44> Authentication: rejected, Session Type: Admin.
 May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp> User <malory> IP <172.31.98.44> Authentication: rejected, Session Type: WebVPN.
+<190>Mar 03 2023 09:01:16 sac-firewall : %ASA-6-113004: AAA user accounting Successful : server =  192.168.0.8 : user = sample-user
+<190>Mar 03 2023 08:50:32 sac-firewall : %ASA-6-113012: AAA user authentication Successful : local database : user = sample.user
+<190>Mar 03 2023 09:13:09 sac-firewall : %ASA-6-716039: Group <DfltGrpPolicy> User <*****> IP <192.168.0.8> Authentication: rejected, Session Type: WebVPN.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -6986,6 +6986,214 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2023-03-03T09:01:16.000Z",
+            "cisco": {
+                "asa": {
+                    "aaa_type": "accounting"
+                }
+            },
+            "destination": {
+                "address": "192.168.0.8",
+                "ip": "192.168.0.8"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "logged-in",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113004",
+                "kind": "event",
+                "original": "\u003c190\u003eMar 03 2023 09:01:16 sac-firewall : %ASA-6-113004: AAA user accounting Successful : server =  192.168.0.8 : user = sample-user",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "allowed",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "sac-firewall"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "sac-firewall",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "sac-firewall"
+                ],
+                "ip": [
+                    "192.168.0.8"
+                ],
+                "user": [
+                    "sample-user"
+                ]
+            },
+            "source": {
+                "user": {
+                    "name": "sample-user"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-03-03T08:50:32.000Z",
+            "cisco": {
+                "asa": {}
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "logged-in",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113012",
+                "kind": "event",
+                "original": "\u003c190\u003eMar 03 2023 08:50:32 sac-firewall : %ASA-6-113012: AAA user authentication Successful : local database : user = sample.user",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "allowed",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "sac-firewall"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "sac-firewall",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "sac-firewall"
+                ],
+                "user": [
+                    "sample.user"
+                ]
+            },
+            "source": {
+                "user": {
+                    "name": "sample.user"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-03-03T09:13:09.000Z",
+            "cisco": {
+                "asa": {
+                    "session_type": "WebVPN"
+                }
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "logon-failed",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "716039",
+                "kind": "event",
+                "original": "\u003c190\u003eMar 03 2023 09:13:09 sac-firewall : %ASA-6-716039: Group \u003cDfltGrpPolicy\u003e User \u003c*****\u003e IP \u003c192.168.0.8\u003e Authentication: rejected, Session Type: WebVPN.",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "denied",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "sac-firewall"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "sac-firewall",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "sac-firewall"
+                ],
+                "ip": [
+                    "192.168.0.8"
+                ],
+                "user": [
+                    "*****"
+                ]
+            },
+            "source": {
+                "address": "192.168.0.8",
+                "ip": "192.168.0.8",
+                "user": {
+                    "group": {
+                        "name": "DfltGrpPolicy"
+                    },
+                    "name": "*****"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4,7 +4,13 @@ processors:
   - rename:
       field: message
       target_field: event.original
-      ignore_missing: true
+      tag: "rename_message"
+      on_failure: 
+        - append:
+            field: error.message
+            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+        - fail:
+            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - set:
       field: ecs.version
       value: '8.6.0'
@@ -434,11 +440,14 @@ processors:
       description: "111010"
       patterns:
       - "User '%{NOTSPACE:server.user.name}', running %{QUOTEDSTRING} from IP %{IP:source.address}, executed %{QUOTEDSTRING:_temp_.cisco.command_line_arguments}"
-  - dissect:
+  - grok:
       if: "ctx._temp_.cisco.message_id == '113004'"
       field: "message"
       description: "113004"
-      pattern: "AAA user %{_temp_.cisco.aaa_type} Successful: server = %{destination.address} , User = %{source.user.name}"
+      patterns:
+      - "AAA user %{DATA:_temp_.cisco.aaa_type} Successful(%{SPACE})?: server =(%{SPACE}+)?%{IP:destination.address} [:,] [Uu]ser = %{CISCO_USER:source.user.name}"
+      pattern_definitions:
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - grok:
       if: "ctx._temp_.cisco.message_id == '113005'"
       description: "113005"
@@ -448,11 +457,15 @@ processors:
       pattern_definitions:
         REASON: (AAA failure|Account has been disabled)
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
-  - dissect:
+  - grok:
       if: "ctx._temp_.cisco.message_id == '113012'"
       field: "message"
       description: "113012"
-      pattern: "AAA user authentication Successful: local database: user = %{source.user.name}"
+      patterns:
+      - "AAA user authentication Successful(%{SPACE})?: local database(%{SPACE})?: [Uu]ser = %{CISCO_USER:source.user.name}"
+      pattern_definitions:
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
+
   - dissect:
       if: "ctx._temp_.cisco.message_id == '113019'"
       field: "message"
@@ -936,12 +949,13 @@ processors:
       if: "ctx._temp_.cisco.message_id == '713202'"
       field: "message"
       pattern: "IP = %{source.address}, %{event.reason}. %{} packet."
+# Support masked user
   - grok:
       if: "ctx._temp_.cisco.message_id == '716039'"
       field: "message"
       patterns:
         - "Authentication: rejected, group = %{NOTSPACE:source.user.group.name} user = %{USER:source.user.name} , Session Type: %{NOTSPACE:_temp_.cisco.session_type}"
-        - "Group <%{NOTSPACE:source.user.group.name}> User <%{USER:source.user.name}> IP <%{IP:source.address}> Authentication: rejected, Session Type: %{NOTSPACE:_temp_.cisco.session_type}\\."
+        - "Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> Authentication: rejected, Session Type: %{NOTSPACE:_temp_.cisco.session_type}\\."
   - dissect:
       if: "ctx._temp_.cisco.message_id == '750003'"
       field: "message"

--- a/packages/cisco_asa/data_stream/log/manifest.yml
+++ b/packages/cisco_asa/data_stream/log/manifest.yml
@@ -70,6 +70,7 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
       - name: tz_offset
         type: text
         title: Timezone
@@ -78,7 +79,6 @@ streams:
         show_user: false
         default: UTC
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
-
   - input: tcp
     title: Cisco ASA logs
     description: Collect Cisco ASA logs
@@ -167,7 +167,6 @@ streams:
         show_user: false
         default: UTC
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
-
   - input: logfile
     enabled: false
     title: Cisco ASA logs

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.13.1"
+version: "2.13.2"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
- Parses additional patterns for message ids: 113012, 113004, and 716039 as underlined in issue: https://github.com/elastic/integrations/issues/5443
- Removes `ignore_missing: true` and raises error when renaming `message` into `event.original` to avoid consuming empty messages.

 
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/5443

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
