### PR TITLE
[AWS] Add `number_of_workers` and `latency` to all CloudWatch Logs based integrations

### DIFF
--- a/packages/aws/_dev/build/docs/cloudtrail.md
+++ b/packages/aws/_dev/build/docs/cloudtrail.md
@@ -40,6 +40,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 {{ url "getting-started-observability" "Getting started" }} guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `cloudtrail` data stream collects AWS CloudTrail logs. CloudTrail monitors events like

--- a/packages/aws/_dev/build/docs/cloudwatch.md
+++ b/packages/aws/_dev/build/docs/cloudwatch.md
@@ -40,13 +40,23 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 {{ url "getting-started-observability" "Getting started" }} guide.
 
-### Advanced
+### Advanced options
 
-#### Latency
+#### CloudWatch
 
-Log events on the busies log groups may require a longer time before they are available to CloudWatch Logs.
+The CloudWatch logs input has several advanced options to fit specific use cases.
 
-The CloudWatch integration offers the `latency` setting to cope with this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
 
 ## Logs reference
 

--- a/packages/aws/_dev/build/docs/ec2.md
+++ b/packages/aws/_dev/build/docs/ec2.md
@@ -40,6 +40,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 {{ url "getting-started-observability" "Getting started" }} guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `ec2` data stream supports both EC2 logs stored in AWS CloudWatch and EC2 logs stored in Amazon S3.

--- a/packages/aws/_dev/build/docs/elb.md
+++ b/packages/aws/_dev/build/docs/elb.md
@@ -47,6 +47,24 @@ For an application load balancer, see [enable access log for application load ba
 
 For a network load balancer, see [enable access log for network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest//network/load-balancer-access-logs.html).
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `elb` dataset collects logs from AWS ELBs.

--- a/packages/aws/_dev/build/docs/firewall.md
+++ b/packages/aws/_dev/build/docs/firewall.md
@@ -40,6 +40,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 {{ url "getting-started-observability" "Getting started" }} guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `firewall_logs` dataset collects AWS Network Firewall logs. Users can use these logs to

--- a/packages/aws/_dev/build/docs/route53.md
+++ b/packages/aws/_dev/build/docs/route53.md
@@ -37,6 +37,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 {{ url "getting-started-observability" "Getting started" }} guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 ### Public Hosted Zone logs

--- a/packages/aws/_dev/build/docs/vpcflow.md
+++ b/packages/aws/_dev/build/docs/vpcflow.md
@@ -58,6 +58,24 @@ This integration supports various plain text VPC flow log formats:
 ${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status} ${vpc-id} ${subnet-id} ${instance-id} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr} ${region} ${az-id} ${sublocation-type} ${sublocation-id} ${pkt-src-aws-service} ${pkt-dst-aws-service} ${flow-direction} ${traffic-path}
 ```
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 > Note: The Parquet format is not supported.

--- a/packages/aws/_dev/build/docs/waf.md
+++ b/packages/aws/_dev/build/docs/waf.md
@@ -41,6 +41,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 {{ url "getting-started-observability" "Getting started" }} guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `waf` dataset is specifically for WAF logs. Export logs from Kinesis Data Firehose to Amazon S3 bucket which has SQS notification setup already.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.33.3"
+  changes:
+    - description: Add number_of_workers and latency to all CloudWatch Logs based integrations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5794
 - version: "1.33.2"
   changes:
     - description: Add missing permissions in the AWS Billing integration documentation.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -12,7 +12,7 @@
 - version: "1.33.0"
   changes:
     - description: Add latency configuration option on the CloudWatch Logs integration.
-      type: bugfix
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/5777
 - version: "1.32.2"
   changes:

--- a/packages/aws/data_stream/cloudtrail/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/cloudtrail/agent/stream/aws-cloudwatch.yml.hbs
@@ -50,6 +50,13 @@ scan_frequency: {{ scan_frequency }}
 api_sleep: {{ api_sleep }}
 {{/if}}
 
+{{#if latency }}
+latency: {{ latency }}
+{{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/cloudtrail/manifest.yml
+++ b/packages/aws/data_stream/cloudtrail/manifest.yml
@@ -273,6 +273,19 @@ streams:
         show_user: false
         default: 200ms
         description: This is used to sleep between AWS FilterLogEvents API calls inside the same collection period. `FilterLogEvents` API has a quota of 5 transactions per second (TPS)/account/Region. This value should only be adjusted when there are multiple Filebeats or multiple Filebeat inputs collecting logs from the same region and AWS account.
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/cloudwatch_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -56,6 +56,9 @@ api_sleep: {{ api_sleep }}
 {{#if latency }}
 latency: {{ latency }}
 {{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
 
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -156,6 +156,12 @@ streams:
         required: false
         show_user: false
         description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching the `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/ec2_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/ec2_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -50,6 +50,13 @@ scan_frequency: {{ scan_frequency }}
 api_sleep: {{ api_sleep }}
 {{/if}}
 
+{{#if latency }}
+latency: {{ latency }}
+{{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -148,6 +148,19 @@ streams:
         show_user: false
         default: 200ms
         description: This is used to sleep between AWS FilterLogEvents API calls inside the same collection period. `FilterLogEvents` API has a quota of 5 transactions per second (TPS)/account/Region. This value should only be adjusted when there are multiple Filebeats or multiple Filebeat inputs collecting logs from the same region and AWS account.
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/elb_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/elb_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -50,6 +50,13 @@ scan_frequency: {{ scan_frequency }}
 api_sleep: {{ api_sleep }}
 {{/if}}
 
+{{#if latency }}
+latency: {{ latency }}
+{{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/elb_logs/manifest.yml
+++ b/packages/aws/data_stream/elb_logs/manifest.yml
@@ -148,6 +148,19 @@ streams:
         show_user: false
         default: 200ms
         description: This is used to sleep between AWS FilterLogEvents API calls inside the same collection period. `FilterLogEvents` API has a quota of 5 transactions per second (TPS)/account/Region. This value should only be adjusted when there are multiple Filebeats or multiple Filebeat inputs collecting logs from the same region and AWS account.
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/firewall_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/firewall_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -50,6 +50,13 @@ scan_frequency: {{ scan_frequency }}
 api_sleep: {{ api_sleep }}
 {{/if}}
 
+{{#if latency }}
+latency: {{ latency }}
+{{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/firewall_logs/manifest.yml
+++ b/packages/aws/data_stream/firewall_logs/manifest.yml
@@ -148,6 +148,19 @@ streams:
         show_user: false
         default: 200ms
         description: This is used to sleep between AWS FilterLogEvents API calls inside the same collection period. `FilterLogEvents` API has a quota of 5 transactions per second (TPS)/account/Region. This value should only be adjusted when there are multiple Filebeats or multiple Filebeat inputs collecting logs from the same region and AWS account.
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/route53_public_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/route53_public_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -50,6 +50,13 @@ scan_frequency: {{ scan_frequency }}
 api_sleep: {{ api_sleep }}
 {{/if}}
 
+{{#if latency }}
+latency: {{ latency }}
+{{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/route53_public_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_public_logs/manifest.yml
@@ -78,6 +78,19 @@ streams:
         multi: false
         show_user: false
         required: false
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/route53_resolver_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/route53_resolver_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -50,6 +50,13 @@ scan_frequency: {{ scan_frequency }}
 api_sleep: {{ api_sleep }}
 {{/if}}
 
+{{#if latency }}
+latency: {{ latency }}
+{{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/route53_resolver_logs/manifest.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/manifest.yml
@@ -78,6 +78,19 @@ streams:
         multi: false
         show_user: false
         required: false
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/vpcflow/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/vpcflow/agent/stream/aws-cloudwatch.yml.hbs
@@ -50,6 +50,13 @@ scan_frequency: {{ scan_frequency }}
 api_sleep: {{ api_sleep }}
 {{/if}}
 
+{{#if latency }}
+latency: {{ latency }}
+{{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/vpcflow/manifest.yml
+++ b/packages/aws/data_stream/vpcflow/manifest.yml
@@ -148,6 +148,19 @@ streams:
         show_user: false
         default: 200ms
         description: This is used to sleep between AWS FilterLogEvents API calls inside the same collection period. `FilterLogEvents` API has a quota of 5 transactions per second (TPS)/account/Region. This value should only be adjusted when there are multiple Filebeats or multiple Filebeat inputs collecting logs from the same region and AWS account.
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/data_stream/waf/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/waf/agent/stream/aws-cloudwatch.yml.hbs
@@ -50,6 +50,13 @@ scan_frequency: {{ scan_frequency }}
 api_sleep: {{ api_sleep }}
 {{/if}}
 
+{{#if latency }}
+latency: {{ latency }}
+{{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}
 {{/if}}

--- a/packages/aws/data_stream/waf/manifest.yml
+++ b/packages/aws/data_stream/waf/manifest.yml
@@ -148,6 +148,19 @@ streams:
         show_user: false
         default: 200ms
         description: This is used to sleep between AWS FilterLogEvents API calls inside the same collection period. `FilterLogEvents` API has a quota of 5 transactions per second (TPS)/account/Region. This value should only be adjusted when there are multiple Filebeats or multiple Filebeat inputs collecting logs from the same region and AWS account.
+      - name: latency
+        type: text
+        title: Latency
+        multi: false
+        required: false
+        show_user: false
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws/docs/cloudtrail.md
+++ b/packages/aws/docs/cloudtrail.md
@@ -40,6 +40,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `cloudtrail` data stream collects AWS CloudTrail logs. CloudTrail monitors events like

--- a/packages/aws/docs/cloudwatch.md
+++ b/packages/aws/docs/cloudwatch.md
@@ -40,13 +40,23 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
-### Advanced
+### Advanced options
 
-#### Latency
+#### CloudWatch
 
-Log events on the busies log groups may require a longer time before they are available to CloudWatch Logs.
+The CloudWatch logs input has several advanced options to fit specific use cases.
 
-The CloudWatch integration offers the `latency` setting to cope with this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
 
 ## Logs reference
 
@@ -240,3 +250,4 @@ An example event for `cloudwatch` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+

--- a/packages/aws/docs/ec2.md
+++ b/packages/aws/docs/ec2.md
@@ -40,6 +40,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `ec2` data stream supports both EC2 logs stored in AWS CloudWatch and EC2 logs stored in Amazon S3.

--- a/packages/aws/docs/elb.md
+++ b/packages/aws/docs/elb.md
@@ -47,6 +47,24 @@ For an application load balancer, see [enable access log for application load ba
 
 For a network load balancer, see [enable access log for network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest//network/load-balancer-access-logs.html).
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `elb` dataset collects logs from AWS ELBs.
@@ -472,3 +490,4 @@ An example event for `elb` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+

--- a/packages/aws/docs/firewall.md
+++ b/packages/aws/docs/firewall.md
@@ -40,6 +40,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `firewall_logs` dataset collects AWS Network Firewall logs. Users can use these logs to

--- a/packages/aws/docs/route53.md
+++ b/packages/aws/docs/route53.md
@@ -37,6 +37,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 ### Public Hosted Zone logs

--- a/packages/aws/docs/vpcflow.md
+++ b/packages/aws/docs/vpcflow.md
@@ -58,6 +58,24 @@ This integration supports various plain text VPC flow log formats:
 ${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status} ${vpc-id} ${subnet-id} ${instance-id} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr} ${region} ${az-id} ${sublocation-type} ${sublocation-id} ${pkt-src-aws-service} ${pkt-dst-aws-service} ${flow-direction} ${traffic-path}
 ```
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 > Note: The Parquet format is not supported.

--- a/packages/aws/docs/waf.md
+++ b/packages/aws/docs/waf.md
@@ -41,6 +41,24 @@ When you configure the AWS integration, you can collect data from as many AWS se
 For step-by-step instructions on how to set up an integration, see the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
+### Advanced options
+
+#### CloudWatch
+
+The CloudWatch logs input has several advanced options to fit specific use cases.
+
+##### Latency
+
+AWS CloudWatch Logs sometimes takes extra time to make the latest logs available to clients like the Agent.
+
+The CloudWatch integration offers the `latency` setting to address this scenario. Latency translates the query's time range to consider the CloudWatch Logs latency. For example, a `5m` latency means the integration will query CloudWatch for logs available 5 minutes ago.
+
+##### Number of workers
+
+If you are collecting log events from multiple log groups using `log_group_name_prefix`, you should review the value of the `number_of_workers`.
+
+The `number_of_workers` setting defines the number of workers assigned to reading from log groups. Each log group matching the `log_group_name_prefix` requires a worker to keep log ingestion as close to real-time as possible. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+
 ## Logs reference
 
 The `waf` dataset is specifically for WAF logs. Export logs from Kinesis Data Firehose to Amazon S3 bucket which has SQS notification setup already.

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.33.2
+version: 1.33.3
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
@@ -62,6 +62,9 @@ api_sleep: {{ api_sleep }}
 {{#if latency }}
 latency: {{ latency }}
 {{/if}}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
 
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -94,7 +94,13 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: Some AWS services send logs to CloudWatch with a latency to process larger than aws-cloudwatch input scan_frequency. This case, please use this latency parameter so collection start time and end time will be shifted by the given latency amount.
+        description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
+      - name: number_of_workers
+        type: integer
+        title: Number of workers
+        required: false
+        show_user: false
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

### Motivation
<!-- Why this pull request? -->

#### Number of workers

When users set up the integration to collect logs from a single log group, the default value (`1`) for `number_of_workers` is adequate to fetch the log events at each iteration.

However, when users utilize `log_group_name_prefix` to collect log events from multiple log groups, according to elastic/beats#29695, the `number_of_workers` should be increased to reach the number of log groups matching the prefix.

#### Latency

The `latency` can be required on the busiest log groups to deal with potential latency.

#### Conclusion

All the CloudWatch Logs-based integration should have these options available to them.


### Change description
<!-- What does your code do? -->

Updates the configuration template and integration variables to make these Filebeat configuration options available to the integration settings UI.

It also added a new "Advanced options" section under the "Setup" section to give more details about these options. I plan to add leverage this and other new sections to explain how the integration works.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->


## How to test this PR locally
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

I created four logs groups with plain text data:

- `test-mbranca-groucho`
- `test-mbranca-gummo`
- `test-mbranca-harpo`
- `test-mbranca-zeppo`

And I configured a CloudWatch Logs integration with the following settings:

- Log Group Name Prefix: `test-mbranca`
- Region: `<REGION FOR THE LOG GROUPS>`
- All other settings have been left with their default value

The only existing worker will pick up one log group at a time during each iteration.

![CleanShot 2023-04-12 at 19 23 59@2x](https://user-images.githubusercontent.com/25941/231538181-2d60fa8b-4ec6-45f8-9615-afb2873b8ed6.png)

Each log group will process data every four iterations.

Then I changed the following settings:

- Number of workers: `4` (previously was unset)

![CleanShot 2023-04-12 at 19 28 27@2x](https://user-images.githubusercontent.com/25941/231537914-61dd39a4-0592-466b-a392-bb6ddba0a459.png)

The four available workers will pick up one log group each during each iteration.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates elastic/beats#29695

<!-- Optional
## Screenshots

Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
