### PR TITLE
netflow: enrich network direction and type

### DIFF
--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Enrich for network direction and type.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5500
 - version: "2.4.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json
+++ b/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json
@@ -3015,6 +3015,359 @@
             "host": {
                 "name": "mbp.local"
             }
+        },
+        {
+            "@timestamp": "2020-04-16T23:22:51Z",
+            "destination": {
+                "ip": "10.36.236.100",
+                "locality": "internal",
+                "port": 54594
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "6mUV1nPVG80",
+                "locality": "internal"
+            },
+            "netflow": {
+                "destination_ipv4_address": "10.36.236.100",
+                "destination_transport_port": 54594,
+                "egress_interface": 1,
+                "exporter": {
+                    "address": "81.2.69.144:10000",
+                    "source_id": 1,
+                    "timestamp": "2020-04-16T23:22:51Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_milliseconds": "2020-04-16T23:22:48.963Z",
+                "flow_end_reason": 3,
+                "flow_start_milliseconds": "2020-04-16T23:22:48.96Z",
+                "ingress_interface": 1,
+                "octet_delta_count": 1855,
+                "packet_delta_count": 5,
+                "protocol_identifier": 6,
+                "source_ipv4_address": "10.127.32.11",
+                "source_transport_port": 53,
+                "tcp_control_bits": 27,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "bytes": 1855,
+                "community_id": "1:+/kh1SKruHHnZ5JGSMfWk9nZx8o=",
+                "direction": "unknown",
+                "iana_number": 6,
+                "packets": 5,
+                "transport": "tcp"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "10.36.236.100",
+                    "10.127.32.11"
+                ]
+            },
+            "source": {
+                "bytes": 1855,
+                "ip": "10.127.32.11",
+                "locality": "internal",
+                "packets": 5,
+                "port": 53
+            }
+        },
+        {
+            "@timestamp": "2020-04-16T23:22:51Z",
+            "destination": {
+                "ip": "10.36.236.100",
+                "locality": "internal",
+                "port": 49180
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "HVg4SttTufc",
+                "locality": "external"
+            },
+            "netflow": {
+                "destination_ipv4_address": "10.36.236.100",
+                "destination_transport_port": 49180,
+                "egress_interface": 1,
+                "exporter": {
+                    "address": "81.2.69.144:10000",
+                    "source_id": 1,
+                    "timestamp": "2020-04-16T23:22:51Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_milliseconds": "2020-04-16T23:22:48.404Z",
+                "flow_end_reason": 3,
+                "flow_start_milliseconds": "2020-04-16T23:22:47.995Z",
+                "ingress_interface": 1,
+                "octet_delta_count": 7158,
+                "packet_delta_count": 10,
+                "protocol_identifier": 6,
+                "source_ipv4_address": "89.160.20.112",
+                "source_transport_port": 443,
+                "tcp_control_bits": 27,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "bytes": 7158,
+                "community_id": "1:Zyly7BCJ6D7luuRJJazRxZ/mFZM=",
+                "direction": "unknown",
+                "iana_number": 6,
+                "packets": 10,
+                "transport": "tcp"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "10.36.236.100",
+                    "89.160.20.112"
+                ]
+            },
+            "source": {
+                "bytes": 7158,
+                "ip": "89.160.20.112",
+                "locality": "external",
+                "packets": 10,
+                "port": 443
+            }
+        },
+        {
+            "@timestamp": "2020-04-16T23:22:51Z",
+            "destination": {
+                "ip": "89.160.20.112",
+                "locality": "external",
+                "port": 443
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "HVg4SttTufc",
+                "locality": "external"
+            },
+            "netflow": {
+                "destination_ipv4_address": "89.160.20.112",
+                "destination_transport_port": 443,
+                "egress_interface": 1,
+                "exporter": {
+                    "address": "81.2.69.144:10000",
+                    "source_id": 1,
+                    "timestamp": "2020-04-16T23:22:51Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_milliseconds": "2020-04-16T23:22:48.404Z",
+                "flow_end_reason": 3,
+                "flow_start_milliseconds": "2020-04-16T23:22:47.92Z",
+                "ingress_interface": 1,
+                "octet_delta_count": 1538,
+                "packet_delta_count": 11,
+                "protocol_identifier": 6,
+                "source_ipv4_address": "10.36.236.100",
+                "source_transport_port": 49180,
+                "tcp_control_bits": 27,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "bytes": 1538,
+                "community_id": "1:Zyly7BCJ6D7luuRJJazRxZ/mFZM=",
+                "direction": "unknown",
+                "iana_number": 6,
+                "packets": 11,
+                "transport": "tcp"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "10.36.236.100",
+                    "89.160.20.112"
+                ]
+            },
+            "source": {
+                "bytes": 1538,
+                "ip": "10.36.236.100",
+                "locality": "internal",
+                "packets": 11,
+                "port": 49180
+            }
+        },
+        {
+            "@timestamp": "2018-04-15T03:30:00Z",
+            "destination": {
+                "ip": "0.0.0.0",
+                "locality": "internal",
+                "port": 135
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "GYmhjYyvaAI",
+                "locality": "internal"
+            },
+            "netflow": {
+                "bgp_destination_as_number": 0,
+                "bgp_source_as_number": 0,
+                "destination_ipv4_address": "0.0.0.0",
+                "destination_ipv6_address": "2a02:cf40::2",
+                "destination_transport_port": 135,
+                "exporter": {
+                    "address": "81.2.69.144:4444",
+                    "source_id": 2875616939,
+                    "timestamp": "2018-04-15T03:30:00Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_seconds": "2018-04-15T03:29:02Z",
+                "flow_start_seconds": "2018-04-15T03:28:44Z",
+                "procera_base_service": "IP protocol 58 (IPv6-ICMP)",
+                "procera_content_categories": "",
+                "procera_flow_behavior": "INITIAL,SERVER_IS_LOCAL,BEGINNING,ESTABLISHED",
+                "procera_http_content_type": "",
+                "procera_http_file_length": 0,
+                "procera_http_location": "",
+                "procera_http_url": "",
+                "procera_incoming_octets": 86,
+                "procera_outgoing_octets": 78,
+                "procera_service": "IP protocol 58 (IPv6-ICMP)",
+                "procera_subscriber_identifier": "",
+                "procera_template_name": "IPFIX",
+                "protocol_identifier": 58,
+                "source_ipv4_address": "0.0.0.0",
+                "source_ipv6_address": "2a02:cf40::1",
+                "source_transport_port": 136,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "community_id": "1:vK+Zeop1Y3GHxfFGVF2/COcNBWw=",
+                "direction": "unknown",
+                "iana_number": 58,
+                "transport": "ipv6-icmp"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "0.0.0.0"
+                ]
+            },
+            "source": {
+                "ip": "0.0.0.0",
+                "locality": "internal",
+                "port": 136
+            }
+        },
+        {
+            "@timestamp": "2018-04-15T03:30:00Z",
+            "destination": {
+                "ip": "0.0.0.0",
+                "locality": "internal",
+                "port": 135
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "GYmhjYyvaAI",
+                "locality": "internal"
+            },
+            "netflow": {
+                "bgp_destination_as_number": 0,
+                "bgp_source_as_number": 0,
+                "destination_ipv6_address": "2a02:cf40::2",
+                "destination_transport_port": 135,
+                "exporter": {
+                    "address": "81.2.69.144:4444",
+                    "source_id": 2875616939,
+                    "timestamp": "2018-04-15T03:30:00Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_seconds": "2018-04-15T03:29:02Z",
+                "flow_start_seconds": "2018-04-15T03:28:44Z",
+                "procera_base_service": "IP protocol 58 (IPv6-ICMP)",
+                "procera_content_categories": "",
+                "procera_flow_behavior": "INITIAL,SERVER_IS_LOCAL,BEGINNING,ESTABLISHED",
+                "procera_http_content_type": "",
+                "procera_http_file_length": 0,
+                "procera_http_location": "",
+                "procera_http_url": "",
+                "procera_incoming_octets": 86,
+                "procera_outgoing_octets": 78,
+                "procera_service": "IP protocol 58 (IPv6-ICMP)",
+                "procera_subscriber_identifier": "",
+                "procera_template_name": "IPFIX",
+                "protocol_identifier": 58,
+                "source_ipv6_address": "2a02:cf40::1",
+                "source_transport_port": 136,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "community_id": "1:vK+Zeop1Y3GHxfFGVF2/COcNBWw=",
+                "direction": "unknown",
+                "iana_number": 58,
+                "transport": "ipv6-icmp"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "0.0.0.0"
+                ]
+            },
+            "source": {
+                "ip": "0.0.0.0",
+                "locality": "internal",
+                "port": 136
+            }
         }
     ]
 }

--- a/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json-expected.json
+++ b/packages/netflow/data_stream/log/_dev/test/pipeline/test-netflow-log-events.json-expected.json
@@ -3102,6 +3102,418 @@
                 "bytes": 28373,
                 "packets": 133
             }
+        },
+        {
+            "@timestamp": "2020-04-16T23:22:51Z",
+            "destination": {
+                "ip": "10.36.236.100",
+                "locality": "internal",
+                "port": 54594
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "6mUV1nPVG80",
+                "locality": "internal"
+            },
+            "netflow": {
+                "destination_ipv4_address": "10.36.236.100",
+                "destination_transport_port": 54594,
+                "egress_interface": 1,
+                "exporter": {
+                    "address": "81.2.69.144:10000",
+                    "source_id": 1,
+                    "timestamp": "2020-04-16T23:22:51Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_milliseconds": "2020-04-16T23:22:48.963Z",
+                "flow_end_reason": 3,
+                "flow_start_milliseconds": "2020-04-16T23:22:48.96Z",
+                "ingress_interface": 1,
+                "octet_delta_count": 1855,
+                "packet_delta_count": 5,
+                "protocol_identifier": 6,
+                "source_ipv4_address": "10.127.32.11",
+                "source_transport_port": 53,
+                "tcp_control_bits": 27,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "bytes": 1855,
+                "community_id": "1:+/kh1SKruHHnZ5JGSMfWk9nZx8o=",
+                "direction": "internal",
+                "iana_number": "6",
+                "packets": 5,
+                "transport": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "10.36.236.100",
+                    "10.127.32.11"
+                ]
+            },
+            "source": {
+                "bytes": 1855,
+                "ip": "10.127.32.11",
+                "locality": "internal",
+                "packets": 5,
+                "port": 53
+            }
+        },
+        {
+            "@timestamp": "2020-04-16T23:22:51Z",
+            "destination": {
+                "ip": "10.36.236.100",
+                "locality": "internal",
+                "port": 49180
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "HVg4SttTufc",
+                "locality": "external"
+            },
+            "netflow": {
+                "destination_ipv4_address": "10.36.236.100",
+                "destination_transport_port": 49180,
+                "egress_interface": 1,
+                "exporter": {
+                    "address": "81.2.69.144:10000",
+                    "source_id": 1,
+                    "timestamp": "2020-04-16T23:22:51Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_milliseconds": "2020-04-16T23:22:48.404Z",
+                "flow_end_reason": 3,
+                "flow_start_milliseconds": "2020-04-16T23:22:47.995Z",
+                "ingress_interface": 1,
+                "octet_delta_count": 7158,
+                "packet_delta_count": 10,
+                "protocol_identifier": 6,
+                "source_ipv4_address": "89.160.20.112",
+                "source_transport_port": 443,
+                "tcp_control_bits": 27,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "bytes": 7158,
+                "community_id": "1:Zyly7BCJ6D7luuRJJazRxZ/mFZM=",
+                "direction": "inbound",
+                "iana_number": "6",
+                "packets": 10,
+                "transport": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "10.36.236.100",
+                    "89.160.20.112"
+                ]
+            },
+            "source": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "bytes": 7158,
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "locality": "external",
+                "packets": 10,
+                "port": 443
+            }
+        },
+        {
+            "@timestamp": "2020-04-16T23:22:51Z",
+            "destination": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "locality": "external",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "HVg4SttTufc",
+                "locality": "external"
+            },
+            "netflow": {
+                "destination_ipv4_address": "89.160.20.112",
+                "destination_transport_port": 443,
+                "egress_interface": 1,
+                "exporter": {
+                    "address": "81.2.69.144:10000",
+                    "source_id": 1,
+                    "timestamp": "2020-04-16T23:22:51Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_milliseconds": "2020-04-16T23:22:48.404Z",
+                "flow_end_reason": 3,
+                "flow_start_milliseconds": "2020-04-16T23:22:47.92Z",
+                "ingress_interface": 1,
+                "octet_delta_count": 1538,
+                "packet_delta_count": 11,
+                "protocol_identifier": 6,
+                "source_ipv4_address": "10.36.236.100",
+                "source_transport_port": 49180,
+                "tcp_control_bits": 27,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "bytes": 1538,
+                "community_id": "1:Zyly7BCJ6D7luuRJJazRxZ/mFZM=",
+                "direction": "outbound",
+                "iana_number": "6",
+                "packets": 11,
+                "transport": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "10.36.236.100",
+                    "89.160.20.112"
+                ]
+            },
+            "source": {
+                "bytes": 1538,
+                "ip": "10.36.236.100",
+                "locality": "internal",
+                "packets": 11,
+                "port": 49180
+            }
+        },
+        {
+            "@timestamp": "2018-04-15T03:30:00Z",
+            "destination": {
+                "ip": "0.0.0.0",
+                "locality": "internal",
+                "port": 135
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "GYmhjYyvaAI",
+                "locality": "internal"
+            },
+            "netflow": {
+                "bgp_destination_as_number": 0,
+                "bgp_source_as_number": 0,
+                "destination_ipv4_address": "0.0.0.0",
+                "destination_ipv6_address": "2a02:cf40::2",
+                "destination_transport_port": 135,
+                "exporter": {
+                    "address": "81.2.69.144:4444",
+                    "source_id": 2875616939,
+                    "timestamp": "2018-04-15T03:30:00Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_seconds": "2018-04-15T03:29:02Z",
+                "flow_start_seconds": "2018-04-15T03:28:44Z",
+                "procera_base_service": "IP protocol 58 (IPv6-ICMP)",
+                "procera_content_categories": "",
+                "procera_flow_behavior": "INITIAL,SERVER_IS_LOCAL,BEGINNING,ESTABLISHED",
+                "procera_http_content_type": "",
+                "procera_http_file_length": 0,
+                "procera_http_location": "",
+                "procera_http_url": "",
+                "procera_incoming_octets": 86,
+                "procera_outgoing_octets": 78,
+                "procera_service": "IP protocol 58 (IPv6-ICMP)",
+                "procera_subscriber_identifier": "",
+                "procera_template_name": "IPFIX",
+                "protocol_identifier": 58,
+                "source_ipv4_address": "0.0.0.0",
+                "source_ipv6_address": "2a02:cf40::1",
+                "source_transport_port": 136,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "community_id": "1:vK+Zeop1Y3GHxfFGVF2/COcNBWw=",
+                "direction": "internal",
+                "iana_number": "58",
+                "transport": "ipv6-icmp",
+                "type": [
+                    "ipv4",
+                    "ipv6"
+                ]
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "0.0.0.0"
+                ]
+            },
+            "source": {
+                "ip": "0.0.0.0",
+                "locality": "internal",
+                "port": 136
+            }
+        },
+        {
+            "@timestamp": "2018-04-15T03:30:00Z",
+            "destination": {
+                "ip": "0.0.0.0",
+                "locality": "internal",
+                "port": 135
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "action": "netflow_flow",
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "type": [
+                    "connection"
+                ]
+            },
+            "flow": {
+                "id": "GYmhjYyvaAI",
+                "locality": "internal"
+            },
+            "netflow": {
+                "bgp_destination_as_number": 0,
+                "bgp_source_as_number": 0,
+                "destination_ipv6_address": "2a02:cf40::2",
+                "destination_transport_port": 135,
+                "exporter": {
+                    "address": "81.2.69.144:4444",
+                    "source_id": 2875616939,
+                    "timestamp": "2018-04-15T03:30:00Z",
+                    "uptime_millis": 0,
+                    "version": 10
+                },
+                "flow_end_seconds": "2018-04-15T03:29:02Z",
+                "flow_start_seconds": "2018-04-15T03:28:44Z",
+                "procera_base_service": "IP protocol 58 (IPv6-ICMP)",
+                "procera_content_categories": "",
+                "procera_flow_behavior": "INITIAL,SERVER_IS_LOCAL,BEGINNING,ESTABLISHED",
+                "procera_http_content_type": "",
+                "procera_http_file_length": 0,
+                "procera_http_location": "",
+                "procera_http_url": "",
+                "procera_incoming_octets": 86,
+                "procera_outgoing_octets": 78,
+                "procera_service": "IP protocol 58 (IPv6-ICMP)",
+                "procera_subscriber_identifier": "",
+                "procera_template_name": "IPFIX",
+                "protocol_identifier": 58,
+                "source_ipv6_address": "2a02:cf40::1",
+                "source_transport_port": 136,
+                "type": "netflow_flow"
+            },
+            "network": {
+                "community_id": "1:vK+Zeop1Y3GHxfFGVF2/COcNBWw=",
+                "direction": "internal",
+                "iana_number": "58",
+                "transport": "ipv6-icmp",
+                "type": "ipv6"
+            },
+            "observer": {
+                "ip": "81.2.69.144"
+            },
+            "related": {
+                "ip": [
+                    "0.0.0.0"
+                ]
+            },
+            "source": {
+                "ip": "0.0.0.0",
+                "locality": "internal",
+                "port": 136
+            }
         }
     ]
 }

--- a/packages/netflow/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/netflow/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -16,7 +16,39 @@ processors:
       value:
         - network
         - session
-      if: 'ctx.event?.category != null && ctx.event?.category == "network_session"'
+      if: ctx.event?.category != null && ctx.event?.category == "network_session"
+  - set: 
+      field: network.type
+      value: ipv4
+      if: ctx.netflow?.source_ipv4_address != null || ctx.netflow?.destination_ipv4_address != null
+  - set: 
+      field: network.type
+      value: ipv6
+      if: (ctx.netflow?.source_ipv6_address != null || ctx.netflow?.destination_ipv6_address != null) && ctx.network?.type == null
+  - append: 
+      field: network.type
+      value: ipv6
+      if: (ctx.netflow?.source_ipv6_address != null || ctx.netflow?.destination_ipv6_address != null) && ctx.network?.type == "ipv4"
+  - set:
+      field: network.direction
+      value: inbound
+      if: ctx.source?.locality == "external" && ctx.destination?.locality == "internal"
+  - set:
+      field: network.direction
+      value: outbound
+      if: ctx.source?.locality == "internal" && ctx.destination?.locality == "external"
+  - set:
+      field: network.direction
+      value: internal
+      if: ctx.source?.locality == "internal" && ctx.destination?.locality == "internal"
+  - set:
+      field: network.direction
+      value: external
+      if: ctx.source?.locality == "external" && ctx.destination?.locality == "external"
+  - set:
+      field: network.direction
+      value: unknown
+      if: ctx.network?.direction == null
 
   # IP Geolocation Lookup
   - geoip:

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow Records
-version: "2.4.0"
+version: "2.5.0"
 license: basic
 description: Collect flow records from NetFlow and IPFIX exporters with Elastic Agent.
 type: integration


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds enrich network direction and type.

New test events are from the netflow9_e10s_4_7byte_pad.pcap and ipfix_test_procera_*52935.dat files in the netflow tests from elastic/beats@b6aa37560e130b97278b99fb32ae93a646bb4256 with adjustment for integration package testing.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5452

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
