### PR TITLE
[Airflow] Modifed the dimension field mapping to support public cloud d…

### DIFF
--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.0.5
+  changes:
+    - description: Modifed the dimension field mapping to support public cloud deployment.
+      type: bugfix
+      link: tbd
 - version: 0.0.4
   changes:
     - description: Added dimensions fields to enable TSDB.

--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Modifed the dimension field mapping to support public cloud deployment.
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/6157
 - version: 0.0.4
   changes:
     - description: Added dimensions fields to enable TSDB.

--- a/packages/airflow/data_stream/statsd/fields/agent.yml
+++ b/packages/airflow/data_stream/statsd/fields/agent.yml
@@ -8,12 +8,14 @@
     - name: account.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
       example: 666777888999
     - name: availability_zone
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
@@ -45,13 +47,13 @@
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
     - name: project.id
       type: keyword
       description: Name of the project in Google Cloud.
-      dimension: true
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -1,6 +1,6 @@
 name: airflow
 title: Airflow
-version: 0.0.4
+version: 0.0.5
 description: Airflow Integration.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
- Bug

## What does this PR do?

Modify the dimension field mapping to support public cloud deployment for airflow.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues

- Relates #6031 


