### PR TITLE
Added dimensions fields to mongodb collStats datastream to enable TSDB.

### DIFF
--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.9.0"
+  changes:
+    - description: Added dimensions fields for collStats datastream to enable TSDB.
+      type: enhancement
+      link: tsdb
 - version: "1.8.0"
   changes:
     - description: Migrate `Logs Overview` dashboard visualizations to lens.

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Added dimensions fields for collStats datastream to enable TSDB.
       type: enhancement
-      link: tsdb
+      link: https://github.com/elastic/integrations/pull/5945
 - version: "1.8.0"
   changes:
     - description: Migrate `Logs Overview` dashboard visualizations to lens.

--- a/packages/mongodb/data_stream/collstats/fields/agent.yml
+++ b/packages/mongodb/data_stream/collstats/fields/agent.yml
@@ -25,6 +25,7 @@
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
+      dimension: true
     - name: instance.name
       level: extended
       type: keyword
@@ -42,6 +43,7 @@
       ignore_above: 1024
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
+      dimension: true
     - name: region
       level: extended
       type: keyword
@@ -51,6 +53,7 @@
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
+      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -67,6 +70,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+      dimension: true
     - name: image.name
       level: extended
       type: keyword
@@ -134,6 +138,7 @@
       level: core
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: 'Name of the host.
 
         It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
@@ -196,3 +201,11 @@
       description: >
         OS codename, if any.
 
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/mongodb/data_stream/collstats/fields/base-fields.yml
+++ b/packages/mongodb/data_stream/collstats/fields/base-fields.yml
@@ -20,4 +20,5 @@
   description: Event timestamp.
 - name: service.address
   type: keyword
+  dimension: true
   description: Address of the machine where the service is running.

--- a/packages/mongodb/data_stream/collstats/fields/fields.yml
+++ b/packages/mongodb/data_stream/collstats/fields/fields.yml
@@ -3,11 +3,13 @@
   fields:
     - name: db
       type: keyword
+      # Reason to add as a dimension field: There can be multiple dbs with same collection name.
       dimension: true
       description: |
         Database name.
     - name: collection
       type: keyword
+      # Reason to add as a dimension field: To differentiate different collections.
       dimension: true
       description: |
         Collection name.

--- a/packages/mongodb/data_stream/collstats/fields/fields.yml
+++ b/packages/mongodb/data_stream/collstats/fields/fields.yml
@@ -3,10 +3,12 @@
   fields:
     - name: db
       type: keyword
+      dimension: true
       description: |
         Database name.
     - name: collection
       type: keyword
+      dimension: true
       description: |
         Collection name.
     - name: name

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -349,6 +349,7 @@ The fields reported are:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
+| agent.id |  | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.availability_zone | Availability zone in which this host is running. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: 1.8.0
+version: 1.9.0
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement


## What does this PR do?

This PR updates dimension fields for collStats datastream of mongoldb to support TSDB enablement.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues


- Relates #5281 



