### PR TITLE
[Elastic Agent] Update dashboard filters and adding agent.* fields

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,7 +68,7 @@
 /packages/darktrace @elastic/security-external-integrations
 /packages/dga @elastic/ml-ui @elastic/sec-applied-ml
 /packages/docker @elastic/obs-cloudnative-monitoring
-/packages/elastic_agent @elastic/elastic-agent-control-plane
+/packages/elastic_agent @elastic/elastic-agent
 /packages/elastic_package_registry @elastic/ecosystem
 /packages/elasticsearch @elastic/infra-monitoring-ui
 /packages/enterprisesearch @elastic/infra-monitoring-ui

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Added agent.* field mappings and updated filters on certain dashboards
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5186
 - version: "1.6.0"
   changes:
     - description: Adding new Agent Health dashboards, and remaking Agent Metrics.

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added agent.* field mappings and updated filters on certain dashboards
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5186
+      link: https://github.com/elastic/integrations/pull/5618
 - version: "1.6.0"
   changes:
     - description: Adding new Agent Health dashboards, and remaking Agent Metrics.

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/ecs.yml
@@ -1,5 +1,17 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
 - external: ecs
   name: log.level
 - external: ecs

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/ecs.yml
@@ -1,5 +1,17 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
 - external: ecs
   name: log.level
 - external: ecs

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/filebeat_input_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_logs/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/ecs.yml
@@ -1,14 +1,16 @@
 - external: ecs
   name: ecs.version
-- name: log
-  title: Log
-  group: 2
-  description: "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields."
-  type: group
-  fields:
-    - name: level
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`."
-      example: error
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/ecs.yml
@@ -1,2 +1,16 @@
 - external: ecs
   name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -800,7 +800,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-03-21T15:18:05.779Z",
+    "created_at": "2023-03-23T12:54:12.591Z",
     "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
     "migrationVersion": {
         "dashboard": "8.6.0"

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -70,6 +70,11 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-299e2c43-13cd-477a-ba36-4c0f84bd32a4",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "ffe5b460-523c-4b2c-9403-4f6b7917c660",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
@@ -127,7 +132,46 @@
                                     }
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "ffe5b460-523c-4b2c-9403-4f6b7917c660",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": [
+                                            "elastic_agent*",
+                                            "apm.*"
+                                        ],
+                                        "type": "phrases",
+                                        "value": [
+                                            "elastic_agent*",
+                                            "apm.*"
+                                        ]
+                                    },
+                                    "query": {
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent*"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "apm.*"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -208,6 +252,11 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-d2a77691-eb30-480e-b021-e323a1f67f07",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
@@ -270,7 +319,29 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "apm.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "apm.*"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -322,6 +393,11 @@
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-501c5bb4-5af0-46bf-99c1-e08ed2c31111",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "1f7f4c46-4a2f-4cf8-8509-dc41aab93385",
                                 "type": "index-pattern"
                             }
                         ],
@@ -447,7 +523,29 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "1f7f4c46-4a2f-4cf8-8509-dc41aab93385",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -528,6 +626,11 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-2b14e40b-0f07-4713-b7fb-96b4df2c93aa",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "5aae4230-61df-4557-972b-cf52a1c78870",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
@@ -587,7 +690,29 @@
                                     }
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "5aae4230-61df-4557-972b-cf52a1c78870",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -675,7 +800,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-02-27T07:40:15.902Z",
+    "created_at": "2023-03-21T15:18:05.779Z",
     "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
     "migrationVersion": {
         "dashboard": "8.6.0"
@@ -688,7 +813,17 @@
         },
         {
             "id": "logs-*",
+            "name": "1fa17cb8-3a19-4fc7-9631-0f44ce8692b4:ffe5b460-523c-4b2c-9403-4f6b7917c660",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
             "name": "36dd783f-4b32-41db-8d33-e2fb7b4d9365:indexpattern-datasource-layer-d2a77691-eb30-480e-b021-e323a1f67f07",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "36dd783f-4b32-41db-8d33-e2fb7b4d9365:79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
             "type": "index-pattern"
         },
         {
@@ -698,7 +833,17 @@
         },
         {
             "id": "logs-*",
+            "name": "5848c519-791c-45e2-b350-0740a12c3ace:1f7f4c46-4a2f-4cf8-8509-dc41aab93385",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
             "name": "ea70f89b-accb-4972-9119-b04d1afae410:indexpattern-datasource-layer-2b14e40b-0f07-4713-b7fb-96b4df2c93aa",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "ea70f89b-accb-4972-9119-b04d1afae410:5aae4230-61df-4557-972b-cf52a1c78870",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
@@ -70,6 +70,11 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-d125ad67-b062-4e41-ae8b-1db28534246f",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "ec330081-de01-4c31-808f-3bfa4c01193b",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
@@ -141,7 +146,46 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "ec330081-de01-4c31-808f-3bfa4c01193b",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": [
+                                            "elastic_agent.*",
+                                            "elastic_agent"
+                                        ],
+                                        "type": "phrases",
+                                        "value": [
+                                            "elastic_agent.*",
+                                            "elastic_agent"
+                                        ]
+                                    },
+                                    "query": {
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent.*"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -186,13 +230,13 @@
                                             "type": "palette"
                                         },
                                         "summaryLabel": "Total Errors",
-                                        "summaryRow": "count",
-                                        "width": 116
+                                        "summaryRow": "none",
+                                        "width": 170
                                     },
                                     {
                                         "columnId": "7fded190-da7d-4eb2-8a9b-0c21e50f699e",
                                         "isTransposed": false,
-                                        "width": 193
+                                        "width": 429
                                     }
                                 ],
                                 "headerRowHeight": "single",
@@ -237,6 +281,11 @@
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-3eae8cc8-c7dd-4928-a680-2d184923881f",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "970463b2-ccd3-4298-8f57-17b6e8dbaef0",
                                 "type": "index-pattern"
                             }
                         ],
@@ -311,7 +360,29 @@
                                     }
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "970463b2-ccd3-4298-8f57-17b6e8dbaef0",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -402,7 +473,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-02-27T07:25:10.323Z",
+    "created_at": "2023-03-21T15:16:40.425Z",
     "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
     "migrationVersion": {
         "dashboard": "8.6.0"
@@ -415,7 +486,17 @@
         },
         {
             "id": "logs-*",
+            "name": "54f07979-6f4b-4535-b97b-0552bbeb9b39:ec330081-de01-4c31-808f-3bfa4c01193b",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
             "name": "e2b6fbdd-506f-4b42-bd11-01a33205f6da:indexpattern-datasource-layer-3eae8cc8-c7dd-4928-a680-2d184923881f",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e2b6fbdd-506f-4b42-bd11-01a33205f6da:970463b2-ccd3-4298-8f57-17b6e8dbaef0",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
@@ -73,7 +73,7 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "ec330081-de01-4c31-808f-3bfa4c01193b",
+                                "name": "1b96343b-d644-4080-a349-927445c21e45",
                                 "type": "index-pattern"
                             }
                         ],
@@ -154,34 +154,17 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "ec330081-de01-4c31-808f-3bfa4c01193b",
+                                        "index": "1b96343b-d644-4080-a349-927445c21e45",
                                         "key": "data_stream.dataset",
                                         "negate": true,
-                                        "params": [
-                                            "elastic_agent.*",
-                                            "elastic_agent"
-                                        ],
-                                        "type": "phrases",
-                                        "value": [
-                                            "elastic_agent.*",
-                                            "elastic_agent"
-                                        ]
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
                                     },
                                     "query": {
-                                        "bool": {
-                                            "minimum_should_match": 1,
-                                            "should": [
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "elastic_agent.*"
-                                                    }
-                                                },
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "elastic_agent"
-                                                    }
-                                                }
-                                            ]
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
                                         }
                                     }
                                 }
@@ -473,7 +456,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-03-21T15:16:40.425Z",
+    "created_at": "2023-03-21T15:44:11.751Z",
     "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
     "migrationVersion": {
         "dashboard": "8.6.0"
@@ -486,7 +469,7 @@
         },
         {
             "id": "logs-*",
-            "name": "54f07979-6f4b-4535-b97b-0552bbeb9b39:ec330081-de01-4c31-808f-3bfa4c01193b",
+            "name": "54f07979-6f4b-4535-b97b-0552bbeb9b39:1b96343b-d644-4080-a349-927445c21e45",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
@@ -73,7 +73,7 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "1b96343b-d644-4080-a349-927445c21e45",
+                                "name": "ec330081-de01-4c31-808f-3bfa4c01193b",
                                 "type": "index-pattern"
                             }
                         ],
@@ -154,17 +154,34 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "1b96343b-d644-4080-a349-927445c21e45",
+                                        "index": "ec330081-de01-4c31-808f-3bfa4c01193b",
                                         "key": "data_stream.dataset",
                                         "negate": true,
-                                        "params": {
-                                            "query": "elastic_agent*"
-                                        },
-                                        "type": "phrase"
+                                        "params": [
+                                            "elastic_agent.*",
+                                            "elastic_agent"
+                                        ],
+                                        "type": "phrases",
+                                        "value": [
+                                            "elastic_agent.*",
+                                            "elastic_agent"
+                                        ]
                                     },
                                     "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent*"
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent.*"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "elastic_agent"
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 }
@@ -456,7 +473,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-03-21T15:44:11.751Z",
+    "created_at": "2023-03-23T12:54:12.591Z",
     "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
     "migrationVersion": {
         "dashboard": "8.6.0"
@@ -469,7 +486,7 @@
         },
         {
             "id": "logs-*",
-            "name": "54f07979-6f4b-4535-b97b-0552bbeb9b39:1b96343b-d644-4080-a349-927445c21e45",
+            "name": "54f07979-6f4b-4535-b97b-0552bbeb9b39:ec330081-de01-4c31-808f-3bfa4c01193b",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
@@ -259,7 +259,8 @@
                                 }
                             ]
                         }
-                    }
+                    },
+                    "hidePanelTitles": true
                 },
                 "gridData": {
                     "h": 4,
@@ -432,7 +433,8 @@
                                 }
                             ]
                         }
-                    }
+                    },
+                    "hidePanelTitles": true
                 },
                 "gridData": {
                     "h": 4,
@@ -610,7 +612,7 @@
                             ]
                         }
                     },
-                    "hidePanelTitles": false
+                    "hidePanelTitles": true
                 },
                 "gridData": {
                     "h": 4,
@@ -815,7 +817,8 @@
                                 }
                             ]
                         }
-                    }
+                    },
+                    "hidePanelTitles": true
                 },
                 "gridData": {
                     "h": 4,
@@ -825,7 +828,6 @@
                     "y": 0
                 },
                 "panelIndex": "e8be8d39-4557-4077-bf45-e8c481f90699",
-                "title": "",
                 "type": "lens",
                 "version": "8.6.1"
             },
@@ -1330,7 +1332,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-03-23T12:54:12.591Z",
+    "created_at": "2023-03-23T12:59:59.906Z",
     "id": "elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824",
     "migrationVersion": {
         "dashboard": "8.6.0"

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
@@ -1330,7 +1330,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-03-21T15:22:44.450Z",
+    "created_at": "2023-03-23T12:54:12.591Z",
     "id": "elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824",
     "migrationVersion": {
         "dashboard": "8.6.0"

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
@@ -73,7 +73,7 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "5443dc85-71c6-4379-b04a-c87691cd2f64",
+                                "name": "cb5da399-620a-4db3-91d2-13febb4e0811",
                                 "type": "index-pattern"
                             }
                         ],
@@ -174,17 +174,17 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "5443dc85-71c6-4379-b04a-c87691cd2f64",
+                                        "index": "cb5da399-620a-4db3-91d2-13febb4e0811",
                                         "key": "data_stream.dataset",
                                         "negate": true,
                                         "params": {
-                                            "query": "elastic_agent.*"
+                                            "query": "elastic_agent*"
                                         },
                                         "type": "phrase"
                                     },
                                     "query": {
                                         "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent.*"
+                                            "data_stream.dataset": "elastic_agent*"
                                         }
                                     }
                                 }
@@ -635,7 +635,7 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "f59189d4-b02e-4d87-8575-a7e17d393499",
+                                "name": "3f0b51ab-5242-4904-8e6c-c8654c68bbec",
                                 "type": "index-pattern"
                             }
                         ],
@@ -678,7 +678,7 @@
                                                         "query": "log.level: error"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Part of defaults(count(kql='log.level: error'), 0)",
+                                                    "label": "Part of Agent Errors",
                                                     "operationType": "count",
                                                     "params": {
                                                         "emptyAsNull": false
@@ -690,7 +690,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of defaults(count(kql='log.level: error'), 0)",
+                                                    "label": "Part of Agent Errors",
                                                     "operationType": "math",
                                                     "params": {
                                                         "tinymathAst": {
@@ -730,9 +730,9 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "f59189d4-b02e-4d87-8575-a7e17d393499",
+                                        "index": "3f0b51ab-5242-4904-8e6c-c8654c68bbec",
                                         "key": "data_stream.dataset",
-                                        "negate": false,
+                                        "negate": true,
                                         "params": {
                                             "query": "elastic_agent*"
                                         },
@@ -837,6 +837,11 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-6c39da5e-0bfa-4ac0-b52c-75491ad21e8a",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "fbb56fc8-f301-483f-8d45-f6b2203ed246",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
@@ -891,7 +896,29 @@
                                     }
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "fbb56fc8-f301-483f-8d45-f6b2203ed246",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -1151,7 +1178,7 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "75e82db5-ff30-43c3-81f9-d7fa270e1be7",
+                                "name": "0769541a-e3f2-49c1-beb8-aaf9ecf101e2",
                                 "type": "index-pattern"
                             }
                         ],
@@ -1216,7 +1243,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "75e82db5-ff30-43c3-81f9-d7fa270e1be7",
+                                        "index": "0769541a-e3f2-49c1-beb8-aaf9ecf101e2",
                                         "key": "data_stream.dataset",
                                         "negate": true,
                                         "params": {
@@ -1303,7 +1330,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-02-27T07:24:38.530Z",
+    "created_at": "2023-03-21T15:22:44.450Z",
     "id": "elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824",
     "migrationVersion": {
         "dashboard": "8.6.0"
@@ -1316,7 +1343,7 @@
         },
         {
             "id": "logs-*",
-            "name": "106d153c-b2ce-497f-92a2-a6e37f3fee48:5443dc85-71c6-4379-b04a-c87691cd2f64",
+            "name": "106d153c-b2ce-497f-92a2-a6e37f3fee48:cb5da399-620a-4db3-91d2-13febb4e0811",
             "type": "index-pattern"
         },
         {
@@ -1351,7 +1378,7 @@
         },
         {
             "id": "logs-*",
-            "name": "e8be8d39-4557-4077-bf45-e8c481f90699:f59189d4-b02e-4d87-8575-a7e17d393499",
+            "name": "e8be8d39-4557-4077-bf45-e8c481f90699:3f0b51ab-5242-4904-8e6c-c8654c68bbec",
             "type": "index-pattern"
         },
         {
@@ -1362,6 +1389,11 @@
         {
             "id": "logs-*",
             "name": "b197eb2e-ee86-490c-afe1-605ce8e2edc1:indexpattern-datasource-layer-6c39da5e-0bfa-4ac0-b52c-75491ad21e8a",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "b197eb2e-ee86-490c-afe1-605ce8e2edc1:fbb56fc8-f301-483f-8d45-f6b2203ed246",
             "type": "index-pattern"
         },
         {
@@ -1386,7 +1418,7 @@
         },
         {
             "id": "logs-*",
-            "name": "9ea33099-240d-4f37-b154-216aaccb6f4a:75e82db5-ff30-43c3-81f9-d7fa270e1be7",
+            "name": "9ea33099-240d-4f37-b154-216aaccb6f4a:0769541a-e3f2-49c1-beb8-aaf9ecf101e2",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"2678bf39-3def-453e-9f30-2904bc88efe9\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"host.name\",\"title\":\"Host Name\",\"id\":\"2678bf39-3def-453e-9f30-2904bc88efe9\",\"enhancements\":{},\"selectedOptions\":[]}}}"
+            "panelsJSON": "{\"2678bf39-3def-453e-9f30-2904bc88efe9\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"agent.name\",\"title\":\"Agent Hostname\",\"id\":\"2678bf39-3def-453e-9f30-2904bc88efe9\",\"enhancements\":{},\"selectedOptions\":[]}}}"
         },
         "description": "Elastic Agent metrics dashboard",
         "kibanaSavedObjectMeta": {
@@ -1606,7 +1606,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-03-23T12:54:12.591Z",
+    "created_at": "2023-03-23T12:59:27.223Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "migrationVersion": {
         "dashboard": "8.6.0"

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -1606,7 +1606,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-02-27T09:02:58.208Z",
+    "created_at": "2023-03-23T12:54:12.591Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "migrationVersion": {
         "dashboard": "8.6.0"

--- a/packages/elastic_agent/kibana/search/elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287.json
+++ b/packages/elastic_agent/kibana/search/elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287.json
@@ -35,7 +35,7 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-02-27T07:08:12.758Z",
+    "created_at": "2023-03-21T14:57:40.730Z",
     "id": "elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/elastic_agent/kibana/search/elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287.json
+++ b/packages/elastic_agent/kibana/search/elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287.json
@@ -35,7 +35,7 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-03-21T14:57:40.730Z",
+    "created_at": "2023-03-23T12:54:12.591Z",
     "id": "elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/elastic_agent/kibana/search/elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287.json
+++ b/packages/elastic_agent/kibana/search/elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287.json
@@ -78,7 +78,7 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-03-21T14:57:40.730Z",
+    "created_at": "2023-03-23T12:54:12.591Z",
     "id": "elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/elastic_agent/kibana/search/elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287.json
+++ b/packages/elastic_agent/kibana/search/elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287.json
@@ -78,7 +78,7 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.6.1",
-    "created_at": "2023-02-27T07:08:12.758Z",
+    "created_at": "2023-03-21T14:57:40.730Z",
     "id": "elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -9,7 +9,7 @@ categories: ["elastic_stack"]
 conditions:
   kibana.version: "^8.6.1"
 owner:
-  github: elastic/elastic-agent-control-plane
+  github: elastic/elastic-agent
 icons:
   - src: /img/logo_elastic_agent.svg
     title: logo Elastic Agent

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.6.0
+version: 1.7.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

1. Adds field mapping definitions for `agent.*` fields that are missing from most datastreams, since `dynamic: false` we are unable to filter/search/aggregate on them properly without it.

2. Filtered out APM on certain charts, as they also use `agent.name`

3. Added `elastic_agent*` as a datastream filter for certain charts, and to filter out that datastream from others. This way we do not count our internal metrics/logging datastreams as "integrations", making them clutter the UI.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


