### PR TITLE
[DOCS] Update Microsoft SQL Server integration docs with required permissions to the database

### DIFF
--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -17,6 +17,19 @@ Microsoft SQL Server has a feature that allows running multiple databases on the
 
 The data can be visualized in Kibana by filtering based on the instance name and server name. The instance name can be filtered by `mssql.metrics.instance_name` and server name by `mssql.metrics.server_name` fields.
 
+## Permission/Access required for tables
+
+If you browse MSDN for the following tables, you will find a "Permissions" section which defines the permission needed for each table, e.g [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver15) Permissions section.
+
+### 1.transaction_log
+
+- [sys.databases](https://learn.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysdatabases-transact-sql?view=sql-server-ver16)
+- [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver16)
+- [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16)
+
+### 2.performance
+ 
+- [sys.dm_os_performance_counters](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver16)
 
 ## Host Configuration
 

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Document required database permissions
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5934
 - version: "1.22.0"
   changes:
     - description: Add missing agent and ECS fields mapping.

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.23.0"
   changes:
-    - description: Document required database permissions
+    - description: Update documentation with database permissions link.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5934
 - version: "1.22.0"

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -17,6 +17,19 @@ Microsoft SQL Server has a feature that allows running multiple databases on the
 
 The data can be visualized in Kibana by filtering based on the instance name and server name. The instance name can be filtered by `mssql.metrics.instance_name` and server name by `mssql.metrics.server_name` fields.
 
+## Permission/Access required for tables
+
+If you browse MSDN for the following tables, you will find a "Permissions" section which defines the permission needed for each table, e.g [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver15) Permissions section.
+
+### 1.transaction_log
+
+- [sys.databases](https://learn.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysdatabases-transact-sql?view=sql-server-ver16)
+- [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver16)
+- [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16)
+
+### 2.performance
+ 
+- [sys.dm_os_performance_counters](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver16)
 
 ## Host Configuration
 

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "1.22.0"
+version: "1.23.0"
 license: basic
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add missing required information to the docs for Microsoft SQL Server integration.
This detail was already documented for the [Metricbeat MSSQL Module docs ](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-mssql.html#_permissionaccess_required_for_tables) and I've taken this detail directly from there.

## Related issues

- Closes https://github.com/elastic/integrations/issues/5397
