### PR TITLE
[Cloud Security Posture] Remove required from vars

### DIFF
--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -46,14 +46,14 @@ vars:
     type: text
     title: Posture type
     multi: false
-    required: true
+    required: false
     show_user: false
     description: Chosen posture type (cspm/kspm)
   - name: deployment
     type: text
     title: Deployment type
     multi: false
-    required: true
+    required: false
     show_user: false
     description: Chosen deployment type (aws/gcp/azure/eks/k8s)
 policy_templates:


### PR DESCRIPTION
This is a candidate fix for this [Kibana issue](https://github.com/elastic/security-team/issues/6001) .

In the video, we can see that these validations are causing the bug and that the bug occurrence is intermittent. 

https://user-images.githubusercontent.com/19270322/225405313-b3b8f1ee-036a-424f-9c3f-58425873c366.mov

In the console log, we have the useEffect that CSP integration calls in kibana (calling `setEnabledPolicyInput`), but we can also see that when the bug happens (in the end of the video) is when the package policy is being updated from outside of the CSP integration. 


As additional info on why this bug happens is in the nature of React's `useEffect` in combination with the Lazy Load and Suspense strategy used in Fleet's wrapper.

It's a known bug, as stated [here](https://17.reactjs.org/docs/concurrent-mode-suspense.html#race-conditions-with-useeffect), and this quote describes very well what's happening:

> Requests from the previous profiles may sometimes “come back” after we’ve already switched the profile to another ID — and in that case, they can overwrite the new state with a stale response for a different ID.
> 
> This problem is possible to fix (you could use the effect cleanup function to either ignore or cancel stale requests), but it’s unintuitive and difficult to debug.

So what is happening in our context, as we can see in the video, is when using Suspense, React can't always guarantee the useEffect order of execution. We are running an useEffect to custom update the validations in Cloud security posture integration, and it's being (occasionally) overridden by useEffect that runs in Fleet to apply the initial validation (The one coming from this manifest). Since `cloud_security_posture` integration handle its own validation instead of using Fleet's one, I believe we can remove the required of this manifest. (And avoid such workarounds like [this](https://github.com/elastic/kibana/pull/153214/files) one). 


