### PR TITLE
[elasticsearch] add read exceptions mappings

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add mappings for ccr read_exceptions
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/5759
 - version: 1.4.2
   changes:
     - description: Clarify that the metrics collected power the Stack Monitoring application

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.4.3
+  changes:
+    - description: Add mappings for ccr read_exceptions
+      type: bugfix
+      link: tbd
 - version: 1.4.2
   changes:
     - description: Clarify that the metrics collected power the Stack Monitoring application

--- a/packages/elasticsearch/data_stream/ccr/fields/fields.yml
+++ b/packages/elasticsearch/data_stream/ccr/fields/fields.yml
@@ -20,6 +20,16 @@
           type: long
     - name: read_exceptions
       type: nested
+    - name: read_exceptions.from_seq_no
+      type: long
+    - name: read_exceptions.retries
+      type: integer
+    - name: read_exceptions.exception
+      type: object
+    - name: read_exceptions.exception.type
+      type: keyword
+    - name: read_exceptions.exception.reason
+      type: text
     - name: requests
       type: group
       fields:

--- a/packages/elasticsearch/docs/README.md
+++ b/packages/elasticsearch/docs/README.md
@@ -325,6 +325,11 @@ will not collect metrics. A DEBUG log message about this will be emitted in the 
 | elasticsearch.ccr.leader.index | Name of leader index | keyword |
 | elasticsearch.ccr.leader.max_seq_no | Maximum sequence number of operation on the leader shard | long |
 | elasticsearch.ccr.read_exceptions |  | nested |
+| elasticsearch.ccr.read_exceptions.exception |  | object |
+| elasticsearch.ccr.read_exceptions.exception.reason |  | text |
+| elasticsearch.ccr.read_exceptions.exception.type |  | keyword |
+| elasticsearch.ccr.read_exceptions.from_seq_no |  | long |
+| elasticsearch.ccr.read_exceptions.retries |  | integer |
 | elasticsearch.ccr.remote_cluster |  | keyword |
 | elasticsearch.ccr.requests.failed.read.count |  | long |
 | elasticsearch.ccr.requests.failed.write.count |  | long |

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.4.2
+version: 1.4.3
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
Related https://github.com/elastic/kibana/issues/153298

Add missing `read_exceptions` mappings to the `ccr` data stream