### PR TITLE
[Cloud Security] Set default CSPM period

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -10,6 +10,9 @@
     - description: Added vulnerability management period and removing region
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5841
+    - description: Change CSPM resource collection period
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5898/
 - version: "1.2.11"
   changes:
     - description: Fixed readme

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -12,7 +12,7 @@
       link: https://github.com/elastic/integrations/pull/5841
     - description: Change CSPM resource collection period
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5898/
+      link: https://github.com/elastic/integrations/pull/5898
 - version: "1.2.11"
   changes:
     - description: Fixed readme

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -1,3 +1,4 @@
+period: 24h
 fetchers:
   - name: aws-iam
   - name: aws-ec2-network


### PR DESCRIPTION
## What does this PR do?

sets `period` to `24h` on the `aws.yml` config

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues


- Closes https://github.com/elastic/cloudbeat/issues/752


