### PR TITLE
pulse_connect_secure: allow user-defined TCP options

### DIFF
--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Allow user-defined TCP options.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5887
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/pulse_connect_secure/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/pulse_connect_secure/data_stream/log/agent/stream/tcp.yml.hbs
@@ -1,4 +1,7 @@
 host: "{{syslog_host}}:{{syslog_port}}"
+{{#if tcp_options}}
+{{tcp_options}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/pulse_connect_secure/data_stream/log/manifest.yml
+++ b/packages/pulse_connect_secure/data_stream/log/manifest.yml
@@ -97,6 +97,18 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tcp_options
+        type: yaml
+        title: Custom TCP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          #framing: rfc6587
+          #max_message_size: 50KiB
+          #max_connections: 1
+          #line_delimiter: "\n"
+        description: Specify custom configuration options for the TCP input.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/pulse_connect_secure/manifest.yml
+++ b/packages/pulse_connect_secure/manifest.yml
@@ -1,6 +1,6 @@
 name: pulse_connect_secure
 title: Pulse Connect Secure
-version: "1.7.0"
+version: "1.8.0"
 release: ga
 description: Collect logs from Pulse Connect Secure with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This add a TCP options configuration field that allows users to pass parameters to the TCP input. This is important to allow setting framing options.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5861

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
