### PR TITLE
[GCP] Support additional input param in PubSub input for all datastreams

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.18.0"
+  changes:
+    - description: Support `subscription_num_goroutines` and `subscription_max_outstanding_messages` for GCP PubSub input
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5630
 - version: "2.17.2"
   changes:
     - description: Fix IP Convert processor in Audit ingest pipeline.

--- a/packages/gcp/data_stream/audit/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/audit/agent/stream/gcp-pubsub.yml.hbs
@@ -11,6 +11,12 @@ credentials_json: '{{credentials_json}}'
 alternative_host: {{alternative_host}}
 {{/if}}
 subscription.create: {{subscription_create}}
+{{#if subscription_num_goroutines}}
+subscription.num_goroutines: {{subscription_num_goroutines}}
+{{/if}}
+{{#if subscription_max_outstanding_messages}}
+subscription.max_outstanding_messages: {{subscription_max_outstanding_messages}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/gcp/data_stream/audit/manifest.yml
+++ b/packages/gcp/data_stream/audit/manifest.yml
@@ -27,6 +27,20 @@ streams:
         required: true
         show_user: false
         default: false
+      - name: subscription_num_goroutines
+        type: text
+        title: Subscription Num Goroutines
+        description: Number of goroutines created to read from the subscription. This does not limit the number of messages that can be processed concurrently or the maximum number of goroutines the input will create.
+        multi: false
+        required: false
+        show_user: false
+      - name: subscription_max_outstanding_messages
+        type: text
+        title: Subscription Max Outstanding Messages
+        description: The maximum number of unprocessed messages (unacknowledged but not yet expired). If the value is negative, then there will be no limit on the number of unprocessed messages. Default is 1000.
+        multi: false
+        required: false
+        show_user: false 
       - name: alternative_host
         type: text
         title: Alternative host

--- a/packages/gcp/data_stream/dns/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/dns/agent/stream/gcp-pubsub.yml.hbs
@@ -11,6 +11,12 @@ credentials_json: '{{credentials_json}}'
 alternative_host: {{alternative_host}}
 {{/if}}
 subscription.create: {{subscription_create}}
+{{#if subscription_num_goroutines}}
+subscription.num_goroutines: {{subscription_num_goroutines}}
+{{/if}}
+{{#if subscription_max_outstanding_messages}}
+subscription.max_outstanding_messages: {{subscription_max_outstanding_messages}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/gcp/data_stream/dns/manifest.yml
+++ b/packages/gcp/data_stream/dns/manifest.yml
@@ -27,6 +27,20 @@ streams:
         required: true
         show_user: false
         default: false
+      - name: subscription_num_goroutines
+        type: text
+        title: Subscription Num Goroutines
+        description: Number of goroutines created to read from the subscription. This does not limit the number of messages that can be processed concurrently or the maximum number of goroutines the input will create.
+        multi: false
+        required: false
+        show_user: false
+      - name: subscription_max_outstanding_messages
+        type: text
+        title: Subscription Max Outstanding Messages
+        description: The maximum number of unprocessed messages (unacknowledged but not yet expired). If the value is negative, then there will be no limit on the number of unprocessed messages. Default is 1000.
+        multi: false
+        required: false
+        show_user: false
       - name: alternative_host
         type: text
         title: Alternative host

--- a/packages/gcp/data_stream/firewall/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/firewall/agent/stream/gcp-pubsub.yml.hbs
@@ -11,6 +11,12 @@ credentials_json: '{{credentials_json}}'
 alternative_host: {{alternative_host}}
 {{/if}}
 subscription.create: {{subscription_create}}
+{{#if subscription_num_goroutines}}
+subscription.num_goroutines: {{subscription_num_goroutines}}
+{{/if}}
+{{#if subscription_max_outstanding_messages}}
+subscription.max_outstanding_messages: {{subscription_max_outstanding_messages}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/gcp/data_stream/firewall/manifest.yml
+++ b/packages/gcp/data_stream/firewall/manifest.yml
@@ -27,6 +27,20 @@ streams:
         required: true
         show_user: false
         default: false
+      - name: subscription_num_goroutines
+        type: text
+        title: Subscription Num Goroutines
+        description: Number of goroutines created to read from the subscription. This does not limit the number of messages that can be processed concurrently or the maximum number of goroutines the input will create.
+        multi: false
+        required: false
+        show_user: false
+      - name: subscription_max_outstanding_messages
+        type: text
+        title: Subscription Max Outstanding Messages
+        description: The maximum number of unprocessed messages (unacknowledged but not yet expired). If the value is negative, then there will be no limit on the number of unprocessed messages. Default is 1000.
+        multi: false
+        required: false
+        show_user: false
       - name: alternative_host
         type: text
         title: Alternative host

--- a/packages/gcp/data_stream/loadbalancing_logs/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/loadbalancing_logs/agent/stream/gcp-pubsub.yml.hbs
@@ -11,6 +11,12 @@ credentials_json: '{{credentials_json}}'
 alternative_host: {{alternative_host}}
 {{/if}}
 subscription.create: {{subscription_create}}
+{{#if subscription_num_goroutines}}
+subscription.num_goroutines: {{subscription_num_goroutines}}
+{{/if}}
+{{#if subscription_max_outstanding_messages}}
+subscription.max_outstanding_messages: {{subscription_max_outstanding_messages}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/gcp/data_stream/loadbalancing_logs/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_logs/manifest.yml
@@ -27,6 +27,20 @@ streams:
         required: true
         show_user: false
         default: false
+      - name: subscription_num_goroutines
+        type: text
+        title: Subscription Num Goroutines
+        description: Number of goroutines created to read from the subscription. This does not limit the number of messages that can be processed concurrently or the maximum number of goroutines the input will create.
+        multi: false
+        required: false
+        show_user: false
+      - name: subscription_max_outstanding_messages
+        type: text
+        title: Subscription Max Outstanding Messages
+        description: The maximum number of unprocessed messages (unacknowledged but not yet expired). If the value is negative, then there will be no limit on the number of unprocessed messages. Default is 1000.
+        multi: false
+        required: false
+        show_user: false  
       - name: alternative_host
         type: text
         title: Alternative host

--- a/packages/gcp/data_stream/vpcflow/agent/stream/gcp-pubsub.yml.hbs
+++ b/packages/gcp/data_stream/vpcflow/agent/stream/gcp-pubsub.yml.hbs
@@ -11,6 +11,12 @@ credentials_json: '{{credentials_json}}'
 alternative_host: {{alternative_host}}
 {{/if}}
 subscription.create: {{subscription_create}}
+{{#if subscription_num_goroutines}}
+subscription.num_goroutines: {{subscription_num_goroutines}}
+{{/if}}
+{{#if subscription_max_outstanding_messages}}
+subscription.max_outstanding_messages: {{subscription_max_outstanding_messages}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/gcp/data_stream/vpcflow/manifest.yml
+++ b/packages/gcp/data_stream/vpcflow/manifest.yml
@@ -27,6 +27,20 @@ streams:
         required: true
         show_user: false
         default: false
+      - name: subscription_num_goroutines
+        type: text
+        title: Subscription Num Goroutines
+        description: Number of goroutines created to read from the subscription. This does not limit the number of messages that can be processed concurrently or the maximum number of goroutines the input will create.
+        multi: false
+        required: false
+        show_user: false
+      - name: subscription_max_outstanding_messages
+        type: text
+        title: Subscription Max Outstanding Messages
+        description: The maximum number of unprocessed messages (unacknowledged but not yet expired). If the value is negative, then there will be no limit on the number of unprocessed messages. Default is 1000.
+        multi: false
+        required: false
+        show_user: false
       - name: alternative_host
         type: text
         title: Alternative host

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.17.2"
+version: "2.18.0"
 release: ga
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Adds support for configuring `subscription_num_goroutines` and `subscription_max_outstanding_messages` parameters across all datastreams having GCP PubSub input.

 
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/5629

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
