### PR TITLE
[Bug][PfSense] Fix squid pipeline's GROK pattern

### DIFF
--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix squid GROK pattern
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/5580
 - version: "1.6.3"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.4"
+  changes:
+    - description: Fix squid GROK pattern
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.6.3"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-squid.log
+++ b/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-squid.log
@@ -1,1 +1,2 @@
 <166>Aug 21 22:08:13 myfirewall.my-domain.tld (squid-1)[6802]: [1598040493.253 325](tel:1598040493.253 325) 175.16.199.1 TCP_MISS/304 2912 GET https://github.com/3ilson/pfelk/file-list/master - HIER_DIRECT/81.2.69.145 -
+<166>Aug 21 22:08:13 myfirewall.my-domain.tld (squid-1)[6802]: [1598040493.253 325](tel:1598040493.253 325) 175.16.199.1 TCP_MISS/304 2912 CONNECT github.com:443 - HIER_DIRECT/81.2.69.145 -

--- a/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-squid.log-expected.json
+++ b/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-squid.log-expected.json
@@ -93,6 +93,97 @@
                 "path": "/3ilson/pfelk/file-list/master",
                 "scheme": "https"
             }
+        },
+        {
+            "destination": {
+                "address": "81.2.69.145",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.145"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "event": {
+                "category": [
+                    "web"
+                ],
+                "kind": "event",
+                "original": "\u003c166\u003eAug 21 22:08:13 myfirewall.my-domain.tld (squid-1)[6802]: [1598040493.253 325](tel:1598040493.253 325) 175.16.199.1 TCP_MISS/304 2912 CONNECT github.com:443 - HIER_DIRECT/81.2.69.145 -",
+                "outcome": "success",
+                "provider": "squid",
+                "timezone": "-04:00"
+            },
+            "http": {
+                "request": {
+                    "method": "CONNECT"
+                },
+                "response": {
+                    "bytes": 2912,
+                    "status_code": 304
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 166
+                }
+            },
+            "message": "[1598040493.253 325](tel:1598040493.253 325) 175.16.199.1 TCP_MISS/304 2912 CONNECT github.com:443 - HIER_DIRECT/81.2.69.145 -",
+            "network": {
+                "type": "ipv4"
+            },
+            "observer": {
+                "name": "myfirewall.my-domain.tld",
+                "type": "firewall",
+                "vendor": "netgate"
+            },
+            "process": {
+                "name": "squid-1",
+                "pid": 6802
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.145",
+                    "175.16.199.1"
+                ]
+            },
+            "source": {
+                "address": "175.16.199.1",
+                "geo": {
+                    "city_name": "Changchun",
+                    "continent_name": "Asia",
+                    "country_iso_code": "CN",
+                    "country_name": "China",
+                    "location": {
+                        "lat": 43.88,
+                        "lon": 125.3228
+                    },
+                    "region_iso_code": "CN-22",
+                    "region_name": "Jilin Sheng"
+                },
+                "ip": "175.16.199.1"
+            },
+            "squid": {
+                "hierarchy_status": "HIER_DIRECT",
+                "request_status": "TCP_MISS"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "github.com",
+                "port": 443
+            }
         }
     ]
 }

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/squid.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/squid.yml
@@ -4,12 +4,16 @@ processors:
   - grok:
       field: message
       patterns:
-      - '%{IPORHOST:source.address} %{NOTSPACE:squid.request_status}/%{NUMBER:http.response.status_code:long} %{NUMBER:http.response.bytes:long} %{NOTSPACE:http.request.method} (%{URI:url.original})?%{SPACE}%{NOTSPACE:http.request.referrer}%{SPACE}%{NOTSPACE:squid.hierarchy_status}/%{IPORHOST:destination.address}%{SPACE}%{NOTSPACE:http.response.mime_type}'
+      - '%{IPORHOST:source.address} %{NOTSPACE:squid.request_status}/%{NUMBER:http.response.status_code:long} %{NUMBER:http.response.bytes:long} %{NOTSPACE:http.request.method} (?:%{URI:url.original}|(%{IPORHOST:url.domain}(?::%{DATA:url.port})?))?%{SPACE}%{NOTSPACE:http.request.referrer}%{SPACE}%{NOTSPACE:squid.hierarchy_status}/(?:%{IPORHOST:destination.address}|-)%{SPACE}%{NOTSPACE:http.response.mime_type}'
       ignore_missing: false
   - uri_parts:
       field: url.original
       ignore_failure: true
       if: ctx.url?.original != null
+  - convert:
+      field: url.port
+      type: long
+      ignore_missing: true
   - append:
       field: event.category
       value: web

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,6 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.6.3"
+version: "1.6.4"
 release: ga
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Handle CONNECT method and lines without destination ip.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

`elastic-package stack down && elastic-package build && elastic-package stack up -d -v && eval "$(elastic-package stack shellinit)" && elastic-package test`

## Related issues

- Fixes #4971
