### PR TITLE
[Fleet] Fix metric types for GCP + elastic package registry integrations

### DIFF
--- a/packages/elastic_package_registry/changelog.yml
+++ b/packages/elastic_package_registry/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.7"
+  changes:
+    - description: Fix invalid TSDS metric type for package_registry.start_time field
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6128
 - version: "0.0.6"
   changes:
     - description: First iteration to support multiple instances in dashboards

--- a/packages/elastic_package_registry/data_stream/metrics/fields/fields.yml
+++ b/packages/elastic_package_registry/data_stream/metrics/fields/fields.yml
@@ -113,7 +113,6 @@
 
 - name: package_registry.start_time
   type: date
-  metric_type: gauge
   description: >
     Date where Elastic Package Registry started
 
@@ -123,4 +122,3 @@
   metric_type: counter
   description: >
     Elastic Package Registry uptime in seconds
-

--- a/packages/elastic_package_registry/docs/README.md
+++ b/packages/elastic_package_registry/docs/README.md
@@ -74,7 +74,7 @@ You can verify that metrics endpoint is enabled by making an HTTP request to
 | package_registry.labels.path | Path of the HTTP request. | keyword |  |  |
 | package_registry.labels.version | Elastic Package Registry version. | keyword |  |  |
 | package_registry.number_indexed_packages | Number of indexed packages | integer |  | gauge |
-| package_registry.start_time | Date where Elastic Package Registry started | date |  | gauge |
+| package_registry.start_time | Date where Elastic Package Registry started | date |  |  |
 | package_registry.start_time_seconds | Start time of the process since unix epoch in seconds | double | s | gauge |
 | package_registry.storage_indexer.update_index_duration_seconds.histogram | A histogram of latencies for update index processes run by the storage indexer | histogram |  |  |
 | package_registry.storage_indexer.update_index_error_total.counter | A counter for all the update index processes that finished with error in the storage indexer | long |  |  |

--- a/packages/elastic_package_registry/manifest.yml
+++ b/packages/elastic_package_registry/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: elastic_package_registry
 title: "Elastic Package Registry"
-version: 0.0.6
+version: 0.0.7
 description: "Collect metrics from a Elastic Package Registry instance"
 type: integration
 categories:

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.20.1"
+  changes:
+    - description: Fix invalid TSDS metric type for persistence.rdb.bgsave_in_progress field
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6128
 - version: "2.20.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -417,7 +417,7 @@
     - description: Convert to generated ECS fields
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1478
-- version: '0.3.2'
+- version: "0.3.2"
   changes:
     - description: update to ECS 1.11.0
       type: enhancement

--- a/packages/gcp/data_stream/redis/fields/fields.yml
+++ b/packages/gcp/data_stream/redis/fields/fields.yml
@@ -39,7 +39,6 @@
       description: Number of keys with an expiration in this database.
     - name: persistence.rdb.bgsave_in_progress
       type: boolean
-      metric_type: gauge
       description: Flag indicating a RDB save is on-going.
     - name: replication.master.slaves.lag.sec
       type: long

--- a/packages/gcp/docs/README.md
+++ b/packages/gcp/docs/README.md
@@ -2289,7 +2289,7 @@ The `redis` dataset is designed to fetch metrics from [GCP Memorystore](https://
 | gcp.redis.keyspace.avg_ttl.sec | Average TTL for keys in this database. | double | s | gauge |
 | gcp.redis.keyspace.keys.count | Number of keys stored in this database. | long |  | gauge |
 | gcp.redis.keyspace.keys_with_expiration.count | Number of keys with an expiration in this database. | long |  | gauge |
-| gcp.redis.persistence.rdb.bgsave_in_progress | Flag indicating a RDB save is on-going. | boolean |  | gauge |
+| gcp.redis.persistence.rdb.bgsave_in_progress | Flag indicating a RDB save is on-going. | boolean |  |  |
 | gcp.redis.replication.master.slaves.lag.sec | The number of seconds that replica is lagging behind primary. | long | s | gauge |
 | gcp.redis.replication.master.slaves.offset.bytes | The number of bytes that have been acknowledged by replicas. | long | byte | gauge |
 | gcp.redis.replication.master_repl_offset.bytes | The number of bytes that master has produced and sent to replicas. | long | byte | gauge |

--- a/packages/gcp/docs/redis.md
+++ b/packages/gcp/docs/redis.md
@@ -104,7 +104,7 @@ An example event for `redis` looks as following:
 | gcp.redis.keyspace.avg_ttl.sec | Average TTL for keys in this database. | double | s | gauge |
 | gcp.redis.keyspace.keys.count | Number of keys stored in this database. | long |  | gauge |
 | gcp.redis.keyspace.keys_with_expiration.count | Number of keys with an expiration in this database. | long |  | gauge |
-| gcp.redis.persistence.rdb.bgsave_in_progress | Flag indicating a RDB save is on-going. | boolean |  | gauge |
+| gcp.redis.persistence.rdb.bgsave_in_progress | Flag indicating a RDB save is on-going. | boolean |  |  |
 | gcp.redis.replication.master.slaves.lag.sec | The number of seconds that replica is lagging behind primary. | long | s | gauge |
 | gcp.redis.replication.master.slaves.offset.bytes | The number of bytes that have been acknowledged by replicas. | long | byte | gauge |
 | gcp.redis.replication.master_repl_offset.bytes | The number of bytes that master has produced and sent to replicas. | long | byte | gauge |

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.20.0"
+version: "2.20.1"
 release: ga
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Fix `metric_type` declarations for GCP and Elastic Package Registry integrations. These integrations had `gauge` metrics declared for non-numeric fields like booleans and dates, which resulted in Elasticsearch errors when enabling TSDB or generating time series metrics in mappings. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).