### PR TITLE
zscaler_zia: map web login user details to ECS

### DIFF
--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.3"
+  changes:
+    - description: Map web login user details to ECS.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5553
 - version: "2.7.2"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/zscaler_zia/data_stream/web/_dev/test/pipeline/test-web-http-endpoint.log-expected.json
+++ b/packages/zscaler_zia/data_stream/web/_dev/test/pipeline/test-web-http-endpoint.log-expected.json
@@ -44,7 +44,8 @@
                     "81.2.69.145"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -70,7 +71,9 @@
                 "scheme": "http"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {
@@ -162,7 +165,8 @@
                     "81.2.69.145"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -188,7 +192,9 @@
                 "scheme": "http"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {

--- a/packages/zscaler_zia/data_stream/web/_dev/test/pipeline/test-web.log-expected.json
+++ b/packages/zscaler_zia/data_stream/web/_dev/test/pipeline/test-web.log-expected.json
@@ -44,7 +44,8 @@
                     "81.2.69.145"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -70,7 +71,9 @@
                 "scheme": "http"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {
@@ -164,7 +167,8 @@
                     "89.160.20.156"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -190,7 +194,9 @@
                 "scheme": "https"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {
@@ -279,7 +285,8 @@
                     "89.160.20.112"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -305,7 +312,9 @@
                 "scheme": "http"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {
@@ -399,7 +408,8 @@
                     "81.2.69.144"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -425,7 +435,9 @@
                 "scheme": "http"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {
@@ -519,7 +531,8 @@
                     "81.2.69.143"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -546,7 +559,9 @@
                 "scheme": "https"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {
@@ -635,7 +650,8 @@
                     "89.160.20.112"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -662,7 +678,9 @@
                 "scheme": "https"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {
@@ -755,7 +773,8 @@
                     "81.2.69.143"
                 ],
                 "user": [
-                    "administrator1"
+                    "administrator1",
+                    "test"
                 ]
             },
             "rule": {
@@ -782,7 +801,9 @@
                 "scheme": "https"
             },
             "user": {
-                "email": "test@example.com"
+                "domain": "example.com",
+                "email": "test@example.com",
+                "name": "test"
             },
             "user_agent": {
                 "device": {

--- a/packages/zscaler_zia/data_stream/web/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/web/elasticsearch/ingest_pipeline/default.yml
@@ -233,6 +233,15 @@ processors:
       field: json.login
       target_field: user.email
       ignore_missing: true
+  - dissect:
+      if: ctx.user?.email != null && ctx.user.email.contains('@')
+      field: user.email
+      pattern: '%{user.name}@%{user.domain}'
+  - append:
+      if: ctx.user?.name != null && ctx.user.name != ""
+      field: related.user
+      value: '{{{user.name}}}'
+      allow_duplicates: false
   - rename:
       field: json.action
       target_field: event.action

--- a/packages/zscaler_zia/data_stream/web/sample_event.json
+++ b/packages/zscaler_zia/data_stream/web/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2021-12-17T07:04:57.000Z",
+    "@timestamp": "2021-12-31T08:08:08.000Z",
     "agent": {
-        "ephemeral_id": "84d9e52c-4c25-475c-b854-3b93ec7ef389",
-        "id": "fc4affb9-ab52-48ec-b9ce-f65f4390f0b9",
+        "ephemeral_id": "444ca1f4-28b9-45cb-8287-ba44516c521b",
+        "id": "08fc14c0-5a92-4649-93f3-68fb5d6c5fbc",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.6.1"
     },
     "data_stream": {
         "dataset": "zscaler_zia.web",
@@ -13,15 +13,15 @@
         "type": "logs"
     },
     "destination": {
-        "ip": "81.2.69.145"
+        "ip": "1.128.3.4"
     },
     "ecs": {
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "fc4affb9-ab52-48ec-b9ce-f65f4390f0b9",
+        "id": "08fc14c0-5a92-4649-93f3-68fb5d6c5fbc",
         "snapshot": false,
-        "version": "8.6.0"
+        "version": "8.6.1"
     },
     "event": {
         "action": "blocked",
@@ -30,7 +30,7 @@
             "web"
         ],
         "dataset": "zscaler_zia.web",
-        "ingested": "2023-02-24T09:45:48Z",
+        "ingested": "2023-03-15T21:02:55Z",
         "kind": "event",
         "risk_score": 0,
         "type": [
@@ -50,12 +50,7 @@
         }
     },
     "input": {
-        "type": "tcp"
-    },
-    "log": {
-        "source": {
-            "address": "172.29.0.7:37704"
-        }
+        "type": "http_endpoint"
     },
     "network": {
         "protocol": "http_proxy"
@@ -65,11 +60,11 @@
             "TestMachine35"
         ],
         "ip": [
-            "81.2.69.193",
-            "81.2.69.145"
+            "1.128.3.4"
         ],
         "user": [
-            "administrator1"
+            "administrator1",
+            "test"
         ]
     },
     "rule": {
@@ -78,7 +73,7 @@
     },
     "source": {
         "nat": {
-            "ip": "81.2.69.193"
+            "ip": "1.128.3.4"
         },
         "user": {
             "name": "administrator1"
@@ -96,7 +91,9 @@
         "scheme": "https"
     },
     "user": {
-        "email": "test@example.com"
+        "domain": "example.com",
+        "email": "test@example.com",
+        "name": "test"
     },
     "user_agent": {
         "device": {

--- a/packages/zscaler_zia/docs/README.md
+++ b/packages/zscaler_zia/docs/README.md
@@ -792,13 +792,13 @@ An example event for `web` looks as following:
 
 ```json
 {
-    "@timestamp": "2021-12-17T07:04:57.000Z",
+    "@timestamp": "2021-12-31T08:08:08.000Z",
     "agent": {
-        "ephemeral_id": "84d9e52c-4c25-475c-b854-3b93ec7ef389",
-        "id": "fc4affb9-ab52-48ec-b9ce-f65f4390f0b9",
+        "ephemeral_id": "444ca1f4-28b9-45cb-8287-ba44516c521b",
+        "id": "08fc14c0-5a92-4649-93f3-68fb5d6c5fbc",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.6.1"
     },
     "data_stream": {
         "dataset": "zscaler_zia.web",
@@ -806,15 +806,15 @@ An example event for `web` looks as following:
         "type": "logs"
     },
     "destination": {
-        "ip": "81.2.69.145"
+        "ip": "1.128.3.4"
     },
     "ecs": {
         "version": "8.6.0"
     },
     "elastic_agent": {
-        "id": "fc4affb9-ab52-48ec-b9ce-f65f4390f0b9",
+        "id": "08fc14c0-5a92-4649-93f3-68fb5d6c5fbc",
         "snapshot": false,
-        "version": "8.6.0"
+        "version": "8.6.1"
     },
     "event": {
         "action": "blocked",
@@ -823,7 +823,7 @@ An example event for `web` looks as following:
             "web"
         ],
         "dataset": "zscaler_zia.web",
-        "ingested": "2023-02-24T09:45:48Z",
+        "ingested": "2023-03-15T21:02:55Z",
         "kind": "event",
         "risk_score": 0,
         "type": [
@@ -843,12 +843,7 @@ An example event for `web` looks as following:
         }
     },
     "input": {
-        "type": "tcp"
-    },
-    "log": {
-        "source": {
-            "address": "172.29.0.7:37704"
-        }
+        "type": "http_endpoint"
     },
     "network": {
         "protocol": "http_proxy"
@@ -858,11 +853,11 @@ An example event for `web` looks as following:
             "TestMachine35"
         ],
         "ip": [
-            "81.2.69.193",
-            "81.2.69.145"
+            "1.128.3.4"
         ],
         "user": [
-            "administrator1"
+            "administrator1",
+            "test"
         ]
     },
     "rule": {
@@ -871,7 +866,7 @@ An example event for `web` looks as following:
     },
     "source": {
         "nat": {
-            "ip": "81.2.69.193"
+            "ip": "1.128.3.4"
         },
         "user": {
             "name": "administrator1"
@@ -889,7 +884,9 @@ An example event for `web` looks as following:
         "scheme": "https"
     },
     "user": {
-        "email": "test@example.com"
+        "domain": "example.com",
+        "email": "test@example.com",
+        "name": "test"
     },
     "user_agent": {
         "device": {

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: zscaler_zia
 title: Zscaler Internet Access
-version: "2.7.2"
+version: "2.7.3"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Maps web login user details to ECS (`user.{name,domain}` and `related.user`).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
