### PR TITLE
[Windows] Support Sysmon New EventIDs - 8, 9, 19, 20, 27, 28, 255

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Support Sysmon EventIDs - 8, 9, 19, 20, 27, 28, 255
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5511
 - version: "1.18.0"
   changes:
     - description: Fix mapping/pipelines for winlog.time_created

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json
@@ -9122,6 +9122,367 @@
                 ],
                 "dataset": "windows.sysmon_operational"
             }
+        },
+        {
+            "@timestamp": "2023-03-10T16:41:26.119Z",
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "version": 2,
+                "record_id": 739823,
+                "computer_name": "rfsH.lab.local",
+                "event_data": {
+                    "TargetProcessGuid": "{A23EAE89-8E5A-5917-0000-00100E3E4D04}",
+                    "TargetProcessId": "2024",
+                    "UtcTime": "2017-05-13 22:53:43.214",
+                    "StartFunction": "DbgUiRemoteBreakin",
+                    "StartModule": "C:\\Windows\\SYSTEM32\\ntdll.dll",
+                    "TargetImage": "C:\\repos\\Supercharger\\Mtg.Supercharger.ControllerService\\bin\\x64\\Debug\\Mtg.Supercharger.ControllerService.exe",
+                    "SourceProcessId": "8804",
+                    "StartAddress": "0x00007FFB09321970",
+                    "NewThreadId": "20532",
+                    "SourceImage": "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\IDE\\Remote Debugger\\x64\\msvsmon.exe",
+                    "SourceProcessGuid": "{A23EAE89-8E6D-5917-0000-0010DFAF5004}"
+                },
+                "event_id": "8",
+                "level": "information",
+                "opcode": "Info",
+                "process": {
+                    "pid": 2848,
+                    "thread": {
+                        "id": 3520
+                    }
+                },
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "time_created": "2017-05-13T22:53:43.2148643Z",
+                "user": {
+                    "identifier": "S-1-5-18"
+                }
+            },
+            "event": {
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e8\u003c/EventID\u003e\u003cVersion\u003e2\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e8\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2017-05-13T22:53:43.214864300Z\" /\u003e\u003cEventRecordID\u003e739823\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"2848\" ThreadID=\"3520\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsH.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"UtcTime\"\u003e2017-05-13 22:53:43.214\u003c/Data\u003e\u003cData Name=\"SourceProcessGuid\"\u003e{A23EAE89-8E6D-5917-0000-0010DFAF5004}\u003c/Data\u003e\u003cData Name=\"SourceProcessId\"\u003e8804\u003c/Data\u003e\u003cData Name=\"SourceImage\"\u003eC:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\IDE\\Remote Debugger\\x64\\msvsmon.exe\u003c/Data\u003e\u003cData Name=\"TargetProcessGuid\"\u003e{A23EAE89-8E5A-5917-0000-00100E3E4D04}\u003c/Data\u003e\u003cData Name=\"TargetProcessId\"\u003e2024\u003c/Data\u003e\u003cData Name=\"TargetImage\"\u003eC:\\repos\\Supercharger\\Mtg.Supercharger.ControllerService\\bin\\x64\\Debug\\Mtg.Supercharger.ControllerService.exe\u003c/Data\u003e\u003cData Name=\"NewThreadId\"\u003e20532\u003c/Data\u003e\u003cData Name=\"StartAddress\"\u003e0x00007FFB09321970\u003c/Data\u003e\u003cData Name=\"StartModule\"\u003eC:\\Windows\\SYSTEM32\\ntdll.dll\u003c/Data\u003e\u003cData Name=\"StartFunction\"\u003eDbgUiRemoteBreakin\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "code": "8",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "rfsH.lab.local"
+            },
+            "log": {
+                "level": "information"
+            }
+        },
+        {
+            "@timestamp": "2023-03-10T16:44:49.726Z",
+            "winlog": {
+                "time_created": "2018-03-22T20:32:22.3337787Z",
+                "version": 2,
+                "event_data": {
+                    "ProcessId": "4",
+                    "UtcTime": "2018-03-22 20:32:22.332",
+                    "Device": "\\Device\\HarddiskVolume2",
+                    "Image": "System",
+                    "ProcessGuid": "{A23EAE89-C65F-5AB2-0000-0010EB030000}"
+                },
+                "event_id": "9",
+                "level": "information",
+                "opcode": "Info",
+                "process": {
+                    "pid": 19572,
+                    "thread": {
+                        "id": 21888
+                    }
+                },
+                "record_id": 1944686,
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "rfsH.lab.local",
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "user": {
+                    "identifier": "S-1-5-18"
+                }
+            },
+            "event": {
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e9\u003c/EventID\u003e\u003cVersion\u003e2\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e9\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-03-22T20:32:22.333778700Z\" /\u003e\u003cEventRecordID\u003e1944686\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"19572\" ThreadID=\"21888\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsH.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"UtcTime\"\u003e2018-03-22 20:32:22.332\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{A23EAE89-C65F-5AB2-0000-0010EB030000}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e4\u003c/Data\u003e\u003cData Name=\"Image\"\u003eSystem\u003c/Data\u003e\u003cData Name=\"Device\"\u003e\\Device\\HarddiskVolume2\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "code": "9",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "rfsH.lab.local"
+            },
+            "log": {
+                "level": "information"
+            }
+        },
+        {
+            "@timestamp": "2023-03-10T16:46:23.102Z",
+            "winlog": {
+                "level": "information",
+                "opcode": "Info",
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "time_created": "2018-04-11T16:26:16.3276987Z",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 3,
+                "event_data": {
+                    "EventNamespace": " \"root\\\\cimv2\"",
+                    "EventType": "WmiFilterEvent",
+                    "Name": " \"BotFilter82\"",
+                    "Operation": "Created",
+                    "Query": " \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime \u003e= 200 AND TargetInstance.SystemUpTime \u003c 320\"",
+                    "User": "LAB\\rsmith",
+                    "UtcTime": "2018-04-11 16:26:16.327"
+                },
+                "computer_name": "rfsh.lab.local",
+                "event_id": "19",
+                "process": {
+                    "pid": 7620,
+                    "thread": {
+                        "id": 21880
+                    }
+                },
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": 63551,
+                "channel": "Microsoft-Windows-Sysmon/Operational"
+            },
+            "event": {
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e19\u003c/EventID\u003e\u003cVersion\u003e3\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e19\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-04-11T16:26:16.327698700Z\" /\u003e\u003cEventRecordID\u003e63551\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"7620\" ThreadID=\"21880\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsh.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"EventType\"\u003eWmiFilterEvent\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2018-04-11 16:26:16.327\u003c/Data\u003e\u003cData Name=\"Operation\"\u003eCreated\u003c/Data\u003e\u003cData Name=\"User\"\u003eLAB\\rsmith\u003c/Data\u003e\u003cData Name=\"EventNamespace\"\u003e \"root\\\\cimv2\"\u003c/Data\u003e\u003cData Name=\"Name\"\u003e \"BotFilter82\"\u003c/Data\u003e\u003cData Name=\"Query\"\u003e \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime \u0026gt;= 200 AND TargetInstance.SystemUpTime \u0026lt; 320\"\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "code": "19",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "rfsh.lab.local"
+            },
+            "log": {
+                "level": "information"
+            }
+        },
+        {
+            "@timestamp": "2023-03-10T16:48:06.865Z",
+            "winlog": {
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": 63557,
+                "version": 3,
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "event_data": {
+                    "User": "LAB\\rsmith",
+                    "UtcTime": "2018-04-11 16:26:16.360",
+                    "Destination": " \"C:\\\\Windows\\\\System32\\\\evil.exe\"",
+                    "EventType": "WmiConsumerEvent",
+                    "Name": " \"BotConsumer23\"",
+                    "Operation": "Created",
+                    "Type": "Command Line"
+                },
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "opcode": "Info",
+                "process": {
+                    "pid": 7620,
+                    "thread": {
+                        "id": 21880
+                    }
+                },
+                "time_created": "2018-04-11T16:26:16.3604732Z",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "computer_name": "rfsh.lab.local",
+                "event_id": "20",
+                "level": "information"
+            },
+            "event": {
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e20\u003c/EventID\u003e\u003cVersion\u003e3\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e20\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-04-11T16:26:16.360473200Z\" /\u003e\u003cEventRecordID\u003e63557\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"7620\" ThreadID=\"21880\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsh.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"EventType\"\u003eWmiConsumerEvent\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2018-04-11 16:26:16.360\u003c/Data\u003e\u003cData Name=\"Operation\"\u003eCreated\u003c/Data\u003e\u003cData Name=\"User\"\u003eLAB\\rsmith\u003c/Data\u003e\u003cData Name=\"Name\"\u003e \"BotConsumer23\"\u003c/Data\u003e\u003cData Name=\"Type\"\u003eCommand Line\u003c/Data\u003e\u003cData Name=\"Destination\"\u003e \"C:\\\\Windows\\\\System32\\\\evil.exe\"\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "code": "20",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "rfsh.lab.local"
+            },
+            "log": {
+                "level": "information"
+            }
+        },
+        {
+            "@timestamp": "2023-03-10T17:41:38.273Z",
+            "winlog": {
+                "level": "error",
+                "opcode": "Info",
+                "process": {
+                    "pid": 1112,
+                    "thread": {
+                        "id": 1332
+                    }
+                },
+                "record_id": 278772,
+                "time_created": "2015-01-21T17:00:44.0014533Z",
+                "version": 1,
+                "computer_name": "WIN-RKSC06DQ86F",
+                "event_data": {
+                    "Description": "Failed to retrieve events (Last error: Insufficient system resources exist to complete the requested service.).",
+                    "ID": "DriverCommunication"
+                },
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "event_id": "255"
+            },
+            "event": {
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e255\u003c/EventID\u003e\u003cVersion\u003e1\u003c/Version\u003e\u003cLevel\u003e2\u003c/Level\u003e\u003cTask\u003e255\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2015-01-21T17:00:44.001453300Z\" /\u003e\u003cEventRecordID\u003e278772\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"1112\" ThreadID=\"1332\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003eWIN-RKSC06DQ86F\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"ID\"\u003eDriverCommunication\u003c/Data\u003e\u003cData Name=\"Description\"\u003eFailed to retrieve events (Last error: Insufficient system resources exist to complete the requested service.).\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon",
+                "code": "255",
+                "kind": "event"
+            },
+            "host": {
+                "name": "WIN-RKSC06DQ86F"
+            },
+            "log": {
+                "level": "error"
+            }
+        },
+        {
+            "@timestamp": "2023-03-12T08:03:28.403Z",
+            "winlog": {
+                "computer_name": "sample-wind-sysmon",
+                "level": "information",
+                "opcode": "Info",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": 406,
+                "time_created": "2023-03-12T08:01:25.4286552Z",
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "event_data": {
+                    "Hashes": "SHA256=F2835A7EE42F30AA78659FAE1510F791A38E63480B099CDD20D402760EE7A391",
+                    "Image": "C:\\Windows\\Explorer.EXE",
+                    "ProcessGuid": "{4299a14b-71fa-640d-bc00-000000000700}",
+                    "ProcessId": "868",
+                    "RuleName": "fileblocktest",
+                    "TargetFilename": "C:\\ProgramData\\notepad.exe",
+                    "User": "SAMPLE-WI\\sampleuser",
+                    "UtcTime": "2023-03-12 08:01:25.423"
+                },
+                "event_id": "27",
+                "process": {
+                    "pid": 3804,
+                    "thread": {
+                        "id": 4760
+                    }
+                },
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "version": 5
+            },
+            "event": {
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e27\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e27\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T08:01:25.4286552Z\" /\u003e\u003cEventRecordID\u003e406\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblocktest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 08:01:25.423\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-71fa-640d-bc00-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e868\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sampleuser\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Windows\\Explorer.EXE\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\ProgramData\\notepad.exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=F2835A7EE42F30AA78659FAE1510F791A38E63480B099CDD20D402760EE7A391\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "code": "27",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "sample-wind-sysmon"
+            },
+            "log": {
+                "level": "information"
+            }
+        },
+        {
+            "@timestamp": "2023-03-12T08:16:19.639Z",
+            "winlog": {
+                "opcode": "Info",
+                "process": {
+                    "thread": {
+                        "id": 4760
+                    },
+                    "pid": 3804
+                },
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "time_created": "2023-03-12T08:13:25.3808395Z",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "computer_name": "sample-wind-sysmon",
+                "event_data": {
+                    "Image": "C:\\Windows\\Explorer.EXE",
+                    "ProcessGuid": "{4299a14b-71fa-640d-bc00-000000000700}",
+                    "ProcessId": "868",
+                    "RuleName": "fileblocktest",
+                    "TargetFilename": "C:\\Users\\sampleuser\\Music\\notepad.exe",
+                    "User": "SAMPLE-WI\\sampleuser",
+                    "UtcTime": "2023-03-12 08:13:25.375",
+                    "Hashes": "SHA256=F2835A7EE42F30AA78659FAE1510F791A38E63480B099CDD20D402760EE7A391"
+                },
+                "event_id": "27",
+                "level": "information",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": 438,
+                "version": 5,
+                "channel": "Microsoft-Windows-Sysmon/Operational"
+            },
+            "event": {
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e27\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e27\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T08:13:25.3808395Z\" /\u003e\u003cEventRecordID\u003e438\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblocktest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 08:13:25.375\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-71fa-640d-bc00-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e868\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sampleuser\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Windows\\Explorer.EXE\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\Users\\sampleuser\\Music\\notepad.exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=F2835A7EE42F30AA78659FAE1510F791A38E63480B099CDD20D402760EE7A391\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "code": "27",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "sample-wind-sysmon"
+            },
+            "log": {
+                "level": "information"
+            }
+        },
+        {
+            "@timestamp": "2023-03-12T09:23:18.632Z",
+            "winlog": {
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 5,
+                "level": "information",
+                "opcode": "Info",
+                "process": {
+                    "pid": 3804,
+                    "thread": {
+                        "id": 4760
+                    }
+                },
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": 583,
+                "time_created": "2023-03-12T09:20:46.9436239Z",
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "sample-wind-sysmon",
+                "event_data": {
+                    "IsExecutable": "true",
+                    "TargetFilename": "C:\\Users\\sample\\Downloads\\ChromeSetup (1).exe",
+                    "User": "SAMPLE-WI\\sample",
+                    "UtcTime": "2023-03-12 09:20:46.943",
+                    "Hashes": "SHA256=8DDCCA3D2A78660524D73C51DD148DE7B76DF1573EBCC8C5B2AC36FDE2FF2396",
+                    "Image": "C:\\Users\\sample\\Downloads\\SDelete\\sdelete64.exe",
+                    "ProcessGuid": "{4299a14b-996c-640d-8d02-000000000700}",
+                    "ProcessId": "6788",
+                    "RuleName": "fileblockshredtest"
+                },
+                "event_id": "28",
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}"
+            },
+            "event": {
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e28\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e28\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T09:20:46.9436239Z\" /\u003e\u003cEventRecordID\u003e583\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblockshredtest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 09:20:46.943\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-996c-640d-8d02-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e6788\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sample\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Users\\sample\\Downloads\\SDelete\\sdelete64.exe\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\Users\\sample\\Downloads\\ChromeSetup (1).exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=8DDCCA3D2A78660524D73C51DD148DE7B76DF1573EBCC8C5B2AC36FDE2FF2396\u003c/Data\u003e\u003cData Name=\"IsExecutable\"\u003etrue\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon",
+                "code": "28"
+            },
+            "host": {
+                "name": "sample-wind-sysmon"
+            },
+            "log": {
+                "level": "information"
+            }
         }
     ]
 }

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
@@ -22230,6 +22230,481 @@
                 },
                 "version": 3
             }
+        },
+        {
+            "@timestamp": "2017-05-13T22:53:43.214Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "code": "8",
+                "created": "2017-05-13T22:53:43.214Z",
+                "kind": "event",
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e8\u003c/EventID\u003e\u003cVersion\u003e2\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e8\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2017-05-13T22:53:43.214864300Z\" /\u003e\u003cEventRecordID\u003e739823\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"2848\" ThreadID=\"3520\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsH.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"UtcTime\"\u003e2017-05-13 22:53:43.214\u003c/Data\u003e\u003cData Name=\"SourceProcessGuid\"\u003e{A23EAE89-8E6D-5917-0000-0010DFAF5004}\u003c/Data\u003e\u003cData Name=\"SourceProcessId\"\u003e8804\u003c/Data\u003e\u003cData Name=\"SourceImage\"\u003eC:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\IDE\\Remote Debugger\\x64\\msvsmon.exe\u003c/Data\u003e\u003cData Name=\"TargetProcessGuid\"\u003e{A23EAE89-8E5A-5917-0000-00100E3E4D04}\u003c/Data\u003e\u003cData Name=\"TargetProcessId\"\u003e2024\u003c/Data\u003e\u003cData Name=\"TargetImage\"\u003eC:\\repos\\Supercharger\\Mtg.Supercharger.ControllerService\\bin\\x64\\Debug\\Mtg.Supercharger.ControllerService.exe\u003c/Data\u003e\u003cData Name=\"NewThreadId\"\u003e20532\u003c/Data\u003e\u003cData Name=\"StartAddress\"\u003e0x00007FFB09321970\u003c/Data\u003e\u003cData Name=\"StartModule\"\u003eC:\\Windows\\SYSTEM32\\ntdll.dll\u003c/Data\u003e\u003cData Name=\"StartFunction\"\u003eDbgUiRemoteBreakin\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "rfsH.lab.local"
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "entity_id": "{A23EAE89-8E6D-5917-0000-0010DFAF5004}",
+                "executable": "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\IDE\\Remote Debugger\\x64\\msvsmon.exe",
+                "name": "msvsmon.exe",
+                "pid": 8804
+            },
+            "user": {
+                "id": "S-1-5-18"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "rfsH.lab.local",
+                "event_data": {
+                    "NewThreadId": "20532",
+                    "StartAddress": "0x00007FFB09321970",
+                    "StartFunction": "DbgUiRemoteBreakin",
+                    "StartModule": "C:\\Windows\\SYSTEM32\\ntdll.dll",
+                    "TargetImage": "C:\\repos\\Supercharger\\Mtg.Supercharger.ControllerService\\bin\\x64\\Debug\\Mtg.Supercharger.ControllerService.exe",
+                    "TargetProcessGUID": "{A23EAE89-8E5A-5917-0000-00100E3E4D04}",
+                    "TargetProcessId": "2024"
+                },
+                "event_id": "8",
+                "opcode": "Info",
+                "process": {
+                    "pid": 2848,
+                    "thread": {
+                        "id": 3520
+                    }
+                },
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "739823",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 2
+            }
+        },
+        {
+            "@timestamp": "2018-03-22T20:32:22.332Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "code": "9",
+                "created": "2018-03-22T20:32:22.333Z",
+                "kind": "event",
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e9\u003c/EventID\u003e\u003cVersion\u003e2\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e9\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-03-22T20:32:22.333778700Z\" /\u003e\u003cEventRecordID\u003e1944686\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"19572\" ThreadID=\"21888\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsH.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"UtcTime\"\u003e2018-03-22 20:32:22.332\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{A23EAE89-C65F-5AB2-0000-0010EB030000}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e4\u003c/Data\u003e\u003cData Name=\"Image\"\u003eSystem\u003c/Data\u003e\u003cData Name=\"Device\"\u003e\\Device\\HarddiskVolume2\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "file": {
+                "directory": "\\Device",
+                "name": "HarddiskVolume2",
+                "path": "\\Device\\HarddiskVolume2"
+            },
+            "host": {
+                "name": "rfsH.lab.local"
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "entity_id": "{A23EAE89-C65F-5AB2-0000-0010EB030000}",
+                "executable": "System",
+                "pid": 4
+            },
+            "user": {
+                "id": "S-1-5-18"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "rfsH.lab.local",
+                "event_id": "9",
+                "opcode": "Info",
+                "process": {
+                    "pid": 19572,
+                    "thread": {
+                        "id": 21888
+                    }
+                },
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "1944686",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 2
+            }
+        },
+        {
+            "@timestamp": "2018-04-11T16:26:16.327Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "code": "19",
+                "created": "2018-04-11T16:26:16.327Z",
+                "kind": "event",
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e19\u003c/EventID\u003e\u003cVersion\u003e3\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e19\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-04-11T16:26:16.327698700Z\" /\u003e\u003cEventRecordID\u003e63551\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"7620\" ThreadID=\"21880\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsh.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"EventType\"\u003eWmiFilterEvent\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2018-04-11 16:26:16.327\u003c/Data\u003e\u003cData Name=\"Operation\"\u003eCreated\u003c/Data\u003e\u003cData Name=\"User\"\u003eLAB\\rsmith\u003c/Data\u003e\u003cData Name=\"EventNamespace\"\u003e \"root\\\\cimv2\"\u003c/Data\u003e\u003cData Name=\"Name\"\u003e \"BotFilter82\"\u003c/Data\u003e\u003cData Name=\"Query\"\u003e \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime \u0026gt;= 200 AND TargetInstance.SystemUpTime \u0026lt; 320\"\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "rfsh.lab.local"
+            },
+            "log": {
+                "level": "information"
+            },
+            "related": {
+                "user": [
+                    "rsmith"
+                ]
+            },
+            "user": {
+                "domain": "LAB",
+                "id": "S-1-5-18",
+                "name": "rsmith"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "rfsh.lab.local",
+                "event_data": {
+                    "EventNamespace": " \"root\\\\cimv2\"",
+                    "EventType": "WmiFilterEvent",
+                    "Name": " \"BotFilter82\"",
+                    "Operation": "Created",
+                    "Query": " \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime \u003e= 200 AND TargetInstance.SystemUpTime \u003c 320\""
+                },
+                "event_id": "19",
+                "opcode": "Info",
+                "process": {
+                    "pid": 7620,
+                    "thread": {
+                        "id": 21880
+                    }
+                },
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "63551",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 3
+            }
+        },
+        {
+            "@timestamp": "2018-04-11T16:26:16.360Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "code": "20",
+                "created": "2018-04-11T16:26:16.360Z",
+                "kind": "event",
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e20\u003c/EventID\u003e\u003cVersion\u003e3\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e20\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-04-11T16:26:16.360473200Z\" /\u003e\u003cEventRecordID\u003e63557\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"7620\" ThreadID=\"21880\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsh.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"EventType\"\u003eWmiConsumerEvent\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2018-04-11 16:26:16.360\u003c/Data\u003e\u003cData Name=\"Operation\"\u003eCreated\u003c/Data\u003e\u003cData Name=\"User\"\u003eLAB\\rsmith\u003c/Data\u003e\u003cData Name=\"Name\"\u003e \"BotConsumer23\"\u003c/Data\u003e\u003cData Name=\"Type\"\u003eCommand Line\u003c/Data\u003e\u003cData Name=\"Destination\"\u003e \"C:\\\\Windows\\\\System32\\\\evil.exe\"\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "rfsh.lab.local"
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "executable": " \"C:\\\\Windows\\\\System32\\\\evil.exe\"",
+                "name": "evil.exe\""
+            },
+            "related": {
+                "user": [
+                    "rsmith"
+                ]
+            },
+            "user": {
+                "domain": "LAB",
+                "id": "S-1-5-18",
+                "name": "rsmith"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "rfsh.lab.local",
+                "event_data": {
+                    "EventType": "WmiConsumerEvent",
+                    "Name": " \"BotConsumer23\"",
+                    "Operation": "Created",
+                    "Type": "Command Line"
+                },
+                "event_id": "20",
+                "opcode": "Info",
+                "process": {
+                    "pid": 7620,
+                    "thread": {
+                        "id": 21880
+                    }
+                },
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "63557",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 3
+            }
+        },
+        {
+            "@timestamp": "2023-03-10T17:41:38.273Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "error": {
+                "code": "DriverCommunication"
+            },
+            "event": {
+                "code": "255",
+                "created": "2015-01-21T17:00:44.001Z",
+                "kind": "event",
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e255\u003c/EventID\u003e\u003cVersion\u003e1\u003c/Version\u003e\u003cLevel\u003e2\u003c/Level\u003e\u003cTask\u003e255\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2015-01-21T17:00:44.001453300Z\" /\u003e\u003cEventRecordID\u003e278772\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"1112\" ThreadID=\"1332\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003eWIN-RKSC06DQ86F\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"ID\"\u003eDriverCommunication\u003c/Data\u003e\u003cData Name=\"Description\"\u003eFailed to retrieve events (Last error: Insufficient system resources exist to complete the requested service.).\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "WIN-RKSC06DQ86F"
+            },
+            "log": {
+                "level": "error"
+            },
+            "process": {
+                "pe": {
+                    "description": "Failed to retrieve events (Last error: Insufficient system resources exist to complete the requested service.)."
+                }
+            },
+            "user": {
+                "id": "S-1-5-18"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "WIN-RKSC06DQ86F",
+                "event_data": {
+                    "Description": "Failed to retrieve events (Last error: Insufficient system resources exist to complete the requested service.)."
+                },
+                "event_id": "255",
+                "opcode": "Info",
+                "process": {
+                    "pid": 1112,
+                    "thread": {
+                        "id": 1332
+                    }
+                },
+                "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "278772",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 1
+            }
+        },
+        {
+            "@timestamp": "2023-03-12T08:01:25.423Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "code": "27",
+                "created": "2023-03-12T08:01:25.428Z",
+                "kind": "event",
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e27\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e27\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T08:01:25.4286552Z\" /\u003e\u003cEventRecordID\u003e406\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblocktest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 08:01:25.423\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-71fa-640d-bc00-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e868\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sampleuser\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Windows\\Explorer.EXE\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\ProgramData\\notepad.exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=F2835A7EE42F30AA78659FAE1510F791A38E63480B099CDD20D402760EE7A391\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "file": {
+                "directory": "C:\\ProgramData",
+                "extension": "exe",
+                "name": "notepad.exe",
+                "path": "C:\\ProgramData\\notepad.exe"
+            },
+            "host": {
+                "name": "sample-wind-sysmon"
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "entity_id": "{4299a14b-71fa-640d-bc00-000000000700}",
+                "executable": "C:\\Windows\\Explorer.EXE",
+                "name": "Explorer.EXE",
+                "pid": 868
+            },
+            "related": {
+                "hash": [
+                    "f2835a7ee42f30aa78659fae1510f791a38e63480b099cdd20d402760ee7a391"
+                ],
+                "user": [
+                    "sampleuser"
+                ]
+            },
+            "rule": {
+                "name": "fileblocktest"
+            },
+            "user": {
+                "domain": "SAMPLE-WI",
+                "id": "S-1-5-18",
+                "name": "sampleuser"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "sample-wind-sysmon",
+                "event_id": "27",
+                "opcode": "Info",
+                "process": {
+                    "pid": 3804,
+                    "thread": {
+                        "id": 4760
+                    }
+                },
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "406",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 5
+            }
+        },
+        {
+            "@timestamp": "2023-03-12T08:13:25.375Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "code": "27",
+                "created": "2023-03-12T08:13:25.380Z",
+                "kind": "event",
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e27\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e27\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T08:13:25.3808395Z\" /\u003e\u003cEventRecordID\u003e438\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblocktest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 08:13:25.375\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-71fa-640d-bc00-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e868\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sampleuser\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Windows\\Explorer.EXE\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\Users\\sampleuser\\Music\\notepad.exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=F2835A7EE42F30AA78659FAE1510F791A38E63480B099CDD20D402760EE7A391\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "file": {
+                "directory": "C:\\Users\\sampleuser\\Music",
+                "extension": "exe",
+                "name": "notepad.exe",
+                "path": "C:\\Users\\sampleuser\\Music\\notepad.exe"
+            },
+            "host": {
+                "name": "sample-wind-sysmon"
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "entity_id": "{4299a14b-71fa-640d-bc00-000000000700}",
+                "executable": "C:\\Windows\\Explorer.EXE",
+                "name": "Explorer.EXE",
+                "pid": 868
+            },
+            "related": {
+                "hash": [
+                    "f2835a7ee42f30aa78659fae1510f791a38e63480b099cdd20d402760ee7a391"
+                ],
+                "user": [
+                    "sampleuser"
+                ]
+            },
+            "rule": {
+                "name": "fileblocktest"
+            },
+            "user": {
+                "domain": "SAMPLE-WI",
+                "id": "S-1-5-18",
+                "name": "sampleuser"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "sample-wind-sysmon",
+                "event_id": "27",
+                "opcode": "Info",
+                "process": {
+                    "pid": 3804,
+                    "thread": {
+                        "id": 4760
+                    }
+                },
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "438",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 5
+            }
+        },
+        {
+            "@timestamp": "2023-03-12T09:20:46.943Z",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "code": "28",
+                "created": "2023-03-12T09:20:46.943Z",
+                "kind": "event",
+                "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e28\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e28\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T09:20:46.9436239Z\" /\u003e\u003cEventRecordID\u003e583\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblockshredtest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 09:20:46.943\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-996c-640d-8d02-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e6788\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sample\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Users\\sample\\Downloads\\SDelete\\sdelete64.exe\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\Users\\sample\\Downloads\\ChromeSetup (1).exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=8DDCCA3D2A78660524D73C51DD148DE7B76DF1573EBCC8C5B2AC36FDE2FF2396\u003c/Data\u003e\u003cData Name=\"IsExecutable\"\u003etrue\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "file": {
+                "directory": "C:\\Users\\sample\\Downloads",
+                "extension": "exe",
+                "name": "ChromeSetup (1).exe",
+                "path": "C:\\Users\\sample\\Downloads\\ChromeSetup (1).exe"
+            },
+            "host": {
+                "name": "sample-wind-sysmon"
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "entity_id": "{4299a14b-996c-640d-8d02-000000000700}",
+                "executable": "C:\\Users\\sample\\Downloads\\SDelete\\sdelete64.exe",
+                "name": "sdelete64.exe",
+                "pid": 6788
+            },
+            "related": {
+                "hash": [
+                    "8ddcca3d2a78660524d73c51dd148de7b76df1573ebcc8c5b2ac36fde2ff2396"
+                ],
+                "user": [
+                    "sample"
+                ]
+            },
+            "rule": {
+                "name": "fileblockshredtest"
+            },
+            "sysmon": {
+                "file": {
+                    "is_executable": true
+                }
+            },
+            "user": {
+                "domain": "SAMPLE-WI",
+                "id": "S-1-5-18",
+                "name": "sample"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "sample-wind-sysmon",
+                "event_id": "28",
+                "opcode": "Info",
+                "process": {
+                    "pid": 3804,
+                    "thread": {
+                        "id": 4760
+                    }
+                },
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "583",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 5
+            }
         }
     ]
 }

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -1226,6 +1226,13 @@ processors:
           ];
         }
 
+
+## Conformity
+  - rename:
+      field: winlog.event_data.TargetProcessGuid
+      target_field: winlog.event_data.TargetProcessGUID
+      if: ctx.winlog?.event_data?.TargetProcessGuid != null
+
 ## Cleanup
 
   - remove:

--- a/packages/windows/data_stream/sysmon_operational/fields/winlog.yml
+++ b/packages/windows/data_stream/sysmon_operational/fields/winlog.yml
@@ -87,6 +87,8 @@
           type: keyword
         - name: EventType
           type: keyword
+        - name: EventNamespace
+          type: keyword
         - name: ExtraInfo
           type: keyword
         - name: FailureName
@@ -143,11 +145,15 @@
           type: keyword
         - name: MinorVersion
           type: keyword
+        - name: Name
+          type: keyword
         - name: NewProcessId
           type: keyword
         - name: NewProcessName
           type: keyword
         - name: NewSchemeGuid
+          type: keyword
+        - name: NewThreadId
           type: keyword
         - name: NewTime
           type: keyword
@@ -158,6 +164,8 @@
         - name: OldSchemeGuid
           type: keyword
         - name: OldTime
+          type: keyword
+        - name: Operation
           type: keyword
         - name: OriginalFileName
           type: keyword
@@ -187,6 +195,8 @@
           type: keyword
         - name: QfeVersion
           type: keyword
+        - name: Query
+          type: keyword
         - name: Reason
           type: keyword
         - name: SchemaVersion
@@ -210,6 +220,12 @@
         - name: SignatureStatus
           type: keyword
         - name: Signed
+          type: keyword
+        - name: StartAddress
+          type: keyword
+        - name: StartFunction
+          type: keyword
+        - name: StartModule
           type: keyword
         - name: StartTime
           type: keyword

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -1073,6 +1073,7 @@ An example event for `sysmon_operational` looks as following:
 | winlog.event_data.DriverNameLength |  | keyword |
 | winlog.event_data.DwordVal |  | keyword |
 | winlog.event_data.EntryCount |  | keyword |
+| winlog.event_data.EventNamespace |  | keyword |
 | winlog.event_data.EventType |  | keyword |
 | winlog.event_data.ExtraInfo |  | keyword |
 | winlog.event_data.FailureName |  | keyword |
@@ -1102,14 +1103,17 @@ An example event for `sysmon_operational` looks as following:
 | winlog.event_data.MinimumPerformancePercent |  | keyword |
 | winlog.event_data.MinimumThrottlePercent |  | keyword |
 | winlog.event_data.MinorVersion |  | keyword |
+| winlog.event_data.Name |  | keyword |
 | winlog.event_data.NewProcessId |  | keyword |
 | winlog.event_data.NewProcessName |  | keyword |
 | winlog.event_data.NewSchemeGuid |  | keyword |
+| winlog.event_data.NewThreadId |  | keyword |
 | winlog.event_data.NewTime |  | keyword |
 | winlog.event_data.NominalFrequency |  | keyword |
 | winlog.event_data.Number |  | keyword |
 | winlog.event_data.OldSchemeGuid |  | keyword |
 | winlog.event_data.OldTime |  | keyword |
+| winlog.event_data.Operation |  | keyword |
 | winlog.event_data.OriginalFileName |  | keyword |
 | winlog.event_data.Path |  | keyword |
 | winlog.event_data.PerformanceImplementation |  | keyword |
@@ -1124,6 +1128,7 @@ An example event for `sysmon_operational` looks as following:
 | winlog.event_data.PuaCount |  | keyword |
 | winlog.event_data.PuaPolicyId |  | keyword |
 | winlog.event_data.QfeVersion |  | keyword |
+| winlog.event_data.Query |  | keyword |
 | winlog.event_data.Reason |  | keyword |
 | winlog.event_data.SchemaVersion |  | keyword |
 | winlog.event_data.ScriptBlockText |  | keyword |
@@ -1136,6 +1141,9 @@ An example event for `sysmon_operational` looks as following:
 | winlog.event_data.Signature |  | keyword |
 | winlog.event_data.SignatureStatus |  | keyword |
 | winlog.event_data.Signed |  | keyword |
+| winlog.event_data.StartAddress |  | keyword |
+| winlog.event_data.StartFunction |  | keyword |
+| winlog.event_data.StartModule |  | keyword |
 | winlog.event_data.StartTime |  | keyword |
 | winlog.event_data.State |  | keyword |
 | winlog.event_data.Status |  | keyword |

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.18.0
+version: 1.19.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Supports more Sysmon events introduced since v13.10. Following EventIDs are supported:

EventIDs: `8, 9, 19, 20, 27, 28, 255`
 
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally
`elastic-package stack down && elastic-package build && elastic-package stack up --version=8.6.0 -d -v --services=elasticsearch && eval "$(elastic-package stack shellinit)" && elastic-package test pipeline --generate --data-streams sysmon_operational -v`

```
Run pipeline tests for the package
--- Test results for package: windows - START ---
╭─────────┬────────────────────┬───────────┬──────────────────┬────────┬──────────────╮
│ PACKAGE │ DATA STREAM        │ TEST TYPE │ TEST NAME        │ RESULT │ TIME ELAPSED │
├─────────┼────────────────────┼───────────┼──────────────────┼────────┼──────────────┤
│ windows │ sysmon_operational │ pipeline  │ test-events.json │ PASS   │ 253.876625ms │
╰─────────┴────────────────────┴───────────┴──────────────────┴────────┴──────────────╯
--- Test results for package: windows - END   ---
Done
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/4038

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
