### PR TITLE
[integrations][tennable_io] - Updates package to corelate with latest httpjson change

### DIFF
--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Added response.save_first_response parameter to hbs.yml files to support latest httpjson change.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5741
 - version: "0.2.0"
   changes:
     - description: Add user-configurable Max Retries and Min Wait Time parameter.

--- a/packages/tenable_io/data_stream/asset/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_io/data_stream/asset/agent/stream/httpjson.yml.hbs
@@ -11,6 +11,7 @@ request.url: {{hostname}}/assets/export
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
+response.save_first_response: true
 request.transforms:
   - delete:
       target: header.User-Agent

--- a/packages/tenable_io/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_io/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
@@ -11,6 +11,7 @@ request.url: {{hostname}}/vulns/export
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
+response.save_first_response: true
 request.transforms:
   - delete:
       target: header.User-Agent

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: tenable_io
 title: Tenable.io
-version: 0.2.0
+version: 0.2.1
 description: Collect logs from Tenable.io with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Bug

## What does this PR do?

This adds response.save_first_response parameter to httpjson yml.hbs files to support the latest change in the httpjson input with regards to how the first_response object is saved/accessed.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates [Fix first_response false positive error by making it a flag based object](https://github.com/elastic/beats/pull/34748/files)


