### PR TITLE
[AWS] Change default value for dataset name on cloudwatch logs

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.1"
+  changes:
+    - description: Update the default values for cloudwatch logs dataset
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5212
 - version: "1.32.0"
   changes:
     - description: Migrate AWS EBS dashboard visualizations to lenses.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update the default values for cloudwatch logs dataset
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5212
+      link: https://github.com/elastic/integrations/pull/5501
 - version: "1.32.0"
   changes:
     - description: Migrate AWS EBS dashboard visualizations to lenses.

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -7,6 +7,15 @@ streams:
     enabled: false
     description: (Deprecated) Please use Custom AWS Logs integration instead
     vars:
+      - name: data_stream.dataset
+        type: text
+        required: true
+        default: aws.cloudwatch_logs
+        show_user: true
+        title: Dataset name
+        description: >
+          Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+
       - name: visibility_timeout
         type: text
         title: Visibility Timeout
@@ -75,6 +84,15 @@ streams:
     title: AWS CloudWatch logs via CloudWatch
     description: Collect AWS CloudWatch logs using cloudwatch input.
     vars:
+      - name: data_stream.dataset
+        type: text
+        required: true
+        default: aws.cloudwatch_logs
+        show_user: true
+        title: Dataset name
+        description: >
+          Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+
       - name: log_group_arn
         type: text
         title: Log Group ARN
@@ -175,12 +193,3 @@ streams:
         type: bool
         multi: false
         default: false
-      - name: data_stream.dataset
-        type: text
-        required: true
-        default: generic
-        show_user: false
-        title: Dataset name
-        description: >
-          Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.32.0
+version: 1.32.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This PR is a reaction to https://github.com/elastic/integrations/issues/5467#issuecomment-1461798560.

When the default name of dataset is wrong, the related ingest pipelines and other assets are not working out of the box.

While we wait to convert to "input type" packages, the best course of action is to ensure the default name is correct.

This might be seen as a breaking change, and I will let it be up to the owner of the package to decide on this, any users with using the default value (since the option was hidden at the bottom of the page under advanced options, that is likely), will suddenly send data to a new datastream.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #5467 