### PR TITLE
netflow: allow specification of internal networks

### DIFF
--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.0"
+  changes:
+    - description: Allow specification of internal network ranges.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5623
 - version: "2.5.0"
   changes:
     - description: Enrich for network direction and type.

--- a/packages/netflow/data_stream/log/agent/stream/netflow.yml.hbs
+++ b/packages/netflow/data_stream/log/agent/stream/netflow.yml.hbs
@@ -9,17 +9,23 @@ timeout: '{{timeout}}'
 {{#if read_buffer}}
 read_buffer: '{{read_buffer}}'
 {{/if}}
+{{#if internal_networks}}
+internal_networks:
+{{#each internal_networks as |network|}}
+  - {{network}}
+{{/each}}
+{{/if}}
 {{#if custom_definitions}}
 custom_definitions:
-{{#each custom_definitions}}
-- '{{this}}'
+{{#each custom_definitions as |def|}}
+- '{{def}}'
 {{/each}}
 {{/if}}
 {{#if detect_sequence_reset}}
 detect_sequence_reset: {{detect_sequence_reset}}
 {{/if}}
 tags:
-{{#each tags as |tag i|}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/netflow/data_stream/log/manifest.yml
+++ b/packages/netflow/data_stream/log/manifest.yml
@@ -27,6 +27,13 @@ streams:
         required: true
         show_user: false
         default: 30m
+      - name: internal_networks
+        type: text
+        title: Internal Networks
+        description: List of CIDR ranges describing the IP addresses that is considered internal. This is used in determining the values of `source.locality`, `destination.locality`, and `flow.locality`. The values can be either a CIDR value or one of the named ranges supported by the <<condition-network, `network`>> condition. The default value is `[private]` which classifies RFC 1918 (IPv4) and RFC 4193 (IPv6) addresses as internal.
+        multi: true
+        required: false
+        show_user: true
       - name: queue_size
         type: integer
         title: Maximum number of packets that can be queued for processing

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow Records
-version: "2.5.0"
+version: "2.6.0"
 license: basic
 description: Collect flow records from NetFlow and IPFIX exporters with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Allows user to specify internal networks.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5620 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
