### PR TITLE
[osquery manager] ECS field group.id missing

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
-# newer versions go on top
+# newer versions go on top 5832
+- version: "1.7.3"
+  changes:
+    - description: Fix mapping conflicts
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5832
 - version: "1.7.2"
   changes:
     - description: Fix mapping conflicts

--- a/packages/osquery_manager/data_stream/result/fields/ecs.yml
+++ b/packages/osquery_manager/data_stream/result/fields/ecs.yml
@@ -126,6 +126,8 @@
 - external: ecs
   name: file.x509.public_key_size
 - external: ecs
+  name: group.id
+- external: ecs
   name: host.disk.read.bytes
 - external: ecs
   name: host.disk.write.bytes

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.7.2
+version: 1.7.3
 license: basic
 description: Deploy osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration


### PR DESCRIPTION
Conforming more fields to ECS.

- Enhancement


## What does this PR do?

Add group.id ECS field

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).