### PR TITLE
[System/Windows/Winlog] Document 21 Event ID clause limit under certain situations

### DIFF
--- a/packages/system/_dev/build/docs/README.md
+++ b/packages/system/_dev/build/docs/README.md
@@ -53,6 +53,35 @@ permissions can be blocked by
 In addition, when running inside a container the proc filesystem directory of the host
 should be set using `system.hostfs` setting to `/hostfs`.
 
+### Windows Event ID clause limit
+
+If you specify more than 22 query conditions (event IDs or event ID ranges), some
+versions of Windows will prevent the integration from reading the event log due to
+limits in the query system. If this occurs, a similar warning as shown below:
+
+```
+The specified query is invalid.
+```
+
+In some cases, the limit may be lower than 22 conditions. For instance, using a
+mixture of ranges and single event IDs, along with an additional parameter such
+as `ignore older`, results in a limit of 21 conditions.
+
+If you have more than 22 conditions, you can work around this Windows limitation
+by using a drop_event processor to do the filtering after filebeat has received
+the events from Windows. The filter shown below is equivalent to
+`event_id: 903, 1024, 2000-2004, 4624` but can be expanded beyond 22 event IDs.
+
+```yaml
+- drop_event.when.not.or:
+  - equals.winlog.event_id: "903"
+  - equals.winlog.event_id: "1024"
+  - equals.winlog.event_id: "4624"
+  - range:
+      winlog.event_id.gte: 2000
+      winlog.event_id.lte: 2004
+```
+
 ## Logs reference
 
 ### Application

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -4,6 +4,11 @@
     - description: Clean Windows dashboards.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5653
+- version: "1.25.3"
+  changes:
+    - description: Document 21 Event ID clause limit under certain situations.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/0001 #FIXME: Set to actual PR
 - version: "1.25.2"
   changes:
     - description: Remove duplicate Windows dashboards.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -7,8 +7,8 @@
 - version: "1.25.3"
   changes:
     - description: Document 21 Event ID clause limit under certain situations.
-      type: bugfix
-      link: https://github.com/elastic/integrations/pull/0001 #FIXME: Set to actual PR
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5838
 - version: "1.25.2"
   changes:
     - description: Remove duplicate Windows dashboards.

--- a/packages/system/data_stream/application/manifest.yml
+++ b/packages/system/data_stream/application/manifest.yml
@@ -22,7 +22,7 @@ streams:
         required: false
         show_user: false
         description: >-
-          A list of included and excluded (blocked) event IDs. The value is a comma-separated list. The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800), and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list. The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800), and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.
       - name: ignore_older
         type: text
         title: Ignore events older than

--- a/packages/system/data_stream/security/manifest.yml
+++ b/packages/system/data_stream/security/manifest.yml
@@ -22,7 +22,7 @@ streams:
         required: false
         show_user: false
         description: >-
-          A list of included and excluded (blocked) event IDs. The value is a comma-separated list. The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800), and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list. The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800), and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.
       - name: ignore_older
         type: text
         title: Ignore events older than

--- a/packages/system/data_stream/system/manifest.yml
+++ b/packages/system/data_stream/system/manifest.yml
@@ -22,7 +22,7 @@ streams:
         required: false
         show_user: false
         description: >-
-          A list of included and excluded (blocked) event IDs. The value is a comma-separated list. The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800), and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list. The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800), and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.
       - name: ignore_older
         type: text
         title: Ignore events older than

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -53,6 +53,35 @@ permissions can be blocked by
 In addition, when running inside a container the proc filesystem directory of the host
 should be set using `system.hostfs` setting to `/hostfs`.
 
+### Windows Event ID clause limit
+
+If you specify more than 22 query conditions (event IDs or event ID ranges), some
+versions of Windows will prevent the integration from reading the event log due to
+limits in the query system. If this occurs, a similar warning as shown below:
+
+```
+The specified query is invalid.
+```
+
+In some cases, the limit may be lower than 22 conditions. For instance, using a
+mixture of ranges and single event IDs, along with an additional parameter such
+as `ignore older`, results in a limit of 21 conditions.
+
+If you have more than 22 conditions, you can work around this Windows limitation
+by using a drop_event processor to do the filtering after filebeat has received
+the events from Windows. The filter shown below is equivalent to
+`event_id: 903, 1024, 2000-2004, 4624` but can be expanded beyond 22 event IDs.
+
+```yaml
+- drop_event.when.not.or:
+  - equals.winlog.event_id: "903"
+  - equals.winlog.event_id: "1024"
+  - equals.winlog.event_id: "4624"
+  - range:
+      winlog.event_id.gte: 2000
+      winlog.event_id.lte: 2004
+```
+
 ## Logs reference
 
 ### Application

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.25.2
+version: 1.25.3
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration

--- a/packages/windows/_dev/build/docs/README.md
+++ b/packages/windows/_dev/build/docs/README.md
@@ -49,6 +49,37 @@ For more information see {{ url "observability-ingest-splunk" "Ingest data from 
 Note: This integration requires Windows Events from Splunk to be in XML format.
 To achieve this, `renderXml` needs to be set to `1` in your [`inputs.conf`](https://docs.splunk.com/Documentation/Splunk/latest/Admin/Inputsconf) file.
 
+## Notes
+
+### Windows Event ID clause limit
+
+If you specify more than 22 query conditions (event IDs or event ID ranges), some
+versions of Windows will prevent the integration from reading the event log due to
+limits in the query system. If this occurs, a similar warning as shown below:
+
+```
+The specified query is invalid.
+```
+
+In some cases, the limit may be lower than 22 conditions. For instance, using a
+mixture of ranges and single event IDs, along with an additional parameter such
+as `ignore older`, results in a limit of 21 conditions.
+
+If you have more than 22 conditions, you can work around this Windows limitation
+by using a drop_event processor to do the filtering after filebeat has received
+the events from Windows. The filter shown below is equivalent to
+`event_id: 903, 1024, 2000-2004, 4624` but can be expanded beyond 22 event IDs.
+
+```yaml
+- drop_event.when.not.or:
+  - equals.winlog.event_id: "903"
+  - equals.winlog.event_id: "1024"
+  - equals.winlog.event_id: "4624"
+  - range:
+      winlog.event_id.gte: 2000
+      winlog.event_id.lte: 2004
+```
+
 ## Logs reference
 
 ### Forwarded

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.2"
+  changes:
+    - description: Document 21 Event ID clause limit under certain situations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0001 # FIXME
 - version: "1.19.1"
   changes:
     - description: Update event code in powershell_operational ingest pipeline processor description

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Document 21 Event ID clause limit under certain situations.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0001 # FIXME
+      link: https://github.com/elastic/integrations/pull/5838
 - version: "1.19.1"
   changes:
     - description: Update event code in powershell_operational ingest pipeline processor description

--- a/packages/windows/data_stream/forwarded/manifest.yml
+++ b/packages/windows/data_stream/forwarded/manifest.yml
@@ -27,7 +27,7 @@ streams:
         type: text
         title: Event ID
         description: >-
-          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.
         required: false
         show_user: false
       - name: ignore_older

--- a/packages/windows/data_stream/powershell/manifest.yml
+++ b/packages/windows/data_stream/powershell/manifest.yml
@@ -27,7 +27,7 @@ streams:
         type: text
         title: Event ID
         description: >-
-          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.
         required: true
         show_user: false
         default: 400, 403, 600, 800

--- a/packages/windows/data_stream/powershell_operational/manifest.yml
+++ b/packages/windows/data_stream/powershell_operational/manifest.yml
@@ -27,7 +27,7 @@ streams:
         type: text
         title: Event ID
         description: >-
-          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.
         required: true
         show_user: false
         default: 4103, 4104, 4105, 4106

--- a/packages/windows/data_stream/sysmon_operational/manifest.yml
+++ b/packages/windows/data_stream/sysmon_operational/manifest.yml
@@ -19,7 +19,7 @@ streams:
         type: text
         title: Event ID
         description: >-
-          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.
         required: false
         show_user: false
       - name: ignore_older

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -49,6 +49,37 @@ For more information see [Ingest data from Splunk](https://www.elastic.co/guide/
 Note: This integration requires Windows Events from Splunk to be in XML format.
 To achieve this, `renderXml` needs to be set to `1` in your [`inputs.conf`](https://docs.splunk.com/Documentation/Splunk/latest/Admin/Inputsconf) file.
 
+## Notes
+
+### Windows Event ID clause limit
+
+If you specify more than 22 query conditions (event IDs or event ID ranges), some
+versions of Windows will prevent the integration from reading the event log due to
+limits in the query system. If this occurs, a similar warning as shown below:
+
+```
+The specified query is invalid.
+```
+
+In some cases, the limit may be lower than 22 conditions. For instance, using a
+mixture of ranges and single event IDs, along with an additional parameter such
+as `ignore older`, results in a limit of 21 conditions.
+
+If you have more than 22 conditions, you can work around this Windows limitation
+by using a drop_event processor to do the filtering after filebeat has received
+the events from Windows. The filter shown below is equivalent to
+`event_id: 903, 1024, 2000-2004, 4624` but can be expanded beyond 22 event IDs.
+
+```yaml
+- drop_event.when.not.or:
+  - equals.winlog.event_id: "903"
+  - equals.winlog.event_id: "1024"
+  - equals.winlog.event_id: "4624"
+  - range:
+      winlog.event_id.gte: 2000
+      winlog.event_id.lte: 2004
+```
+
 ## Logs reference
 
 ### Forwarded

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.19.1
+version: 1.19.2
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:

--- a/packages/winlog/_dev/build/docs/README.md
+++ b/packages/winlog/_dev/build/docs/README.md
@@ -18,6 +18,35 @@ See the {{ url "observability-ingest-splunk" "Splunk API integration documentati
 This integration requires Windows Events from Splunk to be in XML format.
 To achieve this, `renderXml` needs to be set to `1` in your [inputs.conf](https://docs.splunk.com/Documentation/Splunk/latest/Admin/Inputsconf) file.
 
+### Windows Event ID clause limit
+
+If you specify more than 22 query conditions (event IDs or event ID ranges), some
+versions of Windows will prevent the integration from reading the event log due to
+limits in the query system. If this occurs, a similar warning as shown below:
+
+```
+The specified query is invalid.
+```
+
+In some cases, the limit may be lower than 22 conditions. For instance, using a
+mixture of ranges and single event IDs, along with an additional parameter such
+as `ignore older`, results in a limit of 21 conditions.
+
+If you have more than 22 conditions, you can work around this Windows limitation
+by using a drop_event processor to do the filtering after filebeat has received
+the events from Windows. The filter shown below is equivalent to
+`event_id: 903, 1024, 2000-2004, 4624` but can be expanded beyond 22 event IDs.
+
+```yaml
+- drop_event.when.not.or:
+  - equals.winlog.event_id: "903"
+  - equals.winlog.event_id: "1024"
+  - equals.winlog.event_id: "4624"
+  - range:
+      winlog.event_id.gte: 2000
+      winlog.event_id.lte: 2004
+```
+
 ## Logs
 
 {{fields "winlog"}}

--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.1"
+  changes:
+    - description: Document 21 Event ID clause limit under certain situations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0001 #FIXME
 - version: "1.13.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/winlog/changelog.yml
+++ b/packages/winlog/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Document 21 Event ID clause limit under certain situations.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0001 #FIXME
+      link: https://github.com/elastic/integrations/pull/5838
 - version: "1.13.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/winlog/data_stream/winlog/fields/agent.yml
+++ b/packages/winlog/data_stream/winlog/fields/agent.yml
@@ -195,3 +195,4 @@
       example: "stretch"
       description: >
         OS codename, if any.
+

--- a/packages/winlog/data_stream/winlog/manifest.yml
+++ b/packages/winlog/data_stream/winlog/manifest.yml
@@ -41,7 +41,7 @@ streams:
         type: text
         title: Event ID
         description: >-
-          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 IDs.
+          A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.
         required: false
         show_user: false
       - name: ignore_older

--- a/packages/winlog/docs/README.md
+++ b/packages/winlog/docs/README.md
@@ -18,6 +18,35 @@ See the [Splunk API integration documentation](https://www.elastic.co/guide/en/o
 This integration requires Windows Events from Splunk to be in XML format.
 To achieve this, `renderXml` needs to be set to `1` in your [inputs.conf](https://docs.splunk.com/Documentation/Splunk/latest/Admin/Inputsconf) file.
 
+### Windows Event ID clause limit
+
+If you specify more than 22 query conditions (event IDs or event ID ranges), some
+versions of Windows will prevent the integration from reading the event log due to
+limits in the query system. If this occurs, a similar warning as shown below:
+
+```
+The specified query is invalid.
+```
+
+In some cases, the limit may be lower than 22 conditions. For instance, using a
+mixture of ranges and single event IDs, along with an additional parameter such
+as `ignore older`, results in a limit of 21 conditions.
+
+If you have more than 22 conditions, you can work around this Windows limitation
+by using a drop_event processor to do the filtering after filebeat has received
+the events from Windows. The filter shown below is equivalent to
+`event_id: 903, 1024, 2000-2004, 4624` but can be expanded beyond 22 event IDs.
+
+```yaml
+- drop_event.when.not.or:
+  - equals.winlog.event_id: "903"
+  - equals.winlog.event_id: "1024"
+  - equals.winlog.event_id: "4624"
+  - range:
+      winlog.event_id.gte: 2000
+      winlog.event_id.lte: 2004
+```
+
 ## Logs
 
 **Exported fields**

--- a/packages/winlog/manifest.yml
+++ b/packages/winlog/manifest.yml
@@ -3,7 +3,7 @@ name: winlog
 title: Custom Windows Event Logs
 description: Collect and parse logs from any Windows event log channel with Elastic Agent.
 type: integration
-version: "1.13.0"
+version: "1.13.1"
 release: ga
 conditions:
   kibana.version: '^7.16.0 || ^8.0.0'
@@ -11,7 +11,6 @@ license: basic
 categories:
   - custom
   - os_system
-  - custom_logs
 policy_templates:
   - name: winlogs
     title: Custom Windows event logs


### PR DESCRIPTION
## What does this PR do?

- Add documentation around case where the event ID clause limit is lower than what is claimed by current docs.
- Add additional documentation for workaround when event ID clause limit is exceeded.
- Formatting and cleanup per elastic-package

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~~[ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #5835 
