### PR TITLE
[Synthetics] Fix mapping for state.ends.id

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.8"
+  changes:
+    - description: Fix broken mapping for state.ends.id.
+      type: bug
+      link: https://github.com/elastic/integrations/pull/5625
 - version: "0.11.7"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -2,7 +2,7 @@
 - version: "0.11.8"
   changes:
     - description: Fix broken mapping for state.ends.id.
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/5625
 - version: "0.11.7"
   changes:

--- a/packages/synthetics/data_stream/browser/fields/common.yml
+++ b/packages/synthetics/data_stream/browser/fields/common.yml
@@ -130,7 +130,7 @@
       description: the state that was ended by this state
       fields:
         - name: id
-          type: integer
+          type: keyword
           description: >
             ID of this state
 

--- a/packages/synthetics/data_stream/http/fields/common.yml
+++ b/packages/synthetics/data_stream/http/fields/common.yml
@@ -130,7 +130,7 @@
       description: the state that was ended by this state
       fields:
         - name: id
-          type: integer
+          type: keyword
           description: >
             ID of this state
 

--- a/packages/synthetics/data_stream/icmp/fields/common.yml
+++ b/packages/synthetics/data_stream/icmp/fields/common.yml
@@ -130,7 +130,7 @@
       description: the state that was ended by this state
       fields:
         - name: id
-          type: integer
+          type: keyword
           description: >
             ID of this state
 

--- a/packages/synthetics/data_stream/tcp/fields/common.yml
+++ b/packages/synthetics/data_stream/tcp/fields/common.yml
@@ -130,7 +130,7 @@
       description: the state that was ended by this state
       fields:
         - name: id
-          type: integer
+          type: keyword
           description: >
             ID of this state
 

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.11.7
+version: 0.11.8
 categories: ["observability"]
 release: beta
 type: integration


### PR DESCRIPTION
Fix inconsistent mapping between state.id and state.ends.id, these should both be keyword since heartbeat sends strings.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
