### PR TITLE
[Vulnerability Management] Update CloudFormation template ElasticAgentVersion

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.3.0-preview7"
+- version: "1.3.0-preview8"
   changes:
     - description: New vulnerability management integration
       type: enhancement

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
-- version: "1.3.0-preview8"
+- version: "1.4.0-preview1"
+  changes:
+    - description: Send short notation of ElasticAgentVersion
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6034
+- version: "1.3.0"
   changes:
     - description: New vulnerability management integration
       type: enhancement

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -4,7 +4,7 @@
     - description: Send short notation of ElasticAgentVersion
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6034
-- version: "1.3.0"
+- version: "1.3.0-preview7"
   changes:
     - description: New vulnerability management integration
       type: enhancement

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -11,7 +11,7 @@ categories:
   - kubernetes
   - security
 conditions:
-  kibana.version: "^8.8.0"
+  kibana.version: "^8.9.0"
   elastic.subscription: basic
 screenshots:
   - src: /img/dashboard.png

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.3.0-preview8"
+version: "1.4.0-preview1"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.3.0-preview7"
+version: "1.3.0-preview8"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -135,6 +135,6 @@ policy_templates:
             required: true
             show_user: false
             description: Template URL to Cloud Formation Quick Create Stack
-            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-04-25-08-33-32.yml&stackName=Elastic-Vulnerability-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=elastic-agent-KIBANA_VERSION-linux-arm64
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.9.0-2023-04-30-08-56-40.yml&stackName=Elastic-Vulnerability-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION
 owner:
   github: elastic/cloud-security-posture


### PR DESCRIPTION
## What does this PR do?

The meaning of `ElasticAgentVersion` parameter has changed as part of the new cloudformation template.
The template used to expect a value in the form of `elastic-agent-KIBANA_VERSION-linux-arm64`, and as of the new template it only expects `KIBANA_VERSION`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
