### PR TITLE
network_traffic: remove redundant field cleanup scripts

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.1"
+  changes:
+    - description: Remove redundant field cleanup scripts.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6121
 - version: "1.15.0"
   changes:
     - description: Enable `forwarded` tags for `observer.*` fields

--- a/packages/network_traffic/data_stream/amqp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/amqp/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/cassandra/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/cassandra/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/dhcpv4/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/dhcpv4/elasticsearch/ingest_pipeline/default.yml
@@ -58,20 +58,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/http/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/icmp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/icmp/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/memcached/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/memcached/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/mongodb/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/mongodb/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/mysql/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/mysql/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/nfs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/nfs/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/pgsql/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/pgsql/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/redis/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/redis/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
@@ -45,18 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-# Remove invalid "protocol" term added by packetbeat prior to v7.17.4/8.2.1.
-- script:
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "protocol") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/thrift/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/thrift/elasticsearch/ingest_pipeline/default.yml
@@ -45,20 +45,6 @@ processors:
     field: _conf
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 on_failure:
 - set:
     field: error.message

--- a/packages/network_traffic/data_stream/tls/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/tls/elasticsearch/ingest_pipeline/default.yml
@@ -73,20 +73,6 @@ processors:
       - tls.server.x509.version          # Duplicated as tls.server.x509.version_number.
     ignore_missing: true
 
-- script:
-    description: Remove invalid "network_traffic" term added by packetbeat prior to v8.
-    # This string-based comparison is valid while versions are below v10.x.
-    if: 'ctx.agent?.version == null || ctx.agent.version.compareTo("8.") < 0'
-    lang: painless
-    source: >
-        if (ctx.event?.category != null) {
-            for (int i=ctx.event.category.length-1; i>=0; i--) {
-                if (ctx.event.category[i] == "network_traffic") {
-                    ctx.event.category.remove(i);
-                }
-            }
-        }
-
 - append:
     field: related.hash
     value: "{{tls.server.ja3s}}"

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.15.0"
+version: "1.15.1"
 license: basic
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Versions of packetbeat that add the offending fields are no longer supported by the integration, so this removes the script that cleans them from the document.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
