### PR TITLE
ti_recordedfuture: scrape provider details from evidence fields

### DIFF
--- a/packages/ti_recordedfuture/changelog.yml
+++ b/packages/ti_recordedfuture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Scrape provider details from evidence field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5966
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-domain-default.log-expected.json
+++ b/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-domain-default.log-expected.json
@@ -90,6 +90,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Proofpoint",
+                        "PasteBin",
+                        "The Daily Advance",
+                        "@DGAFeedAlerts",
+                        "Insikt Group",
+                        "Bitdefender",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "xohrikvjhiu.eu"
@@ -194,6 +203,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "DHS Automated Indicator Sharing",
+                        "MALWARE BREAKDOWN",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "wgwuhauaqcrx.com"
@@ -298,6 +315,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "wbmpvebw.com"
@@ -390,6 +415,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "ckgryagcibbcf.com"
@@ -482,6 +514,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "jpuityvakjgg.com"
@@ -574,6 +613,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "jexgpprgph.com"
@@ -666,6 +712,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "cascotqhij.com"
@@ -758,6 +811,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "DHS Automated Indicator Sharing",
+                        "MALWARE BREAKDOWN",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "npcvnorvyhelagx.com"
@@ -850,6 +910,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "uxlyihgvfnqcrfcf.com"

--- a/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-hash-default.log-expected.json
+++ b/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-hash-default.log-expected.json
@@ -186,6 +186,31 @@
                             "sha256": "38e992eb852ab0c4ac03955fb0dc9bb38e64010fdf9c05331d2b02b6e05689c2"
                         }
                     },
+                    "provider": [
+                        "Security Bloggers Network",
+                        "TechTarget Search Security",
+                        "Bleeping Computer",
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "Carder Forum (carder.uk)",
+                        "wordpress.com",
+                        "AAPKS.com",
+                        "malwareresearch",
+                        "@phishingalert",
+                        "@GelosSnake",
+                        "@neonprimetime",
+                        "@rpsanch",
+                        "Messaging Platforms - Uncategorized",
+                        "@_mr_touch",
+                        "Malware-Traffic-Analysis.net - Blog Entries",
+                        "Doc Player",
+                        "GhostBin",
+                        "Data Breach Today.eu | Updates",
+                        "Codex  - Recent changes en",
+                        "DHS Automated Indicator Sharing",
+                        "ReversingLabs",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -360,6 +385,26 @@
                             "sha256": "c15abaf51e78ca56c0376522d699c978217bf041a3bd3c71d09193efa5717c71"
                         }
                     },
+                    "provider": [
+                        "Dancho Danchev's Blog",
+                        "SecureWorks",
+                        "Talos Intel",
+                        "Unit 42 Palo Alto Networks",
+                        "Cisco Japan Blog",
+                        "Stock market news Company News  MarketScreenercom",
+                        "HackDig Posts",
+                        "Sesin at",
+                        "US CERT CISA Alerts",
+                        "citizensudo.com",
+                        "GitHub",
+                        "Insikt Group",
+                        "4-traders.com",
+                        "SentinelLabs",
+                        "McAfee",
+                        "DHS Automated Indicator Sharing",
+                        "Sophos Virus and Spyware Threats",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -543,6 +588,22 @@
                             "md5": "b66db3a06c2955a9cb71a8718970c592"
                         }
                     },
+                    "provider": [
+                        "ISC Sans Diary Archive",
+                        "SecureWorks",
+                        "InfoCON: green",
+                        "ISC | Latest Headlines",
+                        "SANS Internet Storm Center",
+                        "GitHub",
+                        "Messaging Platforms - Uncategorized",
+                        "@decalage2",
+                        "@simonwargniez",
+                        "bund.de",
+                        "tistory.com",
+                        "PasteBin",
+                        "Sesin at",
+                        "Naked Security"
+                    ],
                     "type": "file"
                 }
             }
@@ -905,6 +966,28 @@
                             "sha256": "027cc450ef5f8c5f653329641ec1fed91f694e0d229928963b30f6b0d7d3a745"
                         }
                     },
+                    "provider": [
+                        "Security News Concentrator",
+                        "Fortinet",
+                        "Trend Micro",
+                        "CrowdStrike",
+                        "FireEye Threat Research Blog",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "Assiste.Forum",
+                        "@arturodicorinto",
+                        "GitHub",
+                        "BitcoinTalk.org",
+                        "@Noemi_hcke",
+                        "New Jersey Cybersecurity \u0026amp; Communications Integration Cell",
+                        "lnkd.in",
+                        "avtech24h.com",
+                        "Malwr.com",
+                        "Talos Intel",
+                        "DHS Automated Indicator Sharing",
+                        "Recorded Future Malware Detonation",
+                        "ReversingLabs",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -1022,6 +1105,23 @@
                             "sha256": "ad2ad0249fafe85877bc79a01e1afd1a44d983c064ad8cb5bc694d29d166217b"
                         }
                     },
+                    "provider": [
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "ISC | All Updates",
+                        "Malwarebytes Unpacked",
+                        "malwareresearch",
+                        "AAPKS.com",
+                        "@Shouvik95232310",
+                        "@santGM",
+                        "Messaging Platforms - Uncategorized",
+                        "Ichunqiu Forum",
+                        "Doc Player",
+                        "ArXiv",
+                        "GitHub",
+                        "droppdf.com",
+                        "ReversingLabs"
+                    ],
                     "type": "file"
                 }
             }
@@ -1136,6 +1236,22 @@
                             "sha256": "01ba1fb41632594997a41d0c3a911ae5b3034d566ebb991ef76ad76e6f9e283a"
                         }
                     },
+                    "provider": [
+                        "Trend Micro",
+                        "@m0rb",
+                        "@bad_packets",
+                        "@InfoSex11",
+                        "@luc4m",
+                        "@swarmdotmarket",
+                        "lumen.com",
+                        "HackDig Posts",
+                        "Anquanke News",
+                        "Daily Dot",
+                        "centurylink.com",
+                        "Recorded Future Malware Detonation",
+                        "ReversingLabs",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -1321,6 +1437,31 @@
                             "sha256": "fecddb7f3fa478be4687ca542c0ecf232ec35a0c2418c8bfe4875686ec373c1e"
                         }
                     },
+                    "provider": [
+                        "Security Bloggers Network",
+                        "Bleeping Computer",
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "TheServerSide.com | Updates",
+                        "Carder Forum (carder.uk)",
+                        "wordpress.com",
+                        "AAPKS.com",
+                        "malwareresearch",
+                        "@phishingalert",
+                        "@GelosSnake",
+                        "@rpsanch",
+                        "@rce_coder",
+                        "Messaging Platforms - Uncategorized",
+                        "SANS Institute Course Selector Results",
+                        "@ecstatic_nobel",
+                        "@Artilllerie",
+                        "Doc Player",
+                        "GhostBin",
+                        "Codex  - Recent changes en",
+                        "droppdf.com",
+                        "ReversingLabs",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -1420,6 +1561,19 @@
                             "sha256": "a1d9cd6f189beff28a0a49b10f8fe4510128471f004b3e4283ddc7f78594906b"
                         }
                     },
+                    "provider": [
+                        "SecureWorks",
+                        "InfoCON: green",
+                        "McAfee",
+                        "Talos Intel",
+                        "Kaspersky Securelist and Lab",
+                        "lnkd.in",
+                        "Doc Player",
+                        "Cyber4Sight",
+                        "voicebox.pt",
+                        "VKontakte",
+                        "Recorded Future Malware Detonation"
+                    ],
                     "type": "file"
                 }
             }
@@ -1535,6 +1689,23 @@
                             "sha256": "85aba198a0ba204e8549ea0c8980447249d30dece0d430e3f517315ad10f32ce"
                         }
                     },
+                    "provider": [
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "ISC | All Updates",
+                        "Malwarebytes Unpacked",
+                        "malwareresearch",
+                        "AAPKS.com",
+                        "@Shouvik95232310",
+                        "@santGM",
+                        "Messaging Platforms - Uncategorized",
+                        "Ichunqiu Forum",
+                        "Doc Player",
+                        "ArXiv",
+                        "GitHub",
+                        "droppdf.com",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }

--- a/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-httpjson.log-expected.json
+++ b/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-httpjson.log-expected.json
@@ -89,6 +89,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Proofpoint",
+                        "PasteBin",
+                        "The Daily Advance",
+                        "@DGAFeedAlerts",
+                        "Insikt Group",
+                        "Bitdefender",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "xohrikvjhiu.eu"
@@ -193,6 +202,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "DHS Automated Indicator Sharing",
+                        "MALWARE BREAKDOWN",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "wgwuhauaqcrx.com"
@@ -297,6 +314,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "wbmpvebw.com"
@@ -389,6 +414,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "ckgryagcibbcf.com"
@@ -481,6 +513,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "jpuityvakjgg.com"
@@ -573,6 +612,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "jexgpprgph.com"
@@ -665,6 +711,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "cascotqhij.com"
@@ -757,6 +810,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "DHS Automated Indicator Sharing",
+                        "MALWARE BREAKDOWN",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "npcvnorvyhelagx.com"
@@ -849,6 +909,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "@DGAFeedAlerts",
+                        "Dynamoos Blog",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "uxlyihgvfnqcrfcf.com"
@@ -941,6 +1008,13 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "DHS Automated Indicator Sharing",
+                        "@DGAFeedAlerts",
+                        "Bitdefender",
+                        "Malwr.com",
+                        "Bambenek Consulting C\u0026C Blocklist"
+                    ],
                     "type": "domain-name",
                     "url": {
                         "domain": "bjfwfqviu.com"
@@ -1133,6 +1207,31 @@
                             "sha256": "38e992eb852ab0c4ac03955fb0dc9bb38e64010fdf9c05331d2b02b6e05689c2"
                         }
                     },
+                    "provider": [
+                        "Security Bloggers Network",
+                        "TechTarget Search Security",
+                        "Bleeping Computer",
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "Carder Forum (carder.uk)",
+                        "wordpress.com",
+                        "AAPKS.com",
+                        "malwareresearch",
+                        "@phishingalert",
+                        "@GelosSnake",
+                        "@neonprimetime",
+                        "@rpsanch",
+                        "Messaging Platforms - Uncategorized",
+                        "@_mr_touch",
+                        "Malware-Traffic-Analysis.net - Blog Entries",
+                        "Doc Player",
+                        "GhostBin",
+                        "Data Breach Today.eu | Updates",
+                        "Codex  - Recent changes en",
+                        "DHS Automated Indicator Sharing",
+                        "ReversingLabs",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -1307,6 +1406,26 @@
                             "sha256": "c15abaf51e78ca56c0376522d699c978217bf041a3bd3c71d09193efa5717c71"
                         }
                     },
+                    "provider": [
+                        "Dancho Danchev's Blog",
+                        "SecureWorks",
+                        "Talos Intel",
+                        "Unit 42 Palo Alto Networks",
+                        "Cisco Japan Blog",
+                        "Stock market news Company News  MarketScreenercom",
+                        "HackDig Posts",
+                        "Sesin at",
+                        "US CERT CISA Alerts",
+                        "citizensudo.com",
+                        "GitHub",
+                        "Insikt Group",
+                        "4-traders.com",
+                        "SentinelLabs",
+                        "McAfee",
+                        "DHS Automated Indicator Sharing",
+                        "Sophos Virus and Spyware Threats",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -1490,6 +1609,22 @@
                             "md5": "b66db3a06c2955a9cb71a8718970c592"
                         }
                     },
+                    "provider": [
+                        "ISC Sans Diary Archive",
+                        "SecureWorks",
+                        "InfoCON: green",
+                        "ISC | Latest Headlines",
+                        "SANS Internet Storm Center",
+                        "GitHub",
+                        "Messaging Platforms - Uncategorized",
+                        "@decalage2",
+                        "@simonwargniez",
+                        "bund.de",
+                        "tistory.com",
+                        "PasteBin",
+                        "Sesin at",
+                        "Naked Security"
+                    ],
                     "type": "file"
                 }
             }
@@ -1852,6 +1987,28 @@
                             "sha256": "027cc450ef5f8c5f653329641ec1fed91f694e0d229928963b30f6b0d7d3a745"
                         }
                     },
+                    "provider": [
+                        "Security News Concentrator",
+                        "Fortinet",
+                        "Trend Micro",
+                        "CrowdStrike",
+                        "FireEye Threat Research Blog",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "Assiste.Forum",
+                        "@arturodicorinto",
+                        "GitHub",
+                        "BitcoinTalk.org",
+                        "@Noemi_hcke",
+                        "New Jersey Cybersecurity \u0026amp; Communications Integration Cell",
+                        "lnkd.in",
+                        "avtech24h.com",
+                        "Malwr.com",
+                        "Talos Intel",
+                        "DHS Automated Indicator Sharing",
+                        "Recorded Future Malware Detonation",
+                        "ReversingLabs",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -1969,6 +2126,23 @@
                             "sha256": "ad2ad0249fafe85877bc79a01e1afd1a44d983c064ad8cb5bc694d29d166217b"
                         }
                     },
+                    "provider": [
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "ISC | All Updates",
+                        "Malwarebytes Unpacked",
+                        "malwareresearch",
+                        "AAPKS.com",
+                        "@Shouvik95232310",
+                        "@santGM",
+                        "Messaging Platforms - Uncategorized",
+                        "Ichunqiu Forum",
+                        "Doc Player",
+                        "ArXiv",
+                        "GitHub",
+                        "droppdf.com",
+                        "ReversingLabs"
+                    ],
                     "type": "file"
                 }
             }
@@ -2083,6 +2257,22 @@
                             "sha256": "01ba1fb41632594997a41d0c3a911ae5b3034d566ebb991ef76ad76e6f9e283a"
                         }
                     },
+                    "provider": [
+                        "Trend Micro",
+                        "@m0rb",
+                        "@bad_packets",
+                        "@InfoSex11",
+                        "@luc4m",
+                        "@swarmdotmarket",
+                        "lumen.com",
+                        "HackDig Posts",
+                        "Anquanke News",
+                        "Daily Dot",
+                        "centurylink.com",
+                        "Recorded Future Malware Detonation",
+                        "ReversingLabs",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -2268,6 +2458,31 @@
                             "sha256": "fecddb7f3fa478be4687ca542c0ecf232ec35a0c2418c8bfe4875686ec373c1e"
                         }
                     },
+                    "provider": [
+                        "Security Bloggers Network",
+                        "Bleeping Computer",
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "TheServerSide.com | Updates",
+                        "Carder Forum (carder.uk)",
+                        "wordpress.com",
+                        "AAPKS.com",
+                        "malwareresearch",
+                        "@phishingalert",
+                        "@GelosSnake",
+                        "@rpsanch",
+                        "@rce_coder",
+                        "Messaging Platforms - Uncategorized",
+                        "SANS Institute Course Selector Results",
+                        "@ecstatic_nobel",
+                        "@Artilllerie",
+                        "Doc Player",
+                        "GhostBin",
+                        "Codex  - Recent changes en",
+                        "droppdf.com",
+                        "ReversingLabs",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -2367,6 +2582,19 @@
                             "sha256": "a1d9cd6f189beff28a0a49b10f8fe4510128471f004b3e4283ddc7f78594906b"
                         }
                     },
+                    "provider": [
+                        "SecureWorks",
+                        "InfoCON: green",
+                        "McAfee",
+                        "Talos Intel",
+                        "Kaspersky Securelist and Lab",
+                        "lnkd.in",
+                        "Doc Player",
+                        "Cyber4Sight",
+                        "voicebox.pt",
+                        "VKontakte",
+                        "Recorded Future Malware Detonation"
+                    ],
                     "type": "file"
                 }
             }
@@ -2482,6 +2710,23 @@
                             "sha256": "85aba198a0ba204e8549ea0c8980447249d30dece0d430e3f517315ad10f32ce"
                         }
                     },
+                    "provider": [
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "ISC | All Updates",
+                        "Malwarebytes Unpacked",
+                        "malwareresearch",
+                        "AAPKS.com",
+                        "@Shouvik95232310",
+                        "@santGM",
+                        "Messaging Platforms - Uncategorized",
+                        "Ichunqiu Forum",
+                        "Doc Player",
+                        "ArXiv",
+                        "GitHub",
+                        "droppdf.com",
+                        "PolySwarm"
+                    ],
                     "type": "file"
                 }
             }
@@ -2601,6 +2846,24 @@
                             "sha256": "7531fcea7002c8b52a8d023d0f3bb938efb2cbfec91d2433694930b426d84865"
                         }
                     },
+                    "provider": [
+                        "Guided Collection",
+                        "Bleepingcomputer Forums",
+                        "ISC | All Updates",
+                        "Malwarebytes Unpacked",
+                        "malwareresearch",
+                        "Malwr.com",
+                        "AAPKS.com",
+                        "@Shouvik95232310",
+                        "@santGM",
+                        "@aa419",
+                        "Messaging Platforms - Uncategorized",
+                        "Ichunqiu Forum",
+                        "Doc Player",
+                        "ArXiv",
+                        "GitHub",
+                        "ReversingLabs"
+                    ],
                     "type": "file"
                 }
             }
@@ -2682,6 +2945,15 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.12",
+                    "provider": [
+                        "PasteBin",
+                        "GitHub",
+                        "Recorded Future Command \u0026 Control List",
+                        "Joe Security Sandbox Analysis - Malware C2 Extractions",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Polyswarm Sandbox Analysis - Malware C2 Extractions",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -2787,6 +3059,15 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.13",
+                    "provider": [
+                        "GitHub",
+                        "Bitdefender IP Reputation",
+                        "hpHosts Latest Additions",
+                        "Recorded Future Fast Flux DNS IP List",
+                        "Recorded Future Command \u0026 Control List",
+                        "Joe Security Sandbox Analysis - Malware C2 Extractions",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -2891,6 +3172,14 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.14",
+                    "provider": [
+                        "C2IntelFeeds IPC2s",
+                        "@drb_ra",
+                        "Cobalt Strike Default Certificate Detected - Shodan / Recorded Future",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "Recorded Future Command \u0026 Control List",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -3051,6 +3340,20 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.15",
+                    "provider": [
+                        "paloaltonetworks.jp",
+                        "Palo Alto Networks",
+                        "Unit 42 Palo Alto Networks",
+                        "PasteBin",
+                        "Cryptolaemus Pastedump",
+                        "AbuseIP Database",
+                        "External Sensor Spam",
+                        "University of Science and Technology of China Black IP List",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Polyswarm Sandbox Analysis - Malware C2 Extractions",
+                        "Talos IP Blacklist",
+                        "Joe Security Sandbox Analysis - Malware C2 Extractions"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -3118,6 +3421,12 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.12",
+                    "provider": [
+                        "PasteBin",
+                        "Recorded Future Command \u0026 Control List",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -3234,6 +3543,17 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.13",
+                    "provider": [
+                        "Project Honey Pot",
+                        "@HoneyFog",
+                        "GitHub",
+                        "External Sensor Spam",
+                        "CloudSEK",
+                        "University of Science and Technology of China Black IP List",
+                        "Recorded Future Command \u0026 Control List",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -3315,6 +3635,15 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.14",
+                    "provider": [
+                        "Cobalt Strike Default Certificate Detected - Shodan / Recorded Future",
+                        "CINS: CI Army List",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "DShield: Recommended Block List",
+                        "Recorded Future Command \u0026 Control List",
+                        "@TheDFIRReport",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -3453,6 +3782,22 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.15",
+                    "provider": [
+                        "TBN",
+                        "BlackHatWorld Forum",
+                        "Carding Mafia Forum",
+                        "Inforge Forum Hacker Trucchi Giochi Informatica",
+                        "ProxyFire - The Best Proxy Software and Forum",
+                        "@HoneyFog",
+                        "Manato Kumagai Hatena Blog",
+                        "sentinelone.com",
+                        "PasteBin",
+                        "AbuseIP Database",
+                        "BlockList.de: Fail2ban Reporting Service",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Proxies: SOCKS Open Proxies",
+                        "Polyswarm Sandbox Analysis - Malware C2 Extractions"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -3557,6 +3902,15 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.12",
+                    "provider": [
+                        "PasteBin",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Project Honey Pot",
+                        "Recorded Future Command \u0026 Control List",
+                        "Joe Security Sandbox Analysis - Malware C2 Extractions",
+                        "Recorded Future Network Traffic Analysis",
+                        "Polyswarm Sandbox Analysis - Malware C2 Extractions"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -3681,6 +4035,20 @@
                 },
                 "indicator": {
                     "ip": "67.43.156.13",
+                    "provider": [
+                        "Malware News - Malware Analysis",
+                        "News and Indicators",
+                        "PasteBin",
+                        "Segurana Informtica",
+                        "The Cyber Feed",
+                        "Kaspersky Securelist and Lab",
+                        "urlscan.io",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Recorded Future Command \u0026 Control List",
+                        "Polyswarm Sandbox Analysis - Malware C2 Extractions",
+                        "Joe Security Sandbox Analysis - Malware C2 Extractions",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -3755,6 +4123,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Ars Technica",
+                        "fook.news",
+                        "urdupresss.com",
+                        "HackDig Posts",
+                        "apple.news",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "144.34.179.162",
@@ -3856,6 +4232,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Stock market news Company News  MarketScreenercom",
+                        "GlobeNewswire | Software",
+                        "Yahoo!",
+                        "globenewswirecom",
+                        "otcdynamics.com",
+                        "Bitdefender",
+                        "Recorded Future Domain Analysis URLs"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "adminsys.serveftp.com",
@@ -3928,6 +4313,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Security Affairs",
+                        "sensorstechforum.com",
+                        "Heimdal Security Blog",
+                        "securitynewspaper",
+                        "BBS Kafan Card Forum",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "3.145.115.94",
@@ -4001,6 +4394,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "HackDig Posts",
+                        "Anquanke News",
+                        "mrhacker.co",
+                        "Sesin at",
+                        "Check Point Research",
+                        "Bitdefender"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "gxbrowser.net",
@@ -4083,6 +4484,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Palo Alto Networks",
+                        "tistory.com",
+                        "HackDig Posts",
+                        "Anquanke News",
+                        "airmagnet.technology",
+                        "Insikt Group",
+                        "Recorded Future Domain Analysis URLs"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "881.000webhostapp.com",
@@ -4173,6 +4583,16 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "cybersecdn.com",
+                        "WeLiveSecurity Spain",
+                        "deepcheck.one",
+                        "hackeridiot.com",
+                        "PasteBin",
+                        "Bitdefender",
+                        "Insikt Group",
+                        "Recorded Future Domain Analysis URLs"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "comunicador.duckdns.org",
@@ -4246,6 +4666,11 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Recorded Future Domain Analysis URLs",
+                        "Bitdefender",
+                        "Urlscan.io"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "www.jeanninecatddns.chickenkiller.com",
@@ -4325,6 +4750,16 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Malware News - Malware Analysis",
+                        "News and Indicators",
+                        "microsoft.com",
+                        "sociabble.com",
+                        "4-traders.com",
+                        "MarketScreener.com | Stock Market News",
+                        "Bitdefender",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "coollab.jp",
@@ -4405,6 +4840,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "The Official Google Blog",
+                        "eccouncil.org",
+                        "frsecure.com",
+                        "SoyaCincau",
+                        "PasteBin",
+                        "Bitdefender",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "blog.br0vvnn.io",
@@ -4473,6 +4917,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "lnkd.in",
+                        "digitalforensicsmagazineblog PH",
+                        "mediosdemexico.com",
+                        "Palo Alto Networks",
+                        "Security Art Work",
+                        "Bitdefender"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "init.icloud-analysis.com",

--- a/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-ip-default.log-expected.json
+++ b/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-ip-default.log-expected.json
@@ -78,6 +78,15 @@
                 },
                 "indicator": {
                     "ip": "1.128.3.4",
+                    "provider": [
+                        "PasteBin",
+                        "GitHub",
+                        "Recorded Future Command \u0026 Control List",
+                        "Joe Security Sandbox Analysis - Malware C2 Extractions",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Polyswarm Sandbox Analysis - Malware C2 Extractions",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -168,6 +177,12 @@
                 },
                 "indicator": {
                     "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                    "provider": [
+                        "AbuseIPDB Community Submissions",
+                        "AbuseIPDB Spam",
+                        "DataPlane SSH Client Connection List",
+                        "BlockList.de: Fail2ban Reporting Service"
+                    ],
                     "type": "ipv6-addr"
                 }
             }
@@ -273,6 +288,15 @@
                 },
                 "indicator": {
                     "ip": "175.16.199.1",
+                    "provider": [
+                        "GitHub",
+                        "Bitdefender IP Reputation",
+                        "hpHosts Latest Additions",
+                        "Recorded Future Fast Flux DNS IP List",
+                        "Recorded Future Command \u0026 Control List",
+                        "Joe Security Sandbox Analysis - Malware C2 Extractions",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -377,6 +401,14 @@
                 },
                 "indicator": {
                     "ip": "216.160.83.57",
+                    "provider": [
+                        "C2IntelFeeds IPC2s",
+                        "@drb_ra",
+                        "Cobalt Strike Default Certificate Detected - Shodan / Recorded Future",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "Recorded Future Command \u0026 Control List",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -537,6 +569,20 @@
                 },
                 "indicator": {
                     "ip": "216.160.83.61",
+                    "provider": [
+                        "paloaltonetworks.jp",
+                        "Palo Alto Networks",
+                        "Unit 42 Palo Alto Networks",
+                        "PasteBin",
+                        "Cryptolaemus Pastedump",
+                        "AbuseIP Database",
+                        "External Sensor Spam",
+                        "University of Science and Technology of China Black IP List",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Polyswarm Sandbox Analysis - Malware C2 Extractions",
+                        "Talos IP Blacklist",
+                        "Joe Security Sandbox Analysis - Malware C2 Extractions"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -604,6 +650,12 @@
                 },
                 "indicator": {
                     "ip": "81.2.69.143",
+                    "provider": [
+                        "PasteBin",
+                        "Recorded Future Command \u0026 Control List",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -720,6 +772,17 @@
                 },
                 "indicator": {
                     "ip": "81.2.69.144",
+                    "provider": [
+                        "Project Honey Pot",
+                        "@HoneyFog",
+                        "GitHub",
+                        "External Sensor Spam",
+                        "CloudSEK",
+                        "University of Science and Technology of China Black IP List",
+                        "Recorded Future Command \u0026 Control List",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -801,6 +864,15 @@
                 },
                 "indicator": {
                     "ip": "81.2.69.145",
+                    "provider": [
+                        "Cobalt Strike Default Certificate Detected - Shodan / Recorded Future",
+                        "CINS: CI Army List",
+                        "Recorded Future Analyst Community Trending Indicators",
+                        "DShield: Recommended Block List",
+                        "Recorded Future Command \u0026 Control List",
+                        "@TheDFIRReport",
+                        "Recorded Future Network Traffic Analysis"
+                    ],
                     "type": "ipv4-addr"
                 }
             }
@@ -939,6 +1011,22 @@
                 },
                 "indicator": {
                     "ip": "81.2.69.193",
+                    "provider": [
+                        "TBN",
+                        "BlackHatWorld Forum",
+                        "Carding Mafia Forum",
+                        "Inforge Forum Hacker Trucchi Giochi Informatica",
+                        "ProxyFire - The Best Proxy Software and Forum",
+                        "@HoneyFog",
+                        "Manato Kumagai Hatena Blog",
+                        "sentinelone.com",
+                        "PasteBin",
+                        "AbuseIP Database",
+                        "BlockList.de: Fail2ban Reporting Service",
+                        "Abuse.ch: Feodo IP Blocklist",
+                        "Proxies: SOCKS Open Proxies",
+                        "Polyswarm Sandbox Analysis - Malware C2 Extractions"
+                    ],
                     "type": "ipv4-addr"
                 }
             }

--- a/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-url-default.log-expected.json
+++ b/packages/ti_recordedfuture/data_stream/threat/_dev/test/pipeline/test-url-default.log-expected.json
@@ -71,6 +71,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Ars Technica",
+                        "fook.news",
+                        "urdupresss.com",
+                        "HackDig Posts",
+                        "apple.news",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "144.34.179.162",
@@ -172,6 +180,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Stock market news Company News  MarketScreenercom",
+                        "GlobeNewswire | Software",
+                        "Yahoo!",
+                        "globenewswirecom",
+                        "otcdynamics.com",
+                        "Bitdefender",
+                        "Recorded Future Domain Analysis URLs"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "adminsys.serveftp.com",
@@ -244,6 +261,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Security Affairs",
+                        "sensorstechforum.com",
+                        "Heimdal Security Blog",
+                        "securitynewspaper",
+                        "BBS Kafan Card Forum",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "3.145.115.94",
@@ -317,6 +342,14 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "HackDig Posts",
+                        "Anquanke News",
+                        "mrhacker.co",
+                        "Sesin at",
+                        "Check Point Research",
+                        "Bitdefender"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "gxbrowser.net",
@@ -399,6 +432,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Palo Alto Networks",
+                        "tistory.com",
+                        "HackDig Posts",
+                        "Anquanke News",
+                        "airmagnet.technology",
+                        "Insikt Group",
+                        "Recorded Future Domain Analysis URLs"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "881.000webhostapp.com",
@@ -489,6 +531,16 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "cybersecdn.com",
+                        "WeLiveSecurity Spain",
+                        "deepcheck.one",
+                        "hackeridiot.com",
+                        "PasteBin",
+                        "Bitdefender",
+                        "Insikt Group",
+                        "Recorded Future Domain Analysis URLs"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "comunicador.duckdns.org",
@@ -562,6 +614,11 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Recorded Future Domain Analysis URLs",
+                        "Bitdefender",
+                        "Urlscan.io"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "www.jeanninecatddns.chickenkiller.com",
@@ -641,6 +698,16 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "Malware News - Malware Analysis",
+                        "News and Indicators",
+                        "microsoft.com",
+                        "sociabble.com",
+                        "4-traders.com",
+                        "MarketScreener.com | Stock Market News",
+                        "Bitdefender",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "coollab.jp",
@@ -721,6 +788,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "The Official Google Blog",
+                        "eccouncil.org",
+                        "frsecure.com",
+                        "SoyaCincau",
+                        "PasteBin",
+                        "Bitdefender",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "domain": "blog.br0vvnn.io",
@@ -800,6 +876,15 @@
                     "name": "Recorded Future"
                 },
                 "indicator": {
+                    "provider": [
+                        "The Official Google Blog",
+                        "eccouncil.org",
+                        "frsecure.com",
+                        "SoyaCincau",
+                        "PasteBin",
+                        "Bitdefender",
+                        "Insikt Group"
+                    ],
                     "type": "url",
                     "url": {
                         "original": "example.net/%e3%83%9d%e3%82%b1%e3%83%a2%e3%83%b3-%e3%82%bb%e3%83%b3%e3%82%bf%e3%83%bc-%e6%a8%aa%e6%b5%9c-%e7%a7%bb%e8%bb%a2-%e3%81%aa%e3%81%9c/%e3%81%b5%e3%82%8b%e3%81%95%e3%81%a8-%e7%b4%8d%e7%a8%8e-%e3%83%88%e3%82%a4%e3%83%ac%e3%83%83%e3%83%88-%e3%83%9a%e3%83%bc%e3%83%91%e3%83%bc-%e9%82%84%e5%85%83-%e7%8e%87/%e6%9c%9d%e6%97%a5-%e6%96%b0%e8%81%9e-be-%e3%83%91%e3%82%ba%e3%83%a"

--- a/packages/ti_recordedfuture/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_recordedfuture/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -71,6 +71,41 @@ processors:
       target_field: json.evidence_details
       ignore_missing: true
 
+  - foreach:
+      field: json.evidence_details
+      ignore_missing: true
+      processor:
+        append:
+          field: _temp_.providers
+          value: "{{{ _ingest._value.EvidenceString }}}"
+  - foreach:
+      field: _temp_.providers
+      ignore_missing: true
+      processor:
+        gsub:
+          field: '_ingest._value'
+          pattern: '^.+sources?(?: including)?: (.*?)\.(?: .*)?$'
+          replacement: '$1'
+  - foreach:
+      field: _temp_.providers
+      ignore_missing: true
+      processor:
+        split:
+          field: '_ingest._value'
+          separator: ', *'
+  - foreach:
+      field: _temp_.providers
+      ignore_missing: true
+      processor:
+        foreach:
+          field: '_ingest._value'
+          ignore_missing: true
+          processor:
+            append:
+              field: threat.indicator.provider
+              value: '{{{ _ingest._value }}}'
+              allow_duplicates: false
+
 #
 # Hash indicators (threat.indicator.type=file)
 # As risklist indicators don't have a "type" field, it's necessary

--- a/packages/ti_recordedfuture/data_stream/threat/sample_event.json
+++ b/packages/ti_recordedfuture/data_stream/threat/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-06-28T00:51:15.439Z",
+    "@timestamp": "2023-04-24T01:13:37.004Z",
     "agent": {
-        "ephemeral_id": "ab36e75a-d84f-4a16-9896-44e791dc923d",
-        "id": "33b93e16-9d01-4487-9b09-99db9e860912",
+        "ephemeral_id": "32aafc9a-68e1-47fe-bef5-36d8890a898f",
+        "id": "c5e28d1b-c611-499c-9a49-08340eeaa6a0",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.2"
+        "version": "8.6.2"
     },
     "data_stream": {
         "dataset": "ti_recordedfuture.threat",
@@ -16,15 +16,15 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "33b93e16-9d01-4487-9b09-99db9e860912",
+        "id": "c5e28d1b-c611-499c-9a49-08340eeaa6a0",
         "snapshot": false,
-        "version": "8.2.2"
+        "version": "8.6.2"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "threat",
         "dataset": "ti_recordedfuture.threat",
-        "ingested": "2022-06-28T00:51:16Z",
+        "ingested": "2023-04-24T01:13:38Z",
         "kind": "enrichment",
         "risk_score": 87,
         "timezone": "+00:00",
@@ -98,6 +98,14 @@
             "name": "Recorded Future"
         },
         "indicator": {
+            "provider": [
+                "Ars Technica",
+                "fook.news",
+                "urdupresss.com",
+                "HackDig Posts",
+                "apple.news",
+                "Insikt Group"
+            ],
             "type": "url",
             "url": {
                 "domain": "144.34.179.162",

--- a/packages/ti_recordedfuture/docs/README.md
+++ b/packages/ti_recordedfuture/docs/README.md
@@ -16,13 +16,13 @@ An example event for `threat` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-06-28T00:51:15.439Z",
+    "@timestamp": "2023-04-24T01:13:37.004Z",
     "agent": {
-        "ephemeral_id": "ab36e75a-d84f-4a16-9896-44e791dc923d",
-        "id": "33b93e16-9d01-4487-9b09-99db9e860912",
+        "ephemeral_id": "32aafc9a-68e1-47fe-bef5-36d8890a898f",
+        "id": "c5e28d1b-c611-499c-9a49-08340eeaa6a0",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.2"
+        "version": "8.6.2"
     },
     "data_stream": {
         "dataset": "ti_recordedfuture.threat",
@@ -33,15 +33,15 @@ An example event for `threat` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "33b93e16-9d01-4487-9b09-99db9e860912",
+        "id": "c5e28d1b-c611-499c-9a49-08340eeaa6a0",
         "snapshot": false,
-        "version": "8.2.2"
+        "version": "8.6.2"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "threat",
         "dataset": "ti_recordedfuture.threat",
-        "ingested": "2022-06-28T00:51:16Z",
+        "ingested": "2023-04-24T01:13:38Z",
         "kind": "enrichment",
         "risk_score": 87,
         "timezone": "+00:00",
@@ -115,6 +115,14 @@ An example event for `threat` looks as following:
             "name": "Recorded Future"
         },
         "indicator": {
+            "provider": [
+                "Ars Technica",
+                "fook.news",
+                "urdupresss.com",
+                "HackDig Posts",
+                "apple.news",
+                "Insikt Group"
+            ],
             "type": "url",
             "url": {
                 "domain": "144.34.179.162",

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "1.6.0"
+version: "1.7.0"
 release: ga
 description: Ingest threat intelligence indicators from Recorded Future risk lists with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This extracts provider names from the evidence details fields in order to populate `threat.indicator.provider`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #5960

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
