### PR TITLE
[Fleet] Remove host and port for Fleet Server

### DIFF
--- a/packages/fleet_server/agent/input/agent.yml.hbs
+++ b/packages/fleet_server/agent/input/agent.yml.hbs
@@ -1,10 +1,4 @@
 server:
-{{#if port}}
-  port: {{port}}
-{{/if}}
-{{#if host}}
-  host: {{host}}
-{{/if}}
 {{#if max_connections}}
   limits.max_connections: {{max_connections}}
 {{/if}}

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove host and port
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/2531
+      link: https://github.com/elastic/integrations/pull/5896
 - version: "1.2.0"
   changes:
     - description: Added max agents field, deprecated max connections

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Remove host and port
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/2531
 - version: "1.2.0"
   changes:
     - description: Added max agents field, deprecated max connections

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 1.2.0
+version: 1.3.0
 release: ga
 description: Centrally manage Elastic Agents with the Fleet Server integration.
 type: integration
@@ -26,20 +26,6 @@ policy_templates:
         description: "Fleet Server Configuration"
         template_path: "agent.yml.hbs"
         vars:
-          - name: host
-            type: text
-            title: Host
-            required: true
-            show_user: true
-            default:
-              - 0.0.0.0
-          - name: port
-            type: integer
-            title: Port
-            required: true
-            show_user: true
-            default:
-              - 8220
           - name: max_agents
             type: integer
             title: Max agents (per server)

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: "^7.16.0 || ^8.0.0"
+  kibana.version: "^8.8.0"
 owner:
   github: elastic/elastic-agent-control-plane
 icons:


### PR DESCRIPTION
## Description 

Remove the host and port field from the Fleet server integration as it seems those values are only configurable during Fleet server installation.

Related to [154674](https://github.com/elastic/kibana/pull/154674)

cc @jen-huang @michel-laterman 

Should we restrict that package to newest version of Kibana (8.7?)

## Tests

I tested manually:
* that a fleet server is available when not providing any port or host
* that you can customize fleet server port with `--fleet-server-port`