### PR TITLE
Enable TSDB index mode for beta testing

### DIFF
--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0-beta"
+  changes:
+    - description: Enable TSDB on Nginx for beta testing.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6033
 - version: "1.11.1"
   changes:
     - description: Modifed the dimension field mapping to support public cloud deployment.

--- a/packages/nginx/data_stream/stubstatus/manifest.yml
+++ b/packages/nginx/data_stream/stubstatus/manifest.yml
@@ -19,3 +19,5 @@ streams:
         default: /nginx_status
     title: Nginx stub status metrics
     description: Collect Nginx stub status metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,16 +1,16 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: 1.11.1
+version: 1.12.0-beta
 license: basic
-description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent.
+description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent (TSDB Beta).
 type: integration
 categories:
   - web
   - observability
 release: ga
 conditions:
-  kibana.version: "^8.5.0"
+  kibana.version: "^8.8.0"
 screenshots:
   - src: /img/nginx-metrics-overview.png
     title: Nginx metrics overview


### PR DESCRIPTION

## What does this PR do?
This PR enables beta testing of Nginx package for TSDB. The [package](https://github.com/elastic/integrations/issues/5282) has been already migrated with dimension and metric type mapping. Here it enables index_mode: "time_series" for _nginx stubstatus_ data stream and also upgrades stack version to 8.8.0.

Package version made _-beta_ to avoid accidental use from other users.
## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally
- Load 8.8.0+ stack
- Run nginx server.
- Load latest package locally/cloud and follow detailed testing plan.

## Related issues


- Relates [#[5233]](https://github.com/elastic/integrations/issues/5233)


## Screenshots

<img width="1293" alt="Screenshot 2023-05-09 at 6 37 13 PM" src="https://github.com/elastic/integrations/assets/69236064/7b9e98eb-f3b4-419e-84d8-cafb14ae1064">
