### PR TITLE
[cisco_umbrella] Fix indentation

### DIFF
--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix indentation.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/5784
 - version: "1.9.0"
   changes:
     - description: Add DLP and intrusion datasets.

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Fix indentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.9.0"
   changes:
     - description: Add DLP and intrusion datasets.

--- a/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
+++ b/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
@@ -17,11 +17,11 @@ file_selectors:
   - regex: {{bucket_list_prefix}}/intrusionlogs/.+
   - regex: {{bucket_list_prefix}}/dlplogs/.+
   - regex: {{bucket_list_prefix}}/auditlogs/.+
-      parsers:
+    parsers:
       - multiline:
-          pattern: '"$'
-          negate:  true
-          match:   before
+        pattern: '"$'
+        negate: true
+        match: before
 {{/if}}
 {{#if region}}
 default_region: {{region}}

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_umbrella
 title: Cisco Umbrella
-version: "1.9.0"
+version: "1.9.1"
 license: basic
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fixes an indentation error that disables configuration of the integration in Kibana.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


