### PR TITLE
[D4C] change resource.label and resource.annotation to keyword type

### DIFF
--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Updated orchestrator.resource.label and annotation to use keyword type.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5836
+      link: https://github.com/elastic/integrations/pull/5902
 - version: "1.0.3"
   changes:
     - description: Added kubernetes as a category. Renamed trace_point to hook_point

--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.4"
+  changes:
+    - description: Updated orchestrator.resource.label and annotation to use keyword type.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5836
 - version: "1.0.3"
   changes:
     - description: Added kubernetes as a category. Renamed trace_point to hook_point

--- a/packages/cloud_defend/data_stream/alerts/fields/fields.yml
+++ b/packages/cloud_defend/data_stream/alerts/fields/fields.yml
@@ -11,8 +11,8 @@
   type: keyword
   description: An array of hook points used to source the events data.
 - name: orchestrator.resource.label
-  type: flattened
-  description: An object containing the labels for the resource being acted upon.
+  type: keyword
+  description: An array of labels added to the resource. e.g. ['key:value', 'key2:value2']
 - name: orchestrator.resource.annotation
-  type: flattened
-  description: An object containing the annotations for the resource being acted upon.
+  type: keyword
+  description: An array of annotations added to the resource. e.g. ['key:value', 'key2:value2']

--- a/packages/cloud_defend/data_stream/file/fields/fields.yml
+++ b/packages/cloud_defend/data_stream/file/fields/fields.yml
@@ -11,8 +11,8 @@
   type: keyword
   description: An array of hook points used to source the events data.
 - name: orchestrator.resource.label
-  type: flattened
-  description: An object containing the labels for the resource being acted upon.
+  type: keyword
+  description: An array of labels added to the resource. e.g. ['key:value', 'key2:value2']
 - name: orchestrator.resource.annotation
-  type: flattened
-  description: An object containing the annotations for the resource being acted upon.
+  type: keyword
+  description: An array of annotations added to the resource. e.g. ['key:value', 'key2:value2']

--- a/packages/cloud_defend/data_stream/process/fields/fields.yml
+++ b/packages/cloud_defend/data_stream/process/fields/fields.yml
@@ -11,8 +11,8 @@
   type: keyword
   description: An array of hook points used to source the events data.
 - name: orchestrator.resource.label
-  type: flattened
-  description: An object containing the labels for the resource being acted upon.
+  type: keyword
+  description: An array of labels added to the resource. e.g. ['key:value', 'key2:value2']
 - name: orchestrator.resource.annotation
-  type: flattened
-  description: An object containing the annotations for the resource being acted upon.
+  type: keyword
+  description: An array of annotations added to the resource. e.g. ['key:value', 'key2:value2']

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -210,8 +210,8 @@ responses:
 | [orchestrator.cluster.name](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-cluster-name) | 'website' |
 | [orchestrator.namespace](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-namespace) | default |
 | [orchestrator.resource.ip](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-ip) | '172.18.0.6' |
-| [orchestrator.resource.annotation](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-annotation) | ['test one two'] |
-| [orchestrator.resource.label](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-label) | ['service:webapp'] |
+| orchestrator.resource.annotation | ['note:testing'] |
+| orchestrator.resource.label | ['service:webapp'] |
 | [orchestrator.resource.name](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-name) | webapp-proxy |
 | [orchestrator.resource.parent.type](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-parent-type) | 'DaemonSet', 'ReplicaSet' etc... |
 | [orchestrator.resource.type](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-type) | pod |
@@ -334,8 +334,8 @@ responses:
 | [orchestrator.cluster.name](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-cluster-name) | 'website' |
 | [orchestrator.namespace](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-namespace) | default |
 | [orchestrator.resource.ip](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-ip) | '172.18.0.6' |
-| [orchestrator.resource.annotation](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-annotation) | ['test one two'] |
-| [orchestrator.resource.label](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-label) | ['service:webapp'] |
+| orchestrator.resource.annotation | ['note:testing'] |
+| orchestrator.resource.label | ['service:webapp'] |
 | [orchestrator.resource.name](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-name) | webapp-proxy |
 | [orchestrator.resource.parent.type](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-parent-type) | ... |
 | [orchestrator.resource.type](https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html#field-orchestrator-resource-type) | pod |

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -1,10 +1,10 @@
 format_version: 2.3.0
 name: cloud_defend
 title: "Defend for Containers"
-version: 1.0.3
+version: 1.0.4
 source:
   license: "Elastic-2.0"
-description: "Elastic Defend for Containers provides cloud-native runtime protections for containerized environments."
+description: "Elastic Defend for Containers (BETA) provides cloud-native runtime protections for containerized environments."
 type: integration
 categories:
   - containers


### PR DESCRIPTION
## What does this PR do?

Changes the type for orchestrator.resource.label and orchestrator.resource.annotation to type keyword. "flattened" type has too many limitations for our use cases. Also added (BETA) to the integration description in the manifest.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues
- Relates https://github.com/elastic/ecs/pull/2181