### PR TITLE
network_traffic: allow user-defined processors on flows

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Allow user-defined processors on flows.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5972
 - version: "1.13.0"
   changes:
     - description: Allow setting never install Npcap option in integration.

--- a/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
+++ b/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
@@ -13,6 +13,10 @@ fields:
 procs:
   enabled: true
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
 {{#if interface}}
 interface:
 {{#if (contains ".pcap" interface)}}

--- a/packages/network_traffic/data_stream/flow/manifest.yml
+++ b/packages/network_traffic/data_stream/flow/manifest.yml
@@ -37,3 +37,10 @@ streams:
         required: false
         show_user: false
         default: '30s'
+      - name: processors
+        type: yaml
+        title: Processors
+        description: Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+        show_user: false
+        multi: false
+        required: false

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.13.0"
+version: "1.14.0"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Allows users to specify processors to run on packetbeat data in flows datastream.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #5969

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
