### PR TITLE
[Kubernetes][Container] Add container name as dimension

### DIFF
--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -6,3 +6,8 @@ nodes:
       - |
         kind: KubeProxyConfiguration
         metricsBindAddress: "0.0.0.0"
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: KubeProxyConfiguration
+        metricsBindAddress: "0.0.0.0"

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -6,8 +6,3 @@ nodes:
       - |
         kind: KubeProxyConfiguration
         metricsBindAddress: "0.0.0.0"
-  - role: control-plane
-    kubeadmConfigPatches:
-      - |
-        kind: KubeProxyConfiguration
-        metricsBindAddress: "0.0.0.0"

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.36.0"
+  changes:
+    - description: Add container.name dimension to container data stream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5760
 - version: "1.35.0"
   changes:
     - description: Add NetworkUnavailable condition to state node

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add container.name dimension to container data stream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5760
+      link: https://github.com/elastic/integrations/pull/6108
 - version: "1.35.0"
   changes:
     - description: Add NetworkUnavailable condition to state node

--- a/packages/kubernetes/data_stream/container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container/fields/base-fields.yml
@@ -134,6 +134,7 @@
         Name of the CronJob to which the Pod belongs
 
     - name: container.name
+      dimension: true
       type: keyword
       description: >
         Kubernetes container name

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.35.0
+version: 1.36.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

The dimensions set for the container data stream are not enough, since a pod can have multiple containers. In that case, without setting the container name (unique per pod) as dimension, there would be no way to distinguish between documents from different containers in the same pod.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/4618.