### PR TITLE
[Kafka] [TSDB] Added metric_type mapping for broker datastream

### DIFF
--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Add metric_type mapping for broker datastream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5123
 - version: "1.4.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add metric_type mapping for broker datastream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5123
+      link: https://github.com/elastic/integrations/pull/5923
 - version: "1.4.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/kafka/data_stream/broker/fields/fields.yml
+++ b/packages/kafka/data_stream/broker/fields/fields.yml
@@ -6,61 +6,81 @@
       description: Mbean that this event is related to
     - name: request.channel.queue.size
       type: long
+      metric_type: gauge
       description: The size of the request queue
     - name: request.produce.failed_per_second
       type: float
+      metric_type: gauge
       description: The rate of failed produce requests per second
     - name: request.fetch.failed_per_second
       type: float
+      metric_type: gauge
       description: The rate of client fetch request failures per second
     - name: request.produce.failed
       type: float
+      metric_type: counter
       description: The number of failed produce requests
     - name: request.fetch.failed
       type: float
+      metric_type: counter
       description: The number of client fetch request failures
     - name: replication.leader_elections
       type: float
+      metric_type: gauge
       description: The leader election rate
     - name: replication.unclean_leader_elections
       type: float
+      metric_type: gauge
       description: The unclean leader election rate
     - name: session.zookeeper.disconnect
       type: float
+      metric_type: gauge
       description: The ZooKeeper closed sessions per second
     - name: session.zookeeper.expire
       type: float
+      metric_type: gauge
       description: The ZooKeeper expired sessions per second
     - name: session.zookeeper.readonly
       type: float
+      metric_type: gauge
       description: The ZooKeeper readonly sessions per second
     - name: session.zookeeper.sync
       type: float
+      metric_type: gauge
       description: The ZooKeeper client connections per second
     - name: log.flush_rate
       type: float
+      metric_type: gauge
       description: The log flush rate
     - name: topic.net.in.bytes_per_sec
       type: float
+      metric_type: gauge
       description: The incoming byte rate per topic
     - name: topic.net.out.bytes_per_sec
       type: float
+      metric_type: gauge
       description: The outgoing byte rate per topic
     - name: topic.net.rejected.bytes_per_sec
       type: float
+      metric_type: gauge
       description: The rejected byte rate per topic
     - name: topic.messages_in
       type: float
+      metric_type: gauge
       description: The incoming message rate per topic
     - name: net.in.bytes_per_sec
       type: float
+      metric_type: gauge
       description: The incoming byte rate
     - name: net.out.bytes_per_sec
       type: float
+      metric_type: gauge
       description: The outgoing byte rate
     - name: net.rejected.bytes_per_sec
       type: float
+      metric_type: gauge
       description: The rejected byte rate
     - name: messages_in
       type: float
+      metric_type: gauge
       description: The incoming message rate

--- a/packages/kafka/docs/README.md
+++ b/packages/kafka/docs/README.md
@@ -126,75 +126,75 @@ An example event for `broker` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| kafka.broker.address | Broker advertised address | keyword |
-| kafka.broker.id | Broker id | long |
-| kafka.broker.log.flush_rate | The log flush rate | float |
-| kafka.broker.mbean | Mbean that this event is related to | keyword |
-| kafka.broker.messages_in | The incoming message rate | float |
-| kafka.broker.net.in.bytes_per_sec | The incoming byte rate | float |
-| kafka.broker.net.out.bytes_per_sec | The outgoing byte rate | float |
-| kafka.broker.net.rejected.bytes_per_sec | The rejected byte rate | float |
-| kafka.broker.replication.leader_elections | The leader election rate | float |
-| kafka.broker.replication.unclean_leader_elections | The unclean leader election rate | float |
-| kafka.broker.request.channel.queue.size | The size of the request queue | long |
-| kafka.broker.request.fetch.failed | The number of client fetch request failures | float |
-| kafka.broker.request.fetch.failed_per_second | The rate of client fetch request failures per second | float |
-| kafka.broker.request.produce.failed | The number of failed produce requests | float |
-| kafka.broker.request.produce.failed_per_second | The rate of failed produce requests per second | float |
-| kafka.broker.session.zookeeper.disconnect | The ZooKeeper closed sessions per second | float |
-| kafka.broker.session.zookeeper.expire | The ZooKeeper expired sessions per second | float |
-| kafka.broker.session.zookeeper.readonly | The ZooKeeper readonly sessions per second | float |
-| kafka.broker.session.zookeeper.sync | The ZooKeeper client connections per second | float |
-| kafka.broker.topic.messages_in | The incoming message rate per topic | float |
-| kafka.broker.topic.net.in.bytes_per_sec | The incoming byte rate per topic | float |
-| kafka.broker.topic.net.out.bytes_per_sec | The outgoing byte rate per topic | float |
-| kafka.broker.topic.net.rejected.bytes_per_sec | The rejected byte rate per topic | float |
-| kafka.partition.id | Partition id. | long |
-| kafka.partition.topic_broker_id | Unique id of the partition in the topic and the broker. | keyword |
-| kafka.partition.topic_id | Unique id of the partition in the topic. | keyword |
-| kafka.topic.error.code | Topic error code. | long |
-| kafka.topic.name | Topic name | keyword |
-| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.name.text | Multi-field of `host.os.name`. | text |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| kafka.broker.address | Broker advertised address | keyword |  |
+| kafka.broker.id | Broker id | long |  |
+| kafka.broker.log.flush_rate | The log flush rate | float | gauge |
+| kafka.broker.mbean | Mbean that this event is related to | keyword |  |
+| kafka.broker.messages_in | The incoming message rate | float | gauge |
+| kafka.broker.net.in.bytes_per_sec | The incoming byte rate | float | gauge |
+| kafka.broker.net.out.bytes_per_sec | The outgoing byte rate | float | gauge |
+| kafka.broker.net.rejected.bytes_per_sec | The rejected byte rate | float | gauge |
+| kafka.broker.replication.leader_elections | The leader election rate | float | gauge |
+| kafka.broker.replication.unclean_leader_elections | The unclean leader election rate | float | gauge |
+| kafka.broker.request.channel.queue.size | The size of the request queue | long | gauge |
+| kafka.broker.request.fetch.failed | The number of client fetch request failures | float | counter |
+| kafka.broker.request.fetch.failed_per_second | The rate of client fetch request failures per second | float | gauge |
+| kafka.broker.request.produce.failed | The number of failed produce requests | float | counter |
+| kafka.broker.request.produce.failed_per_second | The rate of failed produce requests per second | float | gauge |
+| kafka.broker.session.zookeeper.disconnect | The ZooKeeper closed sessions per second | float | gauge |
+| kafka.broker.session.zookeeper.expire | The ZooKeeper expired sessions per second | float | gauge |
+| kafka.broker.session.zookeeper.readonly | The ZooKeeper readonly sessions per second | float | gauge |
+| kafka.broker.session.zookeeper.sync | The ZooKeeper client connections per second | float | gauge |
+| kafka.broker.topic.messages_in | The incoming message rate per topic | float | gauge |
+| kafka.broker.topic.net.in.bytes_per_sec | The incoming byte rate per topic | float | gauge |
+| kafka.broker.topic.net.out.bytes_per_sec | The outgoing byte rate per topic | float | gauge |
+| kafka.broker.topic.net.rejected.bytes_per_sec | The rejected byte rate per topic | float | gauge |
+| kafka.partition.id | Partition id. | long |  |
+| kafka.partition.topic_broker_id | Unique id of the partition in the topic and the broker. | keyword |  |
+| kafka.partition.topic_id | Unique id of the partition in the topic. | keyword |  |
+| kafka.topic.error.code | Topic error code. | long |  |
+| kafka.topic.name | Topic name | keyword |  |
+| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 
 
 ### consumergroup

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kafka
 title: Kafka
-version: 1.4.1
+version: 1.5.0
 license: basic
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
Type of change

- Enhancement

## What does this PR do?

Added metric_type mapping for broker datastream

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Relates #5905 

