### PR TITLE
[Azure Metrics] Fix CassandraConnectionClosures metric configuration

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.14"
+  changes:
+    - description: Fix CassandraConnectionClosures metric configuration
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5447
 - version: "1.0.13"
   changes:
     - description: Replace the link to Indonesian docs with English docs

--- a/packages/azure_metrics/data_stream/database_account/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/database_account/agent/stream/stream.yml.hbs
@@ -29,7 +29,7 @@ resources:
           resource_type: "Microsoft.DocumentDb/databaseAccounts"
           metrics:
           - name: ["AddRegion", "RemoveRegion", "UpdateAccountReplicationSettings", "UpdateAccountNetworkSettings", "UpdateAccountKeys", "ServiceAvailability", "ReplicationLatency",
-                   "RegionFailover", "DeleteAccount", "CreateAccount", "CassandraConnectionClosures", "UpdateDiagnosticsSettings"]
+                   "RegionFailover", "DeleteAccount", "CreateAccount", "UpdateDiagnosticsSettings"]
             namespace: "Microsoft.DocumentDb/databaseAccounts"
           - name: ["AvailableStorage", "DataUsage","DocumentCount", "DocumentQuota", "IndexUsage", "MetadataRequests", "MongoRequestCharge", "MongoRequests", "MongoRequestsCount",
                    "MongoRequestsInsert", "MongoRequestsDelete", "MongoRequestsQuery", "MongoRequestsUpdate","ProvisionedThroughput", "NormalizedRUConsumption"]
@@ -48,7 +48,7 @@ resources:
               value: "*"
             - name: "StatusCode"
               value: "*"
-          - name: ["CassandraRequestCharges", "CassandraRequests"]
+          - name: ["CassandraConnectionClosures", "CassandraRequestCharges", "CassandraRequests"]
             namespace: "Microsoft.DocumentDb/databaseAccounts"
             ignore_unsupported: true
             timegrain: "PT1M"
@@ -72,7 +72,7 @@ resources:
         - resource_id: "{{this}}"
           metrics:
           - name: ["AddRegion", "RemoveRegion", "UpdateAccountReplicationSettings", "UpdateAccountNetworkSettings", "UpdateAccountKeys", "ServiceAvailability", "ReplicationLatency",
-                   "RegionFailover", "DeleteAccount", "CreateAccount", "CassandraConnectionClosures", "UpdateDiagnosticsSettings"]
+                   "RegionFailover", "DeleteAccount", "CreateAccount", "UpdateDiagnosticsSettings"]
             namespace: "Microsoft.DocumentDb/databaseAccounts"
           - name: ["AvailableStorage", "DataUsage","DocumentCount", "DocumentQuota", "IndexUsage", "MetadataRequests", "MongoRequestCharge", "MongoRequests", "MongoRequestsCount",
                    "MongoRequestsInsert", "MongoRequestsDelete", "MongoRequestsQuery", "MongoRequestsUpdate","ProvisionedThroughput", "NormalizedRUConsumption"]
@@ -91,7 +91,7 @@ resources:
               value: "*"
             - name: "StatusCode"
               value: "*"
-          - name: ["CassandraRequestCharges", "CassandraRequests"]
+          - name: ["CassandraConnectionClosures", "CassandraRequestCharges", "CassandraRequests"]
             namespace: "Microsoft.DocumentDb/databaseAccounts"
             ignore_unsupported: true
             timegrain: "PT1M"
@@ -121,7 +121,7 @@ resources:
         - resource_query: "resourceType eq 'Microsoft.DocumentDb/databaseAccounts'"
           metrics:
           - name: ["AddRegion", "RemoveRegion", "UpdateAccountReplicationSettings", "UpdateAccountNetworkSettings", "UpdateAccountKeys", "ServiceAvailability", "ReplicationLatency",
-                   "RegionFailover", "DeleteAccount", "CreateAccount", "CassandraConnectionClosures", "UpdateDiagnosticsSettings"]
+                   "RegionFailover", "DeleteAccount", "CreateAccount", "UpdateDiagnosticsSettings"]
             namespace: "Microsoft.DocumentDb/databaseAccounts"
           - name: ["AvailableStorage", "DataUsage","DocumentCount", "DocumentQuota", "IndexUsage", "MetadataRequests", "MongoRequestCharge", "MongoRequests", "MongoRequestsCount",
                    "MongoRequestsInsert", "MongoRequestsDelete", "MongoRequestsQuery", "MongoRequestsUpdate","ProvisionedThroughput", "NormalizedRUConsumption"]
@@ -140,7 +140,7 @@ resources:
               value: "*"
             - name: "StatusCode"
               value: "*"
-          - name: ["CassandraRequestCharges", "CassandraRequests"]
+          - name: ["CassandraConnectionClosures", "CassandraRequestCharges", "CassandraRequests"]
             namespace: "Microsoft.DocumentDb/databaseAccounts"
             ignore_unsupported: true
             timegrain: "PT1M"

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.13
+version: 1.0.14
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Move the `CassandraConnectionClosures` metric name from the always-available list of metrics to the Cassandra-focused list of metrics.

Metric names that are not always available should be listed in a section marked with the [ignore_unsupported](https://www.elastic.co/guide/en/beats/metricbeat/8.6/metricbeat-metricset-azure-monitor.html) setting set to `true`.

The integration works if the subscription has at least one Cassandra cluster available but fails otherwise.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->


<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Related issues
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #5453


<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
