### PR TITLE
[Cisco FTD] Convert source.bytes and network.bytes to integer for proper calculation of network.bytes

### DIFF
--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1454,6 +1454,21 @@ processors:
       field: "_temp_.duration_hms"
       value: "{{{event.duration}}}"
       ignore_empty_value: true
+  #
+  # Ensure source.bytes is integer
+  #
+  - convert:
+      if: "ctx.source?.bytes != null"
+      field: "source.bytes"
+      type: "integer"
+
+  #
+  # Ensure destination.bytes is integer
+  #
+  - convert:
+      if: "ctx.destination?.bytes != null"
+      field: "destination.bytes"
+      type: "integer"
 
   #
   # Sum source.bytes and destination.bytes in network.bytes


### PR DESCRIPTION
## Type of change
- Bug

## What does this PR do?

The values of `source.bytes` and `network.bytes` may enter the pipeline as string values instead of integers. This is causing the combination of strings instead of addition of integers in the calculation of `network.bytes`. This PR adds two `convert` processors immediately before the `network.bytes` calculation to ensure both `source.bytes` and `destination.bytes` are integers. 

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist
- [X] Tested Ingest Pipeline modifications locally


## Related issues

- Closes #5858 