### PR TITLE
windows: update tests expectations to match processor behaviour

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.0"
+  changes:
+    - description: Update test expectations for processor behaviour.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5964
 - version: "1.19.2"
   changes:
     - description: Document 21 Event ID clause limit under certain situations.

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-operational-events.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-operational-events.json-expected.json
@@ -847,8 +847,9 @@
                 ],
                 "question": {
                     "name": "confiant-integrations.global.ssl.fastly.net",
-                    "registered_domain": "confiant-integrations.global.ssl.fastly.net",
-                    "top_level_domain": "global.ssl.fastly.net"
+                    "registered_domain": "global.ssl.fastly.net",
+                    "subdomain": "confiant-integrations",
+                    "top_level_domain": "ssl.fastly.net"
                 },
                 "resolved_ip": [
                     "89.160.20.156",
@@ -2434,8 +2435,9 @@
                 ],
                 "question": {
                     "name": "clarium.freetls.fastly.net",
-                    "registered_domain": "clarium.freetls.fastly.net",
-                    "top_level_domain": "freetls.fastly.net"
+                    "registered_domain": "freetls.fastly.net",
+                    "subdomain": "clarium",
+                    "top_level_domain": "fastly.net"
                 },
                 "resolved_ip": [
                     "89.160.20.156",

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
@@ -723,8 +723,9 @@
                 ],
                 "question": {
                     "name": "confiant-integrations.global.ssl.fastly.net",
-                    "registered_domain": "confiant-integrations.global.ssl.fastly.net",
-                    "top_level_domain": "global.ssl.fastly.net"
+                    "registered_domain": "global.ssl.fastly.net",
+                    "subdomain": "confiant-integrations",
+                    "top_level_domain": "ssl.fastly.net"
                 },
                 "resolved_ip": [
                     "89.160.20.156",
@@ -2322,8 +2323,9 @@
                 ],
                 "question": {
                     "name": "clarium.freetls.fastly.net",
-                    "registered_domain": "clarium.freetls.fastly.net",
-                    "top_level_domain": "freetls.fastly.net"
+                    "registered_domain": "freetls.fastly.net",
+                    "subdomain": "clarium",
+                    "top_level_domain": "fastly.net"
                 },
                 "resolved_ip": [
                     "89.160.20.156",

--- a/packages/windows/data_stream/sysmon_operational/sample_event.json
+++ b/packages/windows/data_stream/sysmon_operational/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2019-07-18T03:34:01.261Z",
     "agent": {
-        "ephemeral_id": "e90c830e-2d46-424a-8adf-c7b37b885e11",
-        "id": "ef922225-3c64-4634-8160-c93dfcee8f20",
+        "ephemeral_id": "69741349-7f7f-48bd-88c9-9e10a682f135",
+        "id": "c3c8f438-e38f-457a-8051-8a016f0370c6",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.6.2"
     },
     "data_stream": {
         "dataset": "windows.sysmon_operational",
@@ -41,9 +41,9 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "ef922225-3c64-4634-8160-c93dfcee8f20",
+        "id": "c3c8f438-e38f-457a-8051-8a016f0370c6",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.6.2"
     },
     "event": {
         "agent_id_status": "verified",
@@ -53,7 +53,7 @@
         "code": "22",
         "created": "2019-07-18T03:34:02.025Z",
         "dataset": "windows.sysmon_operational",
-        "ingested": "2023-01-31T21:24:36Z",
+        "ingested": "2023-04-23T22:45:37Z",
         "kind": "event",
         "original": "\u003cEvent xmlns='http://schemas.microsoft.com/win/2004/08/events/event'\u003e\u003cSystem\u003e\u003cProvider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/\u003e\u003cEventID\u003e22\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e22\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime='2019-07-18T03:34:02.025237700Z'/\u003e\u003cEventRecordID\u003e67\u003c/EventRecordID\u003e\u003cCorrelation/\u003e\u003cExecution ProcessID='2828' ThreadID='1684'/\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003evagrant-2016\u003c/Computer\u003e\u003cSecurity UserID='S-1-5-18'/\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name='RuleName'\u003e\u003c/Data\u003e\u003cData Name='UtcTime'\u003e2019-07-18 03:34:01.261\u003c/Data\u003e\u003cData Name='ProcessGuid'\u003e{fa4a0de6-e8a9-5d2f-0000-001053699900}\u003c/Data\u003e\u003cData Name='ProcessId'\u003e2736\u003c/Data\u003e\u003cData Name='QueryName'\u003ewww.msn.com\u003c/Data\u003e\u003cData Name='QueryStatus'\u003e0\u003c/Data\u003e\u003cData Name='QueryResults'\u003etype:  5 www-msn-com.a-0003.a-msedge.net;type:  5 a-0003.a-msedge.net;::ffff:204.79.197.203;\u003c/Data\u003e\u003cData Name='Image'\u003eC:\\Program Files (x86)\\Internet Explorer\\iexplore.exe\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
         "provider": "Microsoft-Windows-Sysmon",

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -778,11 +778,11 @@ An example event for `sysmon_operational` looks as following:
 {
     "@timestamp": "2019-07-18T03:34:01.261Z",
     "agent": {
-        "ephemeral_id": "e90c830e-2d46-424a-8adf-c7b37b885e11",
-        "id": "ef922225-3c64-4634-8160-c93dfcee8f20",
+        "ephemeral_id": "69741349-7f7f-48bd-88c9-9e10a682f135",
+        "id": "c3c8f438-e38f-457a-8051-8a016f0370c6",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.6.2"
     },
     "data_stream": {
         "dataset": "windows.sysmon_operational",
@@ -818,9 +818,9 @@ An example event for `sysmon_operational` looks as following:
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "ef922225-3c64-4634-8160-c93dfcee8f20",
+        "id": "c3c8f438-e38f-457a-8051-8a016f0370c6",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.6.2"
     },
     "event": {
         "agent_id_status": "verified",
@@ -830,7 +830,7 @@ An example event for `sysmon_operational` looks as following:
         "code": "22",
         "created": "2019-07-18T03:34:02.025Z",
         "dataset": "windows.sysmon_operational",
-        "ingested": "2023-01-31T21:24:36Z",
+        "ingested": "2023-04-23T22:45:37Z",
         "kind": "event",
         "original": "\u003cEvent xmlns='http://schemas.microsoft.com/win/2004/08/events/event'\u003e\u003cSystem\u003e\u003cProvider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/\u003e\u003cEventID\u003e22\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e22\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime='2019-07-18T03:34:02.025237700Z'/\u003e\u003cEventRecordID\u003e67\u003c/EventRecordID\u003e\u003cCorrelation/\u003e\u003cExecution ProcessID='2828' ThreadID='1684'/\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003evagrant-2016\u003c/Computer\u003e\u003cSecurity UserID='S-1-5-18'/\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name='RuleName'\u003e\u003c/Data\u003e\u003cData Name='UtcTime'\u003e2019-07-18 03:34:01.261\u003c/Data\u003e\u003cData Name='ProcessGuid'\u003e{fa4a0de6-e8a9-5d2f-0000-001053699900}\u003c/Data\u003e\u003cData Name='ProcessId'\u003e2736\u003c/Data\u003e\u003cData Name='QueryName'\u003ewww.msn.com\u003c/Data\u003e\u003cData Name='QueryStatus'\u003e0\u003c/Data\u003e\u003cData Name='QueryResults'\u003etype:  5 www-msn-com.a-0003.a-msedge.net;type:  5 a-0003.a-msedge.net;::ffff:204.79.197.203;\u003c/Data\u003e\u003cData Name='Image'\u003eC:\\Program Files (x86)\\Internet Explorer\\iexplore.exe\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
         "provider": "Microsoft-Windows-Sysmon",

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.19.2
+version: 1.20.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:
@@ -15,7 +15,7 @@ format_version: 1.0.0
 license: basic
 release: ga
 conditions:
-  kibana.version: "^7.16.0 || ^8.0.0"
+  kibana.version: "^8.4.0"
 screenshots:
   - src: /img/metricbeat-windows-service.png
     title: metricbeat windows service


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This updates the tests expectations to match the bahaviour of ES ingest processors.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] This unfortunately requires dropping support for 7.x stacks. The alternative would be to reimplement the registered_domain processor behaviour for 7.x which I think would be unreasonably brittle.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #5958

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
