### PR TITLE
Fix HTTP parsing issue in Prometheus Integration

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Fixing timeout and connect_timeout parameter parsing issue
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.3.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
@@ -44,10 +44,10 @@ condition: {{ condition }}
 {{headers}}
 {{/if}}
 {{#if connect_timeout}}
-{{connect_timeout}}
+connect_timeout: {{connect_timeout}}
 {{/if}}
 {{#if timeout}}
-{{timeout}}
+timeout: {{timeout}}
 {{/if}}
 data_stream:
   dataset: {{data_stream.dataset}}

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,14 +1,13 @@
 format_version: 1.0.0
 name: prometheus
 title: Prometheus
-version: 1.3.1
+version: 1.3.2
 license: basic
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
-categories:
-  - observability
-  - monitoring
-  - containers
+categories: 
+  - cloud
+  - custom
 release: ga
 conditions:
   kibana.version: "^8.4.0"


### PR DESCRIPTION
- Bug

## What does this PR do?

Fixes the issue with http input options in prometheus integration. 
## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues

- Closes https://github.com/elastic/integrations/issues/6138