### PR TITLE
Adding toggle for enabling tracer logs

### DIFF
--- a/packages/httpjson/changelog.yml
+++ b/packages/httpjson/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.7.2"
+  changes:
+    - description: Added optional toggle to enable debug trace logging.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5123
 - version: "1.7.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
+++ b/packages/httpjson/data_stream/generic/agent/stream/httpjson.yml.hbs
@@ -115,6 +115,9 @@ request.rate_limit.reset: {{request_rate_limit_reset}}
 {{#if request_rate_limit_remaining}}
 request.rate_limit.remaining: {{request_rate_limit_remaining}}
 {{/if}}
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson.ndjson
+{{/if}}
 
 {{#if response_transforms}}
 response.transforms: 

--- a/packages/httpjson/data_stream/generic/manifest.yml
+++ b/packages/httpjson/data_stream/generic/manifest.yml
@@ -300,7 +300,16 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The the request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: tags
         type: text
         title: Tags

--- a/packages/httpjson/manifest.yml
+++ b/packages/httpjson/manifest.yml
@@ -3,14 +3,13 @@ name: httpjson
 title: Custom API
 description: Collect custom events from an API endpoint with Elastic agent
 type: integration
-version: "1.7.1"
+version: "1.7.2"
 release: ga
 conditions:
   kibana.version: "^8.4.0"
 license: basic
 categories:
   - custom
-  - custom_logs
 policy_templates:
   - name: generic
     title: Custom API Input


### PR DESCRIPTION
## What does this PR do?

Adding the ability for the user to enable tracer logs

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/security-team/issues/5867

