### PR TITLE
[Apache] [TSDB] Added dimension fields for status datastream

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Add dimension fields for status datastream for TSDB enablement.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.10.0"
   changes:
     - description: Migrate `Access and error logs` dashboard visualizations to lens.

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add dimension fields for status datastream for TSDB enablement.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6077
 - version: "1.10.0"
   changes:
     - description: Migrate `Access and error logs` dashboard visualizations to lens.

--- a/packages/apache/data_stream/status/fields/agent.yml
+++ b/packages/apache/data_stream/status/fields/agent.yml
@@ -13,6 +13,7 @@
 
         Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
       example: 666777888999
+      dimension: true
     - name: availability_zone
       level: extended
       type: keyword
@@ -51,10 +52,10 @@
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
+      dimension: true
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
-      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/apache/data_stream/status/fields/agent.yml
+++ b/packages/apache/data_stream/status/fields/agent.yml
@@ -19,6 +19,7 @@
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
+      dimension: true
     - name: instance.id
       level: extended
       type: keyword

--- a/packages/apache/data_stream/status/fields/agent.yml
+++ b/packages/apache/data_stream/status/fields/agent.yml
@@ -25,6 +25,7 @@
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
+      dimension: true
     - name: instance.name
       level: extended
       type: keyword
@@ -42,6 +43,7 @@
       ignore_above: 1024
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
+      dimension: true
     - name: region
       level: extended
       type: keyword
@@ -51,6 +53,7 @@
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
+      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -67,6 +70,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+      dimension: true
     - name: image.name
       level: extended
       type: keyword
@@ -134,6 +138,7 @@
       level: core
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: 'Name of the host.
 
         It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
@@ -196,3 +201,11 @@
       description: >
         OS codename, if any.
 
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/apache/data_stream/status/fields/ecs.yml
+++ b/packages/apache/data_stream/status/fields/ecs.yml
@@ -2,6 +2,7 @@
   name: ecs.version
 - external: ecs
   name: service.address
+  dimension: true
 - external: ecs
   name: service.type
 - external: ecs

--- a/packages/apache/docs/README.md
+++ b/packages/apache/docs/README.md
@@ -359,6 +359,7 @@ An example event for `status` looks as following:
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| agent.id |  | keyword |  |  |
 | apache.status.bytes_per_request | Bytes per request. | scaled_float |  | gauge |
 | apache.status.bytes_per_sec | Bytes per second. | scaled_float |  | gauge |
 | apache.status.connections.async.closing | Async closed connections. | long |  | gauge |

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache HTTP Server
-version: 1.10.0
+version: 1.11.0
 license: basic
 source:
   license: Elastic-2.0


### PR DESCRIPTION
Type of change

- Enhancement

## What does this PR do?

Added metric_type mapping for partition datastream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Relates #6075 

