### PR TITLE
(backport) [Cloud Security] Fix upgrade failure to 8.7.* from 8.6.*

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.2.13-preview"
+- version: "1.2.13"
   changes:
     - description: "Fixed multiple for input streams"
       type: bugfix
@@ -7,6 +7,9 @@
     - description: "Fixed commit time formatting and 8.6 BC"
       type: bugfix
       link: "https://github.com/elastic/integrations/pull/5357"
+    - description: "Fixed all findings streams enabled by default"
+      type: bugfix
+      link: "https://github.com/elastic/integrations/pull/1234"
 - version: "1.2.11"
   changes:
     - description: "Fixed readme"

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -7,8 +7,8 @@ fetchers:
   - name: aws-rds
 config:
   v1:
-    posture: {{posture}}
-    deployment: {{deployment}}
+    posture: cspm
+    deployment: aws
     benchmark: cis_aws
     aws:
       credentials:

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/azure.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/azure.yml.hbs
@@ -1,6 +1,6 @@
 fetchers:
 config:
   v1:
-    posture: {{posture}}
-    deployment: {{deployment}}
+    posture: cspm
+    deployment: azure
     benchmark: cis_azure

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/eks.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/eks.yml.hbs
@@ -1,7 +1,7 @@
 config:
   v1:
-    posture: {{posture}}
-    deployment: {{deployment}}
+    posture: kspm
+    deployment: eks
     benchmark: cis_eks
     aws:
       credentials:

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
@@ -1,6 +1,6 @@
 fetchers:
 config:
   v1:
-    posture: {{posture}}
-    deployment: {{deployment}}
+    posture: cspm
+    deployment: gcp
     benchmark: cis_gcp

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/vanilla.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/vanilla.yml.hbs
@@ -1,7 +1,7 @@
 config:
   v1:
-    posture: {{posture}}
-    deployment: {{deployment}}
+    posture: kspm
+    deployment: self_managed
     benchmark: cis_k8s
 
 fetchers:

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -11,10 +11,12 @@ streams:
     title: CIS Kubernetes Benchmark
     description: CIS Benchmark for Kubernetes
     template_path: vanilla.yml.hbs
+    enabled: false
   - input: cloudbeat/cis_eks
     title: Amazon EKS Benchmark
     description: CIS Benchmark for Amazon Elastic Kubernetes Service (EKS)
     template_path: eks.yml.hbs
+    enabled: false
     vars:
       - name: access_key_id
         type: text
@@ -63,6 +65,7 @@ streams:
     title: CIS AWS Benchmark
     description: CIS Benchmark for Amazon Web Services Foundations
     template_path: aws.yml.hbs
+    enabled: false
     vars:
       - name: access_key_id
         type: text
@@ -111,7 +114,9 @@ streams:
     title: CIS GCP Benchmark
     description: CIS Benchmark for Google Cloud Platform Foundation
     template_path: gcp.yml.hbs
+    enabled: false
   - input: cloudbeat/cis_azure
     title: CIS Azure Benchmark
     description: CIS Benchmark for Microsoft Azure Foundations
     template_path: azure.yml.hbs
+    enabled: false

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -60,6 +60,7 @@ policy_templates:
   - name: kspm
     title: Kubernetes Security Posture Management (KSPM)
     description: Identify & remediate configuration risks in Kubernetes
+    multiple: false
     categories:
       - containers
       - kubernetes
@@ -87,6 +88,7 @@ policy_templates:
   - name: cspm
     title: Cloud Security Posture Management (CSPM)
     description: Identify & remediate configuration risks in the Cloud services you leverage
+    multiple: false
     categories:
       - security
       - cloud

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.2.13-preview"
+version: "1.2.13"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
The following PR fixes the upgrade issue we experience when upgrading from 8.6 to 8.7
It appears `CSPM` inputs are being added to the agent policy, making it invalid.
turning these input streams to be disabled by default fixes the issue

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Install `1.1.3` version of the integration
- Wait for the auto-upgrade to kick in
- Explore the agent policy and check if any inputs of `cspm` appear, if so, the issue haven't been fixed.

<details>
<summary>Before</summary>

```yaml
id: d7280e80-c350-11ed-8d30-8d88b3254e9a
revision: 9
outputs:
  default:
    type: elasticsearch
    hosts:
      - 'http://localhost:9200'
output_permissions:
  default:
    _elastic_agent_monitoring:
      indices:
        - names:
            - logs-elastic_agent.apm_server-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.apm_server-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.auditbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.auditbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.cloud_defend-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.cloudbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.cloudbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.elastic_agent-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.endpoint_security-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.endpoint_security-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.filebeat_input-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.filebeat_input-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.filebeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.filebeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.fleet_server-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.fleet_server-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.heartbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.heartbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.metricbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.metricbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.osquerybeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.osquerybeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-elastic_agent.packetbeat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.packetbeat-default
          privileges:
            - auto_configure
            - create_doc
    _elastic_agent_checks:
      cluster:
        - monitor
    2e886460-1c53-4a18-a8da-9cec8d628722:
      indices:
        - names:
            - logs-system.auth-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-system.syslog-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-system.application-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-system.security-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-system.system-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.cpu-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.diskio-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.filesystem-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.fsstat-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.load-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.memory-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.network-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.process-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.process.summary-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.socket_summary-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - metrics-system.uptime-default
          privileges:
            - auto_configure
            - create_doc
    69103c28-aa74-4296-a571-f59475e5ce2e:
      indices:
        - names:
            - logs-cloud_security_posture.findings-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-cloud_security_posture.findings-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-cloud_security_posture.findings-default
          privileges:
            - auto_configure
            - create_doc
        - names:
            - logs-cloud_security_posture.findings-default
          privileges:
            - auto_configure
            - create_doc
agent:
  download:
    sourceURI: 'https://artifacts.elastic.co/downloads/'
  monitoring:
    enabled: true
    use_output: default
    namespace: default
    logs: true
    metrics: true
  features: {}
  protection:
    enabled: true
    uninstall_token_hash: ''
    signing_key: >-
      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbQyb1Vn02tbKe35NWOqttyqmwwFNvJV/GOiGwzjF2Lf88/xV6/DEa7teHN8paGRcYTEkGzaRq5EzvaAcOC/Mww==
inputs:
  - id: logfile-system-2e886460-1c53-4a18-a8da-9cec8d628722
    name: system-1
    revision: 1
    type: logfile
    use_output: default
    meta:
      package:
        name: system
        version: 1.25.0
    data_stream:
      namespace: default
    package_policy_id: 2e886460-1c53-4a18-a8da-9cec8d628722
    streams:
      - id: logfile-system.auth-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.auth
          type: logs
        ignore_older: 72h
        paths:
          - /var/log/auth.log*
          - /var/log/secure*
        exclude_files:
          - .gz$
        multiline:
          pattern: ^\s
          match: after
        tags:
          - system-auth
        processors:
          - add_locale: null
      - id: logfile-system.syslog-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.syslog
          type: logs
        paths:
          - /var/log/messages*
          - /var/log/syslog*
        exclude_files:
          - .gz$
        multiline:
          pattern: ^\s
          match: after
        processors:
          - add_locale: null
        ignore_older: 72h
  - id: winlog-system-2e886460-1c53-4a18-a8da-9cec8d628722
    name: system-1
    revision: 1
    type: winlog
    use_output: default
    meta:
      package:
        name: system
        version: 1.25.0
    data_stream:
      namespace: default
    package_policy_id: 2e886460-1c53-4a18-a8da-9cec8d628722
    streams:
      - id: winlog-system.application-2e886460-1c53-4a18-a8da-9cec8d628722
        name: Application
        data_stream:
          dataset: system.application
          type: logs
        condition: '${host.platform} == ''windows'''
        ignore_older: 72h
      - id: winlog-system.security-2e886460-1c53-4a18-a8da-9cec8d628722
        name: Security
        data_stream:
          dataset: system.security
          type: logs
        condition: '${host.platform} == ''windows'''
        ignore_older: 72h
      - id: winlog-system.system-2e886460-1c53-4a18-a8da-9cec8d628722
        name: System
        data_stream:
          dataset: system.system
          type: logs
        condition: '${host.platform} == ''windows'''
        ignore_older: 72h
  - id: system/metrics-system-2e886460-1c53-4a18-a8da-9cec8d628722
    name: system-1
    revision: 1
    type: system/metrics
    use_output: default
    meta:
      package:
        name: system
        version: 1.25.0
    data_stream:
      namespace: default
    package_policy_id: 2e886460-1c53-4a18-a8da-9cec8d628722
    streams:
      - id: system/metrics-system.cpu-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.cpu
          type: metrics
        metricsets:
          - cpu
        cpu.metrics:
          - percentages
          - normalized_percentages
        period: 10s
      - id: system/metrics-system.diskio-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.diskio
          type: metrics
        metricsets:
          - diskio
        diskio.include_devices: null
        period: 10s
      - id: system/metrics-system.filesystem-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.filesystem
          type: metrics
        metricsets:
          - filesystem
        period: 1m
        processors:
          - drop_event.when.regexp:
              system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
      - id: system/metrics-system.fsstat-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.fsstat
          type: metrics
        metricsets:
          - fsstat
        period: 1m
        processors:
          - drop_event.when.regexp:
              system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
      - id: system/metrics-system.load-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.load
          type: metrics
        metricsets:
          - load
        condition: '${host.platform} != ''windows'''
        period: 10s
      - id: system/metrics-system.memory-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.memory
          type: metrics
        metricsets:
          - memory
        period: 10s
      - id: system/metrics-system.network-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.network
          type: metrics
        metricsets:
          - network
        period: 10s
        network.interfaces: null
      - id: system/metrics-system.process-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.process
          type: metrics
        metricsets:
          - process
        period: 10s
        process.include_top_n.by_cpu: 5
        process.include_top_n.by_memory: 5
        process.cmdline.cache.enabled: true
        process.cgroups.enabled: false
        process.include_cpu_ticks: false
        processes:
          - .*
      - id: >-
          system/metrics-system.process.summary-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.process.summary
          type: metrics
        metricsets:
          - process_summary
        period: 10s
      - id: >-
          system/metrics-system.socket_summary-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.socket_summary
          type: metrics
        metricsets:
          - socket_summary
        period: 10s
      - id: system/metrics-system.uptime-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.uptime
          type: metrics
        metricsets:
          - uptime
        period: 10s
  - id: cloudbeat/cis_k8s-kspm-69103c28-aa74-4296-a571-f59475e5ce2e
    name: cloud_security_posture-1
    revision: 2
    type: cloudbeat/cis_k8s
    use_output: default
    meta:
      package:
        name: cloud_security_posture
        version: 1.2.13
    data_stream:
      namespace: default
    package_policy_id: 69103c28-aa74-4296-a571-f59475e5ce2e
    streams:
      - id: >-
          cloudbeat/cis_k8s-cloud_security_posture.findings-69103c28-aa74-4296-a571-f59475e5ce2e
        data_stream:
          dataset: cloud_security_posture.findings
          type: logs
        processors:
          - add_cluster_id: null
        config:
          v1:
            posture: kspm
            benchmark: cis_k8s
            deployment: self_managed
        fetchers:
          - name: kube-api
          - name: process
            processes:
              kube-apiserver: null
              kubelet:
                config-file-arguments:
                  - config
              kube-scheduler: null
              etcd: null
              kube-controller: null
            directory: /hostfs
          - name: file-system
            patterns:
              - /hostfs/etc/kubernetes/scheduler.conf
              - /hostfs/etc/kubernetes/controller-manager.conf
              - /hostfs/etc/kubernetes/admin.conf
              - /hostfs/etc/kubernetes/kubelet.conf
              - /hostfs/etc/kubernetes/manifests/etcd.yaml
              - /hostfs/etc/kubernetes/manifests/kube-apiserver.yaml
              - /hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml
              - /hostfs/etc/kubernetes/manifests/kube-scheduler.yaml
              - /hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
              - /hostfs/etc/kubernetes/pki/*
              - /hostfs/var/lib/kubelet/config.yaml
              - /hostfs/var/lib/etcd
              - /hostfs/etc/kubernetes/pki
        runtime_cfg:
          activated_rules:
            cis_k8s:
              - cis_1_1_1
              - cis_1_1_2
              - cis_1_1_3
              - cis_1_1_4
              - cis_1_1_5
              - cis_1_1_6
              - cis_1_1_7
              - cis_1_1_8
              - cis_1_1_11
              - cis_1_1_12
              - cis_1_1_13
              - cis_1_1_14
              - cis_1_1_15
              - cis_1_1_16
              - cis_1_1_17
              - cis_1_1_18
              - cis_1_1_19
              - cis_1_1_20
              - cis_1_1_21
              - cis_1_2_2
              - cis_1_2_4
              - cis_1_2_5
              - cis_1_2_6
              - cis_1_2_7
              - cis_1_2_8
              - cis_1_2_9
              - cis_1_2_10
              - cis_1_2_11
              - cis_1_2_12
              - cis_1_2_13
              - cis_1_2_14
              - cis_1_2_15
              - cis_1_2_16
              - cis_1_2_17
              - cis_1_2_18
              - cis_1_2_19
              - cis_1_2_20
              - cis_1_2_21
              - cis_1_2_22
              - cis_1_2_23
              - cis_1_2_24
              - cis_1_2_25
              - cis_1_2_26
              - cis_1_2_27
              - cis_1_2_28
              - cis_1_2_29
              - cis_1_2_32
              - cis_1_3_2
              - cis_1_3_3
              - cis_1_3_4
              - cis_1_3_5
              - cis_1_3_6
              - cis_1_3_7
              - cis_1_4_1
              - cis_1_4_2
              - cis_2_1
              - cis_2_2
              - cis_2_3
              - cis_2_4
              - cis_2_5
              - cis_2_6
              - cis_4_1_1
              - cis_4_1_2
              - cis_4_1_5
              - cis_4_1_6
              - cis_4_1_9
              - cis_4_1_10
              - cis_4_2_1
              - cis_4_2_2
              - cis_4_2_3
              - cis_4_2_4
              - cis_4_2_5
              - cis_4_2_6
              - cis_4_2_7
              - cis_4_2_8
              - cis_4_2_9
              - cis_4_2_10
              - cis_4_2_11
              - cis_4_2_12
              - cis_4_2_13
              - cis_5_1_3
              - cis_5_1_5
              - cis_5_1_6
              - cis_5_2_2
              - cis_5_2_3
              - cis_5_2_4
              - cis_5_2_5
              - cis_5_2_6
              - cis_5_2_7
              - cis_5_2_8
              - cis_5_2_9
              - cis_5_2_10
  - id: cloudbeat/cis_aws-cspm-69103c28-aa74-4296-a571-f59475e5ce2e
    name: cloud_security_posture-1
    revision: 2
    type: cloudbeat/cis_aws
    use_output: default
    meta:
      package:
        name: cloud_security_posture
        version: 1.2.13
    data_stream:
      namespace: default
    package_policy_id: 69103c28-aa74-4296-a571-f59475e5ce2e
    streams:
      - id: >-
          cloudbeat/cis_aws-cloud_security_posture.findings-69103c28-aa74-4296-a571-f59475e5ce2e
        data_stream:
          dataset: cloud_security_posture.findings
          type: logs
        config:
          v1:
            posture: cspm
            aws:
              credentials:
                type: null
            benchmark: cis_aws
            deployment: aws
        fetchers:
          - name: aws-iam
          - name: aws-ec2-network
          - name: aws-s3
          - name: aws-trail
          - name: aws-monitoring
          - name: aws-rds
  - id: cloudbeat/cis_gcp-cspm-69103c28-aa74-4296-a571-f59475e5ce2e
    name: cloud_security_posture-1
    revision: 2
    type: cloudbeat/cis_gcp
    use_output: default
    meta:
      package:
        name: cloud_security_posture
        version: 1.2.13
    data_stream:
      namespace: default
    package_policy_id: 69103c28-aa74-4296-a571-f59475e5ce2e
    streams:
      - id: >-
          cloudbeat/cis_gcp-cloud_security_posture.findings-69103c28-aa74-4296-a571-f59475e5ce2e
        data_stream:
          dataset: cloud_security_posture.findings
          type: logs
        config:
          v1:
            posture: cspm
            benchmark: cis_gcp
            deployment: gcp
        fetchers: null
  - id: cloudbeat/cis_azure-cspm-69103c28-aa74-4296-a571-f59475e5ce2e
    name: cloud_security_posture-1
    revision: 2
    type: cloudbeat/cis_azure
    use_output: default
    meta:
      package:
        name: cloud_security_posture
        version: 1.2.13
    data_stream:
      namespace: default
    package_policy_id: 69103c28-aa74-4296-a571-f59475e5ce2e
    streams:
      - id: >-
          cloudbeat/cis_azure-cloud_security_posture.findings-69103c28-aa74-4296-a571-f59475e5ce2e
        data_stream:
          dataset: cloud_security_posture.findings
          type: logs
        config:
          v1:
            posture: cspm
            benchmark: cis_azure
            deployment: azure
        fetchers: null
signed:
  data: >-
    eyJpZCI6ImQ3MjgwZTgwLWMzNTAtMTFlZC04ZDMwLThkODhiMzI1NGU5YSIsImFnZW50Ijp7InByb3RlY3Rpb24iOnsiZW5hYmxlZCI6dHJ1ZSwidW5pbnN0YWxsX3Rva2VuX2hhc2giOiIiLCJzaWduaW5nX2tleSI6Ik1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRWJReWIxVm4wMnRiS2UzNU5XT3F0dHlxbXd3Rk52SlYvR09pR3d6akYyTGY4OC94VjYvREVhN3RlSE44cGFHUmNZVEVrR3phUnE1RXp2YUFjT0MvTXd3PT0ifX19
  signature: >-
    MEUCIQDXcDpylgKC6YLGld9dJ+S01t97k19S8BUfC3aykIOJiAIgLghi2VWrUabKO0mnvGtrloV1jSsBP4pq3Vayce/arCU=
```

</details>

<details>
<summary>After</summary>

```yaml
id: d7280e80-c350-11ed-8d30-8d88b3254e9a
revision: 3
outputs:
  default:
    type: elasticsearch
    hosts:
      - 'http://localhost:9200'
output_permissions:
  default:
    _elastic_agent_monitoring:
      indices:
        - names:
            - logs-elastic_agent.apm_server-default
          privileges: &ref_0
            - auto_configure
            - create_doc
        - names:
            - metrics-elastic_agent.apm_server-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.auditbeat-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.auditbeat-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.cloud_defend-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.cloudbeat-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.cloudbeat-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.elastic_agent-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.endpoint_security-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.endpoint_security-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.filebeat_input-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.filebeat_input-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.filebeat-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.filebeat-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.fleet_server-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.fleet_server-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.heartbeat-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.heartbeat-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.metricbeat-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.metricbeat-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.osquerybeat-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.osquerybeat-default
          privileges: *ref_0
        - names:
            - logs-elastic_agent.packetbeat-default
          privileges: *ref_0
        - names:
            - metrics-elastic_agent.packetbeat-default
          privileges: *ref_0
    _elastic_agent_checks:
      cluster:
        - monitor
    2e886460-1c53-4a18-a8da-9cec8d628722:
      indices:
        - names:
            - logs-system.auth-default
          privileges: *ref_0
        - names:
            - logs-system.syslog-default
          privileges: *ref_0
        - names:
            - logs-system.application-default
          privileges: *ref_0
        - names:
            - logs-system.security-default
          privileges: *ref_0
        - names:
            - logs-system.system-default
          privileges: *ref_0
        - names:
            - metrics-system.cpu-default
          privileges: *ref_0
        - names:
            - metrics-system.diskio-default
          privileges: *ref_0
        - names:
            - metrics-system.filesystem-default
          privileges: *ref_0
        - names:
            - metrics-system.fsstat-default
          privileges: *ref_0
        - names:
            - metrics-system.load-default
          privileges: *ref_0
        - names:
            - metrics-system.memory-default
          privileges: *ref_0
        - names:
            - metrics-system.network-default
          privileges: *ref_0
        - names:
            - metrics-system.process-default
          privileges: *ref_0
        - names:
            - metrics-system.process.summary-default
          privileges: *ref_0
        - names:
            - metrics-system.socket_summary-default
          privileges: *ref_0
        - names:
            - metrics-system.uptime-default
          privileges: *ref_0
    5fdb5d17-60a3-47cb-9626-a06153e9bdd7:
      indices:
        - names:
            - logs-cloud_security_posture.findings-default
          privileges: *ref_0
agent:
  download:
    sourceURI: 'https://artifacts.elastic.co/downloads/'
  monitoring:
    enabled: true
    use_output: default
    namespace: default
    logs: true
    metrics: true
  features: {}
  protection:
    enabled: true
    uninstall_token_hash: ''
    signing_key: >-
      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbQyb1Vn02tbKe35NWOqttyqmwwFNvJV/GOiGwzjF2Lf88/xV6/DEa7teHN8paGRcYTEkGzaRq5EzvaAcOC/Mww==
inputs:
  - id: logfile-system-2e886460-1c53-4a18-a8da-9cec8d628722
    name: system-1
    revision: 1
    type: logfile
    use_output: default
    meta:
      package:
        name: system
        version: 1.25.0
    data_stream:
      namespace: default
    package_policy_id: 2e886460-1c53-4a18-a8da-9cec8d628722
    streams:
      - id: logfile-system.auth-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.auth
          type: logs
        ignore_older: 72h
        paths:
          - /var/log/auth.log*
          - /var/log/secure*
        exclude_files:
          - .gz$
        multiline:
          pattern: ^\s
          match: after
        tags:
          - system-auth
        processors:
          - add_locale: null
      - id: logfile-system.syslog-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.syslog
          type: logs
        paths:
          - /var/log/messages*
          - /var/log/syslog*
        exclude_files:
          - .gz$
        multiline:
          pattern: ^\s
          match: after
        processors:
          - add_locale: null
        ignore_older: 72h
  - id: winlog-system-2e886460-1c53-4a18-a8da-9cec8d628722
    name: system-1
    revision: 1
    type: winlog
    use_output: default
    meta:
      package:
        name: system
        version: 1.25.0
    data_stream:
      namespace: default
    package_policy_id: 2e886460-1c53-4a18-a8da-9cec8d628722
    streams:
      - id: winlog-system.application-2e886460-1c53-4a18-a8da-9cec8d628722
        name: Application
        data_stream:
          dataset: system.application
          type: logs
        condition: '${host.platform} == ''windows'''
        ignore_older: 72h
      - id: winlog-system.security-2e886460-1c53-4a18-a8da-9cec8d628722
        name: Security
        data_stream:
          dataset: system.security
          type: logs
        condition: '${host.platform} == ''windows'''
        ignore_older: 72h
      - id: winlog-system.system-2e886460-1c53-4a18-a8da-9cec8d628722
        name: System
        data_stream:
          dataset: system.system
          type: logs
        condition: '${host.platform} == ''windows'''
        ignore_older: 72h
  - id: system/metrics-system-2e886460-1c53-4a18-a8da-9cec8d628722
    name: system-1
    revision: 1
    type: system/metrics
    use_output: default
    meta:
      package:
        name: system
        version: 1.25.0
    data_stream:
      namespace: default
    package_policy_id: 2e886460-1c53-4a18-a8da-9cec8d628722
    streams:
      - id: system/metrics-system.cpu-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.cpu
          type: metrics
        metricsets:
          - cpu
        cpu.metrics:
          - percentages
          - normalized_percentages
        period: 10s
      - id: system/metrics-system.diskio-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.diskio
          type: metrics
        metricsets:
          - diskio
        diskio.include_devices: null
        period: 10s
      - id: system/metrics-system.filesystem-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.filesystem
          type: metrics
        metricsets:
          - filesystem
        period: 1m
        processors:
          - drop_event.when.regexp:
              system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
      - id: system/metrics-system.fsstat-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.fsstat
          type: metrics
        metricsets:
          - fsstat
        period: 1m
        processors:
          - drop_event.when.regexp:
              system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
      - id: system/metrics-system.load-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.load
          type: metrics
        metricsets:
          - load
        condition: '${host.platform} != ''windows'''
        period: 10s
      - id: system/metrics-system.memory-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.memory
          type: metrics
        metricsets:
          - memory
        period: 10s
      - id: system/metrics-system.network-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.network
          type: metrics
        metricsets:
          - network
        period: 10s
        network.interfaces: null
      - id: system/metrics-system.process-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.process
          type: metrics
        metricsets:
          - process
        period: 10s
        process.include_top_n.by_cpu: 5
        process.include_top_n.by_memory: 5
        process.cmdline.cache.enabled: true
        process.cgroups.enabled: false
        process.include_cpu_ticks: false
        processes:
          - .*
      - id: >-
          system/metrics-system.process.summary-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.process.summary
          type: metrics
        metricsets:
          - process_summary
        period: 10s
      - id: >-
          system/metrics-system.socket_summary-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.socket_summary
          type: metrics
        metricsets:
          - socket_summary
        period: 10s
      - id: system/metrics-system.uptime-2e886460-1c53-4a18-a8da-9cec8d628722
        data_stream:
          dataset: system.uptime
          type: metrics
        metricsets:
          - uptime
        period: 10s
  - id: cloudbeat/cis_k8s-kspm-5fdb5d17-60a3-47cb-9626-a06153e9bdd7
    name: cloud_security_posture-1
    revision: 2
    type: cloudbeat/cis_k8s
    use_output: default
    meta:
      package:
        name: cloud_security_posture
        version: 1.2.13
    data_stream:
      namespace: default
    package_policy_id: 5fdb5d17-60a3-47cb-9626-a06153e9bdd7
    streams:
      - id: >-
          cloudbeat/cis_k8s-cloud_security_posture.findings-5fdb5d17-60a3-47cb-9626-a06153e9bdd7
        data_stream:
          dataset: cloud_security_posture.findings
          type: logs
        processors:
          - add_cluster_id: null
        config:
          v1:
            posture: kspm
            benchmark: cis_k8s
            deployment: self_managed
        fetchers:
          - name: kube-api
          - name: process
            processes:
              kube-apiserver: null
              kubelet:
                config-file-arguments:
                  - config
              kube-scheduler: null
              etcd: null
              kube-controller: null
            directory: /hostfs
          - name: file-system
            patterns:
              - /hostfs/etc/kubernetes/scheduler.conf
              - /hostfs/etc/kubernetes/controller-manager.conf
              - /hostfs/etc/kubernetes/admin.conf
              - /hostfs/etc/kubernetes/kubelet.conf
              - /hostfs/etc/kubernetes/manifests/etcd.yaml
              - /hostfs/etc/kubernetes/manifests/kube-apiserver.yaml
              - /hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml
              - /hostfs/etc/kubernetes/manifests/kube-scheduler.yaml
              - /hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
              - /hostfs/etc/kubernetes/pki/*
              - /hostfs/var/lib/kubelet/config.yaml
              - /hostfs/var/lib/etcd
              - /hostfs/etc/kubernetes/pki
        runtime_cfg:
          activated_rules:
            cis_k8s:
              - cis_1_1_1
              - cis_1_1_2
              - cis_1_1_3
              - cis_1_1_4
              - cis_1_1_5
              - cis_1_1_6
              - cis_1_1_7
              - cis_1_1_8
              - cis_1_1_11
              - cis_1_1_12
              - cis_1_1_13
              - cis_1_1_14
              - cis_1_1_15
              - cis_1_1_16
              - cis_1_1_17
              - cis_1_1_18
              - cis_1_1_19
              - cis_1_1_20
              - cis_1_1_21
              - cis_1_2_2
              - cis_1_2_4
              - cis_1_2_5
              - cis_1_2_6
              - cis_1_2_7
              - cis_1_2_8
              - cis_1_2_9
              - cis_1_2_10
              - cis_1_2_11
              - cis_1_2_12
              - cis_1_2_13
              - cis_1_2_14
              - cis_1_2_15
              - cis_1_2_16
              - cis_1_2_17
              - cis_1_2_18
              - cis_1_2_19
              - cis_1_2_20
              - cis_1_2_21
              - cis_1_2_22
              - cis_1_2_23
              - cis_1_2_24
              - cis_1_2_25
              - cis_1_2_26
              - cis_1_2_27
              - cis_1_2_28
              - cis_1_2_29
              - cis_1_2_32
              - cis_1_3_2
              - cis_1_3_3
              - cis_1_3_4
              - cis_1_3_5
              - cis_1_3_6
              - cis_1_3_7
              - cis_1_4_1
              - cis_1_4_2
              - cis_2_1
              - cis_2_2
              - cis_2_3
              - cis_2_4
              - cis_2_5
              - cis_2_6
              - cis_4_1_1
              - cis_4_1_2
              - cis_4_1_5
              - cis_4_1_6
              - cis_4_1_9
              - cis_4_1_10
              - cis_4_2_1
              - cis_4_2_2
              - cis_4_2_3
              - cis_4_2_4
              - cis_4_2_5
              - cis_4_2_6
              - cis_4_2_7
              - cis_4_2_8
              - cis_4_2_9
              - cis_4_2_10
              - cis_4_2_11
              - cis_4_2_12
              - cis_4_2_13
              - cis_5_1_3
              - cis_5_1_5
              - cis_5_1_6
              - cis_5_2_2
              - cis_5_2_3
              - cis_5_2_4
              - cis_5_2_5
              - cis_5_2_6
              - cis_5_2_7
              - cis_5_2_8
              - cis_5_2_9
              - cis_5_2_10
signed:
  data: >-
    eyJpZCI6ImQ3MjgwZTgwLWMzNTAtMTFlZC04ZDMwLThkODhiMzI1NGU5YSIsImFnZW50Ijp7InByb3RlY3Rpb24iOnsiZW5hYmxlZCI6dHJ1ZSwidW5pbnN0YWxsX3Rva2VuX2hhc2giOiIiLCJzaWduaW5nX2tleSI6Ik1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRWJReWIxVm4wMnRiS2UzNU5XT3F0dHlxbXd3Rk52SlYvR09pR3d6akYyTGY4OC94VjYvREVhN3RlSE44cGFHUmNZVEVrR3phUnE1RXp2YUFjT0MvTXd3PT0ifX19
  signature: >-
    MEUCIQCX8MHdYKlkYWFgICNMiZuWm70tIBV4bSEw9mWcArCwCgIgSZU1cebIHFenlAUAhxK1gOF2Al1KnabmlHODyr+RSgE=
```

</details>


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
