### PR TITLE
[D4C] cloud_defend. Removed kubernetesPodId. Update docs.

### DIFF
--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.6"
+  changes:
+    - description: Documentation updates. Removed kubernetesPodId.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5985
 - version: "1.0.5"
   changes:
     - description: Documentation updates.

--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Documentation updates. Removed kubernetesPodId.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5985
+      link: https://github.com/elastic/integrations/pull/6112
 - version: "1.0.5"
   changes:
     - description: Documentation updates.

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -1,7 +1,6 @@
 # How Container Workload Protection Works
-> This integration is currently **Beta**
 
-CWP is powered by a lightweight integration (Defend for Containers) that is bundled and configured by the Elastic Agent. The agent is installed as a daemonset on supported Kubernetes clusters and the integration uses eBPF LSM and tracepoint probes to produce system events. Events are evaluated against eBPF LSM hook points, enabling a configured policy to be evaluated before system activity is allowed to proceed.
+CWP is powered by a lightweight integration (Defend for Containers *BETA*) that is bundled and configured by the Elastic Agent. The agent is installed as a daemonset on supported Kubernetes clusters and the integration uses eBPF LSM and tracepoint probes to produce system events. Events are evaluated against eBPF LSM hook points, enabling a configured policy to be evaluated before system activity is allowed to proceed.
 
 The policy determines which system behaviors (for example, process executions, file creations or deletions, etc) will result in an action. Actions are simple: logging the behavior to Elasticsearch, creating an alert in Elasticsearch, or blocking the behavior.
 

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -4,19 +4,19 @@ CWP is powered by a lightweight integration (Defend for Containers *BETA*) that 
 
 The policy determines which system behaviors (for example, process executions, file creations or deletions, etc) will result in an action. Actions are simple: logging the behavior to Elasticsearch, creating an alert in Elasticsearch, or blocking the behavior.
 
-# Threat Detection
+## Threat Detection
 
 The system ships with a default policy configured featuring two selectors and responses. The first selector is designed to stream process telemetry events to the user’s Elasticsearch cluster. The policy uses the selector allProcesses which specifies fork and exec operations. This selector is mapped to the allProcesses response, which specifies a log action.
 
 The resulting telemetry data is transformed into an ECS document and streamed back to the user’s Elasticsearch cluster, where the Elastic Security SIEM evaluates the data to detect malicious behavior.
 
-# Drift Detection & Prevention
+## Drift Detection & Prevention
 
 The second selector is written to detect the modification of existing executables or the creation of new executables within a container (This is how Elastic detects “container drift”). The policy selector is named executableChanges and is mapped to a response section called executableChanges which specifies an alert action.
 
 This policy is configured with an alert response, meaning that when drift conditions are detected, the matching event(s) are collected and written as an alert to the user’s Elasticsearch cluster. A prebuilt rule “escalation rule” in the SIEM watches for these alert documents and raises an alert in the SIEM when drift is detected. This policy can also be modified to block drift operations by changing the response action to block.
 
-# Policies
+## Policies
 
 Users that want to use the full strength of CWP will benefit to understand the system’s policy syntax, which enables fine-grained policies to be constructed. Policies can be built to precisely match expected container behaviors– disallowing any unexpected behaviors– and thereby substantially hardening the security posture of container workloads.
 
@@ -26,17 +26,18 @@ Policies are composed of selectors and responses. A given policy must contain at
 
 The service can be deployed in two ways: declaratively using Elastic Agent in standalone mode, or as a managed D4C integration through Fleet. With the former, teams have the flexibility to integrate their policies into Git for an infrastructure-as-code (IoC) approach, streamlining the deployment process and enabling easier management.
 
-# Support matrix
-
-| &nbsp; | EKS 1.24-1.26 (AL2022) | GKE 1.24-1.26 (COS) |
-| -- | -- | -- |
-| Process event exports | ✅ | ✅ |
-| File event exports | ✅ | ✅ |
-| Drift prevention | ✅ | ✅ |
-| Mount point awareness | ✅ | ✅ |
-| Process blocking| Coming soon | Coming soon |
-| Network event exports | Coming soon | Coming soon |
-| Network blocking| Coming soon | Coming soon |
+Note: if using the Kubernetes yaml provided by the Elastic agent install method, you will need to uncomment the capabilities property in order for the service to operate properly.
+```
+securityContext:
+            runAsUser: 0
+            # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+            # If you are using this integration, please uncomment these lines before applying.
+            #capabilities:
+            #  add:
+            #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+            #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+            #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
+```
 
 # Policy example
 
@@ -410,3 +411,14 @@ The following fields are populated for all events where `event.category: file`
 | [process.user.id](https://www.elastic.co/guide/en/ecs/current/ecs-process.html#field-process-user-id) | '0' |
 | [user.id](https://www.elastic.co/guide/en/ecs/current/ecs-user.html#field-user-id) | '0' |
 
+# Support matrix
+
+| &nbsp; | EKS 1.24-1.26 (AL2022) | GKE 1.24-1.26 (COS) |
+| -- | -- | -- |
+| Process event exports | ✅ | ✅ |
+| File event exports | ✅ | ✅ |
+| Drift prevention | ✅ | ✅ |
+| Mount point awareness | ✅ | ✅ |
+| Process blocking| Coming soon | Coming soon |
+| Network event exports | Coming soon | Coming soon |
+| Network blocking| Coming soon | Coming soon |

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -26,17 +26,17 @@ Policies are composed of selectors and responses. A given policy must contain at
 
 The service can be deployed in two ways: declaratively using Elastic Agent in standalone mode, or as a managed D4C integration through Fleet. With the former, teams have the flexibility to integrate their policies into Git for an infrastructure-as-code (IoC) approach, streamlining the deployment process and enabling easier management.
 
-Note: if using the Kubernetes yaml provided by the Elastic agent install method, you will need to uncomment the capabilities property in order for the service to operate properly.
+Note: You will need to include the following `capabilities` under `securityContext` in your k8s yaml in order for the service to work.
 ```
 securityContext:
-            runAsUser: 0
-            # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
-            # If you are using this integration, please uncomment these lines before applying.
-            #capabilities:
-            #  add:
-            #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
-            #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
-            #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
+    runAsUser: 0
+    # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+    # If you are using this integration, please uncomment these lines before applying.
+    capabilities:
+      add:
+        - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+        - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+        - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
 ```
 
 # Policy example

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -81,7 +81,6 @@ A selector MUST contain a name and at least one of the following conditions.
 | **kubernetesClusterId** | A list of kubernetes cluster IDs to match on. For consistency with KSPM, the 'kube-system' namespace uid is used as a cluster ID. |
 | **kubernetesClusterName** | A list of kubernetes cluster names to match on. |
 | **kubernetesNamespace** | A list of kubernetes namespaces to match on. |
-| **kubernetesPodId** | A list of kubernetes pod names to match on. |
 | **kubernetesPodName** | A list of kubernetes pod names to match on. Trailing wildcards supported. |
 | **kubernetesPodLabel** | A list of resource labels. Trailing wildcards supported (value only). e.g. `key1:val*` |
 

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -28,7 +28,8 @@ The service can be deployed in two ways: declaratively using Elastic Agent in st
 
 # Support matrix
 
-| | EKS 1.24-1.26 (AL2022) | GKE 1.24-1.26 (COS) |
+| &nbsp; | EKS 1.24-1.26 (AL2022) | GKE 1.24-1.26 (COS) |
+| -- | -- | -- |
 | Process event exports | ✅ | ✅ |
 | File event exports | ✅ | ✅ |
 | Network event exports | Coming soon | Coming soon |

--- a/packages/cloud_defend/docs/README.md
+++ b/packages/cloud_defend/docs/README.md
@@ -32,11 +32,11 @@ The service can be deployed in two ways: declaratively using Elastic Agent in st
 | -- | -- | -- |
 | Process event exports | ✅ | ✅ |
 | File event exports | ✅ | ✅ |
-| Network event exports | Coming soon | Coming soon |
 | Drift prevention | ✅ | ✅ |
-| Process blocking| Coming soon | Coming soon |
-| Network blocking| Coming soon | Coming soon |
 | Mount point awareness | ✅ | ✅ |
+| Process blocking| Coming soon | Coming soon |
+| Network event exports | Coming soon | Coming soon |
+| Network blocking| Coming soon | Coming soon |
 
 # Policy example
 

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_defend
 title: "Defend for Containers"
-version: 1.0.5
+version: 1.0.6
 source:
   license: "Elastic-2.0"
 description: "Elastic Defend for Containers (BETA) provides cloud-native runtime protections for containerized environments."


### PR DESCRIPTION
## What does this PR do?

Removes documentation for an unimplemented selector condition.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).