### PR TITLE
[Rabbitmq] modify the dimension field mapping to support public cloud d…

### DIFF
--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.8.8"
+  changes:
+    - description: Modifed the dimension field mapping to support public cloud deployment.
+      type: bugfix
+      link: tbd
 - version: "1.8.7"
   changes:
     - description: Added metrictype for the fields of queue datastream.

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Modifed the dimension field mapping to support public cloud deployment.
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/6155
 - version: "1.8.7"
   changes:
     - description: Added metrictype for the fields of queue datastream.

--- a/packages/rabbitmq/data_stream/connection/fields/agent.yml
+++ b/packages/rabbitmq/data_stream/connection/fields/agent.yml
@@ -8,6 +8,7 @@
     - name: account.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
 
@@ -16,6 +17,7 @@
     - name: availability_zone
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
@@ -47,13 +49,13 @@
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
-      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/rabbitmq/data_stream/exchange/fields/agent.yml
+++ b/packages/rabbitmq/data_stream/exchange/fields/agent.yml
@@ -8,6 +8,7 @@
     - name: account.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
 
@@ -16,6 +17,7 @@
     - name: availability_zone
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
@@ -47,13 +49,13 @@
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
-      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/rabbitmq/data_stream/node/fields/agent.yml
+++ b/packages/rabbitmq/data_stream/node/fields/agent.yml
@@ -8,6 +8,7 @@
     - name: account.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
 
@@ -16,6 +17,7 @@
     - name: availability_zone
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
@@ -47,13 +49,13 @@
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
-      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/rabbitmq/data_stream/queue/fields/agent.yml
+++ b/packages/rabbitmq/data_stream/queue/fields/agent.yml
@@ -8,6 +8,7 @@
     - name: account.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
 
@@ -16,6 +17,7 @@
     - name: availability_zone
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
@@ -47,13 +49,13 @@
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
-      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: rabbitmq
 title: RabbitMQ Logs and Metrics
-version: 1.8.7
+version: 1.8.8
 license: basic
 description: Collect and parse logs from RabbitMQ servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug


## What does this PR do?

This PR updates the dimension fields to support public cloud deployment for rabbitmq.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues


- Relates #6031 

