### PR TITLE
Filter by empty aws.dimensions.TransitGatewayAttachment in transitgat…

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.1"
+  changes:
+    - description: Filter by empty aws.dimensions.TransitGatewayAttachment in transitgateway dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.32.0"
   changes:
     - description: Migrate AWS EBS dashboard visualizations to lenses.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Filter by empty aws.dimensions.TransitGatewayAttachment in transitgateway dashboard.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/5499
 - version: "1.32.0"
   changes:
     - description: Migrate AWS EBS dashboard visualizations to lenses.

--- a/packages/aws/kibana/dashboard/aws-0eb5a6a0-694f-11ea-b0ac-95d4ecb1fecd.json
+++ b/packages/aws/kibana/dashboard/aws-0eb5a6a0-694f-11ea-b0ac-95d4ecb1fecd.json
@@ -1,14 +1,6 @@
 {
-    "id": "aws-0eb5a6a0-694f-11ea-b0ac-95d4ecb1fecd",
-    "type": "dashboard",
-    "namespaces": [
-        "default"
-    ],
-    "updated_at": "2022-08-01T13:47:45.463Z",
-    "version": "Wzg0NCwxXQ==",
     "attributes": {
         "description": "Overview of AWS Transit Gateway Metrics",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -47,17 +39,25 @@
         "panelsJSON": [
             {
                 "embeddableConfig": {
-                    "title": "filters",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "TransitGateway Filters [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "controls": [
                                 {
                                     "fieldName": "cloud.account.name",
                                     "id": "1565034367477",
-                                    "indexPatternRefName": "control_0_index_pattern",
+                                    "indexPatternRefName": "control_af1453d8-04d3-4b44-a3b0-138111255a23_0_index_pattern",
                                     "label": "account name",
                                     "options": {
                                         "dynamicOptions": true,
@@ -72,7 +72,7 @@
                                 {
                                     "fieldName": "cloud.region",
                                     "id": "1584478324642",
-                                    "indexPatternRefName": "control_1_index_pattern",
+                                    "indexPatternRefName": "control_af1453d8-04d3-4b44-a3b0-138111255a23_1_index_pattern",
                                     "label": "region",
                                     "options": {
                                         "dynamicOptions": true,
@@ -87,7 +87,7 @@
                                 {
                                     "fieldName": "aws.dimensions.TransitGateway",
                                     "id": "1584479118709",
-                                    "indexPatternRefName": "control_2_index_pattern",
+                                    "indexPatternRefName": "control_af1453d8-04d3-4b44-a3b0-138111255a23_2_index_pattern",
                                     "label": "transit gateway",
                                     "options": {
                                         "dynamicOptions": true,
@@ -104,17 +104,9 @@
                             "updateFiltersOnChange": true,
                             "useTimeFilter": true
                         },
+                        "title": "TransitGateway Filters [Metrics AWS]",
                         "type": "input_control_vis",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -126,25 +118,38 @@
                 },
                 "panelIndex": "af1453d8-04d3-4b44-a3b0-138111255a23",
                 "title": "filters",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
-                    "title": "Bytes In",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "Transit Gateway Bytes In [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
                             "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": "not aws.dimensions.TransitGatewayAttachment : *"
+                            },
                             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                             "index_pattern": "metrics-*",
                             "interval": "1m",
                             "isModelInvalid": false,
+                            "max_lines_legend": 1,
                             "series": [
                                 {
                                     "axis_position": "right",
@@ -169,20 +174,22 @@
                                     "stacked": "none",
                                     "terms_field": "aws.dimensions.TransitGateway",
                                     "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                    "time_range_mode": "entire_time_range",
                                     "type": "timeseries"
                                 }
                             ],
                             "show_grid": 1,
                             "show_legend": 1,
                             "time_field": "",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
                             "type": "timeseries",
                             "use_kibana_indexes": false
                         },
+                        "title": "Transit Gateway Bytes In [Metrics AWS]",
                         "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -194,25 +201,38 @@
                 },
                 "panelIndex": "14555108-559d-4c07-b240-6e6b14254f16",
                 "title": "Bytes In",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
-                    "title": "Packets In",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "Transit Gateway Packets In [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
                             "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": "not aws.dimensions.TransitGatewayAttachment : *"
+                            },
                             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                             "index_pattern": "metrics-*",
                             "interval": "1m",
                             "isModelInvalid": false,
+                            "max_lines_legend": 1,
                             "series": [
                                 {
                                     "axis_position": "right",
@@ -237,20 +257,22 @@
                                     "stacked": "none",
                                     "terms_field": "aws.dimensions.TransitGateway",
                                     "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                    "time_range_mode": "entire_time_range",
                                     "type": "timeseries"
                                 }
                             ],
                             "show_grid": 1,
                             "show_legend": 1,
                             "time_field": "",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
                             "type": "timeseries",
                             "use_kibana_indexes": false
                         },
+                        "title": "Transit Gateway Packets In [Metrics AWS]",
                         "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -262,25 +284,38 @@
                 },
                 "panelIndex": "9c605367-60e3-4e9c-8036-a6191dbafe4a",
                 "title": "Packets In",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
-                    "title": "Bytes Out",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "Transit Gateway Bytes Out [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
                             "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": "not aws.dimensions.TransitGatewayAttachment : *"
+                            },
                             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                             "index_pattern": "metrics-*",
                             "interval": "1m",
                             "isModelInvalid": false,
+                            "max_lines_legend": 1,
                             "series": [
                                 {
                                     "axis_position": "right",
@@ -305,20 +340,22 @@
                                     "stacked": "none",
                                     "terms_field": "aws.dimensions.TransitGateway",
                                     "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                    "time_range_mode": "entire_time_range",
                                     "type": "timeseries"
                                 }
                             ],
                             "show_grid": 1,
                             "show_legend": 1,
                             "time_field": "",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
                             "type": "timeseries",
                             "use_kibana_indexes": false
                         },
+                        "title": "Transit Gateway Bytes Out [Metrics AWS]",
                         "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -330,25 +367,38 @@
                 },
                 "panelIndex": "271558e6-b208-4e2c-abfb-0a6b2dbb0c66",
                 "title": "Bytes Out",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
-                    "title": "Packets Out",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "Transit Gateway Packets Out [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
                             "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": "not aws.dimensions.TransitGatewayAttachment : *"
+                            },
                             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                             "index_pattern": "metrics-*",
                             "interval": "1m",
                             "isModelInvalid": false,
+                            "max_lines_legend": 1,
                             "series": [
                                 {
                                     "axis_position": "right",
@@ -373,20 +423,22 @@
                                     "stacked": "none",
                                     "terms_field": "aws.dimensions.TransitGateway",
                                     "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                    "time_range_mode": "entire_time_range",
                                     "type": "timeseries"
                                 }
                             ],
                             "show_grid": 1,
                             "show_legend": 1,
                             "time_field": "",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
                             "type": "timeseries",
                             "use_kibana_indexes": false
                         },
+                        "title": "Transit Gateway Packets Out [Metrics AWS]",
                         "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -398,25 +450,38 @@
                 },
                 "panelIndex": "41002ab1-845b-469e-9283-8a46a90e4662",
                 "title": "Packets Out",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
-                    "title": "Bytes Dropped - no route",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "Transit Gateway Bytes Drop Count No Route [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
                             "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": "not aws.dimensions.TransitGatewayAttachment : *"
+                            },
                             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                             "index_pattern": "metrics-*",
                             "interval": "1m",
                             "isModelInvalid": false,
+                            "max_lines_legend": 1,
                             "series": [
                                 {
                                     "axis_position": "right",
@@ -441,20 +506,22 @@
                                     "stacked": "none",
                                     "terms_field": "aws.dimensions.TransitGateway",
                                     "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                    "time_range_mode": "entire_time_range",
                                     "type": "timeseries"
                                 }
                             ],
                             "show_grid": 1,
                             "show_legend": 1,
                             "time_field": "",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
                             "type": "timeseries",
                             "use_kibana_indexes": false
                         },
+                        "title": "Transit Gateway Bytes Drop Count No Route [Metrics AWS]",
                         "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -466,25 +533,38 @@
                 },
                 "panelIndex": "b141f90b-739e-46f3-83c9-9c4661183837",
                 "title": "Bytes Dropped - no route",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
-                    "title": "Packets Dropped - no route",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "Transit Gateway Packets Drop Count No Route [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
                             "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": "not aws.dimensions.TransitGatewayAttachment : *"
+                            },
                             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                             "index_pattern": "metrics-*",
                             "interval": "1m",
                             "isModelInvalid": false,
+                            "max_lines_legend": 1,
                             "series": [
                                 {
                                     "axis_position": "right",
@@ -509,20 +589,22 @@
                                     "stacked": "none",
                                     "terms_field": "aws.dimensions.TransitGateway",
                                     "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                    "time_range_mode": "entire_time_range",
                                     "type": "timeseries"
                                 }
                             ],
                             "show_grid": 1,
                             "show_legend": 1,
                             "time_field": "",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
                             "type": "timeseries",
                             "use_kibana_indexes": false
                         },
+                        "title": "Transit Gateway Packets Drop Count No Route [Metrics AWS]",
                         "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -534,25 +616,38 @@
                 },
                 "panelIndex": "c6a76f92-248b-4cae-a03f-7d34d58098ae",
                 "title": "Packets Dropped - no route",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
-                    "title": "Bytes Dropped - black hole",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "Transit Gateway Bytes Drop Count Blackhole [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
                             "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": "not aws.dimensions.TransitGatewayAttachment : *"
+                            },
                             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                             "index_pattern": "metrics-*",
                             "interval": "1m",
                             "isModelInvalid": false,
+                            "max_lines_legend": 1,
                             "series": [
                                 {
                                     "axis_position": "right",
@@ -577,20 +672,22 @@
                                     "stacked": "none",
                                     "terms_field": "aws.dimensions.TransitGateway",
                                     "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                    "time_range_mode": "entire_time_range",
                                     "type": "timeseries"
                                 }
                             ],
                             "show_grid": 1,
                             "show_legend": 1,
                             "time_field": "",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
                             "type": "timeseries",
                             "use_kibana_indexes": false
                         },
+                        "title": "Transit Gateway Bytes Drop Count Blackhole [Metrics AWS]",
                         "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -602,25 +699,38 @@
                 },
                 "panelIndex": "1d08d3b8-3bd7-4f90-854d-be08cb119273",
                 "title": "Bytes Dropped - black hole",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
-                    "title": "Packets Dropped - black hole",
+                    "enhancements": {},
                     "savedVis": {
-                        "title": "Transit Gateway Packets Drop Count Blackhole [Metrics AWS]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
                             "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": "not aws.dimensions.TransitGatewayAttachment : *"
+                            },
                             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                             "index_pattern": "metrics-*",
                             "interval": "1m",
                             "isModelInvalid": false,
+                            "max_lines_legend": 1,
                             "series": [
                                 {
                                     "axis_position": "right",
@@ -645,20 +755,22 @@
                                     "stacked": "none",
                                     "terms_field": "aws.dimensions.TransitGateway",
                                     "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                    "time_range_mode": "entire_time_range",
                                     "type": "timeseries"
                                 }
                             ],
                             "show_grid": 1,
                             "show_legend": 1,
                             "time_field": "",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
                             "type": "timeseries",
                             "use_kibana_indexes": false
                         },
+                        "title": "Transit Gateway Packets Drop Count Blackhole [Metrics AWS]",
                         "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
+                        "uiState": {}
                     }
                 },
                 "gridData": {
@@ -670,13 +782,19 @@
                 },
                 "panelIndex": "40e82e50-b30c-40eb-bbee-9bbfc3d3311f",
                 "title": "Packets Dropped - black hole",
-                "version": "8.0.0",
-                "type": "visualization"
+                "type": "visualization",
+                "version": "8.6.0"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics AWS] TransitGateway Overview",
         "version": 1
+    },
+    "coreMigrationVersion": "8.6.0",
+    "created_at": "2023-03-10T05:35:05.221Z",
+    "id": "aws-0eb5a6a0-694f-11ea-b0ac-95d4ecb1fecd",
+    "migrationVersion": {
+        "dashboard": "8.6.0"
     },
     "references": [
         {
@@ -685,23 +803,32 @@
             "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "af1453d8-04d3-4b44-a3b0-138111255a23:control_0_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "af1453d8-04d3-4b44-a3b0-138111255a23:control_af1453d8-04d3-4b44-a3b0-138111255a23_0_index_pattern",
+            "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "af1453d8-04d3-4b44-a3b0-138111255a23:control_1_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "af1453d8-04d3-4b44-a3b0-138111255a23:control_af1453d8-04d3-4b44-a3b0-138111255a23_1_index_pattern",
+            "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "af1453d8-04d3-4b44-a3b0-138111255a23:control_2_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "af1453d8-04d3-4b44-a3b0-138111255a23:control_af1453d8-04d3-4b44-a3b0-138111255a23_2_index_pattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "fleet-managed-default",
+            "name": "tag-ref-fleet-managed-default",
+            "type": "tag"
+        },
+        {
+            "id": "fleet-pkg-aws-default",
+            "name": "tag-ref-fleet-pkg-aws-default",
+            "type": "tag"
         }
     ],
-    "migrationVersion": {
-        "dashboard": "8.1.0"
-    },
-    "coreMigrationVersion": "8.1.0"
+    "type": "dashboard",
+    "updated_at": "2023-03-10T05:35:05.221Z",
+    "version": "WzI3ODc1LDJd"
 }

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.32.0
+version: 1.32.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
…eway dashboard

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
Bug
## What does this PR do?
Transitgateway metrics are reported with two dimensions:
- `aws.dimensions.TransitGateway`
- `aws.dimensions.TransitGatewayAttachment`

The sum of the metrics with the same `aws.dimensions.TransitGateway` value and different `aws.dimensions.TransitGatewayAttachment` values is equal to the value of the metrics with the same `aws.dimensions.TransitGateway` value only and empty `aws.dimensions.TransitGatewayAttachment`.
The dashboard for the integration shows stats at `aws.dimensions.TransitGateway` level, and not at `aws.dimensions.TransitGatewayAttachment`. Therefore we have to filter by empty `aws.dimensions.TransitGatewayAttachment` values, so that the values showed in the dashboard are not doubled respect their reality.
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~- [ ] I have verified that all data streams collect metrics or logs.~
- [] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
