### PR TITLE
[Redis] [TSDB] Enable dimension fields for info datastream

### DIFF
--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Added dimension fields for info datastream for TSDB enablement .
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5123
 - version: "1.5.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added dimension fields for info datastream for TSDB enablement .
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5123
+      link: https://github.com/elastic/integrations/pull/5702
 - version: "1.5.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/redis/data_stream/info/fields/agent.yml
+++ b/packages/redis/data_stream/info/fields/agent.yml
@@ -25,6 +25,7 @@
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
+      dimension: true
     - name: instance.name
       level: extended
       type: keyword
@@ -42,6 +43,7 @@
       ignore_above: 1024
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
+      dimension: true
     - name: region
       level: extended
       type: keyword
@@ -51,6 +53,7 @@
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
+      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -67,6 +70,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+      dimension: true
     - name: image.name
       level: extended
       type: keyword
@@ -134,6 +138,7 @@
       level: core
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: 'Name of the host.
 
         It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
@@ -196,3 +201,11 @@
       description: >
         OS codename, if any.
 
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/redis/data_stream/info/fields/ecs.yml
+++ b/packages/redis/data_stream/info/fields/ecs.yml
@@ -10,6 +10,7 @@
   name: ecs.version
 - external: ecs
   name: service.address
+  dimension: true
 - external: ecs
   name: service.type
 - external: ecs

--- a/packages/redis/data_stream/info/fields/fields.yml
+++ b/packages/redis/data_stream/info/fields/fields.yml
@@ -450,6 +450,8 @@
         Count of slow operations
 - name: service.address
   type: keyword
+  # Reason for adding as dimension field : A connection string to the server.
+  dimension: true
   description: Client address
 - name: service.version
   type: keyword

--- a/packages/redis/docs/README.md
+++ b/packages/redis/docs/README.md
@@ -320,6 +320,7 @@ An example event for `info` looks as following:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
+| agent.id |  | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.availability_zone | Availability zone in which this host is running. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: redis
 title: Redis
-version: 1.5.1
+version: 1.6.0
 license: basic
 description: Collect logs and metrics from Redis servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
Type of change

- Enhancement

## What does this PR do?

 Enable dimension fields for info datastream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
https://github.com/elastic/integrations/issues/5698

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
