### PR TITLE
ti_misp: add toggle to enable request tracing

### DIFF
--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Add toggle to enable request tracing.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5965
 - version: "1.12.1"
   changes:
     - description: Harmonise distribution fields to type long.

--- a/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -3,7 +3,7 @@ interval: {{interval}}
 request.method: "POST"
 
 {{#if enable_request_tracer}}
-request.tracer.filename: http-request-trace-httpjson-akamai.ndjson
+request.tracer.filename: http-request-trace-httpjson-ti_misp-threat.ndjson
 {{/if}}
 {{#if url}}
 request.url: {{url}}/events/restSearch

--- a/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.method: "POST"
 
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-akamai.ndjson
+{{/if}}
 {{#if url}}
 request.url: {{url}}/events/restSearch
 {{/if}}

--- a/packages/ti_misp/data_stream/threat/manifest.yml
+++ b/packages/ti_misp/data_stream/threat/manifest.yml
@@ -95,6 +95,16 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
 
     template_path: httpjson.yml.hbs
     title: MISP

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,9 @@ config_version: "2"
 interval: {{interval}}
 request.method: "POST"
 
+{{#if enable_request_tracer}}
+request.tracer.filename: http-request-trace-httpjson-ti_misp-threat_attributes.ndjson
+{{/if}}
 {{#if url}}
 request.url: {{url}}/attributes/restSearch
 {{/if}}

--- a/packages/ti_misp/data_stream/threat_attributes/manifest.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/manifest.yml
@@ -95,6 +95,16 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
+          Enabling this request tracing compromises security and should only be used for debugging.
+          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
 
     template_path: httpjson.yml.hbs
     title: MISP

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.12.1"
+version: "1.13.0"
 release: ga
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: ["security", "threat_intel"]
 conditions:
-  kibana.version: ^8.0.0
+  kibana.version: ^8.5.0
 icons:
   - src: /img/misp.svg
     title: MISP


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds an advanced option to enable http request trace logging for debugging purposes and bumps kibana constraint to 8.5.0 which is when the request tracer feature was introduced to Agent.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #5956

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
