### PR TITLE
[panw] Enable RFC 6587 framing by default on TCP input

### DIFF
--- a/packages/panw/_dev/build/docs/README.md
+++ b/packages/panw/_dev/build/docs/README.md
@@ -20,6 +20,8 @@ To configure syslog monitoring, please follow the steps mentioned in the [_Confi
 - If events are getting truncated, then increase `max_message_size` option for TCP and UDP input type.
   - It can be found under Advanced Options and can be configured as per requirements. The default value of `max_message_size` is set to 50KiB.
 
+- If the TCP input is used, it is recommended that PAN-OS should be configured to send syslog messages using the IETF (RFC 5424) format. In addition, RFC 6587 framing (Octet Counting) will be enabled by default on the TCP input.
+
 ## Logs
 
 ### PAN-OS

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.6.0"
+  changes:
+    - description: Enable RFC6587 framing by default on TCP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0001
 - version: "3.5.2"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/panw/data_stream/panos/manifest.yml
+++ b/packages/panw/data_stream/panos/manifest.yml
@@ -96,9 +96,8 @@ streams:
         show_user: false
         default: |
           max_message_size: 50KiB
+          framing: rfc6587
           #max_connections: 1
-          #framing: delimiter
-          #line_delimiter: "\n"
         description: Specify custom configuration options for the TCP input. See [TCP](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-tcp.html) for details.
   - input: udp
     title: "Collect logs via syslog over UDP"

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -20,6 +20,8 @@ To configure syslog monitoring, please follow the steps mentioned in the [_Confi
 - If events are getting truncated, then increase `max_message_size` option for TCP and UDP input type.
   - It can be found under Advanced Options and can be configured as per requirements. The default value of `max_message_size` is set to 50KiB.
 
+- If the TCP input is used, it is recommended that PAN-OS should be configured to send syslog messages using the IETF (RFC 5424) format. In addition, RFC 6587 framing (Octet Counting) will be enabled by default on the TCP input.
+
 ## Logs
 
 ### PAN-OS

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,12 +1,12 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "3.5.2"
+version: "3.6.0"
 release: ga
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
 format_version: 1.0.0
 license: basic
-categories: [security, network, firewall_security]
+categories: [security, network]
 conditions:
   kibana.version: ^8.2.1
 icons:


### PR DESCRIPTION
## What does this PR do?

- Enabled RFC 6587 framing by default on the TCP input, as PAN-OS devices will use this framing by default when TCP (and TLS) is used.
- Added note in docs recommending that IETF format is used on PAN-OS and that RFC 6587 is enabled by default with TCP input
- Remove non-compliant category from manifest

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/panw && elastic-package test
```

## Related issues

- Closes #4511 
