### PR TITLE
[Synthetics] Release Synthetics Integration as GA.

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0-rc-2"
+  changes:
+    - description: Mark as GA
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5951
 - version: "1.0.0-rc-1"
   changes:
     - description: RC of upcoming GA release

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -1,6 +1,5 @@
 type: synthetics
 title: synthetic monitor check
-release: ga
 dataset: browser
 ilm_policy: synthetics-synthetics.browser-default_policy
 elasticsearch:

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -1,6 +1,6 @@
 type: synthetics
 title: synthetic monitor check
-release: beta
+release: ga
 dataset: browser
 ilm_policy: synthetics-synthetics.browser-default_policy
 elasticsearch:

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -1,6 +1,5 @@
 type: synthetics
 title: synthetic monitor check
-release: ga
 dataset: browser.network
 ilm_policy: synthetics-synthetics.browser_network-default_policy
 elasticsearch:

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -1,6 +1,6 @@
 type: synthetics
 title: synthetic monitor check
-release: beta
+release: ga
 dataset: browser.network
 ilm_policy: synthetics-synthetics.browser_network-default_policy
 elasticsearch:

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -1,6 +1,6 @@
 type: synthetics
 title: synthetic monitor check
-release: beta
+release: ga
 dataset: browser.screenshot
 ilm_policy: synthetics-synthetics.browser_screenshot-default_policy
 elasticsearch:

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -1,6 +1,5 @@
 type: synthetics
 title: synthetic monitor check
-release: ga
 dataset: browser.screenshot
 ilm_policy: synthetics-synthetics.browser_screenshot-default_policy
 elasticsearch:

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -1,6 +1,5 @@
 type: synthetics
 title: synthetic monitor check
-release: experimental
 dataset: http
 ilm_policy: synthetics-synthetics.http-default_policy
 elasticsearch:

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -1,6 +1,5 @@
 type: synthetics
 title: synthetic monitor check
-release: experimental
 dataset: icmp
 ilm_policy: synthetics-synthetics.icmp-default_policy
 elasticsearch:

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -1,6 +1,5 @@
 type: synthetics
 title: synthetic monitor check
-release: experimental
 dataset: tcp
 ilm_policy: synthetics-synthetics.tcp-default_policy
 elasticsearch:

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -4,7 +4,7 @@ title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
 version: 1.0.0-rc-1
 categories: ["observability"]
-release: beta
+release: ga
 type: integration
 license: basic
 policy_templates:

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.0.0-rc-1
+version: 1.0.0-rc-2
 categories: ["observability"]
 release: ga
 type: integration


### PR DESCRIPTION
## Type of change
- Enhancement

## What does this PR do?

Change synthetics integration from `beta` to `ga`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

- Relates [#123](https://github.com/elastic/synthetics-dev/issues/180)
