### PR TITLE
[D4C] Added mapping for cloud_defend.trace_point. Fixed host.name and host…

### DIFF
--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Added mapping for cloud_defend.trace_point. Fixed host.name and host.hostname examples, and added cloud.instance.name to field list in README.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5514
 - version: "1.0.1"
   changes:
     - description: Default policy updated to include new file/process selector schema.

--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added mapping for cloud_defend.trace_point. Fixed host.name and host.hostname examples, and added cloud.instance.name to field list in README.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5514
+      link: https://github.com/elastic/integrations/pull/5793
 - version: "1.0.1"
   changes:
     - description: Default policy updated to include new file/process selector schema.

--- a/packages/cloud_defend/data_stream/alerts/fields/fields.yml
+++ b/packages/cloud_defend/data_stream/alerts/fields/fields.yml
@@ -7,6 +7,9 @@
 - name: cloud_defend.package_policy_revision
   type: short
   description: The revision of the cloud_defend.package_policy_id
+- name: cloud_defend.trace_point
+  type: keyword
+  description: The trace point used to trigger the event.
 - name: orchestrator.resource.label
   type: flattened
   description: An object containing the labels for the resource being acted upon.

--- a/packages/cloud_defend/data_stream/file/fields/fields.yml
+++ b/packages/cloud_defend/data_stream/file/fields/fields.yml
@@ -7,6 +7,9 @@
 - name: cloud_defend.package_policy_revision
   type: short
   description: The revision of the cloud_defend.package_policy_id
+- name: cloud_defend.trace_point
+  type: keyword
+  description: The trace point used to trigger the event.
 - name: orchestrator.resource.label
   type: flattened
   description: An object containing the labels for the resource being acted upon.

--- a/packages/cloud_defend/data_stream/process/fields/fields.yml
+++ b/packages/cloud_defend/data_stream/process/fields/fields.yml
@@ -7,6 +7,9 @@
 - name: cloud_defend.package_policy_revision
   type: short
   description: The revision of the cloud_defend.package_policy_id
+- name: cloud_defend.trace_point
+  type: keyword
+  description: The trace point used to trigger the event.
 - name: orchestrator.resource.label
   type: flattened
   description: An object containing the labels for the resource being acted upon.

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -166,6 +166,7 @@ responses:
 | [cloud.account.id](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-account-id) | '1234567abc' |
 | [cloud.account.name](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-account-name) | 'elastic-dev' |
 | [cloud.availability_zone](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-availability-zone) | us-east-1c |
+| [cloud.instance.name](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-instance-name) | 'webapp-node' |
 | [cloud.project.id](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-project-id) | '123456abc' |
 | [cloud.project.name](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-project-name) | 'staging' |
 | [cloud.provider](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-provider) | aws |
@@ -196,9 +197,9 @@ responses:
 | [host.boot.id](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-boot-id) | '815a760f-8153-49e1-9d0b-da0d3b2a468c' |
 | [host.id](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-id) | '1bb9e6a948dfb1c3cd38d1fdc8de4481' |
 | [host.ip](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-ip) | ['127.0.0.1', '172.20.0.2', '172.18.0.6'] |
-| [host.hostname](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname) | 'docker-custom-agent' |
+| [host.hostname](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname) | 'kibana-node' |
 | [host.mac](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-mac) | ['32:a9:cc:26:4c:e5', '7a:ec:f0:3e:29:ee'] |
-| [host.name](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-name) | 'docker-custom-agent' |
+| [host.name](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-name) | 'kibana-node.myapp.co' |
 | [host.os.family](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-os-family) | 'ubuntu' |
 | [host.os.full](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-os-full) | 'Ubuntu 20.04.5' |
 | [host.os.kernel](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-os-kernel) | '5.10.161+ #1 SMP Thu Jan 5 22:49:42 UTC 2023' |
@@ -320,9 +321,9 @@ responses:
 | [host.boot.id](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-boot-id) | '815a760f-8153-49e1-9d0b-da0d3b2a468c' |
 | [host.id](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-id) | '1bb9e6a948dfb1c3cd38d1fdc8de4481' |
 | [host.ip](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-ip) | ['127.0.0.1', '172.20.0.2', '172.18.0.6'] |
-| [host.hostname](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname) | 'docker-custom-agent' |
+| [host.hostname](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname) | 'kibana-node' |
 | [host.mac](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-mac) | ['32:a9:cc:26:4c:e5', '7a:ec:f0:3e:29:ee'] |
-| [host.name](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-name) | 'docker-custom-agent' |
+| [host.name](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-name) | 'kibana-node.myapp.co' |
 | [host.os.family](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-os-family) | 'ubuntu' |
 | [host.os.full](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-os-full) | 'Ubuntu 20.04.5' |
 | [host.os.kernel](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-os-kernel) | '5.10.161+ #1 SMP Thu Jan 5 22:49:42 UTC 2023' |

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_defend
 title: "Defend for Containers"
-version: 1.0.1
+version: 1.0.2
 source:
   license: "Elastic-2.0"
 description: "Elastic Defend for Containers provides cloud-native runtime protections for containerized environments."


### PR DESCRIPTION
….hostname examples, and added cloud.instance.name to field list in README.

## What does this PR do?

Added mapping for cloud_defend.trace_point. Fixed host.name and host.hostname examples, and added cloud.instance.name to field list in README.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).