### PR TITLE
[Cockroachdb] modify the dimension field mapping to support public clou…

### DIFF
--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.2"
+  changes:
+    - description: Modifed the dimension field mapping to support public cloud deployment.
+      type: bugfix
+      link: tbd
 - version: "1.3.1"
   changes:
     - description: Fix a bug for one dimension field

--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Modifed the dimension field mapping to support public cloud deployment.
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/6156
 - version: "1.3.1"
   changes:
     - description: Fix a bug for one dimension field

--- a/packages/cockroachdb/data_stream/status/fields/agent.yml
+++ b/packages/cockroachdb/data_stream/status/fields/agent.yml
@@ -8,12 +8,14 @@
     - name: account.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
@@ -45,13 +47,13 @@
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
-      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/cockroachdb/data_stream/status/manifest.yml
+++ b/packages/cockroachdb/data_stream/status/manifest.yml
@@ -58,3 +58,8 @@ streams:
         show_user: true
     title: Status
     description: Collect CockroachDB status metrics
+
+elasticsearch:
+  index_template:
+    settings:
+      index.mapping.dimension_fields.limit: 32

--- a/packages/cockroachdb/manifest.yml
+++ b/packages/cockroachdb/manifest.yml
@@ -1,6 +1,6 @@
 name: cockroachdb
 title: CockroachDB Metrics
-version: 1.3.1
+version: 1.3.2
 release: ga
 description: Collect metrics from CockroachDB servers with Elastic Agent.
 type: integration

--- a/packages/cockroachdb/manifest.yml
+++ b/packages/cockroachdb/manifest.yml
@@ -20,7 +20,7 @@ categories:
   - observability
   - datastore
 conditions:
-  kibana.version: "^8.4.0"
+  kibana.version: "^8.6.0"
 vars:
   - name: hosts
     type: text


### PR DESCRIPTION

- Bug


## What does this PR do?

This PR updates the dimension fields to support public cloud deployment for cockroachdb TSDB.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues


- Relates #6031 