### PR TITLE
Update metrictype for fields of performance data stream.

### DIFF
--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Update metrictype for fields of performance data stream.
+      type: enhancement
+      link: tbd
 - version: "1.13.0"
   changes:
     - description: Update documentation for password.

--- a/packages/microsoft_sqlserver/data_stream/performance/fields/fields.yml
+++ b/packages/microsoft_sqlserver/data_stream/performance/fields/fields.yml
@@ -21,12 +21,15 @@
           description: Number of lock requests per second that required the caller to wait.
         - name: user_connections
           type: long
+          metric_type: gauge
           description: Total number of user connections.
         - name: active_temp_tables
           type: long
+          metric_type: gauge
           description: Number of temporary tables/table variables in use.
         - name: transactions
           type: long
+          metric_type: gauge
           description: Total number of transactions
         - name: connection_reset_per_sec
           type: float
@@ -54,9 +57,11 @@
           description: Number of Transact-SQL command batches received per second. This statistic is affected by all constraints (such as I/O, number of users, cache size, complexity of requests, and so on). High batch requests mean good throughput.
         - name: buffer_cache_hit_ratio
           type: double
+          metric_type: gauge
           description: The ratio is the total number of cache hits divided by the total number of cache lookups over the last few thousand page accesses. After a long period of time, the ratio moves very little. Because reading from the cache is much less expensive than reading from disk, you want this ratio to be high.
         - name: buffer_page_life_expectancy
           type: long
+          metric_type: gauge
           description: Indicates the number of seconds a page will stay in the buffer pool without references (in seconds).
         - name: buffer_checkpoint_pages_per_sec
           type: float
@@ -64,9 +69,11 @@
           description: Indicates the number of pages flushed to disk per second by a checkpoint or other operation that require all dirty pages to be flushed.
         - name: buffer_database_pages
           type: long
+          metric_type: gauge
           description: Indicates the number of pages in the buffer pool with database content.
         - name: buffer_target_pages
           type: long
+          metric_type: gauge
           description: Ideal number of pages in the buffer pool.
         - name: memory_grants_pending
           type: long

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -469,13 +469,13 @@ An example event for `performance` looks as following:
 | data_stream.namespace | A user defined namespace. Namespaces are useful to allow grouping of data. Many users already organize their indices this way, and the data stream naming scheme now provides this best practice as a default. Many users will populate this field with `default`. If no value is used, it falls back to `default`. Beyond the Elasticsearch index naming criteria noted above, `namespace` value has the additional restrictions:   \* Must not contain `-`   \* No longer than 100 characters | constant_keyword |  |
 | data_stream.type | An overarching type for the data stream. Currently allowed values are "logs" and "metrics". We expect to also add "traces" and "synthetics" in the near future. | constant_keyword |  |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
-| mssql.metrics.active_temp_tables | Number of temporary tables/table variables in use. | long |  |
+| mssql.metrics.active_temp_tables | Number of temporary tables/table variables in use. | long | gauge |
 | mssql.metrics.batch_requests_per_sec | Number of Transact-SQL command batches received per second. This statistic is affected by all constraints (such as I/O, number of users, cache size, complexity of requests, and so on). High batch requests mean good throughput. | float | gauge |
-| mssql.metrics.buffer_cache_hit_ratio | The ratio is the total number of cache hits divided by the total number of cache lookups over the last few thousand page accesses. After a long period of time, the ratio moves very little. Because reading from the cache is much less expensive than reading from disk, you want this ratio to be high. | double |  |
+| mssql.metrics.buffer_cache_hit_ratio | The ratio is the total number of cache hits divided by the total number of cache lookups over the last few thousand page accesses. After a long period of time, the ratio moves very little. Because reading from the cache is much less expensive than reading from disk, you want this ratio to be high. | double | gauge |
 | mssql.metrics.buffer_checkpoint_pages_per_sec | Indicates the number of pages flushed to disk per second by a checkpoint or other operation that require all dirty pages to be flushed. | float | gauge |
-| mssql.metrics.buffer_database_pages | Indicates the number of pages in the buffer pool with database content. | long |  |
-| mssql.metrics.buffer_page_life_expectancy | Indicates the number of seconds a page will stay in the buffer pool without references (in seconds). | long |  |
-| mssql.metrics.buffer_target_pages | Ideal number of pages in the buffer pool. | long |  |
+| mssql.metrics.buffer_database_pages | Indicates the number of pages in the buffer pool with database content. | long | gauge |
+| mssql.metrics.buffer_page_life_expectancy | Indicates the number of seconds a page will stay in the buffer pool without references (in seconds). | long | gauge |
+| mssql.metrics.buffer_target_pages | Ideal number of pages in the buffer pool. | long | gauge |
 | mssql.metrics.compilations_per_sec | Number of SQL compilations per second. Indicates the number of times the compile code path is entered. Includes compiles caused by statement-level recompilations in SQL Server. After SQL Server user activity is stable, this value reaches a steady state. | float | gauge |
 | mssql.metrics.connection_reset_per_sec | Total number of logins started per second from the connection pool. | float | gauge |
 | mssql.metrics.instance_name | Name of the mssql connected instance. | keyword |  |
@@ -486,8 +486,8 @@ An example event for `performance` looks as following:
 | mssql.metrics.page_splits_per_sec | Number of page splits per second that occur as the result of overflowing index pages. | float | gauge |
 | mssql.metrics.re_compilations_per_sec | Number of statement recompiles per second. Counts the number of times statement recompiles are triggered. Generally, you want the recompiles to be low. | float | gauge |
 | mssql.metrics.server_name | Name of the mssql server. | keyword |  |
-| mssql.metrics.transactions | Total number of transactions | long |  |
-| mssql.metrics.user_connections | Total number of user connections. | long |  |
+| mssql.metrics.transactions | Total number of transactions | long | gauge |
+| mssql.metrics.user_connections | Total number of user connections. | long | gauge |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "1.13.0"
+version: "1.15.0"
 license: basic
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration


### PR DESCRIPTION
- Enhancement


## What does this PR do?

This PR updates the metric_type meta data for fields of performance data stream of mssql

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Add the microsoft_sqlserver integration.
In integration's overview page,  metric type could be confirmed.
Enable performance data stream and you should see metrics successfully.

## Related issues
- Relates #5278 

