### PR TITLE
mimecast: add option to enable http request trace logging for debugging

### DIFF
--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.8.0"
+  changes:
+    - description: Add toggle to enable request tracing.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5889
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/mimecast/data_stream/audit_events/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/audit_events/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.url: {{api_url}}/api/audit/get-audit-events
 request.method: "POST"
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-mimecast-audit-events.ndjson
+{{/if}}
 request.transforms:
 - set:
     target: body.meta.pagination.pageSize

--- a/packages/mimecast/data_stream/audit_events/manifest.yml
+++ b/packages/mimecast/data_stream/audit_events/manifest.yml
@@ -31,6 +31,16 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/mimecast/data_stream/dlp_logs/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/dlp_logs/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.url: {{api_url}}/api/dlp/get-logs
 request.method: "POST"
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-mimecast-dlp-logs.ndjson
+{{/if}}
 request.transforms:
     - set:
         target: body.data

--- a/packages/mimecast/data_stream/dlp_logs/manifest.yml
+++ b/packages/mimecast/data_stream/dlp_logs/manifest.yml
@@ -31,6 +31,16 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/mimecast/data_stream/siem_logs/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/siem_logs/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.url: {{api_url}}/api/audit/get-siem-logs
 request.method: "POST"
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-mimecast-siem-logs.ndjson
+{{/if}}
 request.transforms:
    - set:
       target: body.data

--- a/packages/mimecast/data_stream/siem_logs/manifest.yml
+++ b/packages/mimecast/data_stream/siem_logs/manifest.yml
@@ -31,6 +31,16 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/mimecast/data_stream/threat_intel_malware_customer/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/threat_intel_malware_customer/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.url: {{api_url}}/api/ttp/threat-intel/get-feed
 request.method: "POST"
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-mimecast-threat-intel-malware-customer.ndjson
+{{/if}}
 request.transforms:
 - set:
     target: body.data

--- a/packages/mimecast/data_stream/threat_intel_malware_customer/manifest.yml
+++ b/packages/mimecast/data_stream/threat_intel_malware_customer/manifest.yml
@@ -31,6 +31,16 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/mimecast/data_stream/threat_intel_malware_grid/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/threat_intel_malware_grid/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.url: {{api_url}}/api/ttp/threat-intel/get-feed
 request.method: "POST"
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-mimecast-threat-intel-malware-grid.ndjson
+{{/if}}
 request.transforms:
 - set:
     target: body.data

--- a/packages/mimecast/data_stream/threat_intel_malware_grid/manifest.yml
+++ b/packages/mimecast/data_stream/threat_intel_malware_grid/manifest.yml
@@ -31,6 +31,16 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/mimecast/data_stream/ttp_ap_logs/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_ap_logs/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.url: {{api_url}}/api/ttp/attachment/get-logs
 request.method: "POST"
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-mimecast-ttp-ap-logs.ndjson
+{{/if}}
 request.transforms:
 - set:
     target: body.data

--- a/packages/mimecast/data_stream/ttp_ap_logs/manifest.yml
+++ b/packages/mimecast/data_stream/ttp_ap_logs/manifest.yml
@@ -31,6 +31,16 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/mimecast/data_stream/ttp_ip_logs/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_ip_logs/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.url: {{api_url}}/api/ttp/impersonation/get-logs
 request.method: "POST"
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-mimecast-ttp-ip-logs.ndjson
+{{/if}}
 request.transforms:
 - set:
     target: body.data

--- a/packages/mimecast/data_stream/ttp_ip_logs/manifest.yml
+++ b/packages/mimecast/data_stream/ttp_ip_logs/manifest.yml
@@ -31,6 +31,16 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/mimecast/data_stream/ttp_url_logs/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/ttp_url_logs/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.url: {{api_url}}/api/ttp/url/get-logs
 request.method: "POST"
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-mimecast-ttp-url-logs.ndjson
+{{/if}}
 request.transforms:
 - set:
     target: body.data

--- a/packages/mimecast/data_stream/ttp_url_logs/manifest.yml
+++ b/packages/mimecast/data_stream/ttp_url_logs/manifest.yml
@@ -31,6 +31,16 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -2,14 +2,14 @@
 format_version: 1.0.0
 name: mimecast
 title: "Mimecast"
-version: "1.7.0"
+version: "1.8.0"
 license: basic
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]
 release: ga
 conditions:
-  kibana.version: "^8.3.0"
+  kibana.version: "^8.5.0"
 screenshots:
   - src: /img/mimecast.png
     title: Sample screenshot


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This adds an option to enable the request tracer for each of the Mimecast data streams to enable debugging. It also bump kibana constraint to 8.5.0 which is when the request tracer feature was introduced to Agent.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #5053

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
