### PR TITLE
Fix schedule daily job

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -30,7 +30,7 @@ pipeline {
               job: env.INTEGRATION_JOB,
               parameters: [
                 stringParam(name: 'stackVersion', value: '7.17-SNAPSHOT'),
-                booleanParam(name: 'force_check_all', value: true)
+                booleanParam(name: 'force_check_all', value: true),
                 booleanParam(name: 'skip_publishing', value: true),
               ],
               quietPeriod: 0,


### PR DESCRIPTION
## What does this PR do?

Fix definition of the schedule-daily job.
Follow up of https://github.com/elastic/integrations/pull/5884

Example of job failing: 
https://fleet-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations-daily/detail/integrations-daily/229/pipeline

```
[2023-04-24T03:04:23.996Z] WorkflowScript: 34: expecting ']', found 'booleanParam' @ line 34, column 17.
[2023-04-24T03:04:23.996Z]                    booleanParam(name: 'skip_publishing', value: true),
[2023-04-24T03:04:23.996Z]                    ^
[2023-04-24T03:04:23.996Z] 
[2023-04-24T03:04:23.996Z] 1 error
```
