### PR TITLE
[Akamai] Add toggle to enable request tracing

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.0"
+  changes:
+    - description: Added optional toggle to enable debug trace logging.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5825
 - version: "2.5.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/akamai/data_stream/siem/_dev/test/system/test-default-config.yml
+++ b/packages/akamai/data_stream/siem/_dev/test/system/test-default-config.yml
@@ -10,3 +10,4 @@ data_stream:
     access_token: abcd
     config_ids: aaaa
     ssl.verification_mode: none
+    enable_request_tracer: true

--- a/packages/akamai/data_stream/siem/agent/stream/httpjson.yml.hbs
+++ b/packages/akamai/data_stream/siem/agent/stream/httpjson.yml.hbs
@@ -11,6 +11,9 @@ request.timeout: {{http_client_timeout}}
 {{#if proxy_url }}
 request.proxy_url: {{proxy_url}}
 {{/if}}
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-akamai.ndjson
+{{/if}}
 request.transforms:
   - set:
       target: url.params.from

--- a/packages/akamai/data_stream/siem/manifest.yml
+++ b/packages/akamai/data_stream/siem/manifest.yml
@@ -103,6 +103,16 @@ streams:
         required: false
         show_user: false
         description: "Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. \nThis executes in the agent before the logs are parsed. \nSee [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.\n"
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
   - input: gcs
     title: Collect Akamai SIEM logs via Google Cloud Storage [Beta]
     description: Collecting SIEM logs from Akamai via Google Cloud Storage.

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.5.0"
+version: "2.6.0"
 release: ga
 description: Collect logs from Akamai with Elastic Agent.
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: [security, cdn_security]
 conditions:
-  kibana.version: "^8.3.0"
+  kibana.version: "^8.5.0"
 icons:
   - src: /img/akamai_logo.svg
     title: Akamai


### PR DESCRIPTION
## What does this PR do?

Add an advanced option to enable http request trace logging for debugging purposes.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

1. elastic-package build
2. elastic-package install
3. Use Kibana to add the integration to an Agent policy and toggle on the tracer feature.
4. Verify request/response logs are in `/usr/share/elastic-agent/state/data/run/httpjson-default/http-request-trace-httpjson*.ndjson`.
