### PR TITLE
Update SEI packages to package-spec format 2.7.0 (Part 2)

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.1.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,9 +1,7 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.1.0"
-release: ga
-license: basic
+version: "1.2.0"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:

--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/cisco_duo/data_stream/admin/sample_event.json
+++ b/packages/cisco_duo/data_stream/admin/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-07-20T11:41:31.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "2785cbfe-5f49-4cf2-b1c4-7dbc52b0f1fa",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "admin": {
@@ -24,16 +24,16 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "action": "activation_begin",
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:04:03.222Z",
+        "created": "2023-05-10T14:54:46.085Z",
         "dataset": "cisco_duo.admin",
-        "ingested": "2023-01-13T12:04:04Z",
+        "ingested": "2023-05-10T14:54:47Z",
         "kind": "event",
         "original": "{\"action\":\"activation_begin\",\"description\":\"Starting activation process\",\"isotimestamp\":\"2021-07-20T11: 41: 31+00: 00\",\"object\":null,\"timestamp\":1626781291,\"username\":\"narroway\"}",
         "outcome": "success",

--- a/packages/cisco_duo/data_stream/auth/sample_event.json
+++ b/packages/cisco_duo/data_stream/auth/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-02-13T18:56:20.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "d12366d8-e76c-4b7a-a521-cf8f709b7fd3",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "auth": {
@@ -53,18 +53,18 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "authentication"
         ],
-        "created": "2023-01-13T12:04:41.471Z",
+        "created": "2023-05-10T14:55:22.717Z",
         "dataset": "cisco_duo.auth",
-        "ingested": "2023-01-13T12:04:42Z",
+        "ingested": "2023-05-10T14:55:23Z",
         "kind": "event",
         "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"67.0.3396.99\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"89.160.20.156\",\"is_encryption_enabled\":true,\"is_firewall_enabled\":true,\"is_password_set\":true,\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Mac OS X\",\"os_version\":\"10.14.1\",\"security_agents\":null},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Microsoft Azure Active Directory\"},\"auth_device\":{\"ip\":\"192.168.225.254\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"My iPhone X (734-555-2342)\"},\"email\":\"narroway@example.com\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2020-02-13T18:56:20.351346+00:00\",\"ood_software\":null,\"reason\":\"user_approved\",\"result\":\"success\",\"timestamp\":1581620180,\"trusted_endpoint_status\":\"not trusted\",\"txid\":\"340a23e3-23f3-23c1-87dc-1491a23dfdbb\",\"user\":{\"groups\":[\"Duo Users\",\"CorpHQ Users\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway@example.com\"}}",
         "outcome": "success",

--- a/packages/cisco_duo/data_stream/offline_enrollment/sample_event.json
+++ b/packages/cisco_duo/data_stream/offline_enrollment/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2019-08-30T16:10:05.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "24599b3c-1dd1-45c6-802a-ec30f6e720cc",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "offline_enrollment": {
@@ -30,15 +30,15 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:05:20.677Z",
+        "created": "2023-05-10T14:56:00.686Z",
         "dataset": "cisco_duo.offline_enrollment",
-        "ingested": "2023-01-13T12:05:21Z",
+        "ingested": "2023-05-10T14:56:04Z",
         "original": "{\"action\":\"o2fa_user_provisioned\",\"description\":\"{\\\"user_agent\\\": \\\"DuoCredProv/4.0.6.413 (Windows NT 6.3.9600; x64; Server)\\\", \\\"hostname\\\": \\\"WKSW10x64\\\", \\\"factor\\\": \\\"duo_otp\\\"}\",\"isotimestamp\":\"2019-08-30T16:10:05+00:00\",\"object\":\"Acme Laptop Windows Logon\",\"timestamp\":1567181405,\"username\":\"narroway\"}"
     },
     "input": {

--- a/packages/cisco_duo/data_stream/summary/_dev/test/pipeline/test-summary.log-expected.json
+++ b/packages/cisco_duo/data_stream/summary/_dev/test/pipeline/test-summary.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2023-03-31T13:28:00.749830837Z",
+            "@timestamp": "2023-05-10T14:53:30.657737Z",
             "cisco_duo": {
                 "summary": {
                     "admin_count": 6,
@@ -21,7 +21,7 @@
             ]
         },
         {
-            "@timestamp": "2023-03-31T13:28:00.749839671Z",
+            "@timestamp": "2023-05-10T14:53:30.657748400Z",
             "cisco_duo": {
                 "summary": {
                     "admin_count": 3,

--- a/packages/cisco_duo/data_stream/summary/sample_event.json
+++ b/packages/cisco_duo/data_stream/summary/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-01-13T12:05:57.885963717Z",
+    "@timestamp": "2023-05-10T14:56:41.873942700Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "e03bb3c3-0d99-45e9-bd9d-a30e435ed069",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "summary": {
@@ -24,15 +24,15 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:05:56.871Z",
+        "created": "2023-05-10T14:56:40.862Z",
         "dataset": "cisco_duo.summary",
-        "ingested": "2023-01-13T12:05:57Z",
+        "ingested": "2023-05-10T14:56:41Z",
         "original": "{\"response\":{\"admin_count\":3,\"integration_count\":9,\"telephony_credits_remaining\":960,\"user_count\":8},\"stat\":\"OK\"}"
     },
     "input": {

--- a/packages/cisco_duo/data_stream/telephony/sample_event.json
+++ b/packages/cisco_duo/data_stream/telephony/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-03-20T15:38:12.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "fc6cd027-e67d-45f2-81f3-547c668998c6",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "telephony": {
@@ -24,15 +24,15 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:06:36.078Z",
+        "created": "2023-05-10T14:57:17.933Z",
         "dataset": "cisco_duo.telephony",
-        "ingested": "2023-01-13T12:06:37Z",
+        "ingested": "2023-05-10T14:57:18Z",
         "kind": "event",
         "original": "{\"context\":\"authentication\",\"credits\":1,\"isotimestamp\":\"2020-03-20T15:38:12+00:00\",\"phone\":\"+121234512345\",\"timestamp\":1584718692,\"type\":\"sms\"}"
     },

--- a/packages/cisco_duo/docs/README.md
+++ b/packages/cisco_duo/docs/README.md
@@ -34,11 +34,11 @@ An example event for `admin` looks as following:
 {
     "@timestamp": "2021-07-20T11:41:31.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "2785cbfe-5f49-4cf2-b1c4-7dbc52b0f1fa",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "admin": {
@@ -57,16 +57,16 @@ An example event for `admin` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "action": "activation_begin",
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:04:03.222Z",
+        "created": "2023-05-10T14:54:46.085Z",
         "dataset": "cisco_duo.admin",
-        "ingested": "2023-01-13T12:04:04Z",
+        "ingested": "2023-05-10T14:54:47Z",
         "kind": "event",
         "original": "{\"action\":\"activation_begin\",\"description\":\"Starting activation process\",\"isotimestamp\":\"2021-07-20T11: 41: 31+00: 00\",\"object\":null,\"timestamp\":1626781291,\"username\":\"narroway\"}",
         "outcome": "success",
@@ -174,11 +174,11 @@ An example event for `auth` looks as following:
 {
     "@timestamp": "2020-02-13T18:56:20.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "d12366d8-e76c-4b7a-a521-cf8f709b7fd3",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "auth": {
@@ -226,18 +226,18 @@ An example event for `auth` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "authentication"
         ],
-        "created": "2023-01-13T12:04:41.471Z",
+        "created": "2023-05-10T14:55:22.717Z",
         "dataset": "cisco_duo.auth",
-        "ingested": "2023-01-13T12:04:42Z",
+        "ingested": "2023-05-10T14:55:23Z",
         "kind": "event",
         "original": "{\"access_device\":{\"browser\":\"Chrome\",\"browser_version\":\"67.0.3396.99\",\"flash_version\":\"uninstalled\",\"hostname\":null,\"ip\":\"89.160.20.156\",\"is_encryption_enabled\":true,\"is_firewall_enabled\":true,\"is_password_set\":true,\"java_version\":\"uninstalled\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"os\":\"Mac OS X\",\"os_version\":\"10.14.1\",\"security_agents\":null},\"alias\":\"\",\"application\":{\"key\":\"DIY231J8BR23QK4UKBY8\",\"name\":\"Microsoft Azure Active Directory\"},\"auth_device\":{\"ip\":\"192.168.225.254\",\"location\":{\"city\":\"Ann Arbor\",\"country\":\"United States\",\"state\":\"Michigan\"},\"name\":\"My iPhone X (734-555-2342)\"},\"email\":\"narroway@example.com\",\"event_type\":\"authentication\",\"factor\":\"duo_push\",\"isotimestamp\":\"2020-02-13T18:56:20.351346+00:00\",\"ood_software\":null,\"reason\":\"user_approved\",\"result\":\"success\",\"timestamp\":1581620180,\"trusted_endpoint_status\":\"not trusted\",\"txid\":\"340a23e3-23f3-23c1-87dc-1491a23dfdbb\",\"user\":{\"groups\":[\"Duo Users\",\"CorpHQ Users\"],\"key\":\"DU3KC77WJ06Y5HIV7XKQ\",\"name\":\"narroway@example.com\"}}",
         "outcome": "success",
@@ -447,11 +447,11 @@ An example event for `offline_enrollment` looks as following:
 {
     "@timestamp": "2019-08-30T16:10:05.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "24599b3c-1dd1-45c6-802a-ec30f6e720cc",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "offline_enrollment": {
@@ -476,15 +476,15 @@ An example event for `offline_enrollment` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:05:20.677Z",
+        "created": "2023-05-10T14:56:00.686Z",
         "dataset": "cisco_duo.offline_enrollment",
-        "ingested": "2023-01-13T12:05:21Z",
+        "ingested": "2023-05-10T14:56:04Z",
         "original": "{\"action\":\"o2fa_user_provisioned\",\"description\":\"{\\\"user_agent\\\": \\\"DuoCredProv/4.0.6.413 (Windows NT 6.3.9600; x64; Server)\\\", \\\"hostname\\\": \\\"WKSW10x64\\\", \\\"factor\\\": \\\"duo_otp\\\"}\",\"isotimestamp\":\"2019-08-30T16:10:05+00:00\",\"object\":\"Acme Laptop Windows Logon\",\"timestamp\":1567181405,\"username\":\"narroway\"}"
     },
     "input": {
@@ -575,13 +575,13 @@ An example event for `summary` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-01-13T12:05:57.885963717Z",
+    "@timestamp": "2023-05-10T14:56:41.873942700Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "e03bb3c3-0d99-45e9-bd9d-a30e435ed069",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "summary": {
@@ -600,15 +600,15 @@ An example event for `summary` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:05:56.871Z",
+        "created": "2023-05-10T14:56:40.862Z",
         "dataset": "cisco_duo.summary",
-        "ingested": "2023-01-13T12:05:57Z",
+        "ingested": "2023-05-10T14:56:41Z",
         "original": "{\"response\":{\"admin_count\":3,\"integration_count\":9,\"telephony_credits_remaining\":960,\"user_count\":8},\"stat\":\"OK\"}"
     },
     "input": {
@@ -684,11 +684,11 @@ An example event for `telephony` looks as following:
 {
     "@timestamp": "2020-03-20T15:38:12.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "fc6cd027-e67d-45f2-81f3-547c668998c6",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco_duo": {
         "telephony": {
@@ -707,15 +707,15 @@ An example event for `telephony` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:06:36.078Z",
+        "created": "2023-05-10T14:57:17.933Z",
         "dataset": "cisco_duo.telephony",
-        "ingested": "2023-01-13T12:06:37Z",
+        "ingested": "2023-05-10T14:57:18Z",
         "kind": "event",
         "original": "{\"context\":\"authentication\",\"credits\":1,\"isotimestamp\":\"2020-03-20T15:38:12+00:00\",\"phone\":\"+121234512345\",\"timestamp\":1584718692,\"type\":\"sms\"}"
     },

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,14 +1,12 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cisco_duo
 title: Cisco Duo
-version: "1.9.0"
-license: basic
+version: "1.10.0"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:
   - security
   - iam
-release: ga
 conditions:
   kibana.version: ^7.17.2 || ^8.0.0
 screenshots:

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.13.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-asr920.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-asr920.log-expected.json
@@ -17,13 +17,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "LOGIN_SUCCESS",
                 "original": "\u003c165\u003e7433: ASR920: 007439: 2y10w: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: username] [Source: 192.168.0.1] [localport: 22] at 07:57:58 VIENNA Thu Jan 27 2022",
                 "provider": "firewall",
                 "sequence": 7439,
                 "severity": 5,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "notification",
@@ -73,13 +77,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "LOGOUT",
                 "original": "\u003c166\u003e7432: ASR920: 007438: 2y10w: %SYS-6-LOGOUT: User username has exited tty session 3(192.168.0.1)",
                 "provider": "firewall",
                 "sequence": 7438,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -129,13 +137,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "LOGOUT",
                 "original": "\u003c166\u003e7431: ASR920: 007437: 2y10w: %SYS-6-LOGOUT: User CPI has exited tty session 1(192.168.0.1)",
                 "provider": "firewall",
                 "sequence": 7437,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -180,13 +192,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "TTY_EXPIRE_TIMER",
                 "original": "\u003c166\u003e7424: ASR920: 007430: 2y10w: %SYS-6-TTY_EXPIRE_TIMER: (exec timer expired, tty 1 (192.168.0.1)), user username",
                 "provider": "firewall",
                 "sequence": 7430,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -213,13 +229,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "CONFIG_I",
                 "original": "\u003c165\u003e7422: ASR920: 007428: 2y10w: %SYS-5-CONFIG_I: Configured from console by username on vty1 (192.168.0.1)",
                 "provider": "firewall",
                 "sequence": 7428,
                 "severity": 5,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "notification",
@@ -245,13 +265,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "UPDOWN",
                 "original": "\u003c165\u003e2029: ASR920: Aug 3 08:11:02.204: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/0/7, changed state to up",
                 "provider": "firewall",
                 "sequence": 2029,
                 "severity": 5,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "notification",
@@ -284,13 +308,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGP",
                 "original": "\u003c166\u003e352134: ASR920: Aug 3 08:08:47.142: %SEC-6-IPACCESSLOGP: list ACL_CE-SECURITY denied udp 81.2.69.192(0) -\u003e 224.0.0.252(0), 1 packet",
                 "provider": "firewall",
                 "sequence": 352134,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -351,13 +380,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGNP",
                 "original": "\u003c166\u003e352133: ASR920: Aug 3 08:04:47.140: %SEC-6-IPACCESSLOGNP: list ACL_CE-SECURITY denied 112 89.160.20.112 -\u003e 224.0.0.18, 295 packets",
                 "provider": "firewall",
                 "sequence": 352133,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -417,13 +451,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "RESPONSE_DELAYED",
                 "original": "\u003c163\u003e81681: CORE: Aug 3 08:09:55.769: %SNMP-SW1-3-RESPONSE_DELAYED: processing Get of cefcFRUPowerStatusEntry.1.2030 (4620 msecs)",
                 "provider": "firewall",
                 "sequence": 81681,
                 "severity": 3,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "error",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
@@ -18,13 +18,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGRP",
                 "original": "Feb  8 04:00:48 192.168.100.2 585917: Feb  8 04:00:47.272: %SEC-6-IPACCESSLOGRP: list 177 denied igmp 192.168.100.197 -\u003e 224.0.0.22, 1 packet",
                 "provider": "firewall",
                 "sequence": 585917,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -72,13 +77,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGSP",
                 "original": "Feb  9 04:00:48 192.168.100.2 585918: Feb  9 04:00:47.272: %SEC-6-IPACCESSLOGSP: list INBOUND-ON-F11 denied igmp 192.168.100.2 -\u003e 224.0.0.2 (20), 1 packet",
                 "provider": "firewall",
                 "sequence": 585918,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "igmp": {
                 "type": "20"
@@ -129,13 +139,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGNP",
                 "original": "Feb 10 04:00:48 192.168.100.2 585919: Feb 10 04:00:47.272: %SEC-6-IPACCESSLOGNP: list 171 denied 0 192.168.100.1 -\u003e 255.255.255.255, 1 packet",
                 "provider": "firewall",
                 "sequence": 585919,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -192,13 +207,18 @@
             },
             "event": {
                 "action": "allow",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "ACCESSLOGP",
                 "original": "May  3 19:11:33 192.168.100.2 585920: May  3 19:11:32.619: %IPV6-6-ACCESSLOGP: list ACL-IPv6-E0/0-IN/10 permitted tcp 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6(1027) -\u003e 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6(22), 9 packets",
                 "provider": "firewall",
                 "sequence": 585920,
                 "severity": 6,
-                "type": "allowed"
+                "type": [
+                    "info",
+                    "allowed"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -256,13 +276,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGP",
                 "original": "Jun 20 02:41:40 192.168.100.2 1663303: Jun 20 02:41:39.326: %SEC-6-IPACCESSLOGP: list 177 denied udp 192.168.100.195(55250) -\u003e 192.168.100.255(15600), 1 packet",
                 "provider": "firewall",
                 "sequence": 1663303,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -311,13 +336,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGDP",
                 "original": "Jun 20 02:41:45 192.168.100.2 1663304: Jun 20 02:41:44.921: %SEC-6-IPACCESSLOGDP: list 151 denied icmp 192.168.100.1 -\u003e 192.168.100.2 (3/4), 1 packet",
                 "provider": "firewall",
                 "sequence": 1663304,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "icmp": {
                 "code": "4",
@@ -370,13 +400,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGP",
                 "original": "Jun 20 02:42:28 192.168.100.2 1663312: Jun 20 02:42:27.342: %SEC-6-IPACCESSLOGP: list 177 denied udp 192.168.100.195(54309) -\u003e 192.168.100.255(15600), 1 packet",
                 "provider": "firewall",
                 "sequence": 1663312,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -419,13 +454,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGRL",
                 "original": "Jun 20 02:42:28 192.168.100.2 1663313: Jun 20 02:42:28.374: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 18 packets",
                 "provider": "firewall",
                 "sequence": 1663313,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -457,13 +496,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGP",
                 "original": "Jun 20 02:42:34 192.168.100.2 1663314: Jun 20 02:42:33.340: %SEC-6-IPACCESSLOGP: list 177 denied udp 192.168.100.195(43989) -\u003e 192.168.100.255(15600), 1 packet",
                 "provider": "firewall",
                 "sequence": 1663314,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -525,13 +569,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGP",
                 "original": "Jun 20 02:43:09 192.168.100.2 1663321: Jun 20 02:43:08.454: %SEC-6-IPACCESSLOGP: list 150 denied tcp 192.168.100.12(59832) -\u003e 81.2.69.144(80), 1 packet",
                 "provider": "firewall",
                 "sequence": 1663321,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -574,13 +623,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGRL",
                 "original": "Jun 20 02:43:29 192.168.100.2 1663325: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 23 packets",
                 "provider": "firewall",
                 "sequence": 1663325,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -611,13 +664,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGDP",
                 "original": "Jun 20 02:43:29 192.168.100.2 1663326: Jun 20 02:43:28.403: %SEC-6-IPACCESSLOGDP: list 150 denied icmp 192.168.100.12 -\u003e 192.168.100.1 (3/3), 32 packets",
                 "provider": "firewall",
                 "sequence": 1663326,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "icmp": {
                 "code": "3",
@@ -682,13 +740,18 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGP",
                 "original": "Jun 20 02:43:30 192.168.100.2 1663327: Jun 20 02:43:29.451: %SEC-6-IPACCESSLOGP: list 150 denied tcp 192.168.100.12(59834) -\u003e 81.2.69.144(80), 1 packet",
                 "provider": "firewall",
                 "sequence": 1663327,
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -735,13 +798,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "LOGIN_SUCCESS",
                 "original": "Mar 24 18:06:03 192.168.100.2 1991219: Mar 24 18:06:03.424 UTC: %SEC_LOGIN-5-LOGIN_SUCCESS: Login Success [user: john.smith] [Source: 10.2.55.3] [localport: 22] at 12:06:03 MST Wed Mar 24 2021",
                 "provider": "firewall",
                 "sequence": 1991219,
                 "severity": 5,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "notification",
@@ -789,13 +856,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "LOGOUT",
                 "original": "Mar 24 18:06:00 192.168.100.2 1991220: Mar 24 18:06:00.364 UTC: %SYS-6-LOGOUT: User john.smith has exited tty session 5(10.5.36.9)",
                 "provider": "firewall",
                 "sequence": 1991220,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -850,7 +921,9 @@
             },
             "event": {
                 "action": "multicast-join",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "INVALID_RP_JOIN",
                 "original": "Mar 24 17:37:39 192.168.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (*, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
                 "outcome": "failure",
@@ -858,7 +931,9 @@
                 "reason": "Invalid RP",
                 "sequence": 1991221,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -911,7 +986,9 @@
             },
             "event": {
                 "action": "multicast-join",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "INVALID_RP_JOIN",
                 "original": "Mar 24 17:37:39 192.168.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (10.50.22.5, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3",
                 "outcome": "failure",
@@ -919,7 +996,9 @@
                 "reason": "Invalid RP",
                 "sequence": 1991221,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -957,13 +1036,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "NOVALIDKEY",
                 "original": "Mar 24 12:09:35 192.168.100.2 1991217: Mar 24 12:09:35.367: %OSPF-4-NOVALIDKEY: No valid authentication send key is available on interface eth0",
                 "provider": "firewall",
                 "sequence": 1991217,
                 "severity": 4,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "warning",
@@ -988,13 +1071,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "CALL_PRESERVED",
                 "original": "Mar 24 12:06:47 192.168.100.2 1991218: Mar 24 12:06:47.099: %CCH323-6-CALL_PRESERVED: cch323_h225_handle_conn_loss: H.323 call preserved due to socket closure or error, Call Id = 6527, fd = 19",
                 "provider": "firewall",
                 "sequence": 1991218,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format-tzoffset.log-expected.json
@@ -12,13 +12,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -44,13 +48,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log-expected.json
@@ -12,13 +12,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43.398 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -44,13 +48,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43.398: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -76,13 +84,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -108,13 +120,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -140,13 +156,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43.398 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -172,13 +192,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43.398: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -204,13 +228,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -236,13 +264,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -268,13 +300,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 2022 22:11:43 EDT: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -300,13 +336,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan  6 22:11:43.398 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -332,13 +372,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan  6 22:11:43.398: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -364,13 +408,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan  6 22:11:43 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -396,13 +444,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan  6 22:11:43: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -428,13 +480,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43.398 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -460,13 +516,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43.398: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -492,13 +552,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43 UTC: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -524,13 +588,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",
@@ -556,13 +624,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "BAR",
                 "original": "\u003c190\u003e2361044: sw01: Jan 16 22:11:43 EDT: %FOO-6-BAR: Test date format.",
                 "provider": "firewall",
                 "sequence": 2361044,
                 "severity": 6,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "informational",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
@@ -12,13 +12,17 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "CONFIG_I",
                 "original": "\u003c189\u003e2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
                 "provider": "firewall",
                 "sequence": 2360957,
                 "severity": 5,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "notification",
@@ -42,12 +46,16 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "CONFIG_I",
                 "original": "\u003c189\u003e: Jan  6 2022 20:54:26.961: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
                 "provider": "firewall",
                 "severity": 5,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "notification",
@@ -77,12 +85,17 @@
             },
             "event": {
                 "action": "deny",
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "IPACCESSLOGDP",
                 "original": "\u003c190\u003e: Jan  6 2022 20:55:50.671: %SEC-6-IPACCESSLOGDP: list 100 denied icmp 172.16.0.26 -\u003e 10.100.8.34 (3/3), 20 packets",
                 "provider": "firewall",
                 "severity": 6,
-                "type": "denied"
+                "type": [
+                    "info",
+                    "denied"
+                ]
             },
             "icmp": {
                 "code": "3",
@@ -127,12 +140,16 @@
                 "version": "8.7.0"
             },
             "event": {
-                "category": "network",
+                "category": [
+                    "network"
+                ],
                 "code": "CONFIG_I",
                 "original": "\u003c189\u003e: sw01: Jan  6 2022 21:01:34.964: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
                 "provider": "firewall",
                 "severity": 5,
-                "type": "info"
+                "type": [
+                    "info"
+                ]
             },
             "log": {
                 "level": "notification",

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -7,13 +7,13 @@ processors:
       value: '8.7.0'
   - set:
       field: event.category
-      value: network
+      value: [network]
   - set:
       field: event.provider
       value: firewall
   - set:
       field: event.type
-      value: info
+      value: [info]
 
   - set:
       field: event.original
@@ -172,7 +172,7 @@ processors:
       field: event.action
       value: deny
       if: "ctx._temp_?.event?.action == 'denied'"
-  - set:
+  - append:
       field: event.type
       value: denied
       if: "ctx.event?.action == 'deny'"
@@ -180,7 +180,7 @@ processors:
       field: event.action
       value: allow
       if: "ctx._temp_?.event?.action == 'permitted'"
-  - set:
+  - append:
       field: event.type
       value: allowed
       if: "ctx.event?.action == 'allow'"

--- a/packages/cisco_ios/data_stream/log/sample_event.json
+++ b/packages/cisco_ios/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-01-06T20:52:12.861Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "453f05a5-66d2-4433-b533-c88a98ed3062",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco": {
         "ios": {
@@ -22,22 +22,26 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "network",
+        "category": [
+            "network"
+        ],
         "code": "CONFIG_I",
         "dataset": "cisco_ios.log",
-        "ingested": "2023-01-13T12:12:57Z",
+        "ingested": "2023-05-10T15:24:26Z",
         "original": "\u003c189\u003e2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
         "provider": "firewall",
         "sequence": 2360957,
         "severity": 5,
         "timezone": "+00:00",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "input": {
         "type": "tcp"
@@ -45,7 +49,7 @@
     "log": {
         "level": "notification",
         "source": {
-            "address": "172.27.0.4:59426"
+            "address": "172.23.0.4:42422"
         },
         "syslog": {
             "priority": 189

--- a/packages/cisco_ios/docs/README.md
+++ b/packages/cisco_ios/docs/README.md
@@ -17,11 +17,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2022-01-06T20:52:12.861Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "453f05a5-66d2-4433-b533-c88a98ed3062",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "cisco": {
         "ios": {
@@ -38,22 +38,26 @@ An example event for `log` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "snapshot": true,
-        "version": "8.6.0"
+        "version": "8.8.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "network",
+        "category": [
+            "network"
+        ],
         "code": "CONFIG_I",
         "dataset": "cisco_ios.log",
-        "ingested": "2023-01-13T12:12:57Z",
+        "ingested": "2023-05-10T15:24:26Z",
         "original": "\u003c189\u003e2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
         "provider": "firewall",
         "sequence": 2360957,
         "severity": 5,
         "timezone": "+00:00",
-        "type": "info"
+        "type": [
+            "info"
+        ]
     },
     "input": {
         "type": "tcp"
@@ -61,7 +65,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "notification",
         "source": {
-            "address": "172.27.0.4:59426"
+            "address": "172.23.0.4:42422"
         },
         "syslog": {
             "priority": 189

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,14 +1,12 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cisco_ios
 title: Cisco IOS
-version: "1.13.0"
-license: basic
+version: "1.14.0"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:
   - network
   - security
-release: ga
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"
 icons:

--- a/packages/cisco_nexus/changelog.yml
+++ b/packages/cisco_nexus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "0.10.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/cisco_nexus/manifest.yml
+++ b/packages/cisco_nexus/manifest.yml
@@ -1,14 +1,12 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cisco_nexus
 title: Cisco Nexus
-version: "0.10.0"
-license: basic
+version: "0.11.0"
 description: Collect logs from Cisco Nexus with Elastic Agent.
 type: integration
 categories:
   - network
   - security
-release: experimental
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"
 icons:

--- a/packages/cisco_secure_endpoint/changelog.yml
+++ b/packages/cisco_secure_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "2.9.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/cisco_secure_endpoint/data_stream/event/fields/fields.yml
+++ b/packages/cisco_secure_endpoint/data_stream/event/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: cisco.secure_endpoint
   type: group
-  release: beta
   default_field: false
   description: >
     Module for parsing Cisco Secure Endpoint logs.

--- a/packages/cisco_secure_endpoint/data_stream/event/sample_event.json
+++ b/packages/cisco_secure_endpoint/data_stream/event/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-01-13T10:13:08.000Z",
     "agent": {
-        "ephemeral_id": "1bee52ec-b713-415e-9d9b-32c5217f9796",
-        "id": "83d8d392-d20c-40ef-a257-bf9cf314d1db",
+        "ephemeral_id": "df9fbda5-4f22-4ab6-b0c3-439dd2c5f242",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.8.0"
     },
     "cisco": {
         "secure_endpoint": {
@@ -53,9 +53,9 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "83d8d392-d20c-40ef-a257-bf9cf314d1db",
-        "snapshot": false,
-        "version": "8.0.0"
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
+        "snapshot": true,
+        "version": "8.8.0"
     },
     "event": {
         "action": "Cloud IOC",
@@ -64,12 +64,12 @@
             "file"
         ],
         "code": "1107296274",
-        "created": "2022-04-13T11:54:03.909Z",
+        "created": "2023-05-10T16:03:43.178Z",
         "dataset": "cisco_secure_endpoint.event",
         "id": "1515298355162029000",
-        "ingested": "2022-04-13T11:54:04Z",
+        "ingested": "2023-05-10T16:03:44Z",
         "kind": "alert",
-        "original": "{\"data\":{\"cloud_ioc\":{\"description\":\"Microsoft Word launched PowerShell. This is indicative of multiple dropper variants that make use of Visual Basic Application macros to perform nefarious activities, such as downloading and executing malicious executables.\",\"short_description\":\"W32.WinWord.Powershell\"},\"computer\":{\"active\":true,\"connector_guid\":\"test_connector_guid\",\"external_ip\":\"8.8.8.8\",\"hostname\":\"Demo_AMP\",\"links\":{\"computer\":\"https://api.eu.amp.cisco.com/v1/computers/test_computer\",\"group\":\"https://api.eu.amp.cisco.com/v1/groups/test_group\",\"trajectory\":\"https://api.eu.amp.cisco.com/v1/computers/test_computer/trajectory\"},\"network_addresses\":[{\"ip\":\"10.10.10.10\",\"mac\":\"38:1e:eb:ba:2c:15\"}]},\"connector_guid\":\"test_connector_guid\",\"date\":\"2021-01-13T10:13:08+00:00\",\"event_type\":\"Cloud IOC\",\"event_type_id\":1107296274,\"file\":{\"disposition\":\"Clean\",\"file_name\":\"PowerShell.exe\",\"file_path\":\"/C:/Windows/SysWOW64/WindowsPowerShell/v1.0/PowerShell.exe\",\"identity\":{\"sha256\":\"6c05e11399b7e3c8ed31bae72014cf249c144a8f4a2c54a758eb2e6fad47aec7\"},\"parent\":{\"disposition\":\"Clean\",\"identity\":{\"sha256\":\"3d46e95284f93bbb76b3b7e1bf0e1b2d51e8a9411c2b6e649112f22f92de63c2\"}}},\"group_guids\":[\"test_group_guid\"],\"id\":1515298355162029000,\"severity\":\"Medium\",\"start_date\":\"2021-01-13T10:13:08+00:00\",\"start_timestamp\":1610532788,\"timestamp\":1610532788,\"timestamp_nanoseconds\":162019000},\"metadata\":{\"links\":{\"next\":\"http://7d3a7ffa9a19:8080/v1/events?start_date=2022-04-12T11:54:03+00:00\\u0026limit=1\\u0026offset=1\",\"self\":\"http://7d3a7ffa9a19:8080/v1/events?start_date=2022-04-12T11:54:03+00:00\\u0026limit=1\"},\"results\":{\"current_item_count\":1,\"index\":0,\"items_per_page\":1,\"total\":2}},\"version\":\"v1.2.0\"}",
+        "original": "{\"data\":{\"cloud_ioc\":{\"description\":\"Microsoft Word launched PowerShell. This is indicative of multiple dropper variants that make use of Visual Basic Application macros to perform nefarious activities, such as downloading and executing malicious executables.\",\"short_description\":\"W32.WinWord.Powershell\"},\"computer\":{\"active\":true,\"connector_guid\":\"test_connector_guid\",\"external_ip\":\"8.8.8.8\",\"hostname\":\"Demo_AMP\",\"links\":{\"computer\":\"https://api.eu.amp.cisco.com/v1/computers/test_computer\",\"group\":\"https://api.eu.amp.cisco.com/v1/groups/test_group\",\"trajectory\":\"https://api.eu.amp.cisco.com/v1/computers/test_computer/trajectory\"},\"network_addresses\":[{\"ip\":\"10.10.10.10\",\"mac\":\"38:1e:eb:ba:2c:15\"}]},\"connector_guid\":\"test_connector_guid\",\"date\":\"2021-01-13T10:13:08+00:00\",\"event_type\":\"Cloud IOC\",\"event_type_id\":1107296274,\"file\":{\"disposition\":\"Clean\",\"file_name\":\"PowerShell.exe\",\"file_path\":\"/C:/Windows/SysWOW64/WindowsPowerShell/v1.0/PowerShell.exe\",\"identity\":{\"sha256\":\"6c05e11399b7e3c8ed31bae72014cf249c144a8f4a2c54a758eb2e6fad47aec7\"},\"parent\":{\"disposition\":\"Clean\",\"identity\":{\"sha256\":\"3d46e95284f93bbb76b3b7e1bf0e1b2d51e8a9411c2b6e649112f22f92de63c2\"}}},\"group_guids\":[\"test_group_guid\"],\"id\":1515298355162029000,\"severity\":\"Medium\",\"start_date\":\"2021-01-13T10:13:08+00:00\",\"start_timestamp\":1610532788,\"timestamp\":1610532788,\"timestamp_nanoseconds\":162019000},\"metadata\":{\"links\":{\"next\":\"http://afb876975c2a:8080/v1/events?start_date=2023-05-09T16:03:43+00:00\\u0026limit=1\\u0026offset=1\",\"self\":\"http://afb876975c2a:8080/v1/events?start_date=2023-05-09T16:03:43+00:00\\u0026limit=1\"},\"results\":{\"current_item_count\":1,\"index\":0,\"items_per_page\":1,\"total\":2}},\"version\":\"v1.2.0\"}",
         "severity": 2,
         "start": "2021-01-13T10:13:08.000Z"
     },

--- a/packages/cisco_secure_endpoint/docs/README.md
+++ b/packages/cisco_secure_endpoint/docs/README.md
@@ -16,11 +16,11 @@ An example event for `event` looks as following:
 {
     "@timestamp": "2021-01-13T10:13:08.000Z",
     "agent": {
-        "ephemeral_id": "1bee52ec-b713-415e-9d9b-32c5217f9796",
-        "id": "83d8d392-d20c-40ef-a257-bf9cf314d1db",
+        "ephemeral_id": "df9fbda5-4f22-4ab6-b0c3-439dd2c5f242",
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0"
+        "version": "8.8.0"
     },
     "cisco": {
         "secure_endpoint": {
@@ -68,9 +68,9 @@ An example event for `event` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "83d8d392-d20c-40ef-a257-bf9cf314d1db",
-        "snapshot": false,
-        "version": "8.0.0"
+        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
+        "snapshot": true,
+        "version": "8.8.0"
     },
     "event": {
         "action": "Cloud IOC",
@@ -79,12 +79,12 @@ An example event for `event` looks as following:
             "file"
         ],
         "code": "1107296274",
-        "created": "2022-04-13T11:54:03.909Z",
+        "created": "2023-05-10T16:03:43.178Z",
         "dataset": "cisco_secure_endpoint.event",
         "id": "1515298355162029000",
-        "ingested": "2022-04-13T11:54:04Z",
+        "ingested": "2023-05-10T16:03:44Z",
         "kind": "alert",
-        "original": "{\"data\":{\"cloud_ioc\":{\"description\":\"Microsoft Word launched PowerShell. This is indicative of multiple dropper variants that make use of Visual Basic Application macros to perform nefarious activities, such as downloading and executing malicious executables.\",\"short_description\":\"W32.WinWord.Powershell\"},\"computer\":{\"active\":true,\"connector_guid\":\"test_connector_guid\",\"external_ip\":\"8.8.8.8\",\"hostname\":\"Demo_AMP\",\"links\":{\"computer\":\"https://api.eu.amp.cisco.com/v1/computers/test_computer\",\"group\":\"https://api.eu.amp.cisco.com/v1/groups/test_group\",\"trajectory\":\"https://api.eu.amp.cisco.com/v1/computers/test_computer/trajectory\"},\"network_addresses\":[{\"ip\":\"10.10.10.10\",\"mac\":\"38:1e:eb:ba:2c:15\"}]},\"connector_guid\":\"test_connector_guid\",\"date\":\"2021-01-13T10:13:08+00:00\",\"event_type\":\"Cloud IOC\",\"event_type_id\":1107296274,\"file\":{\"disposition\":\"Clean\",\"file_name\":\"PowerShell.exe\",\"file_path\":\"/C:/Windows/SysWOW64/WindowsPowerShell/v1.0/PowerShell.exe\",\"identity\":{\"sha256\":\"6c05e11399b7e3c8ed31bae72014cf249c144a8f4a2c54a758eb2e6fad47aec7\"},\"parent\":{\"disposition\":\"Clean\",\"identity\":{\"sha256\":\"3d46e95284f93bbb76b3b7e1bf0e1b2d51e8a9411c2b6e649112f22f92de63c2\"}}},\"group_guids\":[\"test_group_guid\"],\"id\":1515298355162029000,\"severity\":\"Medium\",\"start_date\":\"2021-01-13T10:13:08+00:00\",\"start_timestamp\":1610532788,\"timestamp\":1610532788,\"timestamp_nanoseconds\":162019000},\"metadata\":{\"links\":{\"next\":\"http://7d3a7ffa9a19:8080/v1/events?start_date=2022-04-12T11:54:03+00:00\\u0026limit=1\\u0026offset=1\",\"self\":\"http://7d3a7ffa9a19:8080/v1/events?start_date=2022-04-12T11:54:03+00:00\\u0026limit=1\"},\"results\":{\"current_item_count\":1,\"index\":0,\"items_per_page\":1,\"total\":2}},\"version\":\"v1.2.0\"}",
+        "original": "{\"data\":{\"cloud_ioc\":{\"description\":\"Microsoft Word launched PowerShell. This is indicative of multiple dropper variants that make use of Visual Basic Application macros to perform nefarious activities, such as downloading and executing malicious executables.\",\"short_description\":\"W32.WinWord.Powershell\"},\"computer\":{\"active\":true,\"connector_guid\":\"test_connector_guid\",\"external_ip\":\"8.8.8.8\",\"hostname\":\"Demo_AMP\",\"links\":{\"computer\":\"https://api.eu.amp.cisco.com/v1/computers/test_computer\",\"group\":\"https://api.eu.amp.cisco.com/v1/groups/test_group\",\"trajectory\":\"https://api.eu.amp.cisco.com/v1/computers/test_computer/trajectory\"},\"network_addresses\":[{\"ip\":\"10.10.10.10\",\"mac\":\"38:1e:eb:ba:2c:15\"}]},\"connector_guid\":\"test_connector_guid\",\"date\":\"2021-01-13T10:13:08+00:00\",\"event_type\":\"Cloud IOC\",\"event_type_id\":1107296274,\"file\":{\"disposition\":\"Clean\",\"file_name\":\"PowerShell.exe\",\"file_path\":\"/C:/Windows/SysWOW64/WindowsPowerShell/v1.0/PowerShell.exe\",\"identity\":{\"sha256\":\"6c05e11399b7e3c8ed31bae72014cf249c144a8f4a2c54a758eb2e6fad47aec7\"},\"parent\":{\"disposition\":\"Clean\",\"identity\":{\"sha256\":\"3d46e95284f93bbb76b3b7e1bf0e1b2d51e8a9411c2b6e649112f22f92de63c2\"}}},\"group_guids\":[\"test_group_guid\"],\"id\":1515298355162029000,\"severity\":\"Medium\",\"start_date\":\"2021-01-13T10:13:08+00:00\",\"start_timestamp\":1610532788,\"timestamp\":1610532788,\"timestamp_nanoseconds\":162019000},\"metadata\":{\"links\":{\"next\":\"http://afb876975c2a:8080/v1/events?start_date=2023-05-09T16:03:43+00:00\\u0026limit=1\\u0026offset=1\",\"self\":\"http://afb876975c2a:8080/v1/events?start_date=2023-05-09T16:03:43+00:00\\u0026limit=1\"},\"results\":{\"current_item_count\":1,\"index\":0,\"items_per_page\":1,\"total\":2}},\"version\":\"v1.2.0\"}",
         "severity": 2,
         "start": "2021-01-13T10:13:08.000Z"
     },

--- a/packages/cisco_secure_endpoint/manifest.yml
+++ b/packages/cisco_secure_endpoint/manifest.yml
@@ -1,14 +1,12 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cisco_secure_endpoint
 title: Cisco Secure Endpoint
-version: "2.9.0"
-license: basic
+version: "2.10.0"
 description: Collect logs from Cisco Secure Endpoint (AMP) with Elastic Agent.
 type: integration
 categories:
   - security
   - edr_xdr
-release: ga
 conditions:
   kibana.version: "^7.17.0 || ^8.0.0"
 icons:

--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.10.1"
   changes:
     - description: Add Mobile Devices as hosts

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/pipeline/test-umbrella-dnslogs.log-expected.json
@@ -780,8 +780,9 @@
             "dns": {
                 "question": {
                     "name": "android.googleapis.com",
-                    "registered_domain": "android.googleapis.com",
-                    "top_level_domain": "googleapis.com",
+                    "registered_domain": "googleapis.com",
+                    "subdomain": "android",
+                    "top_level_domain": "com",
                     "type": "1 (A)"
                 },
                 "response_code": "NOERROR",

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,15 +1,13 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cisco_umbrella
 title: Cisco Umbrella
-version: "1.10.1"
-license: basic
+version: "1.11.0"
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration
 categories:
   - network
   - security
   - dns_security
-release: ga
 conditions:
   kibana.version: "^8.0.0"
 icons:

--- a/packages/citrix_waf/changelog.yml
+++ b/packages/citrix_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/citrix_waf/manifest.yml
+++ b/packages/citrix_waf/manifest.yml
@@ -1,15 +1,13 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: citrix_waf
 title: "Citrix Web App Firewall"
-version: "1.4.0"
-license: basic
+version: "1.5.0"
 description: Ingest events from Citrix Systems Web App Firewall.
 type: integration
 categories:
   - network
   - security
   - web_application_firewall
-release: ga
 conditions:
   kibana.version: "^8.3.0"
 icons:

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.1.1"
   changes:
     - description: Fix collection of url fields in firewall_event and http_request datastreams.

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,9 +1,7 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.1.1"
-release: ga
-license: basic
+version: "1.2.0"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:

--- a/packages/cyberark_pta/changelog.yml
+++ b/packages/cyberark_pta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.1.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/cyberark_pta/manifest.yml
+++ b/packages/cyberark_pta/manifest.yml
@@ -1,11 +1,9 @@
 name: cyberark_pta
 title: Cyberark Privileged Threat Analytics
-version: "1.1.0"
-release: ga
-license: basic
+version: "1.2.0"
 description: Collect security logs from Cyberark PTA integration.
 type: integration
-format_version: 1.0.0
+format_version: 2.7.0
 categories: ["security", "iam"]
 conditions:
   kibana.version: ^7.17.0 || ^8.0.0

--- a/packages/cylance/changelog.yml
+++ b/packages/cylance/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.14.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "0.13.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/cylance/manifest.yml
+++ b/packages/cylance/manifest.yml
@@ -1,11 +1,9 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cylance
 title: CylanceProtect Logs
-version: "0.13.0"
+version: "0.14.0"
 description: Collect logs from CylanceProtect devices with Elastic Agent.
 categories: ["security", "edr_xdr"]
-release: experimental
-license: basic
 type: integration
 conditions:
   kibana.version: "^7.14.1 || ^8.0.0"

--- a/packages/f5/changelog.yml
+++ b/packages/f5/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.15.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "0.14.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/f5/manifest.yml
+++ b/packages/f5/manifest.yml
@@ -1,11 +1,9 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: f5
 title: F5 Logs
-version: "0.14.0"
+version: "0.15.0"
 description: Collect and parse logs from F5 devices with Elastic Agent.
 categories: ["observability", "load_balancer"]
-release: experimental
-license: basic
 type: integration
 conditions:
   kibana.version: "^7.14.1 || ^8.0.0"

--- a/packages/f5_bigip/changelog.yml
+++ b/packages/f5_bigip/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.1.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/f5_bigip/manifest.yml
+++ b/packages/f5_bigip/manifest.yml
@@ -1,8 +1,7 @@
-format_version: 2.0.0
+format_version: 2.7.0
 name: f5_bigip
 title: F5 BIG-IP
-version: "1.1.0"
-release: ga
+version: "1.2.0"
 description: Collect logs from F5 BIG-IP with Elastic Agent.
 type: integration
 categories:

--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,9 +1,7 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: fim
 title: "File Integrity Monitoring"
-version: "1.5.0"
-license: basic
-release: ga
+version: "1.6.0"
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."
 type: integration
 categories:

--- a/packages/forcepoint_web/changelog.yml
+++ b/packages/forcepoint_web/changelog.yml
@@ -1,4 +1,14 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Update package to ECS 8.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/{{ PULL_REQUEST_NUMBER }}
+- version: "0.2.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "0.1.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/forcepoint_web/manifest.yml
+++ b/packages/forcepoint_web/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 2.0.0
+format_version: 2.7.0
 name: forcepoint_web
 title: "Forcepoint Web Security"
-version: "0.1.0"
+version: "0.3.0"
 source:
   license: "Elastic-2.0"
 description: "Forcepoint Web Security"

--- a/packages/fortinet_forticlient/changelog.yml
+++ b/packages/fortinet_forticlient/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/fortinet_forticlient/manifest.yml
+++ b/packages/fortinet_forticlient/manifest.yml
@@ -1,11 +1,9 @@
 name: fortinet_forticlient
 title: Fortinet FortiClient Logs
-version: "1.4.0"
-release: ga
+version: "1.5.0"
 description: Collect logs from Fortinet FortiClient instances with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.7.0
 categories: ["security", "edr_xdr"]
 conditions:
   kibana.version: "^7.14.1 || ^8.0.0"

--- a/packages/fortinet_fortiedr/changelog.yml
+++ b/packages/fortinet_fortiedr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/fortinet_fortiedr/data_stream/log/fields/base-fields.yml
+++ b/packages/fortinet_fortiedr/data_stream/log/fields/base-fields.yml
@@ -15,10 +15,6 @@
   type: constant_keyword
   description: Event dataset
   value: fortinet_fortiedr.log
-- name: container.id
-  description: Unique container id.
-  ignore_above: 1024
-  type: keyword
 - name: input.type
   description: Type of Filebeat input.
   type: keyword

--- a/packages/fortinet_fortiedr/data_stream/log/fields/ecs.yml
+++ b/packages/fortinet_fortiedr/data_stream/log/fields/ecs.yml
@@ -17,14 +17,6 @@
 - external: ecs
   name: event.timezone
 - external: ecs
-  name: host.hostname
-- external: ecs
-  name: host.ip
-- external: ecs
-  name: host.mac
-- external: ecs
-  name: host.name
-- external: ecs
   name: log.syslog.appname
 - external: ecs
   name: log.syslog.facility.code
@@ -60,7 +52,5 @@
   name: related.user
 - external: ecs
   name: service.name
-- external: ecs
-  name: tags
 - external: ecs
   name: user.id

--- a/packages/fortinet_fortiedr/manifest.yml
+++ b/packages/fortinet_fortiedr/manifest.yml
@@ -1,11 +1,9 @@
 name: fortinet_fortiedr
 title: Fortinet FortiEDR Logs
-version: "1.5.0"
-release: ga
+version: "1.6.0"
 description: Collect logs from Fortinet FortiEDR instances with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.7.0
 categories: ["security", "edr_xdr"]
 conditions:
   kibana.version: "^7.17.0 || ^8.0.0"

--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "2.1.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/fortinet_fortimail/manifest.yml
+++ b/packages/fortinet_fortimail/manifest.yml
@@ -1,9 +1,9 @@
 name: fortinet_fortimail
 title: Fortinet FortiMail
-version: "2.1.0"
+version: "2.2.0"
 description: Collect logs from Fortinet FortiMail instances with Elastic Agent.
 type: integration
-format_version: 2.3.0
+format_version: 2.7.0
 categories: ["security", "email_security"]
 conditions:
   kibana.version: ^8.3.0

--- a/packages/fortinet_fortimanager/changelog.yml
+++ b/packages/fortinet_fortimanager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0"
+  changes:
+    - description: Update package to ECS 8.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/{{ PULL_REQUEST_NUMBER }}
 - version: "2.1.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/fortinet_fortimanager/manifest.yml
+++ b/packages/fortinet_fortimanager/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 2.3.0
+format_version: 2.7.0
 name: fortinet_fortimanager
 title: Fortinet FortiManager Logs
-version: "2.1.0"
+version: "2.2.0"
 description: Collect logs from Fortinet FortiManager instances with Elastic Agent.
 type: integration
 categories: ["security", "network", "firewall_security"]

--- a/packages/gcp_pubsub/changelog.yml
+++ b/packages/gcp_pubsub/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/gcp_pubsub/manifest.yml
+++ b/packages/gcp_pubsub/manifest.yml
@@ -1,7 +1,6 @@
 name: gcp_pubsub
 title: Custom Google Pub/Sub Logs
-version: "1.5.0"
-release: ga
+version: "1.6.0"
 description: Collect Logs from Google Pub/Sub topics
 type: integration
 icons:
@@ -9,8 +8,7 @@ icons:
     title: logo gcp
     size: 32x32
     type: image/svg+xml
-format_version: 1.0.0
-license: basic
+format_version: 2.7.0
 categories:
   - observability
   - google_cloud

--- a/packages/google_cloud_storage/changelog.yml
+++ b/packages/google_cloud_storage/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.3.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "0.2.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/google_cloud_storage/manifest.yml
+++ b/packages/google_cloud_storage/manifest.yml
@@ -1,9 +1,9 @@
-format_version: 2.3.0
+format_version: 2.7.0
 name: google_cloud_storage
 title: Custom GCS (Google Cloud Storage) Input
 description: Collect JSON data from configured GCS Bucket with Elastic Agent.
 type: integration
-version: "0.2.0"
+version: "0.3.0"
 conditions:
   kibana.version: "^8.6.2"
 categories:


### PR DESCRIPTION
## What does this PR do?

Updates the following packages to package-spec format version 2.7.0:

- cisco_aironet
- cisco_duo
- cisco_ios
- cisco_nexus
- cisco_secure_endpoint
- cisco_umbrella
- citrix_waf
- cloudflare_logpush
- cyberark_pta
- cylance
- f5
- f5_bigip
- fim
- forcepoint_web
- fortinet_forticlient
- fortinet_fortiedr
- fortinet_fortimail
- fortinet_fortimanager
- gcp_pubsub
- google_cloud_storage

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
elastic-package test
```

## Related issues

- Relates elastic/security-team#5870
