### PR TITLE
network_traffic: allow integration users to specify npcap.never_install

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Allow setting never install Npcap option in integration.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5888
 - version: "1.12.0"
   changes:
     - description: Fix flows dashboard.

--- a/packages/network_traffic/data_stream/amqp/agent/stream/amqp.yml.hbs
+++ b/packages/network_traffic/data_stream/amqp/agent/stream/amqp.yml.hbs
@@ -55,3 +55,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/cassandra/agent/stream/cassandra.yml.hbs
+++ b/packages/network_traffic/data_stream/cassandra/agent/stream/cassandra.yml.hbs
@@ -55,3 +55,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/dhcpv4/agent/stream/dhcpv4.yml.hbs
+++ b/packages/network_traffic/data_stream/dhcpv4/agent/stream/dhcpv4.yml.hbs
@@ -34,3 +34,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/dns/agent/stream/dns.yml.hbs
+++ b/packages/network_traffic/data_stream/dns/agent/stream/dns.yml.hbs
@@ -49,3 +49,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
+++ b/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
@@ -21,3 +21,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
@@ -94,3 +94,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/network_traffic/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -28,3 +28,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/memcached/agent/stream/memcached.yml.hbs
+++ b/packages/network_traffic/data_stream/memcached/agent/stream/memcached.yml.hbs
@@ -55,3 +55,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/mongodb/agent/stream/mongodb.yml.hbs
+++ b/packages/network_traffic/data_stream/mongodb/agent/stream/mongodb.yml.hbs
@@ -49,3 +49,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/mysql/agent/stream/mysql.yml.hbs
+++ b/packages/network_traffic/data_stream/mysql/agent/stream/mysql.yml.hbs
@@ -43,3 +43,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/nfs/agent/stream/nfs.yml.hbs
+++ b/packages/network_traffic/data_stream/nfs/agent/stream/nfs.yml.hbs
@@ -43,3 +43,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/pgsql/agent/stream/pgsql.yml.hbs
+++ b/packages/network_traffic/data_stream/pgsql/agent/stream/pgsql.yml.hbs
@@ -43,3 +43,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/redis/agent/stream/redis.yml.hbs
+++ b/packages/network_traffic/data_stream/redis/agent/stream/redis.yml.hbs
@@ -49,3 +49,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
+++ b/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
@@ -43,3 +43,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/thrift/agent/stream/thrift.yml.hbs
+++ b/packages/network_traffic/data_stream/thrift/agent/stream/thrift.yml.hbs
@@ -70,3 +70,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/data_stream/tls/agent/stream/tls.yml.hbs
+++ b/packages/network_traffic/data_stream/tls/agent/stream/tls.yml.hbs
@@ -46,3 +46,7 @@ interface:
   device: {{interface}}
 {{/if}}
 {{/if}}
+{{#if never_install}}
+npcap:
+  never_install: true
+{{/if}}

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -29,11 +29,11 @@ policy_templates:
             type: bool
             title: Never Install Npcap on Windows
             description: |-
-              On Windows the Network Packet Capture integration requires an Npcap DLL installation.
+              On Windows, the Network Packet Capture integration requires an Npcap DLL installation.
               This is provided by the integration for users of the Elastic Licenced version. In some
-              cases users may wish to use their own installed version. In order to do this this
-              option can be used. Setting this option to `true` will not result in no attempt to
-              install the bundled Npcap library on start-up.
+              cases users may wish to use their own installed version. In order to allow this, this
+              option can be used. Setting it to `true` will disable installation of the bundled Npcap
+              library.
 
               Note that if there is no Npcap installed the integration will not function, and versions
               of the Npcap library other than the bundled version may not provide functionality required

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.12.0"
+version: "1.13.0"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
@@ -25,5 +25,21 @@ policy_templates:
             title: Interface
             required: false
             show_user: false
+          - name: never_install
+            type: bool
+            title: Never Install Npcap on Windows
+            description: |-
+              On Windows the Network Packet Capture integration requires an Npcap DLL installation.
+              This is provided by the integration for users of the Elastic Licenced version. In some
+              cases users may wish to use their own installed version. In order to do this this
+              option can be used. Setting this option to `true` will not result in no attempt to
+              install the bundled Npcap library on start-up.
+
+              Note that if there is no Npcap installed the integration will not function, and versions
+              of the Npcap library other than the bundled version may not provide functionality required
+              by the integration.
+            required: false
+            show_user: false
+            default: false
 owner:
   github: elastic/security-external-integrations


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This feature was added to v8.7, but hooks from the integration were not made available.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Query whether a note should be added about this not being respected prior to v8.7?

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates elastic/beats#34428
- https://discuss.elastic.co/t/block-installation-of-bundled-npcap-via-network-packet-capture-integration/329748

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
