### PR TITLE
Fix build of service images for stan an nats

### DIFF
--- a/packages/nats/_dev/deploy/docker/Dockerfile
+++ b/packages/nats/_dev/deploy/docker/Dockerfile
@@ -2,16 +2,15 @@ ARG NATS_VERSION=2.0.4
 FROM nats:$NATS_VERSION
 
 # build stage
-FROM golang:1.13-alpine3.11 AS build-env
+FROM golang:1.20.2-alpine3.17 AS build-env
 RUN apk --no-cache add build-base git mercurial gcc
-RUN cd src && go get -d github.com/nats-io/nats.go/
-RUN cd src/github.com/nats-io/nats.go/examples/nats-bench && git checkout tags/v1.10.0 && go build .
+RUN go install github.com/nats-io/nats.go/examples/nats-bench@v1.10.0
 
 # create an enhanced container with nc command available since nats is based
 # on scratch image making healthcheck impossible
-FROM alpine:latest
+FROM alpine:3.17
 COPY --from=0 / /opt/nats
-COPY --from=build-env /go/src/github.com/nats-io/nats.go/examples/nats-bench/nats-bench /nats-bench
+COPY --from=build-env /go/bin/nats-bench /nats-bench
 COPY run.sh /run.sh
 # Expose client, management, and cluster ports
 EXPOSE 4222 8222 6222

--- a/packages/stan/_dev/deploy/docker/Dockerfile
+++ b/packages/stan/_dev/deploy/docker/Dockerfile
@@ -2,17 +2,16 @@ ARG STAN_VERSION=0.15.1
 FROM nats-streaming:$STAN_VERSION
 
 # build stage
-FROM golang:1.13-alpine3.11 AS build-env
+FROM golang:1.20.2-alpine3.17 AS build-env
 RUN apk --no-cache add build-base git mercurial gcc
-RUN cd src && go get -d github.com/nats-io/stan.go/
-RUN cd src/github.com/nats-io/stan.go/examples/stan-bench && git checkout tags/v0.5.2 && go build .
+RUN go install github.com/nats-io/stan.go/examples/stan-bench@v0.5.2
 
 # create an enhanced container with nc command available since nats is based
 # on scratch image making healthcheck impossible
-FROM alpine:latest
+FROM alpine:3.17
 RUN apk add --no-cache --upgrade bash
 COPY --from=0 nats-streaming-server /nats-streaming-server
-COPY --from=build-env /go/src/github.com/nats-io/stan.go/examples/stan-bench/stan-bench /stan-bench
+COPY --from=build-env /go/bin/stan-bench /stan-bench
 # Expose client, management, and cluster ports
 EXPOSE 4222 8222
 ADD healthcheck.sh /healthcheck.sh


### PR DESCRIPTION
## What does this PR do?

Fix build of service images for stan and nats, by pinning the versions used for the build.

Before this change, they fail with errors like the following one:
```
------                                                                                                  
 > [elastic-package-service-nats build-env 3/4] RUN cd src && go get -d github.com/nats-io/nats.go/:    
#0 3.980 package crypto/ecdh: unrecognized import path "crypto/ecdh" (import path does not begin with hostname)
------
failed to solve: executor failed running [/bin/sh -c cd src && go get -d github.com/nats-io/nats.go/]: exit code: 1
Error: up command failed: can't set up the service deployer: could not boot up service using Docker Compose: running Docker Compose up command failed: exit status 17
exit status 1
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

From the stan or nats directories, run:
```
go run github.com/elastic/elastic-package stack up -v -d
go run github.com/elastic/elastic-package service up -v
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes https://github.com/elastic/beats/issues/34844

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
