### PR TITLE
[Auditd_Manager] fixing wrong field type for auditd.data.exit

### DIFF
--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Fix wrong field type for auditd.data.exit
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5765
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/auditd_manager/data_stream/auditd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auditd_manager/data_stream/auditd/elasticsearch/ingest_pipeline/default.yml
@@ -190,10 +190,6 @@ processors:
       type: long
       ignore_missing: true
   - convert:
-      field: auditd.data.exit
-      type: long
-      ignore_missing: true
-  - convert:
       field: process.pid
       type: long
       ignore_missing: true

--- a/packages/auditd_manager/data_stream/auditd/fields/fields.yml
+++ b/packages/auditd_manager/data_stream/auditd/fields/fields.yml
@@ -214,7 +214,7 @@
   type: long
 - name: auditd.data.exit
   description: syscall exit code
-  type: long
+  type: keyword
 - name: auditd.data.fp
   description: crypto key finger print
   type: keyword

--- a/packages/auditd_manager/docs/README.md
+++ b/packages/auditd_manager/docs/README.md
@@ -294,7 +294,7 @@ An example event for `auditd` looks as following:
 | auditd.data.dport | remote port number | long |
 | auditd.data.enforcing | new MAC enforcement status | keyword |
 | auditd.data.entries | number of entries in the netfilter table | long |
-| auditd.data.exit | syscall exit code | long |
+| auditd.data.exit | syscall exit code | keyword |
 | auditd.data.fam | socket address family | keyword |
 | auditd.data.family | netfilter protocol | keyword |
 | auditd.data.fd | file descriptor number | keyword |

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: auditd_manager
 title: "Auditd Manager"
-version: "1.7.0"
+version: "1.7.1"
 release: ga
 license: basic
 description: "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel."


### PR DESCRIPTION
## What does this PR do?

Fixes wrong field type. It was keyword in auditbeat, and has never needed to be converted to long, most likely confused with `process.exit_code`.

Not catched because it had no testdata, but there is more than enough evidence to satisfy this PR.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
