### PR TITLE
okta: allow configuration of http keep-alives

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Allow configuration of HTTP keep-alive to allow for connection reuse.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5487
 - version: "1.15.1"
   changes:
     - description: Fix documentation typo.

--- a/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/okta/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -1,6 +1,7 @@
 config_version: "2"
 interval: {{interval}}
 request.method: "GET"
+request.keep_alive.disable: {{disable_keep_alive}}
 request.url: {{url}}
 {{#if ssl}}
 request.ssl: {{ssl}}
@@ -41,7 +42,7 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
-{{#each tags as |tag i|}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/okta/data_stream/system/manifest.yml
+++ b/packages/okta/data_stream/system/manifest.yml
@@ -20,6 +20,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: disable_keep_alive
+        required: true
+        show_user: false
+        title: Disable HTTP Keep-Alives
+        description: Controls whether HTTP keep-alives are disabled.
+        type: bool
+        multi: false
+        default: false
       - name: processors
         type: yaml
         title: Processors

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "1.15.1"
+version: "1.16.0"
 release: ga
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security]
 conditions:
-  kibana.version: ^8.1.0
+  kibana.version: ^8.6.0
 icons:
   - src: /img/okta-logo.svg
     title: Okta


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Allows configuration of HTTP keep-alives. The default used departs from the current behaviour (disabled) to ensure the best experience for most cases by allowing connection reuse, but can be reverted to the old behaviour if needed.

It is an advanced configuation option since it's expected to not be needed in the vast majority of cases.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4844

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
