### PR TITLE
network_traffic: fingerprint flow events

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Fingerprint flows.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6022
 - version: "1.14.0"
   changes:
     - description: Allow user-defined processors on flows.

--- a/packages/network_traffic/data_stream/flow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/flow/elasticsearch/ingest_pipeline/default.yml
@@ -55,6 +55,17 @@ processors:
     field: _conf
     ignore_missing: true
 
+- fingerprint:
+    fields:
+      - flow.id
+      - flow.final
+      - event.start
+      - event.end
+      - network.bytes
+      - network.community_id
+    target_field: _id
+    ignore_missing: true
+
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.14.0"
+version: "1.15.0"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

We have seen duplicate flow events in indexes, presumably due to republication. These duplicates lead to an over-estimate of network traffic in aggregate.

To work around this, this adds a fingerprint processor taking `flow.id`, `flow.final`, `event.start`, `event.end`, `network.bytes` and `network.community_id`. This is expected to differentiate incomplete flows when they are wanted, allowing all flow events to be captured, while preventing identical events being ingested multiple times. Including `flow.id` and `network.community_id` is possibly overkill, but there are terms that contribute to community ID that are not included in the flow ID construction, so both are included in an abundance of caution.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
