### PR TITLE
[Custom AWS Logs] Add multiline support for aws-s3 input

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -2,6 +2,7 @@
   changes:
     - description: Add multiline support for using s3 input
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/6081
 - version: "0.3.3"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,7 @@
+- version: "0.4.0"
+  changes:
+    - description: Add multiline support for using s3 input
+      type: enhancement
 - version: "0.3.3"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
@@ -151,3 +151,7 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+{{#if parsers}}
+parsers:
+{{parsers}}
+{{/if}}

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -258,6 +258,19 @@ streams:
         default: 5
         required: false
         show_user: false
+      - name: parsers
+        type: yaml
+        title: Parsers
+        description: |
+          This option expects a list of parsers that the payload has to go through. For more information see [Parsers](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#input-aws-s3-parsers)
+        required: false
+        show_user: true
+        multi: false
+        default: |
+          #- multiline:
+          #    pattern: "^<Event"
+          #    negate:  true
+          #    match:   after
       - name: non_aws_bucket_name
         type: text
         title: Non AWS Bucket Name

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: 0.3.3
+version: 0.4.0
 release: beta
 license: basic
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to add multiline support for custom AWS logs integration. Here is what the policy looks like after the multiline parser is added:
```
    streams:
      - id: aws-s3-aws_logs.generic-4cc5036f-5f6b-4040-8e4c-ca2720f1481e
        data_stream:
          dataset: aws_logs.generic
        bucket_arn: test_arn
        number_of_workers: 1
        bucket_list_interval: 120s
        max_bytes: 10MiB
        max_number_of_messages: 5
        sqs.max_receive_count: 5
        sqs.wait_time: 20s
        file_selectors: null
        access_key_id: aa
        secret_access_key: bb
        tags:
          - forwarded
        publisher_pipeline.disable_host: true
        parsers:
          - multiline:
              pattern: ^<Event
              negate: true
              match: after
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Step1: create a s3 bucket and upload a file with multiline log sample. For example what I'm using is:
```
kaiyansheng ~/Documents  $ cat test_multiline.log 
<Event><Data>
	A
	B
	C</Data></Event>
<Event><Data>
	D
	E
	F</Data</Event>
```

Step2: setup agent and agent policy to use custom AWS logs integration with the proper authentication for AWS and S3 bucket ARN. The agent policy looks like this:
```
inputs:
  - id: aws-s3-aws_logs-a6d98725-c4ee-4292-acb7-558e747ac909
    name: aws_logs-1
    revision: 1
    type: aws-s3
    use_output: default
    meta:
      package:
        name: aws_logs
        version: 0.4.0
    data_stream:
      namespace: default
    package_policy_id: a6d98725-c4ee-4292-acb7-558e747ac909
    streams:
      - id: aws-s3-aws_logs.generic-a6d98725-c4ee-4292-acb7-558e747ac909
        data_stream:
          dataset: aws_logs.generic
        bucket_arn: 'arn:aws:s3:::test-cloudfront-ks'
        number_of_workers: 1
        bucket_list_interval: 120s
        max_bytes: 10MiB
        max_number_of_messages: 5
        sqs.max_receive_count: 5
        sqs.wait_time: 20s
        file_selectors: null
        access_key_id: foo
        secret_access_key: boo
        tags:
          - preserve_original_event
          - forwarded
        publisher_pipeline.disable_host: true
        parsers:
          - multiline:
              pattern: ^<Event
              negate: true
              match: after
```

Step3: Once the agent starts running, you should see the test_multiline.log get read and stored into Elasticsearch:
<img width="2559" alt="Screenshot 2023-05-05 at 11 01 57 AM" src="https://user-images.githubusercontent.com/14081635/236522460-af5d3efe-ef32-4826-ada1-3d97ab02df29.png">

## Screenshots

<img width="1300" alt="Screenshot 2023-05-03 at 3 45 58 PM" src="https://user-images.githubusercontent.com/14081635/236057021-d9143351-b953-4d0b-b71a-2e7ecfd48bfc.png">

