### PR TITLE
cloudflare: safe escape authentication keys

### DIFF
--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Safe escape authentication keys.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5805
 - version: "2.5.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/cloudflare/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/cloudflare/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -18,7 +18,7 @@ request.transforms:
       value: "{{auth_email}}"
   - set:
       target: header.X-Auth-Key
-      value: "{{auth_key}}"
+      value: {{escape_string auth_key}}
   - set:
       target: url.params.since
       value: "[[.cursor.last_timestamp]]"

--- a/packages/cloudflare/data_stream/logpull/agent/stream/httpjson.yml.hbs
+++ b/packages/cloudflare/data_stream/logpull/agent/stream/httpjson.yml.hbs
@@ -23,7 +23,7 @@ request.transforms:
       value: "{{auth_email}}"
   - set:
       target: header.X-Auth-Key
-      value: "{{auth_key}}"
+      value: {{escape_string auth_key}}
 {{/if}}
   - set:
       target: url.params.start

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: "2.5.0"
+version: "2.5.1"
 release: ga
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security, network, cdn_security]
 conditions:
-  kibana.version: ^8.0.0
+  kibana.version: ^8.4.0
 icons:
   - src: /img/cf-logo-v.svg
     title: Cloudflare


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Previously keys containing double quotes would cause YAML parsing error, so use the handlebars escape_string helper. This is available from v8.3.3 and v8.4.0, so constrain kibana version to ^v8.4.0.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #3388

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
