### PR TITLE
[ci] - Test skipping publishing step for daily 7.17 and 8.x test jobs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
 
     INTEGRATIONS_TESTED = "0"
     FORCE_CHECK_ALL = "${params.force_check_all}"
+    SKIP_PUBLISHING = "${params.skip_publishing}"
   }
   options {
     timeout(time: 4, unit: 'HOURS')
@@ -56,6 +57,7 @@ pipeline {
   parameters {
     string(name: 'stackVersion', defaultValue: '', description: 'Version of the stack to use for testing.')
     booleanParam(name: 'force_check_all', defaultValue: false, description: 'Force checking all integrations.')
+    booleanParam(name: 'skip_publishing', defaultValue: false, description: 'Skip package storage publishing.')
   }
   stages {
     stage('Prepare workspace') {
@@ -428,6 +430,10 @@ def archiveArtifactsSafe(remotePath, artifacts) {
 }
 
 def packageStoragePublish() {
+  if (env.SKIP_PUBLISHING == "true") {
+    echo "packageStoragePublish: skipping because skip_publishing param is ${env.SKIP_PUBLISHING}"
+    return
+  }
   if (env.BRANCH_NAME != 'main' && !env.BRANCH_NAME.startsWith('backport-')) {
     echo "packageStoragePublish: not the main branch or a backport branch, nothing will be published"
     return

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -31,6 +31,7 @@ pipeline {
               parameters: [
                 stringParam(name: 'stackVersion', value: '7.17-SNAPSHOT'),
                 booleanParam(name: 'force_check_all', value: true)
+                booleanParam(name: 'skip_publishing', value: true),
               ],
               quietPeriod: 0,
               wait: true,
@@ -45,6 +46,7 @@ pipeline {
               parameters: [
                 stringParam(name: 'stackVersion', value: '8.7-SNAPSHOT'),
                 booleanParam(name: 'force_check_all', value: true),
+                booleanParam(name: 'skip_publishing', value: true),
               ],
               quietPeriod: 0,
               wait: true,


### PR DESCRIPTION
## What does this PR do?

As an optimization add a parameter to skip the package publishing step.
This avoids any interaction with the remote publishing Jenkins pipeline
so it can avoid errors not related to testing.

There is no need to attempt publishing for jobs that only are concerned
with testing (e.g. daily tests agains 7.17 and 8.x).

## Background

This PR began as just a test to try to understand why CI jobs are failing. 

I am concerned that daily CI testing is not running for all packages against the latest 8.7 snapshot. There is a [job](https://fleet-ci.elastic.co/job/Ingest-manager/job/integrations-daily/) that is running daily, but I suspect it’s not doing any real testing. It mostly fails on publishing and never gets to the point of running package or system tests.

- Test-only type of jobs should never be doing any publishing. We should skip that stage to speed it up.
- Why does the job publish before it tests? Shouldn't we check that the tests are passing before publishing?

## Investigation

<img width="342" alt="Screenshot 2023-04-14 at 09 59 46" src="https://user-images.githubusercontent.com/4565752/232065665-205853da-962e-4d45-ba71-7060411ca470.png">

<img width="1284" alt="Screenshot 2023-04-14 at 09 52 36" src="https://user-images.githubusercontent.com/4565752/232065775-9fffbc28-0128-4307-8399-b6940c3c2fb5.png">

The integrations/main job (https://fleet-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/1283/pipeline) fails while invoking the remote publishing job. Then it never advances to testing. _Why not move the testing before the publishing?_

```
[2023-04-14T03:17:49.092Z] Triggering parameterized remote job 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote'
[2023-04-14T03:17:49.092Z]   Using job-level defined 'Credentials Authentication' as user 'local-readonly' (Credentials ID 'local-readonly-api-token')
[2023-04-14T03:17:49.092Z] Triggering remote job now.
[2023-04-14T03:17:49.092Z] reuse cached crumb: internal-ci.elastic.co
[2023-04-14T03:17:49.286Z]   Remote job queue number: 1327319
[2023-04-14T03:17:49.286Z] Remote build started!
[2023-04-14T03:17:49.286Z]   Remote build URL: https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote/5504/
[2023-04-14T03:17:49.286Z]   Remote build number: 5504
```

------

<img width="488" alt="Screenshot 2023-04-14 at 10 00 35" src="https://user-images.githubusercontent.com/4565752/232065923-c77e8643-3648-487b-a3dd-c8b34b55dbec.png">

publishing-job-remote fails with NPE.

https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote/5504/console

```
[2023-04-14T03:21:05.633Z] INFO: fetchAndPrepareBuildInfo (see build-info.json)
[2023-04-14T03:21:05.633Z] INFO: curl https://internal-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/package_storage/publishing-job-remote/runs/5504/ -o build-info.json
[2023-04-14T03:21:05.834Z] jq: error (at build-info.json:5): Cannot iterate over null (null)
[2023-04-14T03:21:05.935Z] INFO: prepareErrorMetrics(errorMetrics)
[2023-04-14T03:21:05.941Z] [Pipeline] archiveArtifacts
[2023-04-14T03:21:05.944Z] Archiving artifacts
[2023-04-14T03:21:05.959Z] [Pipeline] timeout
[2023-04-14T03:21:05.961Z] Timeout set to expire in 5 min 0 sec
[2023-04-14T03:21:05.961Z] [Pipeline] {
[2023-04-14T03:21:05.976Z] [Pipeline] readJSON
...
[2023-04-14T03:21:06.134Z] ERROR: generateBuildReport: Error generating build report
[2023-04-14T03:21:06.134Z] java.lang.NullPointerException: Cannot invoke method length() on null object