### PR TITLE
network_traffic: fix documentation for flows period

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Fix documentation for flows period.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5779
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/network_traffic/data_stream/flow/manifest.yml
+++ b/packages/network_traffic/data_stream/flow/manifest.yml
@@ -29,7 +29,7 @@ streams:
         title: Period
         required: false
         show_user: false
-        description: Configure the reporting interval. All flows are reported at the very same point in time. Periodical reporting can be disabled by setting the value to -1. If disabled, flows are still reported once being timed out.
+        description: Configure the reporting interval. All flows are reported at the very same point in time. Periodical reporting can be disabled by setting the value to -1s. If disabled, flows are still reported once being timed out.
         default: '10s'
       - name: timeout
         type: text

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.10.0"
+version: "1.10.1"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes documentation that misdirects users to use "-1" as a sentinel. This value causes packetbeat to fail to configure.

See https://github.com/elastic/beats/blob/25acf60399e2c56f544f4f76cb76611a28847cdf/packetbeat/flows/flows.go#L49-L66 and https://play.golang.com/p/Z7Si8WEzDAL.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #5771

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
