### PR TITLE
[Synthetics] add additional lightweight heartbeat configs

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add new lightweight heartbeat configs
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5625
+      link: https://github.com/elastic/integrations/pull/5798
 - version: "0.11.8"
   changes:
     - description: Fix broken mapping for state.ends.id.

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.0"
+  changes:
+    - description: Add new lightweight heartbeat configs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5625
 - version: "0.11.8"
   changes:
     - description: Fix broken mapping for state.ends.id.

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -24,6 +24,9 @@ max_redirects: {{max_redirects}}
 {{#if proxy_url}}
 proxy_url: {{proxy_url}}
 {{/if}}
+{{#if proxy_headers}}
+proxy_headers: {{proxy_headers}}
+{{/if}}
 {{#if tags}}
 tags: {{tags}}
 {{/if}}
@@ -54,6 +57,9 @@ check.response.body.negative: {{check.response.body.negative}}
 {{#if check.response.body.positive}}
 check.response.body.positive: {{check.response.body.positive}}
 {{/if}}
+{{#if check.response.json}}
+check.response.json: {{check.response.json}}
+{{/if}}
 {{#if ssl.certificate}}
 ssl.certificate: {{ssl.certificate}}
 {{/if}}
@@ -72,6 +78,11 @@ ssl.verification_mode: {{ssl.verification_mode}}
 {{#if ssl.supported_protocols}}
 ssl.supported_protocols: {{ssl.supported_protocols}}
 {{/if}}
+{{#if mode}}
+mode: {{mode}}
+{{/if}}
+ipv4: {{ipv4}}
+ipv6: {{ipv6}}
 processors:
   - add_fields:
       target: ''

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -85,6 +85,12 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: proxy_headers
+        type: yaml
+        title: Proxy headers
+        multi: false
+        required: false
+        show_user: true
       - name: tags
         type: yaml
         title: Tags
@@ -112,6 +118,12 @@ streams:
       - name: response.include_body
         type: text
         title: Index response headers
+        multi: false
+        required: false
+        show_user: true
+      - name: response.include_body_max_bytes
+        type: text
+        title: Max bytes to include in response body when indexed
         multi: false
         required: false
         show_user: true
@@ -154,6 +166,12 @@ streams:
       - name: check.response.body.negative
         type: yaml
         title: Check response body does not include
+        multi: false
+        required: false
+        show_user: true
+      - name: check.response.json
+        type: yaml
+        title: A list of expressions executed against the body when parsed as JSON.
         multi: false
         required: false
         show_user: true
@@ -237,3 +255,23 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: mode
+        type: text
+        title: Heartbeat mode
+        multi: false
+        required: false
+        show_user: true   
+      - name: ipv4
+        type: bool
+        title: Use the ipv4 protocol
+        multi: false
+        required: false
+        show_user: true
+        default: true
+      - name: ipv6
+        type: bool
+        title: Use the ipv6 protocol
+        multi: false
+        required: false
+        show_user: true
+        default: true

--- a/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/synthetics/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -24,6 +24,11 @@ timeout: {{timeout}}
 {{#if tags}}
 tags: {{tags}}
 {{/if}}
+{{#if mode}}
+mode: {{mode}}
+{{/if}}
+ipv4: {{ipv4}}
+ipv6: {{ipv6}}
 processors:
   - add_fields:
       target: ''

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -130,3 +130,23 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: mode
+        type: text
+        title: Heartbeat mode
+        multi: false
+        required: false
+        show_user: true   
+      - name: ipv4
+        type: bool
+        title: Use the ipv4 protocol
+        multi: false
+        required: false
+        show_user: true
+        default: true
+      - name: ipv6
+        type: bool
+        title: Use the ipv6 protocol
+        multi: false
+        required: false
+        show_user: true
+        default: true

--- a/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
+++ b/packages/synthetics/data_stream/tcp/agent/stream/tcp.yml.hbs
@@ -51,6 +51,11 @@ ssl.verification_mode: {{ssl.verification_mode}}
 {{#if ssl.supported_protocols}}
 ssl.supported_protocols: {{ssl.supported_protocols}}
 {{/if}}
+{{#if mode}}
+mode: {{mode}}
+{{/if}}
+ipv4: {{ipv4}}
+ipv6: {{ipv6}}
 processors:
   - add_fields:
       target: ''

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -184,3 +184,23 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: mode
+        type: text
+        title: Heartbeat mode
+        multi: false
+        required: false
+        show_user: true   
+      - name: ipv4
+        type: bool
+        title: Use the ipv4 protocol
+        multi: false
+        required: false
+        show_user: true
+        default: true
+      - name: ipv6
+        type: bool
+        title: Use the ipv6 protocol
+        multi: false
+        required: false
+        show_user: true
+        default: true

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Monitor the availability of your services with Elastic Synthetics.
-version: 0.11.8
+version: 0.12.0
 categories: ["observability"]
 release: beta
 type: integration
@@ -25,7 +25,7 @@ policy_templates:
         title: Browser
         description: Perform an Browser check
 conditions:
-  kibana.version: "^8.7.0"
+  kibana.version: "^8.8.0"
 icons:
   - src: /img/uptime-logo-color-64px.svg
     size: 16x16


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/140864

Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement

## What does this PR do?

Adds missing heartbeat lightweight configs to the Synthetics integration