### PR TITLE
modsecurity: Fix modsec.audit.details flattened assignment

### DIFF
--- a/packages/modsecurity/changelog.yml
+++ b/packages/modsecurity/changelog.yml
@@ -1,4 +1,8 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Fix modsec.audit.details flattened assignment.
+      type: bugfix
 - version: "1.6.0"
   changes:
     - description: Handle sub-second resolution timestamps.

--- a/packages/modsecurity/changelog.yml
+++ b/packages/modsecurity/changelog.yml
@@ -3,6 +3,7 @@
   changes:
     - description: Fix modsec.audit.details flattened assignment.
       type: bugfix
+      link: https://github.com/elastic/integrations/pull/5538
 - version: "1.6.0"
   changes:
     - description: Handle sub-second resolution timestamps.

--- a/packages/modsecurity/data_stream/auditlog/elasticsearch/ingest_pipeline/apache-modsec.yml
+++ b/packages/modsecurity/data_stream/auditlog/elasticsearch/ingest_pipeline/apache-modsec.yml
@@ -149,6 +149,8 @@ processors:
       field: json.request.headers.Referer
       target_field: http.request.referrer
       ignore_missing: true
+  - dot_expander:
+      field: json.audit_data.messages
   - rename:
       field: json.audit_data.messages
       target_field: modsec.audit.details

--- a/packages/modsecurity/manifest.yml
+++ b/packages/modsecurity/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: modsecurity
 title: "ModSecurity Audit"
-version: "1.6.0"
+version: "1.6.1"
 license: basic
 description: Collect logs from ModSecurity with Elastic Agent
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
After the bug I've reported [here](https://github.com/elastic/integrations/issues/5404), my local stack was still failing.

After debugging I found out that the error is located in the `logs-modsecurity.auditlog-1.6.0-apache-modsec` ingest pipeline, more precisely in this processor:
```json
{
    "rename": {
        "field": "json.audit_data.messages",
        "target_field": "modsec.audit.details"
    }
}
```

This causes the previously reported error:
```
failed to parse field [modsec.audit.details] of type [flattened]
```

I believe this happens because `json.audit_data.messages` and `modsec.audit` are both array fields. After doing some local tests I found out a solution (not sure if the cleanest one). By using `dot_expander` processor before calling the `rename`, it works.
```json
{
    "dot_expander": {
        "field": "json.audit_data.messages"
    }
}
```

The weird thing is that the local tests included in the package work without this change, and even calling directly the pipeline works. However, when the Elastic Agent process the log file, it doesn't, so maybe the real root case is locate somewhere?

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

This PR passes the package tests (`elastic-package test`).

```
Run test suite for the package
Run system tests for the package
2023/03/14 19:05:54  INFO service container hasn't written anything logs.
2023/03/14 19:06:27  INFO service container hasn't written anything logs.
--- Test results for package: modsecurity - START ---
╭─────────────┬─────────────┬───────────┬────────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME  │ RESULT │  TIME ELAPSED │
├─────────────┼─────────────┼───────────┼────────────┼────────┼───────────────┤
│ modsecurity │ auditlog    │ system    │ logfile    │ PASS   │ 22.094282334s │
│ modsecurity │ auditlog    │ system    │ logfile-tz │ PASS   │ 15.983856208s │
╰─────────────┴─────────────┴───────────┴────────────┴────────┴───────────────╯
--- Test results for package: modsecurity - END   ---
Done
Run asset tests for the package
--- Test results for package: modsecurity - START ---
╭─────────────┬─────────────┬───────────┬───────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME                                                 │ RESULT │ TIME ELAPSED │
├─────────────┼─────────────┼───────────┼───────────────────────────────────────────────────────────┼────────┼──────────────┤
│ modsecurity │ auditlog    │ asset     │ index_template logs-modsecurity.auditlog is loaded        │ PASS   │          3µs │
│ modsecurity │ auditlog    │ asset     │ ingest_pipeline logs-modsecurity.auditlog-1.6.1 is loaded │ PASS   │        250ns │
╰─────────────┴─────────────┴───────────┴───────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: modsecurity - END   ---
Done
Run pipeline tests for the package
--- Test results for package: modsecurity - START ---
╭─────────────┬─────────────┬───────────┬───────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME             │ RESULT │ TIME ELAPSED │
├─────────────┼─────────────┼───────────┼───────────────────────┼────────┼──────────────┤
│ modsecurity │ auditlog    │ pipeline  │ test-apache-audit.log │ PASS   │  50.715041ms │
│ modsecurity │ auditlog    │ pipeline  │ test-audit.log        │ PASS   │  18.601125ms │
╰─────────────┴─────────────┴───────────┴───────────────────────┴────────┴──────────────╯
--- Test results for package: modsecurity - END   ---
Done
Run static tests for the package
--- Test results for package: modsecurity - START ---
╭─────────────┬─────────────┬───────────┬──────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME                │ RESULT │ TIME ELAPSED │
├─────────────┼─────────────┼───────────┼──────────────────────────┼────────┼──────────────┤
│ modsecurity │ auditlog    │ static    │ Verify sample_event.json │ PASS   │  38.306042ms │
╰─────────────┴─────────────┴───────────┴──────────────────────────┴────────┴──────────────╯
--- Test results for package: modsecurity - END   ---
Done
```

## How to test this PR locally

## Related issues

- https://github.com/elastic/integrations/issues/5404

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
