### PR TITLE
Update package-spec with field validation in input packages - DO NOT MERGE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -199,4 +199,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230428075835-79b1c4b12744
+replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502112532-97c2c195bac9

--- a/go.mod
+++ b/go.mod
@@ -199,4 +199,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502143702-d2e643459e2e
+replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502145614-0d3831d70f5f

--- a/go.mod
+++ b/go.mod
@@ -199,4 +199,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502114053-544fc6a4659c
+replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502135214-bd5d96b4a2a5

--- a/go.mod
+++ b/go.mod
@@ -199,4 +199,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502135214-bd5d96b4a2a5
+replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502143702-d2e643459e2e

--- a/go.mod
+++ b/go.mod
@@ -198,3 +198,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230428075835-79b1c4b12744

--- a/go.mod
+++ b/go.mod
@@ -199,4 +199,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502112532-97c2c195bac9
+replace github.com/elastic/package-spec/v2 => github.com/mrodm/package-spec/v2 v2.0.0-20230502114053-544fc6a4659c

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/mrodm/package-spec/v2 v2.0.0-20230502114053-544fc6a4659c h1:Bj5U7uChUAPRx/gPpCaQyrqZ1tDHob4BW08O8Rnx+Q8=
-github.com/mrodm/package-spec/v2 v2.0.0-20230502114053-544fc6a4659c/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502135214-bd5d96b4a2a5 h1:4UW705XI1OWN1Dtt87IGpA0ragmOWbt+YIMWXRnn8so=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502135214-bd5d96b4a2a5/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/mrodm/package-spec/v2 v2.0.0-20230502112532-97c2c195bac9 h1:+8/pGavwbCOqbXp+1lB91e2R6gmlR8C2fl/E7NAL2GY=
-github.com/mrodm/package-spec/v2 v2.0.0-20230502112532-97c2c195bac9/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502114053-544fc6a4659c h1:Bj5U7uChUAPRx/gPpCaQyrqZ1tDHob4BW08O8Rnx+Q8=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502114053-544fc6a4659c/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,6 @@ github.com/elastic/gojsonschema v1.2.1 h1:cUMbgsz0wyEB4x7xf3zUEvUVDl6WCz2RKcQPul
 github.com/elastic/gojsonschema v1.2.1/go.mod h1:biw5eBS2Z4T02wjATMRSfecfjCmwaDPvuaqf844gLrg=
 github.com/elastic/package-registry v1.19.0 h1:Q6LK900p2pt5ajmZvTULtiwbL2O7Q738cjmghkvXxfk=
 github.com/elastic/package-registry v1.19.0/go.mod h1:12c7tiQV4lYhs0zWbo64M6Pzga2PkFOOXVKpABVsuBc=
-github.com/elastic/package-spec/v2 v2.7.0 h1:SZwFOClFcJZQjUySHjHPyNt1+N9R7U1KPd+VQLcJ4Kk=
-github.com/elastic/package-spec/v2 v2.7.0/go.mod h1:aWHJXBMABW90Ogdvbn9yjb+VPEgjzVpAgA+mQr5g3VU=
 github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
 github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -442,6 +440,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/mrodm/package-spec/v2 v2.0.0-20230428075835-79b1c4b12744 h1:fp40b7lzKsmfuIrt9/c0Xk3M+/DSKmQnNvVCD4LgtSQ=
+github.com/mrodm/package-spec/v2 v2.0.0-20230428075835-79b1c4b12744/go.mod h1:aWHJXBMABW90Ogdvbn9yjb+VPEgjzVpAgA+mQr5g3VU=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/mrodm/package-spec/v2 v2.0.0-20230428075835-79b1c4b12744 h1:fp40b7lzKsmfuIrt9/c0Xk3M+/DSKmQnNvVCD4LgtSQ=
-github.com/mrodm/package-spec/v2 v2.0.0-20230428075835-79b1c4b12744/go.mod h1:aWHJXBMABW90Ogdvbn9yjb+VPEgjzVpAgA+mQr5g3VU=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502112532-97c2c195bac9 h1:+8/pGavwbCOqbXp+1lB91e2R6gmlR8C2fl/E7NAL2GY=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502112532-97c2c195bac9/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -456,6 +456,7 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
+github.com/otiai10/copy v1.11.0 h1:OKBD80J/mLBrwnzXqGtFCzprFSGioo30JcmR4APsNwc=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/mrodm/package-spec/v2 v2.0.0-20230502143702-d2e643459e2e h1:Ts5BLh+JKq2aIvpRXeHaL8AfqQWRzkuQbdRNrkH/MEw=
-github.com/mrodm/package-spec/v2 v2.0.0-20230502143702-d2e643459e2e/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502145614-0d3831d70f5f h1:mHROhdluyGYNY3PvbORQFJU52OwoWmacY/SKrTN+0fA=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502145614-0d3831d70f5f/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/mrodm/package-spec/v2 v2.0.0-20230502135214-bd5d96b4a2a5 h1:4UW705XI1OWN1Dtt87IGpA0ragmOWbt+YIMWXRnn8so=
-github.com/mrodm/package-spec/v2 v2.0.0-20230502135214-bd5d96b4a2a5/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502143702-d2e643459e2e h1:Ts5BLh+JKq2aIvpRXeHaL8AfqQWRzkuQbdRNrkH/MEw=
+github.com/mrodm/package-spec/v2 v2.0.0-20230502143702-d2e643459e2e/go.mod h1:/ai13QwQ+/FOUW6KMLRdXk+m6ZI5IrIbeIByac0EAlc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
## What does this PR do?

Test integrations after adding support in packages-spec to:
- validate fields in input packages via `validateFields` helper.
- disallow external fields without `_dev/build/build.yml` file.



## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/package-spec/pull/516
- Relates https://github.com/elastic/package-spec/pull/513


