### PR TITLE
universal_profiling_symbolizer: add data stream

### DIFF
--- a/packages/universal_profiling_symbolizer/changelog.yml
+++ b/packages/universal_profiling_symbolizer/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: 8.8.0-preview
   changes:
+    - description: Add a data stream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5971
     - description: Initial draft of the package
       type: enhancement
       link: https://github.com/elastic/integrations/pull/5879

--- a/packages/universal_profiling_symbolizer/data_stream/fields/base-fields.yml
+++ b/packages/universal_profiling_symbolizer/data_stream/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/packages/universal_profiling_symbolizer/data_stream/manifest.yml
+++ b/packages/universal_profiling_symbolizer/data_stream/manifest.yml
@@ -1,0 +1,8 @@
+title: "Universal Profiling Symbols"
+type: profiling
+release: beta
+streams:
+  - input: pf-elastic-symbolizer
+    title: Universal Profiling Symbols
+    description: "Collect debug symbols for native binaries"
+    enabled: true

--- a/packages/universal_profiling_symbolizer/manifest.yml
+++ b/packages/universal_profiling_symbolizer/manifest.yml
@@ -6,7 +6,7 @@ description: Fleet-wide, whole-system, continuous profiling with zero instrument
 conditions:
   kibana.version: ^8.8.0
   elastic.subscription: basic
-format_version: 1.1.0
+format_version: 2.7.0
 icons:
   - size: 48x46
     src: /img/profiler-logo-color-48px.svg
@@ -21,11 +21,11 @@ policy_templates:
         description: Enhance Universal Profiling with additional symbol information
         type: pf-elastic-symbolizer
         vars:
-          - name: hack
-            type: bool
-            title: hack to workaround a known issue
+          - name: Symbols object store endpoint
+            type: text
+            title: Endpoint where to fetch public symbols for native executables
             description: |
-              Check out elastic/kibana/issues/155064 for the reason of this hack.
+              An object store URL, with an S3-compatible API, where symbolizer will fetch the debug symbols from.
     multiple: false
 type: integration
 owner:


### PR DESCRIPTION
## What does this PR do?

Adds a data stream to `universal_profiling_symbolizer` package.
It makes use of the new `profiling` data stream type created in https://github.com/elastic/package-spec/pull/503 so it needs the `format_version` to be bumped.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Create a deployment in Elastic Cloud, install the package with `elastic-package` and verify the data stream is created.
