### PR TITLE
[Nginx] Modify the dimension field mapping to support public cloud deployment

### DIFF
--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Modifed the dimension field mapping to support public cloud deployment.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.11.0"
   changes:
     - description: Migrate "Access and error logs" dashboard visualizations to lens.

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Modifed the dimension field mapping to support public cloud deployment.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6033
 - version: "1.11.0"
   changes:
     - description: Migrate "Access and error logs" dashboard visualizations to lens.

--- a/packages/nginx/data_stream/stubstatus/fields/agent.yml
+++ b/packages/nginx/data_stream/stubstatus/fields/agent.yml
@@ -18,6 +18,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: Availability zone in which this host is running.
       example: us-east-1c
     - name: instance.id
@@ -49,6 +50,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: Region in which this host is running.
       example: us-east-1
     - name: project.id

--- a/packages/nginx/data_stream/stubstatus/fields/agent.yml
+++ b/packages/nginx/data_stream/stubstatus/fields/agent.yml
@@ -9,6 +9,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
 
         Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
@@ -53,7 +54,6 @@
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
-      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 1.11.0
+version: 1.11.1
 license: basic
 description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug

## What does this PR do?
Modify the dimension field mapping to support public cloud deployment

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

