### PR TITLE
[1password] Stop pagination on has_more=false

### DIFF
--- a/packages/1password/_dev/deploy/docker/config.yml
+++ b/packages/1password/_dev/deploy/docker/config.yml
@@ -44,6 +44,8 @@ rules:
             - "application/json; charset=utf-8"
         body: |-
           {"cursor":"cursor_1","has_more":false,"items":[]}
+
+  # SignInAttempts
   - path: /api/v1/signinattempts
     methods: ["POST"]
     request_headers:
@@ -73,7 +75,7 @@ rules:
           Content-Type:
             - "application/json; charset=utf-8"
         body: |-
-          {"cursor":"cursor_1","has_more":true,"items":[{"uuid":"QVWKEOEWXU2DIDHWTK6HGIF4TV","session_uuid":"UED4KFZ5BH37IQWTJ7LG4VPWK7","timestamp":"2021-08-11T15:04:22Z","country":"AR","category":"success","type":"credentials_ok","details":null,"target_user":{"uuid":"OJQGU46KAPROEJLCK674RHSAY5","name":"Name","email":"email@1password.com"},"client":{"app_name":"1Password Browser Extension","app_version":"1109","platform_name":"Chrome","platform_version":"93.0.4577.62","os_name":"Android","os_version":"10","ip_address":"1.1.1.1"}}]}
+          {"cursor":"cursor_1","has_more":false,"items":[{"uuid":"QVWKEOEWXU2DIDHWTK6HGIF4TV","session_uuid":"UED4KFZ5BH37IQWTJ7LG4VPWK7","timestamp":"2021-08-11T15:04:22Z","country":"AR","category":"success","type":"credentials_ok","details":null,"target_user":{"uuid":"OJQGU46KAPROEJLCK674RHSAY5","name":"Name","email":"email@1password.com"},"client":{"app_name":"1Password Browser Extension","app_version":"1109","platform_name":"Chrome","platform_version":"93.0.4577.62","os_name":"Android","os_version":"10","ip_address":"1.1.1.1"}}]}
   - path: /api/v1/signinattempts
     methods: ["POST"]
     request_headers:

--- a/packages/1password/changelog.yml
+++ b/packages/1password/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Fix pagination termination when response contains has_more=false.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5471
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/1password/data_stream/item_usages/_dev/test/system/test-default-config.yml
+++ b/packages/1password/data_stream/item_usages/_dev/test/system/test-default-config.yml
@@ -6,3 +6,5 @@ vars:
   preserve_original_event: true
 data_stream:
   vars: ~
+assert:
+  hit_count: 2

--- a/packages/1password/data_stream/item_usages/agent/stream/httpjson.yml.hbs
+++ b/packages/1password/data_stream/item_usages/agent/stream/httpjson.yml.hbs
@@ -17,7 +17,7 @@ request.transforms:
       value: "application/json"
   - set:
       target: "header.User-Agent"
-      value: "1Password-Elastic-Filebeat/0.1.0"
+      value: "1Password-Elastic-Filebeat/1.8.1"
   - set:
       target: "header.Authorization"
       value: 'Bearer {{token}}'
@@ -37,7 +37,7 @@ response.split:
 response.pagination:
   - set:
       target: body.cursor
-      value: '[[.last_response.body.cursor]]'
+      value: '[[if eq .last_response.body.has_more true]][[.last_response.body.cursor]][[else]][[/*This is an empty value to stop pagination.*/]][[end]]'
       fail_on_template_error: true
   - delete:
       target: body.limit

--- a/packages/1password/data_stream/signin_attempts/_dev/test/system/test-default-config.yml
+++ b/packages/1password/data_stream/signin_attempts/_dev/test/system/test-default-config.yml
@@ -6,3 +6,5 @@ vars:
   preserve_original_event: true
 data_stream:
   vars: ~
+assert:
+  hit_count: 2

--- a/packages/1password/data_stream/signin_attempts/agent/stream/httpjson.yml.hbs
+++ b/packages/1password/data_stream/signin_attempts/agent/stream/httpjson.yml.hbs
@@ -17,7 +17,7 @@ request.transforms:
       value: "application/json"
   - set:
       target: "header.User-Agent"
-      value: "1Password-Elastic-Filebeat/0.1.0"
+      value: "1Password-Elastic-Filebeat/1.8.1"
   - set:
       target: "header.Authorization"
       value: 'Bearer {{token}}'
@@ -37,7 +37,7 @@ response.split:
 response.pagination:
   - set:
       target: body.cursor
-      value: '[[.last_response.body.cursor]]'
+      value: '[[if eq .last_response.body.has_more true]][[.last_response.body.cursor]][[else]][[/*This is an empty value to stop pagination.*/]][[end]]'
       fail_on_template_error: true
   - delete:
       target: body.limit

--- a/packages/1password/manifest.yml
+++ b/packages/1password/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: 1password
 title: "1Password"
-version: "1.8.0"
+version: "1.8.1"
 license: basic
 description: Collect logs from 1Password with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Exit the pagination loop when the response contains `has_more: false`.

Fixes #5471


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Execute integration with `request.tracer.filename: 1password-signin-attempts.ndjson` in the config. Verify that requests stop until the next iteration after `has_more: false` is returned.

## Related issues

- Closes #5471

## Request Tracer Logs

After the fix for signin_attempts:

```
{"log.level":"debug","@timestamp":"2023-03-08T19:51:29.477Z","message":"HTTP request","transaction.id":"7D8G6EKMH551E-1","url.original":"http://elastic-package-service_1password_eventsapi_mock_1:8080/api/v1/signinattempts","url.scheme":"http","url.path":"/api/v1/signinattempts","url.domain":"elastic-package-service_1password_eventsapi_mock_1","url.port":"8080","url.query":"","http.request.method":"POST","user_agent.original":"Elastic-Filebeat/8.6.1 (linux; amd64; 14f2f8d585f8c380945feee789771bd782cd6b2d; 2023-01-24 13:28:02 +0000 UTC)","http.request.body.content":"{\"limit\":1000}","http.request.body.bytes":14,"http.request.mime_type":"application/json","event.original":"POST /api/v1/signinattempts HTTP/1.1\r\nHost: elastic-package-service_1password_eventsapi_mock_1:8080\r\nUser-Agent: Elastic-Filebeat/8.6.1 (linux; amd64; 14f2f8d585f8c380945feee789771bd782cd6b2d; 2023-01-24 13:28:02 +0000 UTC)\r\nContent-Length: 14\r\nAccept: application/json\r\nAuthorization: Bearer --token--\r\nContent-Type: application/json\r\nAccept-Encoding: gzip\r\n\r\n{\"limit\":1000}","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2023-03-08T19:51:29.495Z","message":"HTTP response","transaction.id":"7D8G6EKMH551E-1","http.response.status_code":200,"http.response.body.content":"{\"cursor\":\"cursor_0\",\"has_more\":true,\"items\":[{\"uuid\":\"HGIF4OEWXDTVWKEQDIWTKV26HU\",\"session_uuid\":\"UED4KFZ5BH37IQWTJ7LG4VPWK7\",\"timestamp\":\"2021-08-11T14:28:03Z\",\"country\":\"AR\",\"category\":\"success\",\"type\":\"credentials_ok\",\"details\":null,\"target_user\":{\"uuid\":\"OJQGU46KAPROEJLCK674RHSAY5\",\"name\":\"Name\",\"email\":\"email@1password.com\"},\"client\":{\"app_name\":\"1Password Browser Extension\",\"app_version\":\"1109\",\"platform_name\":\"Chrome\",\"platform_version\":\"93.0.4577.62\",\"os_name\":\"Android\",\"os_version\":\"10\",\"ip_address\":\"1.1.1.1\"}}]}","http.response.body.bytes":528,"http.response.mime_type":"application/json; charset=utf-8","event.original":"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 528\r\nContent-Type: application/json; charset=utf-8\r\nDate: Wed, 08 Mar 2023 19:51:29 GMT\r\n\r\n{\"cursor\":\"cursor_0\",\"has_more\":true,\"items\":[{\"uuid\":\"HGIF4OEWXDTVWKEQDIWTKV26HU\",\"session_uuid\":\"UED4KFZ5BH37IQWTJ7LG4VPWK7\",\"timestamp\":\"2021-08-11T14:28:03Z\",\"country\":\"AR\",\"category\":\"success\",\"type\":\"credentials_ok\",\"details\":null,\"target_user\":{\"uuid\":\"OJQGU46KAPROEJLCK674RHSAY5\",\"name\":\"Name\",\"email\":\"email@1password.com\"},\"client\":{\"app_name\":\"1Password Browser Extension\",\"app_version\":\"1109\",\"platform_name\":\"Chrome\",\"platform_version\":\"93.0.4577.62\",\"os_name\":\"Android\",\"os_version\":\"10\",\"ip_address\":\"1.1.1.1\"}}]}","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2023-03-08T19:51:29.500Z","message":"HTTP request","transaction.id":"7D8G6EKMH551E-2","url.original":"http://elastic-package-service_1password_eventsapi_mock_1:8080/api/v1/signinattempts","url.scheme":"http","url.path":"/api/v1/signinattempts","url.domain":"elastic-package-service_1password_eventsapi_mock_1","url.port":"8080","url.query":"","http.request.method":"POST","user_agent.original":"Elastic-Filebeat/8.6.1 (linux; amd64; 14f2f8d585f8c380945feee789771bd782cd6b2d; 2023-01-24 13:28:02 +0000 UTC)","http.request.body.content":"{\"cursor\":\"cursor_0\"}","http.request.body.bytes":21,"http.request.mime_type":"application/json","event.original":"POST /api/v1/signinattempts HTTP/1.1\r\nHost: elastic-package-service_1password_eventsapi_mock_1:8080\r\nUser-Agent: Elastic-Filebeat/8.6.1 (linux; amd64; 14f2f8d585f8c380945feee789771bd782cd6b2d; 2023-01-24 13:28:02 +0000 UTC)\r\nContent-Length: 21\r\nAccept: application/json\r\nAuthorization: Bearer --token--\r\nContent-Type: application/json\r\nAccept-Encoding: gzip\r\n\r\n{\"cursor\":\"cursor_0\"}","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2023-03-08T19:51:29.502Z","message":"HTTP response","transaction.id":"7D8G6EKMH551E-2","http.response.status_code":200,"http.response.body.content":"{\"cursor\":\"cursor_1\",\"has_more\":false,\"items\":[{\"uuid\":\"QVWKEOEWXU2DIDHWTK6HGIF4TV\",\"session_uuid\":\"UED4KFZ5BH37IQWTJ7LG4VPWK7\",\"timestamp\":\"2021-08-11T15:04:22Z\",\"country\":\"AR\",\"category\":\"success\",\"type\":\"credentials_ok\",\"details\":null,\"target_user\":{\"uuid\":\"OJQGU46KAPROEJLCK674RHSAY5\",\"name\":\"Name\",\"email\":\"email@1password.com\"},\"client\":{\"app_name\":\"1Password Browser Extension\",\"app_version\":\"1109\",\"platform_name\":\"Chrome\",\"platform_version\":\"93.0.4577.62\",\"os_name\":\"Android\",\"os_version\":\"10\",\"ip_address\":\"1.1.1.1\"}}]}","http.response.body.bytes":529,"http.response.mime_type":"application/json; charset=utf-8","event.original":"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 529\r\nContent-Type: application/json; charset=utf-8\r\nDate: Wed, 08 Mar 2023 19:51:29 GMT\r\n\r\n{\"cursor\":\"cursor_1\",\"has_more\":false,\"items\":[{\"uuid\":\"QVWKEOEWXU2DIDHWTK6HGIF4TV\",\"session_uuid\":\"UED4KFZ5BH37IQWTJ7LG4VPWK7\",\"timestamp\":\"2021-08-11T15:04:22Z\",\"country\":\"AR\",\"category\":\"success\",\"type\":\"credentials_ok\",\"details\":null,\"target_user\":{\"uuid\":\"OJQGU46KAPROEJLCK674RHSAY5\",\"name\":\"Name\",\"email\":\"email@1password.com\"},\"client\":{\"app_name\":\"1Password Browser Extension\",\"app_version\":\"1109\",\"platform_name\":\"Chrome\",\"platform_version\":\"93.0.4577.62\",\"os_name\":\"Android\",\"os_version\":\"10\",\"ip_address\":\"1.1.1.1\"}}]}","ecs.version":"1.6.0"}
---
# Next iteration after 10s.
{"log.level":"debug","@timestamp":"2023-03-08T19:51:42.437Z","message":"HTTP request","transaction.id":"7D8G6EKMH551E-3","url.original":"http://elastic-package-service_1password_eventsapi_mock_1:8080/api/v1/signinattempts","url.scheme":"http","url.path":"/api/v1/signinattempts","url.domain":"elastic-package-service_1password_eventsapi_mock_1","url.port":"8080","url.query":"","http.request.method":"POST","user_agent.original":"Elastic-Filebeat/8.6.1 (linux; amd64; 14f2f8d585f8c380945feee789771bd782cd6b2d; 2023-01-24 13:28:02 +0000 UTC)","http.request.body.content":"{\"cursor\":\"cursor_1\"}","http.request.body.bytes":21,"http.request.mime_type":"application/json","event.original":"POST /api/v1/signinattempts HTTP/1.1\r\nHost: elastic-package-service_1password_eventsapi_mock_1:8080\r\nUser-Agent: Elastic-Filebeat/8.6.1 (linux; amd64; 14f2f8d585f8c380945feee789771bd782cd6b2d; 2023-01-24 13:28:02 +0000 UTC)\r\nContent-Length: 21\r\nAccept: application/json\r\nAuthorization: Bearer --token--\r\nContent-Type: application/json\r\nAccept-Encoding: gzip\r\n\r\n{\"cursor\":\"cursor_1\"}","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2023-03-08T19:51:42.468Z","message":"HTTP response","transaction.id":"7D8G6EKMH551E-3","http.response.status_code":200,"http.response.body.content":"{\"cursor\":\"cursor_1\",\"has_more\":false,\"items\":[]}","http.response.body.bytes":49,"http.response.mime_type":"application/json; charset=utf-8","event.original":"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 49\r\nContent-Type: application/json; charset=utf-8\r\nDate: Wed, 08 Mar 2023 19:51:42 GMT\r\n\r\n{\"cursor\":\"cursor_1\",\"has_more\":false,\"items\":[]}","ecs.version":"1.6.0"}
```
