### PR TITLE
[D4C] updated schema yaml format

### DIFF
--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Default policy updated to include new file/process selector schema.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5417
+      link: https://github.com/elastic/integrations/pull/5514
 - version: "1.0.0"
   changes:
     - description: Adds process and file datastreams to track telemetry.

--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Default policy updated to include new file/process selector schema.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5417
 - version: "1.0.0"
   changes:
     - description: Adds process and file datastreams to track telemetry.

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_defend
 title: "Defend for Containers"
-version: 1.0.0
+version: 1.0.1
 source:
   license: "Elastic-2.0"
 description: "Elastic Defend for Containers provides cloud-native runtime protections for containerized environments."

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -41,31 +41,25 @@ policy_templates:
             description: |
               Configures drift prevention with custom selectors and responses.
             default: |
-              selectors:
-                #default selector (user can modify or remove if they want)
-                - name: default
-                  operation: [createExecutable, modifyExecutable]
+              file:
+                selectors:
+                  # example selector
+                  - name: nginxBinMods
+                    operation: [createExecutable, modifyExecutable]
+                    targetFilePath:
+                      - /usr/bin/**
+                    containerImageName:
+                      - nginx
 
-                # example custom selector
-                - name: example
-                  containerImageName:
-                    - nginx
+                  # example selector used as exclude
+                  - name: excludeTestServers
+                    containerImageTag:
+                      - staging
+                      - preprod
 
-                # example selector used for exclude
-                - name: excludeExample
-                  containerImageTag:
-                    - staging
-
-              # responses are evaluated from top to bottom
-              # only the first response with a match will run its actions
-              responses:
-                - match: [example]
-                  exclude: [excludeExample]
-                  actions: [alert, block]
-
-                # default response
-                # delete this if no default response needed
-                - match: [default]
-                  actions: [alert]
+                responses:
+                  - match: [nginxBinMods]
+                    exclude: [excludeTestServers]
+                    actions: [alert]
 owner:
   github: elastic/sec-cloudnative-integrations


### PR DESCRIPTION
## What does this PR do?

Sets a new default yaml config for the integration. The new policy format looks like this:
```
file:
  selectors:
    - name: nginxBinMods
      operation:
        - createExecutable
        - modifyExecutable
      targetFilePath:
        - /usr/bin/**
      containerImageName:
        - nginx
    - name: excludeTestServers
      containerImageTag:
        - staging
        - preprod
  responses:
    - match:
        - nginxBinMods
      exclude:
        - excludeTestServers
      actions:
        - alert
process:
  selectors:
    - name: allProcesses
      operation:
        - fork
        - exec
  responses:
    - match:
        - allProcesses
      actions:
        - log
```

## Todos
- improve package documentation (reflect new schema and new selector conditions and response actions)
- CI e2e testing with kind (once public artifact is available).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates to https://github.com/elastic/kibana/pull/153126

## Screenshots
https://user-images.githubusercontent.com/16198204/224398453-e41d8bf7-e952-46f4-9cd9-340c4928ad7e.png
