### PR TITLE
Bugfix for a field data

### DIFF
--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.1"
+  changes:
+    - description: Fix a bug for one dimension field
+      type: bugfix
+      link: tbd
 - version: "1.3.0"
   changes:
     - description: Migrate visualizations to lens.

--- a/packages/cockroachdb/data_stream/status/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cockroachdb/data_stream/status/elasticsearch/ingest_pipeline/default.yml
@@ -15,8 +15,8 @@ processors:
       source: |
         if (ctx.cockroachdb.status.up.value == 1){
           ctx.cockroachdb.status.up.value_description = "up"
-          } else if(ctx.cockroachdb.status.up.value.status == 0){
-          ctx.cockroachdb.status.up.value.status = "down"
+          } else if(ctx.cockroachdb.status.up.value == 0){
+          ctx.cockroachdb.status.up.value_description = "down"
         }
 on_failure:
   - set:

--- a/packages/cockroachdb/manifest.yml
+++ b/packages/cockroachdb/manifest.yml
@@ -1,6 +1,6 @@
 name: cockroachdb
 title: CockroachDB Metrics
-version: 1.3.0
+version: 1.3.1
 release: ga
 description: Collect metrics from CockroachDB servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug

## What does this PR do?

This PR fix the data for a field i.e cockroachdb.status.up.value_description, this was getting set properly when the service is up, but for the case when service was down, this was not populating or pipeline was not setting the value for this field.
It was due to some typos in pipeline script, which is fixed by this PR.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



- Relates #5410 