### PR TITLE
[Crowdstrike] | Add support for concurrent messages in SQS mode

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Support `max_number_of_messages` in SQS mode
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5595
 - version: "1.10.2"
   changes:
     - description: Remove redundant GeoIP look-ups.

--- a/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
+++ b/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
@@ -11,6 +11,9 @@ visibility_timeout: {{visibility_timeout}}
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+{{#if max_number_of_messages}}
+max_number_of_messages: {{max_number_of_messages}}
+{{/if}}
 {{#if endpoint}}
 endpoint: {{endpoint}}
 {{/if}}

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -153,6 +153,13 @@ streams:
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
+      - name: max_number_of_messages
+        type: integer
+        title: Maximum Concurrent SQS Messages
+        description: The maximum number of SQS messages that can be in flight at any time.
+        default: 5
+        required: false
+        show_user: false
   - input: logfile
     title: Falcon Data Replicator logs
     description: Collect Falcon Data Replicator logs using a log file

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.10.2"
+version: "1.11.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Adds support for `max_number_of_messages` parameter configuration in SQS mode when using AWS S3 input.

 
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/5595

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
