### PR TITLE
tines: make inputs object arrays flattened

### DIFF
--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.4"
+  changes:
+    - description: Make input object arrays flattnened.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5498
 - version: "0.0.3"
   changes:
     - description: Make email address optional for configuration.

--- a/packages/tines/data_stream/audit_logs/_dev/test/pipeline/test-audit-logs.json
+++ b/packages/tines/data_stream/audit_logs/_dev/test/pipeline/test-audit-logs.json
@@ -8,6 +8,15 @@
     },
     {
       "message": "{\"created_at\":\"2023-01-20T12:14:28Z\",\"id\":3656239,\"inputs\":null,\"operation_name\":\"Login\",\"request_ip\":\"216.160.83.56\",\"request_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\",\"tenant_id\":1234,\"updated_at\":\"2023-01-20T12:14:28Z\",\"user_email\":\"example.user@your.domain.tld\",\"user_id\":1234,\"user_name\":\"Example User\"}"
+    },
+    {
+      "message": "{\"created_at\":\"2023-02-02T17:29:20Z\",\"id\":17008,\"inputs\":{\"inputs\":{\"agents\":[],\"diagramNotes\":[],\"links\":[{\"receiverIdentifier\":\"QWdlbnQtNDU1NA==\",\"sourceIdentifier\":\"QWdlbnQtNDU1MQ==\"}],\"storyId\":193},\"liveEvents\":null},\"operation_name\":\"StoryItemsCreation\",\"request_ip\":\"81.2.69.144\",\"request_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\",\"tenant_id\":1,\"updated_at\":\"2023-02-02T17:29:20Z\",\"user_email\":\"user@email.com\",\"user_id\":4,\"user_name\":\"First Last\"}"
+    },
+    {
+      "message": "{\"created_at\":\"2023-02-06T19:46:45Z\",\"id\":18397,\"inputs\":{\"inputs\":{\"agents\":[],\"diagramNotes\":[{\"content\":\"\\u003c-- IOCs end up here in `{root-path}.individual_item`\",\"position\":{\"x\":-1286,\"y\":1389},\"width\":379}],\"links\":[],\"standardLibVersion\":\"9\",\"storyId\":193},\"liveEvents\":null},\"operation_name\":\"StoryItemsCreation\",\"request_ip\":\"81.2.69.144\",\"request_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\",\"tenant_id\":1,\"updated_at\":\"2023-02-06T19:46:45Z\",\"user_email\":\"user@email.com\",\"user_id\":4,\"user_name\":\"First Last\"}"
+    },
+    {
+      "message": "{\"created_at\":\"2023-03-01T18:10:03Z\",\"operation_name\":\"StoryItemsCreation\",\"id\":26088,\"inputs\":{\"inputs\":{\"storyId\":125,\"links\":[{\"sourceIdentifier\":\"QW=\",\"receiverIdentifier\":\"Q=\"}],\"agents\":[{\"name\":\"Concat\",\"disabled\":false,\"position\":{\"x\":-285,\"y\":750},\"options\":\"{\\\"mode\\\":\\\"message_only\\\",\\\"loop\\\":false,\\\"payload\\\":{\\\"data\\\":\\\"This is an automatically generated message from Tines\\\"}}\",\"schedule\":null,\"type\":\"eventTransformation\",\"timeSavedUnit\":\"minutes\",\"timeSavedValue\":0,\"softDeletedId\":5213}],\"diagramNotes\":[]},\"liveEvents\":null},\"request_ip\":\"81.2.69.144\",\"request_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36\",\"tenant_id\":1,\"updated_at\":\"2023-03-01T18:10:03Z\",\"user_email\":\"user@email.com\",\"user_id\":7,\"user_name\":\"First Last\"}"
     }
   ]
 }

--- a/packages/tines/data_stream/audit_logs/_dev/test/pipeline/test-audit-logs.json-expected.json
+++ b/packages/tines/data_stream/audit_logs/_dev/test/pipeline/test-audit-logs.json-expected.json
@@ -238,6 +238,278 @@
                 },
                 "version": "109.0.0.0"
             }
+        },
+        {
+            "@timestamp": "2023-02-02T17:29:20.000Z",
+            "event": {
+                "action": "StoryItemsCreation",
+                "category": [
+                    "configuration"
+                ],
+                "id": "17008",
+                "original": "{\"created_at\":\"2023-02-02T17:29:20Z\",\"id\":17008,\"inputs\":{\"inputs\":{\"agents\":[],\"diagramNotes\":[],\"links\":[{\"receiverIdentifier\":\"QWdlbnQtNDU1NA==\",\"sourceIdentifier\":\"QWdlbnQtNDU1MQ==\"}],\"storyId\":193},\"liveEvents\":null},\"operation_name\":\"StoryItemsCreation\",\"request_ip\":\"81.2.69.144\",\"request_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\",\"tenant_id\":1,\"updated_at\":\"2023-02-02T17:29:20Z\",\"user_email\":\"user@email.com\",\"user_id\":4,\"user_name\":\"First Last\"}",
+                "type": [
+                    "info"
+                ]
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "First Last"
+                ]
+            },
+            "source": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "tines": {
+                "audit_log": {
+                    "created_at": "2023-02-02T17:29:20Z",
+                    "id": 17008,
+                    "inputs": {
+                        "inputs": {
+                            "links": [
+                                {
+                                    "receiverIdentifier": "QWdlbnQtNDU1NA==",
+                                    "sourceIdentifier": "QWdlbnQtNDU1MQ=="
+                                }
+                            ],
+                            "storyId": 193
+                        }
+                    },
+                    "operation_name": "StoryItemsCreation",
+                    "request_ip": "81.2.69.144",
+                    "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+                    "tenant_id": 1,
+                    "updated_at": "2023-02-02T17:29:20Z",
+                    "user_email": "user@email.com",
+                    "user_id": 4,
+                    "user_name": "First Last"
+                }
+            },
+            "user": {
+                "email": "user@email.com",
+                "id": "4",
+                "name": "First Last"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Mac"
+                },
+                "name": "Chrome",
+                "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+                "os": {
+                    "full": "Mac OS X 10.15.7",
+                    "name": "Mac OS X",
+                    "version": "10.15.7"
+                },
+                "version": "109.0.0.0"
+            }
+        },
+        {
+            "@timestamp": "2023-02-06T19:46:45.000Z",
+            "event": {
+                "action": "StoryItemsCreation",
+                "category": [
+                    "configuration"
+                ],
+                "id": "18397",
+                "original": "{\"created_at\":\"2023-02-06T19:46:45Z\",\"id\":18397,\"inputs\":{\"inputs\":{\"agents\":[],\"diagramNotes\":[{\"content\":\"\\u003c-- IOCs end up here in `{root-path}.individual_item`\",\"position\":{\"x\":-1286,\"y\":1389},\"width\":379}],\"links\":[],\"standardLibVersion\":\"9\",\"storyId\":193},\"liveEvents\":null},\"operation_name\":\"StoryItemsCreation\",\"request_ip\":\"81.2.69.144\",\"request_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\",\"tenant_id\":1,\"updated_at\":\"2023-02-06T19:46:45Z\",\"user_email\":\"user@email.com\",\"user_id\":4,\"user_name\":\"First Last\"}",
+                "type": [
+                    "info"
+                ]
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "First Last"
+                ]
+            },
+            "source": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "tines": {
+                "audit_log": {
+                    "created_at": "2023-02-06T19:46:45Z",
+                    "id": 18397,
+                    "inputs": {
+                        "inputs": {
+                            "diagramNotes": [
+                                {
+                                    "content": "\u003c-- IOCs end up here in `{root-path}.individual_item`",
+                                    "position": {
+                                        "x": -1286,
+                                        "y": 1389
+                                    },
+                                    "width": 379
+                                }
+                            ],
+                            "standardLibVersion": "9",
+                            "storyId": 193
+                        }
+                    },
+                    "operation_name": "StoryItemsCreation",
+                    "request_ip": "81.2.69.144",
+                    "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+                    "tenant_id": 1,
+                    "updated_at": "2023-02-06T19:46:45Z",
+                    "user_email": "user@email.com",
+                    "user_id": 4,
+                    "user_name": "First Last"
+                }
+            },
+            "user": {
+                "email": "user@email.com",
+                "id": "4",
+                "name": "First Last"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Mac"
+                },
+                "name": "Chrome",
+                "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+                "os": {
+                    "full": "Mac OS X 10.15.7",
+                    "name": "Mac OS X",
+                    "version": "10.15.7"
+                },
+                "version": "109.0.0.0"
+            }
+        },
+        {
+            "@timestamp": "2023-03-01T18:10:03.000Z",
+            "event": {
+                "action": "StoryItemsCreation",
+                "category": [
+                    "configuration"
+                ],
+                "id": "26088",
+                "original": "{\"created_at\":\"2023-03-01T18:10:03Z\",\"operation_name\":\"StoryItemsCreation\",\"id\":26088,\"inputs\":{\"inputs\":{\"storyId\":125,\"links\":[{\"sourceIdentifier\":\"QW=\",\"receiverIdentifier\":\"Q=\"}],\"agents\":[{\"name\":\"Concat\",\"disabled\":false,\"position\":{\"x\":-285,\"y\":750},\"options\":\"{\\\"mode\\\":\\\"message_only\\\",\\\"loop\\\":false,\\\"payload\\\":{\\\"data\\\":\\\"This is an automatically generated message from Tines\\\"}}\",\"schedule\":null,\"type\":\"eventTransformation\",\"timeSavedUnit\":\"minutes\",\"timeSavedValue\":0,\"softDeletedId\":5213}],\"diagramNotes\":[]},\"liveEvents\":null},\"request_ip\":\"81.2.69.144\",\"request_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36\",\"tenant_id\":1,\"updated_at\":\"2023-03-01T18:10:03Z\",\"user_email\":\"user@email.com\",\"user_id\":7,\"user_name\":\"First Last\"}",
+                "type": [
+                    "info"
+                ]
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "First Last"
+                ]
+            },
+            "source": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "tines": {
+                "audit_log": {
+                    "created_at": "2023-03-01T18:10:03Z",
+                    "id": 26088,
+                    "inputs": {
+                        "inputs": {
+                            "agents": [
+                                {
+                                    "disabled": false,
+                                    "name": "Concat",
+                                    "options": "{\"mode\":\"message_only\",\"loop\":false,\"payload\":{\"data\":\"This is an automatically generated message from Tines\"}}",
+                                    "position": {
+                                        "x": -285,
+                                        "y": 750
+                                    },
+                                    "softDeletedId": 5213,
+                                    "timeSavedUnit": "minutes",
+                                    "timeSavedValue": 0,
+                                    "type": "eventTransformation"
+                                }
+                            ],
+                            "links": [
+                                {
+                                    "receiverIdentifier": "Q=",
+                                    "sourceIdentifier": "QW="
+                                }
+                            ],
+                            "storyId": 125
+                        }
+                    },
+                    "operation_name": "StoryItemsCreation",
+                    "request_ip": "81.2.69.144",
+                    "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
+                    "tenant_id": 1,
+                    "updated_at": "2023-03-01T18:10:03Z",
+                    "user_email": "user@email.com",
+                    "user_id": 7,
+                    "user_name": "First Last"
+                }
+            },
+            "user": {
+                "email": "user@email.com",
+                "id": "7",
+                "name": "First Last"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Mac"
+                },
+                "name": "Chrome",
+                "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
+                "os": {
+                    "full": "Mac OS X 10.15.7",
+                    "name": "Mac OS X",
+                    "version": "10.15.7"
+                },
+                "version": "110.0.0.0"
+            }
         }
     ]
 }

--- a/packages/tines/data_stream/audit_logs/fields/fields.yml
+++ b/packages/tines/data_stream/audit_logs/fields/fields.yml
@@ -47,7 +47,7 @@
                 - name: actions
                   type: group
                 - name: agents
-                  type: group
+                  type: flattened
                 - name: allowedHosts
                   type: keyword
                 - name: awsAccessKey
@@ -72,7 +72,7 @@
                 - name: diagramNoteIds
                   type: long
                 - name: diagramNotes
-                  type: keyword
+                  type: flattened
                 - name: editingSource
                   type: keyword
                 - name: eventName
@@ -96,7 +96,7 @@
                 - name: jwtPrivateKey
                   type: keyword
                 - name: links
-                  type: keyword
+                  type: flattened
                 - name: mode
                   type: keyword
                 - name: mtlsClientCertificate
@@ -132,6 +132,8 @@
                   type: keyword
                 - name: storyId
                   type: long
+                - name: standardLibVersion
+                  type: keyword
                 - name: teamId
                   type: long
                 - name: value

--- a/packages/tines/docs/README.md
+++ b/packages/tines/docs/README.md
@@ -111,6 +111,7 @@ All fields ingested to this data stream are stored under `tines.audit_log` as ea
 | tines.audit_log.inputs.diagramNoteIds |  | long |
 | tines.audit_log.inputs.inputs.actionId |  | long |
 | tines.audit_log.inputs.inputs.actionIds |  | long |
+| tines.audit_log.inputs.inputs.agents |  | flattened |
 | tines.audit_log.inputs.inputs.allowedHosts |  | keyword |
 | tines.audit_log.inputs.inputs.authenticationTokenId |  | long |
 | tines.audit_log.inputs.inputs.awsAccessKey |  | keyword |
@@ -122,7 +123,7 @@ All fields ingested to this data stream are stored under `tines.audit_log` as ea
 | tines.audit_log.inputs.inputs.delta.y |  | long |
 | tines.audit_log.inputs.inputs.description |  | keyword |
 | tines.audit_log.inputs.inputs.diagramNoteIds |  | long |
-| tines.audit_log.inputs.inputs.diagramNotes |  | keyword |
+| tines.audit_log.inputs.inputs.diagramNotes |  | flattened |
 | tines.audit_log.inputs.inputs.editingSource |  | keyword |
 | tines.audit_log.inputs.inputs.eventName |  | keyword |
 | tines.audit_log.inputs.inputs.httpRequestLocationOfToken |  | keyword |
@@ -135,7 +136,7 @@ All fields ingested to this data stream are stored under `tines.audit_log` as ea
 | tines.audit_log.inputs.inputs.jwtHs256Secret |  | keyword |
 | tines.audit_log.inputs.inputs.jwtPayload |  | keyword |
 | tines.audit_log.inputs.inputs.jwtPrivateKey |  | keyword |
-| tines.audit_log.inputs.inputs.links |  | keyword |
+| tines.audit_log.inputs.inputs.links |  | flattened |
 | tines.audit_log.inputs.inputs.mode |  | keyword |
 | tines.audit_log.inputs.inputs.mtlsClientCertificate |  | keyword |
 | tines.audit_log.inputs.inputs.mtlsClientPrivateKey |  | keyword |
@@ -152,6 +153,7 @@ All fields ingested to this data stream are stored under `tines.audit_log` as ea
 | tines.audit_log.inputs.inputs.readAccess |  | keyword |
 | tines.audit_log.inputs.inputs.sharedTeamSlugs |  | keyword |
 | tines.audit_log.inputs.inputs.source |  | keyword |
+| tines.audit_log.inputs.inputs.standardLibVersion |  | keyword |
 | tines.audit_log.inputs.inputs.storyId |  | long |
 | tines.audit_log.inputs.inputs.teamId |  | long |
 | tines.audit_log.inputs.inputs.value |  | keyword |

--- a/packages/tines/manifest.yml
+++ b/packages/tines/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: tines
 title: "Tines"
-version: 0.0.3
+version: 0.0.4
 description: "Tines Logs & Time Saved Reports"
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Makes `tines.audit_log.inputs.inputs.{agents,diagramNotes,links}` object arrays flattened.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] @SpencerLN Can you confirm any documents with a non-empty `tines.audit_log.inputs.inputs.agents` array? It would be good to know that it is actually an array of object (this is not documented in the Tines docs)
- [x] Can you confirm that we need to map `standardLibVersion` as a `keyword`. It looks like it may well be a number, but I'm being conservative here. Have you seen any non-numeric values? (also apparently not documented).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #5497

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
