### PR TITLE
[AWS][EBS] Add dimensions fields.

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.0"
+  changes:
+    - description: Add dimensions to EBS data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5794
 - version: "1.33.3"
   changes:
     - description: Add number_of_workers and latency to all CloudWatch Logs based integrations.

--- a/packages/aws/data_stream/ebs/fields/ecs.yml
+++ b/packages/aws/data_stream/ebs/fields/ecs.yml
@@ -2,6 +2,7 @@
   name: cloud
 - external: ecs
   name: cloud.account.id
+  dimension: true
 - external: ecs
   name: cloud.account.name
 - external: ecs
@@ -14,6 +15,7 @@
   name: cloud.provider
 - external: ecs
   name: cloud.region
+  dimension: true
 - external: ecs
   name: ecs.version
 - external: ecs

--- a/packages/aws/data_stream/ebs/fields/fields.yml
+++ b/packages/aws/data_stream/ebs/fields/fields.yml
@@ -5,6 +5,7 @@
       type: group
       fields:
         - name: VolumeId
+          dimension: true
           type: keyword
           description: Amazon EBS volume ID
     - name: ebs

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.33.3
+version: 1.34.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add dimension fields to EBS datastream.

## Details

Each EBS resource has a volume ID that is unique within a region in some account. These makes the combination (volume id, region, account) unique. There is no change in the number of documents after enabling TSDB:

![image](https://user-images.githubusercontent.com/113898685/235691602-8ae712f0-d796-4983-9b56-a55b695a272f.png)


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Refer to https://github.com/elastic/integrations/issues/6061

## Related issues

- Relates to https://github.com/elastic/integrations/issues/6061