### PR TITLE
[Elasticsearch] Forward active.only config to datastream config

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.3"
+  changes:
+    - description: Add missing index_recovery.active_only configuration
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/5869
 - version: "1.7.2"
   changes:
     - description: Add missing event fields field mapping

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add missing index_recovery.active_only configuration
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/5869
+      link: https://github.com/elastic/integrations/issues/6146
 - version: "1.7.2"
   changes:
     - description: Add missing event fields field mapping

--- a/packages/elasticsearch/data_stream/index_recovery/_dev/test/system/test-default-config.yml
+++ b/packages/elasticsearch/data_stream/index_recovery/_dev/test/system/test-default-config.yml
@@ -5,4 +5,6 @@ vars:
     - "http://{{Hostname}}:9200"
   username: elastic
   password: changeme
-data_stream: ~
+data_stream:
+  vars:
+    active.only: false

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -24,4 +24,7 @@ condition: ${kubernetes_leaderelection.leader} == true
 {{#if condition }}
 condition: {{ condition }}
 {{/if}}
+{{#if active.only}}
+index_recovery.active_only: {{active.only}}
+{{/if}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+index_recovery.active_only: {{active.only}}
 scope: {{scope}}
 {{#if username}}
 username: {{username}}
@@ -23,8 +24,5 @@ condition: ${kubernetes_leaderelection.leader} == true
 {{ else }}
 {{#if condition }}
 condition: {{ condition }}
-{{/if}}
-{{#if active.only}}
-index_recovery.active_only: {{active.only}}
 {{/if}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -24,4 +24,7 @@ condition: ${kubernetes_leaderelection.leader} == true
 {{#if condition }}
 condition: {{ condition }}
 {{/if}}
+{{#if active.only}}
+index_recovery.active_only: {{active.only}}
+{{/if}}
 {{/if}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -24,7 +24,4 @@ condition: ${kubernetes_leaderelection.leader} == true
 {{#if condition }}
 condition: {{ condition }}
 {{/if}}
-{{#if active.only}}
-index_recovery.active_only: {{active.only}}
-{{/if}}
 {{/if}}

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.7.2
+version: 1.7.3
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR fixes a bug caused by the fact that the `active.only` flag was not being forwarded to the index_recovery data stream configuration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test
- Pull this branch
- run `elastic-package stack up`
- ` cd packages/elasticsearch && elastic-package service up`
- Toggle the "Fech active index only" flag
<img width="867" alt="image" src="https://github.com/elastic/integrations/assets/2767137/0521803c-de79-41c7-8bf3-1e28dcdf42f0">


  - When on, there shouldn't be any docs with `stage: DONE` in `metrics-elasticsearch.stack_monitoring.index_recovery-*` index
  - When off there will be docs with `stage: DONE`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

closes [#5466](https://github.com/elastic/integrations/issues/5466)
