### PR TITLE
[Akamai] Added the 'to' query params to the time based request

### DIFF
--- a/packages/akamai/_dev/deploy/docker/files/config.yml
+++ b/packages/akamai/_dev/deploy/docker/files/config.yml
@@ -1,11 +1,12 @@
 rules:
   # Initial iteration.
   - path: /siem/v1/configs/aaaa
-    methods: [ "GET" ]
+    methods: ["GET"]
     request_headers:
-      authorization: [ "EG1-HMAC-SHA256 client_token=qwerasdf;access_token=abcd;timestamp=\\d{8}T(\\d{2}:){2}\\d{2}\\+0000;nonce=[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12};signature=.*" ]
+      authorization: ["EG1-HMAC-SHA256 client_token=qwerasdf;access_token=abcd;timestamp=\\d{8}T(\\d{2}:){2}\\d{2}\\+0000;nonce=[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12};signature=.*"]
     query_params:
       from: "{from:.*}"
+      to: "{to:.*}"
     responses:
       - status_code: 200
         body: |-
@@ -14,9 +15,9 @@ rules:
           {"total":2,"offset":"offset1","limit":2}
   # Second iteration.
   - path: /siem/v1/configs/aaaa
-    methods: [ "GET" ]
+    methods: ["GET"]
     request_headers:
-      authorization: [ "EG1-HMAC-SHA256 client_token=qwerasdf;access_token=abcd;timestamp=\\d{8}T(\\d{2}:){2}\\d{2}\\+0000;nonce=[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12};signature=.*" ]
+      authorization: ["EG1-HMAC-SHA256 client_token=qwerasdf;access_token=abcd;timestamp=\\d{8}T(\\d{2}:){2}\\d{2}\\+0000;nonce=[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12};signature=.*"]
     query_params:
       offset: "offset1"
     responses:

--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "2.6.2-beta"
   changes:
-    - description: Added support for the 'to' parameter in the initial time based request.
+    - description: Added support for the 'to' query parameter in the initial time based requests.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/5827
+      link: https://github.com/elastic/integrations/pull/6107
 - version: "2.6.1-beta"
   changes:
     - description: Modify pagination to begin with a time based query and then switch to offset based.

--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.2-beta"
+  changes:
+    - description: Added support for the 'to' parameter in the initial time based request.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5827
 - version: "2.6.1-beta"
   changes:
     - description: Modify pagination to begin with a time based query and then switch to offset based.

--- a/packages/akamai/data_stream/siem/agent/stream/httpjson.yml.hbs
+++ b/packages/akamai/data_stream/siem/agent/stream/httpjson.yml.hbs
@@ -20,6 +20,10 @@ request.transforms:
       value: >-
         [[ if not (index .cursor "last_offset") ]][[ (now (parseDuration "{{initial_interval}}")).Unix ]][[ end ]]
   - set:
+      target: url.params.to
+      value: >- 
+        [[ if not (index .cursor "last_offset") ]][[ (now (parseDuration "-1m")).Unix ]][[ end ]]
+  - set:
       target: url.params.offset
       value: >-
         [[ if (index .cursor "last_offset") ]][[ .cursor.last_offset ]][[ end ]]
@@ -58,6 +62,8 @@ response.pagination:
       fail_on_template_error: true
   - delete:
       target: url.params.from
+  - delete:
+      target: url.params.to
 
 cursor:
   last_offset:

--- a/packages/akamai/data_stream/siem/manifest.yml
+++ b/packages/akamai/data_stream/siem/manifest.yml
@@ -110,9 +110,8 @@ streams:
         required: false
         show_user: false
         description: >
-          The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
-          Enabling this request tracing compromises security and should only be used for debugging.
-          See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
+
   - input: gcs
     title: Collect Akamai SIEM logs via Google Cloud Storage [Beta]
     description: Collecting SIEM logs from Akamai via Google Cloud Storage.
@@ -175,12 +174,7 @@ streams:
       - name: buckets
         type: yaml
         title: Buckets
-        description: "This attribute contains the details about a specific bucket like, name, max_workers, poll, 
-        poll_interval and bucket_timeout. The attribute 'name' is specific to a bucket as it describes the bucket name, 
-        while the fields max_workers, poll, poll_interval and bucket_timeout can exist both at the bucket level and at the global level. 
-        If you have already defined the attributes globally, then you can only specify the name in this yaml config. If you want to override any specific 
-        attribute for a specific bucket, then, you can define it here. Any attribute defined in the yaml will override the global definitions.
-        Please see the relevant [Documentation](https://www.elastic.co/guide/en/beats/filebeat/8.5/filebeat-input-gcs.html#attrib-buckets) for further information.\n"
+        description: "This attribute contains the details about a specific bucket like, name, max_workers, poll, poll_interval and bucket_timeout. The attribute 'name' is specific to a bucket as it describes the bucket name, while the fields max_workers, poll, poll_interval and bucket_timeout can exist both at the bucket level and at the global level. If you have already defined the attributes globally, then you can only specify the name in this yaml config. If you want to override any specific attribute for a specific bucket, then, you can define it here. Any attribute defined in the yaml will override the global definitions. Please see the relevant [Documentation](https://www.elastic.co/guide/en/beats/filebeat/8.5/filebeat-input-gcs.html#attrib-buckets) for further information.\n"
         required: true
         show_user: true
         default: |
@@ -209,4 +203,4 @@ streams:
         show_user: false
         default:
           - forwarded
-          - akamai-siem  
+          - akamai-siem

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.6.1-beta"
+version: "2.6.2-beta"
 release: ga
 description: Collect logs from Akamai with Elastic Agent.
 type: integration


### PR DESCRIPTION
## Type of change
- Bug

## What does this PR do?
This adds the 'to' query params to the time based requests and removes it when we transition over to the offset based requests. Even though the 'to' query param is marked as optional by the Akamai siem docs as discussed [here](https://github.com/elastic/sdh-beats/issues/3282#issuecomment-1536156561) , the requests were failing without it.

**NOTE:** **This is a beta release. So users will need to select the version explicitly to test it.**


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #5826
- Supersedes #5827
