### PR TITLE
Update the expected log output files for MYSQL and IIS

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.2"
+  changes:
+    - description: Update expected json of access log files
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5963
 - version: "1.5.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-75.log-expected.json
+++ b/packages/iis/data_stream/access/_dev/test/pipeline/test-iis-access-75.log-expected.json
@@ -3,8 +3,10 @@
         {
             "@timestamp": "2018-08-28T18:24:25.000Z",
             "destination": {
-                "address": "10.100.220.70",
-                "ip": "10.100.220.70",
+                "address": [
+                    "10.100.220.70",
+                    "10.100.220.70"
+                ],
                 "port": 80
             },
             "ecs": {
@@ -12,16 +14,12 @@
             },
             "event": {
                 "category": [
-                    "web",
-                    "network"
+                    "web"
                 ],
                 "duration": 792000000,
                 "kind": "event",
                 "original": "2018-08-28 18:24:25 [10.100.220.70](http://10.100.220.70) GET / - 80 - [10.100.118.31](http://10.100.118.31) Mozilla/4.0+(compatible;+MSIE+7.0;+Windows+NT+6.3;+WOW64;+Trident/7.0;+.NET4.0E;+.NET4.0C;+.NET+CLR+3.5.30729;+.NET+CLR[+2.0.50727](tel:+2050727);+.NET+CLR+3.0.30729) 404 4 2 792",
-                "outcome": "failure",
-                "type": [
-                    "connection"
-                ]
+                "outcome": "failure"
             },
             "http": {
                 "request": {
@@ -37,15 +35,11 @@
                     "win32_status": 2
                 }
             },
-            "related": {
-                "ip": [
-                    "10.100.118.31",
-                    "10.100.220.70"
-                ]
-            },
             "source": {
-                "address": "10.100.118.31",
-                "ip": "10.100.118.31"
+                "address": [
+                    "10.100.118.31",
+                    "10.100.118.31"
+                ]
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: 1.5.1
+version: 1.5.2
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Update the expected json of slowlog files
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5963
 - version: "1.11.0"
   changes:
     - description: Added system test cases for galera_status datastream

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-10-3-13.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mariadb-10-3-13.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 2461578000,
-                "ingested": "2023-02-02T06:11:55.621090091Z",
+                "ingested": "2023-04-23T04:44:24.818344637Z",
                 "kind": "event",
                 "type": [
                     "info"
@@ -36,7 +36,10 @@
                     "rows_affected": 0,
                     "rows_examined": 3145718,
                     "rows_sent": 10,
-                    "schema": "employees-test",
+                    "schema": [
+                        "employees-test",
+                        "employees-test"
+                    ],
                     "tmp_disk_tables": 0,
                     "tmp_table": true,
                     "tmp_table_on_disk": false,

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 2475469000,
-                "ingested": "2023-02-02T06:11:55.908779675Z",
+                "ingested": "2023-04-23T04:44:25.062099721Z",
                 "kind": "event",
                 "type": [
                     "info"
@@ -51,7 +51,7 @@
                 ],
                 "duration": 2631844000,
                 "end": "2019-03-24T14:04:53.713951Z",
-                "ingested": "2023-02-02T06:11:55.908780800Z",
+                "ingested": "2023-04-23T04:44:25.062107179Z",
                 "kind": "event",
                 "start": "2019-03-24T14:04:51.082107Z",
                 "type": [
@@ -86,7 +86,10 @@
                     "tmp_disk_tables": 0,
                     "tmp_tables": 1
                 },
-                "thread_id": 16
+                "thread_id": [
+                    16,
+                    16
+                ]
             },
             "source": {
                 "domain": "localhost"

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-percona-ubuntu-8-0-15.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-percona-ubuntu-8-0-15.log-expected.json
@@ -12,7 +12,7 @@
                     "database"
                 ],
                 "duration": 2746607000,
-                "ingested": "2023-02-02T06:11:56.050249675Z",
+                "ingested": "2023-04-23T04:44:25.177250513Z",
                 "kind": "event",
                 "type": [
                     "info"
@@ -31,7 +31,10 @@
                     "rows_affected": 0,
                     "rows_examined": 3145718,
                     "rows_sent": 10,
-                    "schema": "employees"
+                    "schema": [
+                        "employees",
+                        "employees"
+                    ]
                 },
                 "thread_id": 182
             },
@@ -54,7 +57,7 @@
                     "database"
                 ],
                 "duration": 3133066000,
-                "ingested": "2023-02-02T06:11:56.050250842Z",
+                "ingested": "2023-04-23T04:44:25.177253471Z",
                 "kind": "event",
                 "type": [
                     "info"
@@ -93,7 +96,10 @@
                     "rows_affected": 0,
                     "rows_examined": 3145718,
                     "rows_sent": 10,
-                    "schema": "employees",
+                    "schema": [
+                        "employees",
+                        "employees"
+                    ],
                     "tmp_disk_tables": 0,
                     "tmp_table": true,
                     "tmp_table_on_disk": false,

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: 1.11.0
+version: 1.11.1
 license: basic
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration


### PR DESCRIPTION

- Bug


## What does this PR do?

This PR updates the expected json files for mysql and iis as there was a change in the way grok processing is done by ES.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/beats/issues/35133
- Relates https://github.com/elastic/elasticsearch/issues/92092
