### PR TITLE
[integrations] [microsft message trace] - Deprecated basic auth and added support for Oauth2

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/_dev/build/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/_dev/build/docs/README.md
@@ -15,6 +15,25 @@ The `log` dataset collects the Microsoft Exchange Online Message Trace logs.
 
 [Log Documentation](https://docs.microsoft.com/en-us/previous-versions/office/developer/o365-enterprise-developers/jj984335(v=office.15))
 
+## Configuring with OAuth2
+The basic auth fields have been deprecated from this integration since Microsoft has deprecated them and they no longer work.
+Going forward OAuth2 needs to be configured for working with Microsoft Exchange Online Message Trace APIs.
+
+### Steps :
+You'll need to register your application with Azure Active Directory and obtain the necessary credentials: Client ID, Client Secret, and Tenant ID. 
+You can follow these steps to create an Azure AD application:
+
+1) Go to the Azure portal (https://portal.azure.com/) and sign in.
+2) Click on "Azure Active Directory" in the left-hand menu.
+3) Select "App registrations" and click "New registration".
+4) Enter a name for your application, select "Accounts in this organizational directory only" for "Supported account types", and enter the redirect 
+   URI for your application.
+5) Click "Register" to create the application.
+6) On the application page, make note of the "Application (client) ID" (which is your client ID) and the "Directory (tenant) ID" (which is your 
+   tenant ID).
+7) Under "Certificates & secrets", click "New client secret" to create a new secret. Make note of the secret value (which is your client secret).
+
+With these credentials in hand, you can now configure the integration with the appropriate parameters. 
 ### Logfile collection
 
 The following sample Powershell script may be used to get the logs and put them into a JSON file that can then be

--- a/packages/microsoft_exchange_online_message_trace/_dev/build/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/_dev/build/docs/README.md
@@ -37,7 +37,7 @@ With these credentials in hand, you can now configure the integration with the a
 
 ### Logfile collection 
 
-**Disclaimer:**  Due to Microsoft deprecating basic auth support recently, the powershell script provided below will not work as it is. However you can 
+**Disclaimer:**  With basic authentication support now disabled, the PowerShell script provided below will not work as is. However you can 
 see the [guides here](https://learn.microsoft.com/en-us/powershell/exchange/connect-to-exchange-online-powershell?view=exchange-ps) on how 
 to connect to powershell using different authentication techniques using the EXO V2 and V3 modules. With a combination of the script below
 and the alternate authentication methods mentioned in the guide, you can possibly perform the logfile collection as usual.

--- a/packages/microsoft_exchange_online_message_trace/_dev/deploy/docker/files/config.yml
+++ b/packages/microsoft_exchange_online_message_trace/_dev/deploy/docker/files/config.yml
@@ -1,8 +1,26 @@
 rules:
+  - path: /tenant_id/oauth2/token
+    methods: [POST]
+    query_params:
+      client_id: test-app-id
+      client_secret: test-secret
+      grant_type: client_credentials
+      resource: "{resource:.*}"
+    request_headers:
+      Content-Type:
+        - "application/x-www-form-urlencoded"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ilg1ZVhrN","token_type": "Bearer","not_before": 1549647431,"expires_in": 3600,"resource": "f2a76e08-93f2-4350-833c-965c02483b11"}
   - path: /ecp/reportingwebservice/reporting.svc/MessageTrace
     methods: [GET]
     request_headers:
-      Authorization: 'Basic c29tZV91c2VybmFtZTpzb21lX3Bhc3N3b3Jk'
+      Authorization:
+        - "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ilg1ZVhrN"
     responses:
       - status_code: 200
         headers:

--- a/packages/microsoft_exchange_online_message_trace/_dev/deploy/docker/files/config.yml
+++ b/packages/microsoft_exchange_online_message_trace/_dev/deploy/docker/files/config.yml
@@ -5,7 +5,7 @@ rules:
       client_id: test-app-id
       client_secret: test-secret
       grant_type: client_credentials
-      resource: "{resource:.*}"
+      scope: "{scope:.*}"
     request_headers:
       Content-Type:
         - "application/x-www-form-urlencoded"

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecated basic auth fields and added support for OAuth2.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/{replace}
+      link: https://github.com/elastic/integrations/pull/5775
 - version: "1.0.0"
   changes:
     - description: Release Microsoft Exchange Online Message Trace as GA.

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Deprecated basic auth fields and added support for OAuth2.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/{replace}
 - version: "1.0.0"
   changes:
     - description: Release Microsoft Exchange Online Message Trace as GA.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/_dev/test/system/test-httpjson-config.yml
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/_dev/test/system/test-httpjson-config.yml
@@ -2,8 +2,10 @@ input: httpjson
 service: exchange_online
 vars:
   url: http://{{Hostname}}:{{Port}}/ecp/reportingwebservice/reporting.svc/MessageTrace
-  username: some_username
-  password: some_password
+  client_id: test-app-id
+  client_secret: test-secret
+  tenant_id: tenant_id
+  login_url: http://{{Hostname}}:{{Port}}
 data_stream:
   vars:
     preserve_original_event: true

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,18 @@ config_version: 2
 interval: {{interval}}
 request.method: GET
 request.url: {{url}}
+auth.oauth2.client.id: {{client_id}}
+auth.oauth2.client.secret: {{client_secret}}
+auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/{{token_url}}
+{{#if scopes}}
+auth.oauth2.scopes:
+{{#each scopes as |scope|}}
+  - {{scope}}
+{{/each}}
+{{else}}
+auth.oauth2.provider: azure
+auth.oauth2.azure.resource: {{azure_resource}}
+{{/if}}
 request.transforms:
   - set:
       target: url.params.$filter
@@ -16,12 +28,6 @@ request.proxy_url: {{proxy_url}}
 {{/if}}
 {{#if ssl}}
 request.ssl: {{ssl}}
-{{/if}}
-{{#if username}}
-{{#if password}}
-auth.basic.user: {{username}}
-auth.basic.password: {{password}}
-{{/if}}
 {{/if}}
 fields_under_root: true
 fields:

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -7,7 +7,7 @@ auth.oauth2.client.secret: {{client_secret}}
 auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/{{token_url}}
 {{#if scopes}}
 auth.oauth2.scopes:
-{{#each scopes as |scope i|}}
+{{#each scopes as |scope|}}
   - {{scope}}
 {{/each}}
 {{else}}

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -7,12 +7,19 @@ auth.oauth2.client.secret: {{client_secret}}
 auth.oauth2.token_url: {{login_url}}/{{tenant_id}}/{{token_url}}
 {{#if scopes}}
 auth.oauth2.scopes:
-{{#each scopes as |scope|}}
+{{#each scopes as |scope i|}}
   - {{scope}}
 {{/each}}
 {{else}}
 auth.oauth2.provider: azure
 auth.oauth2.azure.resource: {{azure_resource}}
+{{/if}}
+request.timeout: {{request_timeout}}
+{{#if proxy_url }}
+request.proxy_url: {{proxy_url}}
+{{/if}}
+{{#if ssl}}
+request.ssl: {{ssl}}
 {{/if}}
 request.transforms:
   - set:
@@ -22,13 +29,6 @@ request.transforms:
   - set:
       target: url.params.$skiptoken
       value: 0
-request.timeout: {{request_timeout}}
-{{#if proxy_url }}
-request.proxy_url: {{proxy_url}}
-{{/if}}
-{{#if ssl}}
-request.ssl: {{ssl}}
-{{/if}}
 fields_under_root: true
 fields:
   _conf:

--- a/packages/microsoft_exchange_online_message_trace/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/docs/README.md
@@ -15,6 +15,25 @@ The `log` dataset collects the Microsoft Exchange Online Message Trace logs.
 
 [Log Documentation](https://docs.microsoft.com/en-us/previous-versions/office/developer/o365-enterprise-developers/jj984335(v=office.15))
 
+## Configuring with OAuth2
+The basic auth fields have been deprecated from this integration since Microsoft has deprecated them and they no longer work.
+Going forward OAuth2 needs to be configured for working with Microsoft Exchange Online Message Trace APIs.
+
+### Steps :
+You'll need to register your application with Azure Active Directory and obtain the necessary credentials: Client ID, Client Secret, and Tenant ID. 
+You can follow these steps to create an Azure AD application:
+
+1) Go to the Azure portal (https://portal.azure.com/) and sign in.
+2) Click on "Azure Active Directory" in the left-hand menu.
+3) Select "App registrations" and click "New registration".
+4) Enter a name for your application, select "Accounts in this organizational directory only" for "Supported account types", and enter the redirect 
+   URI for your application.
+5) Click "Register" to create the application.
+6) On the application page, make note of the "Application (client) ID" (which is your client ID) and the "Directory (tenant) ID" (which is your 
+   tenant ID).
+7) Under "Certificates & secrets", click "New client secret" to create a new secret. Make note of the secret value (which is your client secret).
+
+With these credentials in hand, you can now configure the integration with the appropriate parameters. 
 ### Logfile collection
 
 The following sample Powershell script may be used to get the logs and put them into a JSON file that can then be

--- a/packages/microsoft_exchange_online_message_trace/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/docs/README.md
@@ -37,7 +37,7 @@ With these credentials in hand, you can now configure the integration with the a
 
 ### Logfile collection 
 
-**Disclaimer:**  Due to Microsoft deprecating basic auth support recently, the powershell script provided below will not work as it is. However you can 
+**Disclaimer:**  With basic authentication support now disabled, the PowerShell script provided below will not work as is. However you can 
 see the [guides here](https://learn.microsoft.com/en-us/powershell/exchange/connect-to-exchange-online-powershell?view=exchange-ps) on how 
 to connect to powershell using different authentication techniques using the EXO V2 and V3 modules. With a combination of the script below
 and the alternate authentication methods mentioned in the guide, you can possibly perform the logfile collection as usual.

--- a/packages/microsoft_exchange_online_message_trace/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/docs/README.md
@@ -35,7 +35,13 @@ You can follow these steps to create an Azure AD application:
 
 With these credentials in hand, you can now configure the integration with the appropriate parameters.
 
-### Logfile collection
+### Logfile collection 
+
+**Disclaimer:**  Due to Microsoft deprecating basic auth support recently, the powershell script provided below will not work as it is. However you can 
+see the [guides here](https://learn.microsoft.com/en-us/powershell/exchange/connect-to-exchange-online-powershell?view=exchange-ps) on how 
+to connect to powershell using different authentication techniques using the EXO V2 and V3 modules. With a combination of the script below
+and the alternate authentication methods mentioned in the guide, you can possibly perform the logfile collection as usual.
+<br>
 
 The following sample Powershell script may be used to get the logs and put them into a JSON file that can then be
 consumed by the logfile input:
@@ -56,17 +62,13 @@ Import-Module -Name ExchangeOnlineManagement
 
 This script would have to be triggered at a certain interval, in accordance with the look back interval specified.
 In this example script the look back would be 24 hours, so the interval would need to be daily.
-According to the
-[documentation](https://learn.microsoft.com/en-us/powershell/module/exchange/get-messagetrace?view=exchange-ps)
-it is only possible to get up to 1k pages.
-If this should be an issue, try reducing the `$looback` or increasing `$pageSize`.
+According to the [documentation](https://learn.microsoft.com/en-us/powershell/module/exchange/get-messagetrace?view=exchange-ps)
+it is only possible to get up to 1k pages. If this should be an issue, try reducing the `$looback` or increasing `$pageSize`.
 
 ```powershell
-# OAuth2 parameters
-$clientId = "YOUR_CLIENT_ID_HERE"
-$clientSecret = "YOUR_CLIENT_SECRET_HERE"
-$tenantId = "YOUR_TENANT_ID_HERE"
-$scopes = "https://outlook.office365.com/.default"
+# Username and Password
+$username = "USERNAME@DOMAIN.TLD"
+$password = "PASSWORD"
 # Lookback in Hours
 $lookback = "-24"
 # Page Size, should be no problem with 1k
@@ -75,23 +77,22 @@ $pageSize = "1000"
 # This would then be ingested via the integration
 $output_location = "C:\temp\messageTrace.json"
 
-$token = Get-ExoOAuthAccessToken -ClientId $clientId -ClientSecret $clientSecret -TenantId $tenantId -Scopes $scopes
-
-Connect-ExchangeOnline -AccessToken $token.AccessToken
-
+$password = ConvertTo-SecureString $password -AsPlainText -Force
+$Credential = New-Object System.Management.Automation.PSCredential ($username, $password)
 $startDate = (Get-Date).AddHours($lookback)
 $endDate = Get-Date
 
+Connect-ExchangeOnline -Credential $Credential
 $paginate = 1
 $page = 1
 $output = @()
 while ($paginate -eq 1)
 {
-    $messageTrace = Get-MessageTrace -PageSize $pageSize -StartDate $startDate -EndDate $endDate -Page $page -AccessToken $token.AccessToken
+    $messageTrace = Get-MessageTrace -PageSize $pageSize -StartDate $startDate -EndDate $endDate -Page $page
     $page
     if (!$messageTrace)
     {
-     $paginate = 0
+        $paginate = 0
     }
     else
     {
@@ -112,7 +113,6 @@ foreach ($event in $output)
     Add-Content $output_location $event -Encoding UTF8
 }
 ```
-
 An example event for `log` looks as following:
 
 ```json

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -27,14 +27,66 @@ policy_templates:
     description: Microsoft Exchange Online Message Trace logs
     inputs:
       - type: httpjson
+        title: Collect Exchange Online Message Trace logs via API
+        description: Collect Exchange Online  logs
         vars:
           - name: url
             type: text
-            title: URL
-            description: URL for the Exchange Online API (Add https:// before the url).
+            title: Message Trace URL
+            description: URL for the Exchange Online API (Add https:// before the url if you wish to use a custom url).
             default: https://reports.office365.com/ecp/reportingwebservice/reporting.svc/MessageTrace
             show_user: true
             required: true
+          - name: client_id
+            type: text
+            title: Client ID
+            description: The client ID related to creating a new application on Azure.
+            multi: false
+            required: true
+            show_user: true
+          - name: client_secret
+            type: text
+            title: Client Secret
+            description: The secret related to the client ID.
+            multi: false
+            required: true
+            show_user: true
+          - name: tenant_id
+            type: text
+            title: Tenant ID
+            description: The tenant ID related to creating a new application on Azure.
+            multi: false
+            required: true
+            show_user: true
+          - name: scopes
+            type: text
+            title: Oauth2 Scopes
+            multi: true
+            default: https://reports.office365.com/ecp/reportingwebservice/reporting
+            required: false
+            show_user: true
+            description: One or more Oauth2 scopes are required to authenticate with the Microsoft Exchange Online Message Trace API.
+          - name: login_url
+            type: text
+            title: OAuth Server URL
+            required: true
+            show_user: false
+            default: https://login.microsoftonline.com/
+            description: "URL of Login server 'tenant-id/oauth2/token added automatically'"
+          - name: token_url
+            type: text
+            title: OAuth Token endpoint
+            required: true
+            show_user: false
+            default: oauth2/token
+            description: "Microsoft supports multiple Oauth2 URL endpoints, the default is oauth2/token, but can also be oauth2/v2.0/token"
+          - name: azure_resource
+            type: text
+            title: Azure Resource
+            multi: false
+            required: false
+            show_user: false
+            description: URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port>
           - name: proxy_url
             type: text
             title: Proxy URL
@@ -42,16 +94,6 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-          - name: username
-            type: text
-            title: Username
-            description: Username to access Exchange Online
-            required: true
-          - name: password
-            type: password
-            title: Password
-            description: Password to access Exchange Online
-            required: true
           - name: batch_size
             type: text
             title: Batch Size
@@ -118,8 +160,7 @@ policy_templates:
               #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
               #    sxSmbIUfc2SGJGCJD4I=
               #    -----END CERTIFICATE-----
-        title: Collect Exchange Online Message Trace logs via API
-        description: Collect Exchange Online  logs
+      
       - type: logfile
         title: "Collect Microsoft Exchange Online Message Trace logs via file"
         description: "Collecting Exchange Online Message Trace logs via file"

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -28,7 +28,7 @@ policy_templates:
     inputs:
       - type: httpjson
         title: Collect Exchange Online Message Trace logs via API
-        description: Collect Exchange Online  logs
+        description: Collect Exchange Online logs
         vars:
           - name: url
             type: text
@@ -62,7 +62,8 @@ policy_templates:
             type: text
             title: Oauth2 Scopes
             multi: true
-            default: https://reports.office365.com/ecp/reportingwebservice/reporting
+            default: |
+              - https://reports.office365.com/ecp/reportingwebservice/reporting
             required: false
             show_user: true
             description: One or more Oauth2 scopes are required to authenticate with the Microsoft Exchange Online Message Trace API.
@@ -160,7 +161,6 @@ policy_templates:
               #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
               #    sxSmbIUfc2SGJGCJD4I=
               #    -----END CERTIFICATE-----
-      
       - type: logfile
         title: "Collect Microsoft Exchange Online Message Trace logs via file"
         description: "Collecting Exchange Online Message Trace logs via file"

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.0.0"
+version: "1.1.0"
 release: ga
 license: basic
 description: "Microsoft Exchange Online Message Trace Integration"
@@ -32,8 +32,9 @@ policy_templates:
         vars:
           - name: url
             type: text
-            title: Message Trace URL
-            description: URL for the Exchange Online API (Add https:// before the url if you wish to use a custom url).
+            title: URL
+            multi: false
+            description: URL for the Exchange Online API (Add https:// before the url).
             default: https://reports.office365.com/ecp/reportingwebservice/reporting.svc/MessageTrace
             show_user: true
             required: true
@@ -45,7 +46,7 @@ policy_templates:
             required: true
             show_user: true
           - name: client_secret
-            type: text
+            type: password
             title: Client Secret
             description: The secret related to the client ID.
             multi: false
@@ -62,14 +63,18 @@ policy_templates:
             type: text
             title: Oauth2 Scopes
             multi: true
-            default: |
+            default:
               - https://reports.office365.com/ecp/reportingwebservice/reporting
             required: false
-            show_user: true
-            description: One or more Oauth2 scopes are required to authenticate with the Microsoft Exchange Online Message Trace API.
+            show_user: false
+            description: |
+              Generally one or more Oauth2 scopes are required to authenticate with the Microsoft Exchange Online Message Trace API.
+              The only time a scope should no be used is if you are using an azure resource. Scopes & azure resources are mutually
+              exclusive in this scenario.
           - name: login_url
             type: text
             title: OAuth Server URL
+            multi: false
             required: true
             show_user: false
             default: https://login.microsoftonline.com/
@@ -78,6 +83,7 @@ policy_templates:
             type: text
             title: OAuth Token endpoint
             required: true
+            multi: false
             show_user: false
             default: oauth2/token
             description: "Microsoft supports multiple Oauth2 URL endpoints, the default is oauth2/token, but can also be oauth2/v2.0/token"
@@ -87,7 +93,9 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-            description: URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port>
+            description: |
+              URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port>.
+              Only use this when oauth scopes are not used.
           - name: proxy_url
             type: text
             title: Proxy URL


### PR DESCRIPTION
## Type of change
- Enhancement

## What does this PR do?
This deprecates the basic auth fields and adds support for OAuth2. This had to be done because Microsoft has 
completely ended support of basic auth in Message Trace APIs since 31st March 2023. This has been also mentioned
here: https://techcommunity.microsoft.com/t5/exchange-team-blog/basic-authentication-deprecation-in-exchange-online-time-s-up/ba-p/3695312

This change should also fix the SDH: https://github.com/elastic/sdh-beats/issues/3262

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates [Microsoft Exchange Online Message Trace integration Basic auth deprecated](https://github.com/elastic/sdh-beats/issues/3262)


