### PR TITLE
Remove gauge metric type from start_time

### DIFF
--- a/packages/elastic_package_registry/changelog.yml
+++ b/packages/elastic_package_registry/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.7"
+  changes:
+    - description: Remove metric_type gauge from start_time field
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.0.6"
   changes:
     - description: First iteration to support multiple instances in dashboards

--- a/packages/elastic_package_registry/changelog.yml
+++ b/packages/elastic_package_registry/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove metric_type gauge from start_time field
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6125
 - version: "0.0.6"
   changes:
     - description: First iteration to support multiple instances in dashboards

--- a/packages/elastic_package_registry/data_stream/metrics/fields/fields.yml
+++ b/packages/elastic_package_registry/data_stream/metrics/fields/fields.yml
@@ -113,7 +113,6 @@
 
 - name: package_registry.start_time
   type: date
-  metric_type: gauge
   description: >
     Date where Elastic Package Registry started
 

--- a/packages/elastic_package_registry/docs/README.md
+++ b/packages/elastic_package_registry/docs/README.md
@@ -74,7 +74,7 @@ You can verify that metrics endpoint is enabled by making an HTTP request to
 | package_registry.labels.path | Path of the HTTP request. | keyword |  |  |
 | package_registry.labels.version | Elastic Package Registry version. | keyword |  |  |
 | package_registry.number_indexed_packages | Number of indexed packages | integer |  | gauge |
-| package_registry.start_time | Date where Elastic Package Registry started | date |  | gauge |
+| package_registry.start_time | Date where Elastic Package Registry started | date |  |  |
 | package_registry.start_time_seconds | Start time of the process since unix epoch in seconds | double | s | gauge |
 | package_registry.storage_indexer.update_index_duration_seconds.histogram | A histogram of latencies for update index processes run by the storage indexer | histogram |  |  |
 | package_registry.storage_indexer.update_index_error_total.counter | A counter for all the update index processes that finished with error in the storage indexer | long |  |  |

--- a/packages/elastic_package_registry/manifest.yml
+++ b/packages/elastic_package_registry/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: elastic_package_registry
 title: "Elastic Package Registry"
-version: 0.0.6
+version: 0.0.7
 description: "Collect metrics from a Elastic Package Registry instance"
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Remove `metric_type: gauge` from the field `package_registry.start_time`. Metric_type gauge does not support type date.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Check that start_time is mapped as a date in the documents

## Screenshots
![field start_time table](https://user-images.githubusercontent.com/5330827/237043361-d018afe5-aca8-4f23-ae03-3dbded590507.png)

![field start_time json](https://user-images.githubusercontent.com/5330827/237043384-39890a11-d335-4bb8-90ff-49c6ecf962b3.png)
