### PR TITLE
netflow: add missing read buffer size configuration

### DIFF
--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.1"
+  changes:
+    - description: Add UDP read buffer configuration option.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5686
 - version: "2.6.0"
   changes:
     - description: Allow specification of internal network ranges.

--- a/packages/netflow/data_stream/log/manifest.yml
+++ b/packages/netflow/data_stream/log/manifest.yml
@@ -41,6 +41,13 @@ streams:
         required: true
         show_user: false
         default: 8192
+      - name: read_buffer
+        type: text
+        title: Read Buffer Size
+        description: |
+          The size of the read buffer on the UDP socket in the format KiB/MiB, an example would be: 10KiB
+        required: false
+        show_user: false
       - name: custom_definitions
         type: text
         title: Custom definitions

--- a/packages/netflow/data_stream/log/manifest.yml
+++ b/packages/netflow/data_stream/log/manifest.yml
@@ -45,7 +45,7 @@ streams:
         type: text
         title: Read Buffer Size
         description: |
-          The size of the read buffer on the UDP socket in the format KiB/MiB, an example would be: 10KiB
+          Sets the size of the OS read buffer on the UDP socket in the format KiB/MiB, an example would be: 10KiB. If it is not set, the existing operating system's default value is used.
         required: false
         show_user: false
       - name: custom_definitions

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netflow
 title: NetFlow Records
-version: "2.6.0"
+version: "2.6.1"
 license: basic
 description: Collect flow records from NetFlow and IPFIX exporters with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds a missing read buffer size configuration.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #5682

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
