### PR TITLE
network_traffic: fix passing of period and timeout parameters to agent

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Fix passing flow period and timeout to agent.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5804
 - version: "1.11.0"
   changes:
     - description: Add flow is final filter to Network flow dashboard.

--- a/packages/network_traffic/data_stream/flow/_dev/test/system/test-http-get-2k-file-config.yml
+++ b/packages/network_traffic/data_stream/flow/_dev/test/system/test-http-get-2k-file-config.yml
@@ -3,4 +3,4 @@ vars:
 input: packet
 data_stream:
   vars:
-    flows.period: '-1s'
+    period: '-1s'

--- a/packages/network_traffic/data_stream/flow/_dev/test/system/test-icmp-2-pings-config.yml
+++ b/packages/network_traffic/data_stream/flow/_dev/test/system/test-icmp-2-pings-config.yml
@@ -3,4 +3,5 @@ vars:
 input: packet
 data_stream:
   vars:
-    flows.period: '-1s'
+    timeout: '5s'
+    period: '-1s'

--- a/packages/network_traffic/data_stream/flow/_dev/test/system/test-icmp4-ping-config.yml
+++ b/packages/network_traffic/data_stream/flow/_dev/test/system/test-icmp4-ping-config.yml
@@ -3,4 +3,4 @@ vars:
 input: packet
 data_stream:
   vars:
-    flows.period: '1s'
+    period: '1s'

--- a/packages/network_traffic/data_stream/flow/_dev/test/system/test-icmp6-ping-config.yml
+++ b/packages/network_traffic/data_stream/flow/_dev/test/system/test-icmp6-ping-config.yml
@@ -3,4 +3,4 @@ vars:
 input: packet
 data_stream:
   vars:
-    flows.period: '1s'
+    period: '1s'

--- a/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
+++ b/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
@@ -1,9 +1,9 @@
 type: flow
 {{#if timeout}}
-flows.timeout: '{{timeout}}'
+timeout: '{{timeout}}'
 {{/if}}
 {{#if period}}
-flows.period: '{{period}}'
+period: '{{period}}'
 {{/if}}
 fields_under_root: true
 fields:

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.11.0"
+version: "1.11.1"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This fixes the passing of the flows period and timeout parameters which previously were passed to agent in the wrong location always resulting in the agent using the default values specified by packetbeat, 10s and 30s.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

To confirm this is working correctly, before running the tests with `elastic-package`, set the agent logging level to "debug". Run the system tests and when they have completed, step into the agent's terminal and collect diagnostics with `./elastic-agent diagnostics`. Examine the log file for the log line describing packetbeat's understanding of the parameters, e.g. (note the `period=-1s`):
```
$ jq 'select(.message | startswith("new flows worker")).message' < elastic-agent-diagnostics-2023-04-06T04-52-21Z-00/logs/elastic-agent-20230406.ndjson
"new flows worker. timeout=5s, period=-1s, tick=5s, ticksTO=1, ticksP=-1"
"new flows worker. timeout=30s, period=1s, tick=1s, ticksTO=30, ticksP=1"
"new flows worker. timeout=30s, period=1s, tick=1s, ticksTO=30, ticksP=1"
"new flows worker. timeout=30s, period=-1s, tick=30s, ticksTO=1, ticksP=-1"
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #5771

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
