### PR TITLE
Added build manifest setting ECS reference

### DIFF
--- a/packages/cel/_dev/build/build.yml
+++ b/packages/cel/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@v8.7.0

--- a/packages/cel/changelog.yml
+++ b/packages/cel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.1.1"
+  changes:
+    - description: Added build manifest to indicate the ECS reference.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5937
 - version: "0.1.0"
   changes:
     - description: Initial Implementation

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -3,7 +3,7 @@ name: cel
 title: CEL Custom API
 description: Collect custom events from an API with Elastic agent
 type: input
-version: "0.1.0"
+version: "0.1.1"
 categories:
   - custom
 conditions:

--- a/packages/jolokia_input/_dev/build/build.yml
+++ b/packages/jolokia_input/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@v8.7.0

--- a/packages/jolokia_input/changelog.yml
+++ b/packages/jolokia_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.5"
+  changes:
+    - description: Added build manifest to indicate the ECS reference.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5937
 - version: "0.0.4"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/jolokia_input/manifest.yml
+++ b/packages/jolokia_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: jolokia
 title: "Jolokia Input"
-version: 0.0.4
+version: 0.0.5
 description: "Collects Metrics from Jolokia Agents"
 type: input
 categories:


### PR DESCRIPTION
## What does this PR do?

Add the build manifest where the ECS reference is set.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Go to the package folder definition and run `elastic-package build -v`:
```
 ~/Coding/work/integrations/packages/jolokia_input
 $ elastic-package build -v 
2023/04/20 10:20:39 DEBUG Enable verbose logging
2023/04/20 10:20:39 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
Build the package
2023/04/20 10:20:39 DEBUG Use build directory: /home/mariorodriguez/Coding/work/integrations/build
2023/04/20 10:20:39 DEBUG Build directory: /home/mariorodriguez/Coding/work/integrations/build/packages/jolokia/0.0.5
2023/04/20 10:20:39 DEBUG Clear target directory (path: /home/mariorodriguez/Coding/work/integrations/build/packages/jolokia/0.0.5)
2023/04/20 10:20:39 DEBUG Copy package content (source: /home/mariorodriguez/Coding/work/integrations/packages/jolokia_input)
2023/04/20 10:20:39 DEBUG Copy license file if needed
2023/04/20 10:20:39  INFO License text found in "/home/mariorodriguez/Coding/work/integrations/LICENSE.txt" will be included in package
2023/04/20 10:20:39 DEBUG Encode dashboards
2023/04/20 10:20:39 DEBUG Resolve external fields
2023/04/20 10:20:39 DEBUG Package has external dependencies defined
2023/04/20 10:20:39 DEBUG fields/ecs.yml: source file has been changed
2023/04/20 10:20:39 DEBUG fields/input.yml: source file has been changed
2023/04/20 10:20:39 DEBUG Package doesn't have to import ECS mappings
2023/04/20 10:20:39 DEBUG Build zipped package
2023/04/20 10:20:39 DEBUG Compress using archiver.Zip (destination: /home/mariorodriguez/Coding/work/integrations/build/packages/jolokia-0.0.5.zip)
2023/04/20 10:20:39 DEBUG Create work directory for archiving: /tmp/elastic-package-983631803/jolokia-0.0.5
2023/04/20 10:20:39 DEBUG Validating built .zip package (path: /home/mariorodriguez/Coding/work/integrations/build/packages/jolokia-0.0.5.zip)
Package built: /home/mariorodriguez/Coding/work/integrations/build/packages/jolokia-0.0.5.zip
Done
```

The package built folder should have now the external fields resolved (replaced) using the ECS reference added:
```
 ~/Coding/work/integrations/packages/jolokia_input
 $ cat ../../build/packages/jolokia/0.0.5/fields/ecs.yml 
- description: |-
    ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.
    When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events.
  name: ecs.version
  type: keyword
```

## Related issues

- Closes https://github.com/elastic/kibana/issues/155057
