### PR TITLE
[beat] fix cgroup memory aliases

### DIFF
--- a/packages/beat/changelog.yml
+++ b/packages/beat/changelog.yml
@@ -1,3 +1,8 @@
+- version: 0.1.3
+  changes:
+    - description: Add missing cgroup memory aliases
+      type: bugfix
+      link: tbd
 - version: 0.1.2
   changes:
     - description: Clarify that the metrics collected power the Stack Monitoring application

--- a/packages/beat/changelog.yml
+++ b/packages/beat/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add missing cgroup memory aliases
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/5639
 - version: 0.1.2
   changes:
     - description: Clarify that the metrics collected power the Stack Monitoring application

--- a/packages/beat/data_stream/stats/fields/package-fields.yml
+++ b/packages/beat/data_stream/stats/fields/package-fields.yml
@@ -511,15 +511,21 @@
                 - name: cpuacct.total.ns
                   type: alias
                   path: beat.stats.cgroup.cpuacct.total.ns
-                - name: memory.id
-                  type: alias
-                  path: beat.stats.cgroup.memory.id
-                - name: mem.limit.bytes
-                  type: alias
-                  path: beat.stats.cgroup.memory.mem.limit.bytes
-                - name: mem.usage.bytes
-                  type: alias
-                  path: beat.stats.cgroup.memory.mem.usage.bytes
+                - name: memory
+                  type: group
+                  fields:
+                    - name: id
+                      type: alias
+                      path: beat.stats.cgroup.memory.id
+                    - name: mem
+                      type: group
+                      fields:
+                        - name: limit.bytes
+                          type: alias
+                          path: beat.stats.cgroup.memory.mem.limit.bytes
+                        - name: usage.bytes
+                          type: alias
+                          path: beat.stats.cgroup.memory.mem.usage.bytes
             - name: cpu
               type: group
               fields:

--- a/packages/beat/docs/README.md
+++ b/packages/beat/docs/README.md
@@ -996,9 +996,9 @@ An example event for `stats` looks as following:
 | beats_stats.metrics.beat.cgroup.cpu.stats.throttled.periods |  | alias |
 | beats_stats.metrics.beat.cgroup.cpuacct.id |  | alias |
 | beats_stats.metrics.beat.cgroup.cpuacct.total.ns |  | alias |
-| beats_stats.metrics.beat.cgroup.mem.limit.bytes |  | alias |
-| beats_stats.metrics.beat.cgroup.mem.usage.bytes |  | alias |
 | beats_stats.metrics.beat.cgroup.memory.id |  | alias |
+| beats_stats.metrics.beat.cgroup.memory.mem.limit.bytes |  | alias |
+| beats_stats.metrics.beat.cgroup.memory.mem.usage.bytes |  | alias |
 | beats_stats.metrics.beat.cpu.system.ticks |  | alias |
 | beats_stats.metrics.beat.cpu.system.time.ms |  | alias |
 | beats_stats.metrics.beat.cpu.total.ticks |  | alias |

--- a/packages/beat/manifest.yml
+++ b/packages/beat/manifest.yml
@@ -1,6 +1,6 @@
 name: beat
 title: Beat
-version: 0.1.2
+version: 0.1.3
 description: Beat Integration
 type: integration
 conditions:


### PR DESCRIPTION
Add missing cgroup memory aliases from this change https://github.com/elastic/elasticsearch/pull/94400

Related https://github.com/elastic/kibana/issues/153123