### PR TITLE
[InfluxDB] Add  additional dimension field for advstatus datastream

### DIFF
--- a/packages/influxdb/changelog.yml
+++ b/packages/influxdb/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
-- version: "0.4.1"
+- version: "0.5.0"
+  changes:
+    - description: Add additional dimension field for advstatus datastream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5920
+- version: "0.4.0"
   changes:
     - description: Migrate visualizations to lens.
       type: enhancement

--- a/packages/influxdb/changelog.yml
+++ b/packages/influxdb/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.5.0"
+- version: "0.4.1"
   changes:
     - description: Add additional dimension field for advstatus datastream.
       type: bugfix

--- a/packages/influxdb/changelog.yml
+++ b/packages/influxdb/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.4.0"
+- version: "0.4.1"
   changes:
     - description: Migrate visualizations to lens.
       type: enhancement

--- a/packages/influxdb/data_stream/advstatus/fields/fields.yml
+++ b/packages/influxdb/data_stream/advstatus/fields/fields.yml
@@ -87,6 +87,11 @@
           dimension: true
           description: |
             HTTP request endpoint.
+        - name: level
+          type: keyword
+          # Reason to add as a dimension field: To support multiple label values
+          dimension: true
+          description: Represents the level values such as cache / full / etc
     - name: query_controller
       type: group
       fields:

--- a/packages/influxdb/data_stream/advstatus/fields/fields.yml
+++ b/packages/influxdb/data_stream/advstatus/fields/fields.yml
@@ -91,7 +91,7 @@
           type: keyword
           # Reason to add as a dimension field: To support multiple label values
           dimension: true
-          description: Represents the level values such as cache / full / etc
+          description: Represents the level values such as cache, full, etc
     - name: query_controller
       type: group
       fields:

--- a/packages/influxdb/docs/README.md
+++ b/packages/influxdb/docs/README.md
@@ -223,7 +223,7 @@ Advanced status metric include details of query execution statistics, compaction
 | influxdb.advstatus.labels.handler | Request handler. | keyword |
 | influxdb.advstatus.labels.id |  | keyword |
 | influxdb.advstatus.labels.job | Type of the job | keyword |
-| influxdb.advstatus.labels.level | Represents the level values such as cache / full / etc | keyword |
+| influxdb.advstatus.labels.level | Represents the level values such as cache, full, etc | keyword |
 | influxdb.advstatus.labels.method | Type of service operation | keyword |
 | influxdb.advstatus.labels.op | Extended information related to various operations | keyword |
 | influxdb.advstatus.labels.path | HTTP request endpoint. | keyword |

--- a/packages/influxdb/docs/README.md
+++ b/packages/influxdb/docs/README.md
@@ -223,6 +223,7 @@ Advanced status metric include details of query execution statistics, compaction
 | influxdb.advstatus.labels.handler | Request handler. | keyword |
 | influxdb.advstatus.labels.id |  | keyword |
 | influxdb.advstatus.labels.job | Type of the job | keyword |
+| influxdb.advstatus.labels.level | Represents the level values such as cache / full / etc | keyword |
 | influxdb.advstatus.labels.method | Type of service operation | keyword |
 | influxdb.advstatus.labels.op | Extended information related to various operations | keyword |
 | influxdb.advstatus.labels.path | HTTP request endpoint. | keyword |

--- a/packages/influxdb/manifest.yml
+++ b/packages/influxdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: influxdb
 title: "InfluxDb"
-version: 0.4.1
+version: 0.5.0
 license: basic
 description: "Collect metrics from Influxdb database"
 type: integration

--- a/packages/influxdb/manifest.yml
+++ b/packages/influxdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: influxdb
 title: "InfluxDb"
-version: 0.4.0
+version: 0.4.1
 license: basic
 description: "Collect metrics from Influxdb database"
 type: integration

--- a/packages/influxdb/manifest.yml
+++ b/packages/influxdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: influxdb
 title: "InfluxDb"
-version: 0.5.0
+version: 0.4.1
 license: basic
 description: "Collect metrics from Influxdb database"
 type: integration


### PR DESCRIPTION
Type of change

- Bug

## What does this PR do?

Add additional dimension field to advstatus datastream under influxDB
## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues


- Closes #5919 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
