### PR TITLE
[Kubernetes] Add condition NetworkUnavailable to state node

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add NetworkUnavailable condition to state node
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5464
+      link: https://github.com/elastic/integrations/pull/5760
 - version: "1.34.1"
   changes:
     - description: Add support for TSDB on all metric data streams except the state ones

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.35.0"
+  changes:
+    - description: Add NetworkUnavailable condition to state node
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5464
 - version: "1.34.1"
   changes:
     - description: Add support for TSDB on all metric data streams except the state ones

--- a/packages/kubernetes/data_stream/state_node/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_node/fields/fields.yml
@@ -24,6 +24,10 @@
         - name: pid_pressure
           type: keyword
           description: Node PIDPressure status (true, false or unknown)
+        - name: network_unavailable
+          type: keyword
+          description: >
+            Node NetworkUnavailable status (true, false or unknown)
     - name: cpu
       type: group
       fields:

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -1196,6 +1196,7 @@ An example event for `state_node` looks as following:
 | kubernetes.node.pod.capacity.total | Node pod capacity | long |  | gauge |
 | kubernetes.node.status.disk_pressure | Node DiskPressure status (true, false or unknown) | keyword |  |  |
 | kubernetes.node.status.memory_pressure | Node MemoryPressure status (true, false or unknown) | keyword |  |  |
+| kubernetes.node.status.network_unavailable | Node NetworkUnavailable status (true, false or unknown) | keyword |  |  |
 | kubernetes.node.status.out_of_disk | Node OutOfDisk status (true, false or unknown) | keyword |  |  |
 | kubernetes.node.status.pid_pressure | Node PIDPressure status (true, false or unknown) | keyword |  |  |
 | kubernetes.node.status.ready | Node ready status (true, false or unknown) | keyword |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.34.1
+version: 1.35.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add condition NetworkUnavailable to state node.

Follow up to https://github.com/elastic/beats/pull/34976.

