### PR TITLE
[Windows] Add event.category and event.type to Sysmon Operational 

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Add `event.category` and `event.type` to Sysmon events
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5980
 - version: "1.20.0"
   changes:
     - description: Update test expectations for processor behaviour.

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
@@ -22239,11 +22239,17 @@
                 "version": "8.0.0"
             },
             "event": {
+                "category": [
+                    "process"
+                ],
                 "code": "8",
                 "created": "2017-05-13T22:53:43.214Z",
                 "kind": "event",
                 "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e8\u003c/EventID\u003e\u003cVersion\u003e2\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e8\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2017-05-13T22:53:43.214864300Z\" /\u003e\u003cEventRecordID\u003e739823\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"2848\" ThreadID=\"3520\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsH.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"UtcTime\"\u003e2017-05-13 22:53:43.214\u003c/Data\u003e\u003cData Name=\"SourceProcessGuid\"\u003e{A23EAE89-8E6D-5917-0000-0010DFAF5004}\u003c/Data\u003e\u003cData Name=\"SourceProcessId\"\u003e8804\u003c/Data\u003e\u003cData Name=\"SourceImage\"\u003eC:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\IDE\\Remote Debugger\\x64\\msvsmon.exe\u003c/Data\u003e\u003cData Name=\"TargetProcessGuid\"\u003e{A23EAE89-8E5A-5917-0000-00100E3E4D04}\u003c/Data\u003e\u003cData Name=\"TargetProcessId\"\u003e2024\u003c/Data\u003e\u003cData Name=\"TargetImage\"\u003eC:\\repos\\Supercharger\\Mtg.Supercharger.ControllerService\\bin\\x64\\Debug\\Mtg.Supercharger.ControllerService.exe\u003c/Data\u003e\u003cData Name=\"NewThreadId\"\u003e20532\u003c/Data\u003e\u003cData Name=\"StartAddress\"\u003e0x00007FFB09321970\u003c/Data\u003e\u003cData Name=\"StartModule\"\u003eC:\\Windows\\SYSTEM32\\ntdll.dll\u003c/Data\u003e\u003cData Name=\"StartFunction\"\u003eDbgUiRemoteBreakin\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
-                "provider": "Microsoft-Windows-Sysmon"
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "change"
+                ]
             },
             "host": {
                 "name": "rfsH.lab.local"
@@ -22295,11 +22301,17 @@
                 "version": "8.0.0"
             },
             "event": {
+                "category": [
+                    "process"
+                ],
                 "code": "9",
                 "created": "2018-03-22T20:32:22.333Z",
                 "kind": "event",
                 "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e9\u003c/EventID\u003e\u003cVersion\u003e2\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e9\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-03-22T20:32:22.333778700Z\" /\u003e\u003cEventRecordID\u003e1944686\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"19572\" ThreadID=\"21888\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsH.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"UtcTime\"\u003e2018-03-22 20:32:22.332\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{A23EAE89-C65F-5AB2-0000-0010EB030000}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e4\u003c/Data\u003e\u003cData Name=\"Image\"\u003eSystem\u003c/Data\u003e\u003cData Name=\"Device\"\u003e\\Device\\HarddiskVolume2\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
-                "provider": "Microsoft-Windows-Sysmon"
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "access"
+                ]
             },
             "file": {
                 "directory": "\\Device",
@@ -22346,11 +22358,17 @@
                 "version": "8.0.0"
             },
             "event": {
+                "category": [
+                    "process"
+                ],
                 "code": "19",
                 "created": "2018-04-11T16:26:16.327Z",
                 "kind": "event",
                 "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e19\u003c/EventID\u003e\u003cVersion\u003e3\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e19\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-04-11T16:26:16.327698700Z\" /\u003e\u003cEventRecordID\u003e63551\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"7620\" ThreadID=\"21880\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsh.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"EventType\"\u003eWmiFilterEvent\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2018-04-11 16:26:16.327\u003c/Data\u003e\u003cData Name=\"Operation\"\u003eCreated\u003c/Data\u003e\u003cData Name=\"User\"\u003eLAB\\rsmith\u003c/Data\u003e\u003cData Name=\"EventNamespace\"\u003e \"root\\\\cimv2\"\u003c/Data\u003e\u003cData Name=\"Name\"\u003e \"BotFilter82\"\u003c/Data\u003e\u003cData Name=\"Query\"\u003e \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime \u0026gt;= 200 AND TargetInstance.SystemUpTime \u0026lt; 320\"\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
-                "provider": "Microsoft-Windows-Sysmon"
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "creation"
+                ]
             },
             "host": {
                 "name": "rfsh.lab.local"
@@ -22401,11 +22419,17 @@
                 "version": "8.0.0"
             },
             "event": {
+                "category": [
+                    "process"
+                ],
                 "code": "20",
                 "created": "2018-04-11T16:26:16.360Z",
                 "kind": "event",
                 "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e20\u003c/EventID\u003e\u003cVersion\u003e3\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e20\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2018-04-11T16:26:16.360473200Z\" /\u003e\u003cEventRecordID\u003e63557\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"7620\" ThreadID=\"21880\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003erfsh.lab.local\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"EventType\"\u003eWmiConsumerEvent\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2018-04-11 16:26:16.360\u003c/Data\u003e\u003cData Name=\"Operation\"\u003eCreated\u003c/Data\u003e\u003cData Name=\"User\"\u003eLAB\\rsmith\u003c/Data\u003e\u003cData Name=\"Name\"\u003e \"BotConsumer23\"\u003c/Data\u003e\u003cData Name=\"Type\"\u003eCommand Line\u003c/Data\u003e\u003cData Name=\"Destination\"\u003e \"C:\\\\Windows\\\\System32\\\\evil.exe\"\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
-                "provider": "Microsoft-Windows-Sysmon"
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "creation"
+                ]
             },
             "host": {
                 "name": "rfsh.lab.local"
@@ -22462,11 +22486,17 @@
                 "code": "DriverCommunication"
             },
             "event": {
+                "category": [
+                    "process"
+                ],
                 "code": "255",
                 "created": "2015-01-21T17:00:44.001Z",
                 "kind": "event",
                 "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\" /\u003e\u003cEventID\u003e255\u003c/EventID\u003e\u003cVersion\u003e1\u003c/Version\u003e\u003cLevel\u003e2\u003c/Level\u003e\u003cTask\u003e255\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2015-01-21T17:00:44.001453300Z\" /\u003e\u003cEventRecordID\u003e278772\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"1112\" ThreadID=\"1332\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003eWIN-RKSC06DQ86F\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"ID\"\u003eDriverCommunication\u003c/Data\u003e\u003cData Name=\"Description\"\u003eFailed to retrieve events (Last error: Insufficient system resources exist to complete the requested service.).\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
-                "provider": "Microsoft-Windows-Sysmon"
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "error"
+                ]
             },
             "host": {
                 "name": "WIN-RKSC06DQ86F"
@@ -22511,11 +22541,18 @@
                 "version": "8.0.0"
             },
             "event": {
+                "category": [
+                    "file"
+                ],
                 "code": "27",
                 "created": "2023-03-12T08:01:25.428Z",
                 "kind": "event",
                 "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e27\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e27\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T08:01:25.4286552Z\" /\u003e\u003cEventRecordID\u003e406\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblocktest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 08:01:25.423\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-71fa-640d-bc00-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e868\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sampleuser\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Windows\\Explorer.EXE\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\ProgramData\\notepad.exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=F2835A7EE42F30AA78659FAE1510F791A38E63480B099CDD20D402760EE7A391\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
-                "provider": "Microsoft-Windows-Sysmon"
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "creation",
+                    "denied"
+                ]
             },
             "file": {
                 "directory": "C:\\ProgramData",
@@ -22577,11 +22614,18 @@
                 "version": "8.0.0"
             },
             "event": {
+                "category": [
+                    "file"
+                ],
                 "code": "27",
                 "created": "2023-03-12T08:13:25.380Z",
                 "kind": "event",
                 "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e27\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e27\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T08:13:25.3808395Z\" /\u003e\u003cEventRecordID\u003e438\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblocktest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 08:13:25.375\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-71fa-640d-bc00-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e868\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sampleuser\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Windows\\Explorer.EXE\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\Users\\sampleuser\\Music\\notepad.exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=F2835A7EE42F30AA78659FAE1510F791A38E63480B099CDD20D402760EE7A391\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
-                "provider": "Microsoft-Windows-Sysmon"
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "creation",
+                    "denied"
+                ]
             },
             "file": {
                 "directory": "C:\\Users\\sampleuser\\Music",
@@ -22643,11 +22687,18 @@
                 "version": "8.0.0"
             },
             "event": {
+                "category": [
+                    "file"
+                ],
                 "code": "28",
                 "created": "2023-03-12T09:20:46.943Z",
                 "kind": "event",
                 "original": "\u003cEvent xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"\u003e\u003cSystem\u003e\u003cProvider Name=\"Microsoft-Windows-Sysmon\" Guid=\"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}\" /\u003e\u003cEventID\u003e28\u003c/EventID\u003e\u003cVersion\u003e5\u003c/Version\u003e\u003cLevel\u003e4\u003c/Level\u003e\u003cTask\u003e28\u003c/Task\u003e\u003cOpcode\u003e0\u003c/Opcode\u003e\u003cKeywords\u003e0x8000000000000000\u003c/Keywords\u003e\u003cTimeCreated SystemTime=\"2023-03-12T09:20:46.9436239Z\" /\u003e\u003cEventRecordID\u003e583\u003c/EventRecordID\u003e\u003cCorrelation /\u003e\u003cExecution ProcessID=\"3804\" ThreadID=\"4760\" /\u003e\u003cChannel\u003eMicrosoft-Windows-Sysmon/Operational\u003c/Channel\u003e\u003cComputer\u003esample-wind-sysmon\u003c/Computer\u003e\u003cSecurity UserID=\"S-1-5-18\" /\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name=\"RuleName\"\u003efileblockshredtest\u003c/Data\u003e\u003cData Name=\"UtcTime\"\u003e2023-03-12 09:20:46.943\u003c/Data\u003e\u003cData Name=\"ProcessGuid\"\u003e{4299a14b-996c-640d-8d02-000000000700}\u003c/Data\u003e\u003cData Name=\"ProcessId\"\u003e6788\u003c/Data\u003e\u003cData Name=\"User\"\u003eSAMPLE-WI\\sample\u003c/Data\u003e\u003cData Name=\"Image\"\u003eC:\\Users\\sample\\Downloads\\SDelete\\sdelete64.exe\u003c/Data\u003e\u003cData Name=\"TargetFilename\"\u003eC:\\Users\\sample\\Downloads\\ChromeSetup (1).exe\u003c/Data\u003e\u003cData Name=\"Hashes\"\u003eSHA256=8DDCCA3D2A78660524D73C51DD148DE7B76DF1573EBCC8C5B2AC36FDE2FF2396\u003c/Data\u003e\u003cData Name=\"IsExecutable\"\u003etrue\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
-                "provider": "Microsoft-Windows-Sysmon"
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "deletion",
+                    "denied"
+                ]
             },
             "file": {
                 "directory": "C:\\Users\\sample\\Downloads",

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -88,6 +88,16 @@ processors:
             - process
           type:
             - change
+        "8":
+          category:
+            - process
+          type:
+            - change
+        "9":
+          category:
+            - process
+          type:
+            - access
         "10":
           category:
             - process
@@ -136,6 +146,21 @@ processors:
             - file
           type:
             - access
+        "19":
+          category:
+            - process
+          type:
+            - creation
+        "20":
+          category:
+            - process
+          type:
+            - creation
+        "21":
+          category:
+            - process
+          type:
+            - access
         "22":
           category:
             - network
@@ -161,6 +186,23 @@ processors:
             - file
           type:
             - deletion
+        "27":
+          category:
+            - file
+          type:
+            - creation
+            - denied
+        "28":
+          category:
+            - file
+          type:
+            - deletion
+            - denied
+        "255":
+          category:
+            - process
+          type:
+            - error
       tag: Add ECS categorization fields
       source: |-
         if (ctx?.event?.code == null || params.get(ctx.event.code) == null) {

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.20.0
+version: 1.20.1
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Adds `event.category` and `event.type` to Sysmon Operational pipeline which were missed when new EventIDs were incorporated in https://github.com/elastic/integrations/issues/4038

 
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/5976

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

