### PR TITLE
[Cloud Security] Add orchestrator.cluster.id to the index mapping

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,9 +1,12 @@
 # newer versions go on top
-- version: "1.3.0-preview5"
+- version: "1.3.0-preview6"
   changes:
     - description: New vulnerability management integration
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5266
+    - description: Support ECS orchestrator.cluster.id field
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5872
     - description: Added categories and/or subcategories.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5123

--- a/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
@@ -114,6 +114,8 @@
   external: ecs
 - name: event.type
   external: ecs
+- name: orchestrator.cluster.id
+  external: ecs
 - name: orchestrator.cluster.name
   external: ecs
 - name: cloud.account.id

--- a/packages/cloud_security_posture/data_stream/findings/fields/fields.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/fields.yml
@@ -1,2 +1,4 @@
 - name: cluster_id
   type: keyword
+- name: orchestrator.cluster.id
+  type: keyword

--- a/packages/cloud_security_posture/data_stream/findings/fields/fields.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/fields.yml
@@ -1,4 +1,2 @@
 - name: cluster_id
   type: keyword
-- name: orchestrator.cluster.id
-  type: keyword

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.3.0-preview5"
+version: "1.3.0-preview6"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## What does this PR do?

Add `orchestrator.cluster.id` to the index mapping

See https://github.com/elastic/cloudbeat/pull/847

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).