### PR TITLE
[o365] New field detected: FileSizeBytes

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Add FileSizeBytes field in o365.audit
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5840
 - version: "1.14.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -72,6 +72,8 @@
       type: object
     - name: ExternalAccess
       type: boolean
+    - name: FileSizeBytes
+      type: long
     - name: GroupName
       type: keyword
     - name: Id

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -248,6 +248,7 @@ An example event for `audit` looks as following:
 | o365.audit.ExchangeMetaData.\* |  | object |
 | o365.audit.ExtendedProperties.\* |  | object |
 | o365.audit.ExternalAccess |  | boolean |
+| o365.audit.FileSizeBytes |  | long |
 | o365.audit.GroupName |  | keyword |
 | o365.audit.Id |  | keyword |
 | o365.audit.ImplicitShare |  | keyword |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.14.0"
+version: "1.14.1"
 release: ga
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration


### PR DESCRIPTION
An unknown field of o365.audit.FileSizeBytes was found in my logs when trying to reindex some conflict field indices into a new index.

Sadly, M$ does not appear to have these fields documented in their schema here: https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-schema

Furthermoore, it is much to difficult to get a raw event so I don't have a sample. Perhaps someone else out there can share a o365 Audit document from the SharePointFileOperation in event.code.


- Enhancement


## What does this PR do?
Add new FileSizeBytes field to make sure it is properly mapped.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
