### PR TITLE
[AWS] Add missing permissions in the AWS Billing integration documentation

### DIFF
--- a/packages/aws/_dev/build/docs/README.md
+++ b/packages/aws/_dev/build/docs/README.md
@@ -149,13 +149,13 @@ Specific AWS permissions are required for the IAM user to make specific AWS API 
 To enable the AWS integration to collect metrics and logs from all supported services,
 make sure these permissions are given:
 
+* `ce:GetCostAndUsage`
 * `cloudwatch:GetMetricData`
 * `cloudwatch:ListMetrics`
 * `ec2:DescribeInstances`
 * `ec2:DescribeRegions`
 * `iam:ListAccountAliases`
-* `logs:DescribeLogGroups`
-* `logs:FilterLogEvents`
+* `organizations:ListAccounts`
 * `rds:DescribeDBInstances`
 * `rds:ListTagsForResource`
 * `s3:GetObject`

--- a/packages/aws/_dev/build/docs/README.md
+++ b/packages/aws/_dev/build/docs/README.md
@@ -155,6 +155,8 @@ make sure these permissions are given:
 * `ec2:DescribeInstances`
 * `ec2:DescribeRegions`
 * `iam:ListAccountAliases`
+* `logs:DescribeLogGroups`
+* `logs:FilterLogEvents`
 * `organizations:ListAccounts`
 * `rds:DescribeDBInstances`
 * `rds:ListTagsForResource`

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,12 +1,12 @@
 # newer versions go on top
 - version: "1.33.2"
   changes:
-    - description: Add missing permissions for AWS Billing integration
+    - description: Add missing permissions in the AWS Billing integration documentation.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/5791
 - version: "1.33.1"
   changes:
-    - description: Add missing permissions required by the CloudWatch logs integration
+    - description: Add missing permissions in the AWS CloudWatch Logs integration documentation.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/5790
 - version: "1.33.0"

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.33.2"
+  changes:
+    - description: Add missing permissions for AWS Billing integration
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5791
 - version: "1.33.1"
   changes:
     - description: Add missing permissions required by the CloudWatch logs integration

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -149,13 +149,13 @@ Specific AWS permissions are required for the IAM user to make specific AWS API 
 To enable the AWS integration to collect metrics and logs from all supported services,
 make sure these permissions are given:
 
+* `ce:GetCostAndUsage`
 * `cloudwatch:GetMetricData`
 * `cloudwatch:ListMetrics`
 * `ec2:DescribeInstances`
 * `ec2:DescribeRegions`
 * `iam:ListAccountAliases`
-* `logs:DescribeLogGroups`
-* `logs:FilterLogEvents`
+* `organizations:ListAccounts`
 * `rds:DescribeDBInstances`
 * `rds:ListTagsForResource`
 * `s3:GetObject`

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -155,6 +155,8 @@ make sure these permissions are given:
 * `ec2:DescribeInstances`
 * `ec2:DescribeRegions`
 * `iam:ListAccountAliases`
+* `logs:DescribeLogGroups`
+* `logs:FilterLogEvents`
 * `organizations:ListAccounts`
 * `rds:DescribeDBInstances`
 * `rds:ListTagsForResource`

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.33.1
+version: 1.33.2
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
Add two missing permissions to the AWS integration docs. 

* `ce:GetCostAndUsage`
* `organizations:ListAccounts`

The source list comes from the [Metricbeat docs](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-metricset-aws-billing.html):




## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

<!-- Recommended
## How to test this PR locally

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #5019


<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
