### PR TITLE
[O11y][WebSphere Application Server] Release Session Manager, Servlet, Threadpool lens migration work

### DIFF
--- a/packages/websphere_application_server/changelog.yml
+++ b/packages/websphere_application_server/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Release Session Manager, Servlet, Threadpool lens migration work.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIXME
+      link: https://github.com/elastic/integrations/pull/5870
 - version: "0.4.0"
   changes:
     - description: Migrate 'Session Manager' and 'Servlet' data-streams visualizations to lens.

--- a/packages/websphere_application_server/changelog.yml
+++ b/packages/websphere_application_server/changelog.yml
@@ -4,14 +4,14 @@
     - description: Release Session Manager, Servlet, Threadpool lens migration work.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5870
-- version: "0.4.0"
-  changes:
     - description: Migrate 'Session Manager' and 'Servlet' data-streams visualizations to lens.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5633
     - description: Migrate threadpool data-stream visualizations to lens.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5632
+- version: "0.4.0"
+  changes:
     - description: Migrate jdbc data-stream visualizations to lens.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5631

--- a/packages/websphere_application_server/changelog.yml
+++ b/packages/websphere_application_server/changelog.yml
@@ -1,12 +1,11 @@
 # newer versions go on top
-- version: "0.5.0"
+- version: "0.6.0"
   changes:
-    - description: Release Session Manager, Servlet, Threadpool lens migration work.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/5870
     - description: Migrate 'Session Manager' and 'Servlet' data-streams visualizations to lens.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5633
+- version: "0.5.0"
+  changes:
     - description: Migrate threadpool data-stream visualizations to lens.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5632

--- a/packages/websphere_application_server/changelog.yml
+++ b/packages/websphere_application_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Release Session Manager, Servlet, Threadpool lens migration work.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIXME
 - version: "0.4.0"
   changes:
     - description: Migrate 'Session Manager' and 'Servlet' data-streams visualizations to lens.

--- a/packages/websphere_application_server/manifest.yml
+++ b/packages/websphere_application_server/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: websphere_application_server
 title: WebSphere Application Server
-version: 0.5.0
+version: 0.6.0
 license: basic
 description: Collects metrics from IBM WebSphere Application Server with Elastic Agent.
 type: integration

--- a/packages/websphere_application_server/manifest.yml
+++ b/packages/websphere_application_server/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: websphere_application_server
 title: WebSphere Application Server
-version: 0.4.0
+version: 0.5.0
 license: basic
 description: Collects metrics from IBM WebSphere Application Server with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Enhancement

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
Bump up the package version and release Session Manager, Servlet, Threadpool lens migration work

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/issues/5575
- https://github.com/elastic/integrations/issues/5221