### PR TITLE
Update Elastic stack version integrations daily

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -38,12 +38,12 @@ pipeline {
             )
           }
         }
-        stage('with stack v8.6.0') {
+        stage('with stack v8.7') {
           steps {
             build(
               job: env.INTEGRATION_JOB,
               parameters: [
-                stringParam(name: 'stackVersion', value: '8.6.0-SNAPSHOT'),
+                stringParam(name: 'stackVersion', value: '8.7-SNAPSHOT'),
                 booleanParam(name: 'force_check_all', value: true),
               ],
               quietPeriod: 0,


### PR DESCRIPTION
## What does this PR do?
Update Elastic stack version in integrations daily job to use 8.7 SNAPSHOT version.
