### PR TITLE
[Cloud Security Posture] Update CloudFormation template format

### DIFF
--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -127,14 +127,14 @@ policy_templates:
       - type: cloudbeat/vuln_mgmt_aws
         title: Amazon Web Services Vulnerability Management
         description: Vulnerability scan over running resources
-    vars:
-    - name: cloud_formation_template
-      type: text
-      title: Cloud Formation Template
-      multi: false
-      required: true
-      show_user: false
-      description: S3 URL to the Cloud Formation Template
-      default: https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-03-28-15-10-59.yml
+        vars:
+          - name: cloud_formation_template
+            type: text
+            title: Cloud Formation Template
+            multi: false
+            required: true
+            show_user: false
+            description: S3 URL to the Cloud Formation Template
+            default: https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-03-28-15-10-59.yml
 owner:
   github: elastic/cloud-security-posture

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -135,6 +135,6 @@ policy_templates:
             required: true
             show_user: false
             description: Template URL to Cloud Formation Quick Create Stack
-            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-04-02-12-11-35.yml&stackName=Elastic-Vulnerability-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=elastic-agent-KIBANA_VERSION-linux-x86_64
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-04-02-12-11-35.yml&stackName=Elastic-Vulnerability-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=elastic-agent-KIBANA_VERSION-linux-arm64
 owner:
   github: elastic/cloud-security-posture

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -130,11 +130,11 @@ policy_templates:
         vars:
           - name: cloud_formation_template
             type: text
-            title: Cloud Formation Template
+            title: CloudFormation Template
             multi: false
             required: true
             show_user: false
-            description: S3 URL to the Cloud Formation Template
-            default: https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-03-28-15-10-59.yml
+            description: Template URL to Cloud Formation Quick Create Stack
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-04-02-12-11-35.yml&stackName=Elastic-Vulnerability-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=elastic-agent-KIBANA_VERSION-linux-x86_64
 owner:
   github: elastic/cloud-security-posture


### PR DESCRIPTION
### Summary

This PR updates the CloudFormation template format for the Vuln Mgmt policy. The format was now updated to support the full CloudFormation create stack URL, plus these additional parameters to be replaced by Kibana:
- `FLEET_ENROLLMENT_TOKEN`
- `FLEET_URL`
- `KIBANA_VERSION`

### Screenshot

<img width="1505" alt="image" src="https://user-images.githubusercontent.com/19270322/232492627-f549360f-aaff-419e-8950-b42eb9cdf87c.png">
