### PR TITLE
[CouchDB] Modify the dimension field mapping to support public cloud deployment

### DIFF
--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Modifed the dimension field mapping to support public cloud deployment.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.5.0"
   changes:
     - description: Adding dimension fileds to server datastream for TSDB enablement.

--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Modifed the dimension field mapping to support public cloud deployment.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6039
 - version: "0.5.0"
   changes:
     - description: Adding dimension fileds to server datastream for TSDB enablement.

--- a/packages/couchdb/data_stream/server/fields/ecs.yml
+++ b/packages/couchdb/data_stream/server/fields/ecs.yml
@@ -28,7 +28,10 @@
   name: agent.id
   dimension: true
 - external: ecs
-  name: cloud.project.id
+  name: cloud.account.id
+  dimension: true
+- external: ecs
+  name: cloud.region
   dimension: true
 - external: ecs
   name: cloud.instance.id

--- a/packages/couchdb/data_stream/server/fields/ecs.yml
+++ b/packages/couchdb/data_stream/server/fields/ecs.yml
@@ -42,3 +42,7 @@
 - external: ecs
   name: container.id
   dimension: true
+- external: ecs
+  name: cloud.availability_zone
+  dimension: true
+

--- a/packages/couchdb/docs/README.md
+++ b/packages/couchdb/docs/README.md
@@ -157,6 +157,7 @@ An example event for `server` looks as following:
 | @timestamp | Event timestamp. | date |  |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |  |
 | cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
 | cloud.region | Region in which this host, resource, or service is located. | keyword |  |  |

--- a/packages/couchdb/docs/README.md
+++ b/packages/couchdb/docs/README.md
@@ -156,9 +156,10 @@ An example event for `server` looks as following:
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
 | cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
-| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |  |  |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |  |
 | container.id | Unique container id. | keyword |  |  |
 | couchdb.server.auth_cache.hits | Number of authentication cache hits. | long |  | counter |
 | couchdb.server.auth_cache.misses | Number of authentication cache misses. | long |  | counter |

--- a/packages/couchdb/manifest.yml
+++ b/packages/couchdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: couchdb
 title: CouchDB
-version: 0.5.0
+version: 0.5.1
 license: basic
 description: Collect metrics from CouchDB with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug

## What does this PR do?
Modify the dimension field mapping to support public cloud deployment

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

