### PR TITLE
[Tomcat] Deprecate Tomcat package

### DIFF
--- a/packages/tomcat/_dev/build/docs/README.md
+++ b/packages/tomcat/_dev/build/docs/README.md
@@ -1,9 +1,12 @@
-# Tomcat integration
+# Tomcat NetWitness Logs integration (To be deprecated soon)
 
 This integration is for [Tomcat device's](https://tomcat.apache.org/tomcat-10.0-doc/logging.html) logs. It includes the following
 datasets for receiving logs over syslog or read from a file:
 
 - `log` dataset: supports Apache Tomcat logs.
+
+Note:
+- To collect Apache Tomcat Logs and Metrics please use ``Apache Tomcat`` integration since ``Tomcat NetWitness Logs`` integration will be deprecated soon.
 
 ### Log
 

--- a/packages/tomcat/changelog.yml
+++ b/packages/tomcat/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecate Tomcat package.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link.
+      link: https://github.com/elastic/integrations/pull/6091
 - version: "1.8.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/tomcat/changelog.yml
+++ b/packages/tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.2"
+  changes:
+    - description: Deprecate Tomcat package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link.
 - version: "1.8.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/tomcat/docs/README.md
+++ b/packages/tomcat/docs/README.md
@@ -1,9 +1,12 @@
-# Tomcat integration
+# Tomcat NetWitness Logs integration (To be deprecated soon)
 
 This integration is for [Tomcat device's](https://tomcat.apache.org/tomcat-10.0-doc/logging.html) logs. It includes the following
 datasets for receiving logs over syslog or read from a file:
 
 - `log` dataset: supports Apache Tomcat logs.
+
+Note:
+- To collect Apache Tomcat Logs and Metrics please use ``Apache Tomcat`` integration since ``Tomcat NetWitness Logs`` integration will be deprecated soon.
 
 ### Log
 

--- a/packages/tomcat/manifest.yml
+++ b/packages/tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: tomcat
-title: Apache Tomcat
-version: "1.8.1"
+title: Tomcat NetWitness Logs
+version: "1.8.2"
 description: Collect and parse logs from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 release: ga


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Deprecation

## What does this PR do?
- Rename `Tomcat` integration to `Tomcat NetWitness Logs`.
- Add deprecation note in README.md.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist


- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.

## How to test this PR locally

- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/tomcat) directory.
- Run the following command to run tests. elastic-package test

## Related issues
- Relates #5200
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
