### PR TITLE
mysql_enterprise: fix handling of streaming data sent as partial array object

### DIFF
--- a/packages/mysql_enterprise/changelog.yml
+++ b/packages/mysql_enterprise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Fix handling of stream data sent as object.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5942
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/mysql_enterprise/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mysql_enterprise/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -4,13 +4,24 @@ processors:
   - set:
       field: ecs.version
       value: '8.7.0'
-  - rename:
-      field: message
-      target_field: event.original
-      ignore_missing: true
-  - json:
+  - set:
       field: event.original
+      copy_from: message
+  - script:
+      description: Trim trailing commas.
+      # MySQL sends audit logs as parts of a single infinite JSON array
+      # rather than as a JSON stream, and so has comma separators. We
+      # don't have the array open token, so remove the commas.
+      lang: painless
+      source:
+        ctx.message = ctx.message.substring(0, ctx.message.length() - 1);
+      if: ctx.message instanceof String && ctx.message.endsWith(',')
+  - json:
+      field: message
       target_field: mysqlenterprise.audit
+  - remove:
+      field: message
+      ignore_missing: true
   - remove:
       field: "@timestamp"
       ignore_missing: true

--- a/packages/mysql_enterprise/manifest.yml
+++ b/packages/mysql_enterprise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql_enterprise
 title: "MySQL Enterprise"
-version: "1.5.0"
+version: "1.5.1"
 license: basic
 description: Collect audit logs from MySQL Enterprise with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

MySQL send its audit logs as parts of an infinitely long JSON array and so separates each line of the logs with a comma. We don't know that we are in an array since the first line of the log may not have been sent to us, so remove the trailing comma to treat each element of the partial array object as an object in a JSON stream.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #5941

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
