### PR TITLE
[Vulnerability Management] Update CloudFormation template to deploy c6g instance family

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.3.0-preview9"
+- version: "1.3.0-preview10"
   changes:
     - description: New vulnerability management integration
       type: enhancement

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.3.0-preview9"
+version: "1.3.0-preview10"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -135,6 +135,6 @@ policy_templates:
             required: true
             show_user: false
             description: Template URL to Cloud Formation Quick Create Stack
-            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-05-04-12-45-56.yml&stackName=Elastic-Vulnerability-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=elastic-agent-KIBANA_VERSION-linux-arm64&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/vuln-mgmt/cloudformation-8.8.0-2023-05-09-16-08-17.yml&stackName=Elastic-Vulnerability-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=elastic-agent-KIBANA_VERSION-linux-arm64&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
 owner:
   github: elastic/cloud-security-posture


### PR DESCRIPTION
## What does this PR do?

As we saw that a few regions don't support the `a1` instance family we are changing to a more recent instance family `c6g`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Related: https://github.com/elastic/cloudbeat/issues/954

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
