### PR TITLE
Enable Request tracer on System and Windows integrations

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.0"
+  changes:
+    - description: Add a new flag to enable request tracing
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6163
 - version: "1.27.1"
   changes:
     - description: Remove managed tag.

--- a/packages/system/data_stream/application/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/application/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: "2"
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 {{#unless token}}
 {{#if username}}
 {{#if password}}

--- a/packages/system/data_stream/security/_dev/test/system/test-default-config.yml
+++ b/packages/system/data_stream/security/_dev/test/system/test-default-config.yml
@@ -6,5 +6,6 @@ vars:
   username: test
   password: test
   preserve_original_event: true
+  enable_request_tracer: true
 data_stream:
   vars: ~

--- a/packages/system/data_stream/security/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/security/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: "2"
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 {{#unless token}}
 {{#if username}}
 {{#if password}}

--- a/packages/system/data_stream/system/agent/stream/httpjson.yml.hbs
+++ b/packages/system/data_stream/system/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: "2"
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 {{#unless token}}
 {{#if username}}
 {{#if password}}

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -63,7 +63,7 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. The logs are part of agent's diagnostics dump. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: username
             type: text
             title: Splunk REST API Username

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -63,7 +63,7 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. The logs are part of agent's diagnostics dump. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. The logs are part of agent's diagnostics dump under `logs/httpjson/http-request-trace-<InputInstanceId>.ndjson`. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: username
             type: text
             title: Splunk REST API Username

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.27.1
+version: 1.28.0
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
@@ -57,6 +57,13 @@ policy_templates:
             show_user: true
             required: true
             default: https://server.example.com:8089
+          - name: enable_request_tracer
+            type: bool
+            title: Enable request tracing
+            multi: false
+            required: false
+            show_user: false
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: username
             type: text
             title: Splunk REST API Username

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.0"
+  changes:
+    - description: Add a new flag to enable request tracing
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6162
 - version: "1.20.1"
   changes:
     - description: Add `event.category` and `event.type` to Sysmon events

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add a new flag to enable request tracing
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6162
+      link: https://github.com/elastic/integrations/pull/6163
 - version: "1.20.1"
   changes:
     - description: Add `event.category` and `event.type` to Sysmon events

--- a/packages/windows/data_stream/forwarded/_dev/test/system/test-default-config.yml
+++ b/packages/windows/data_stream/forwarded/_dev/test/system/test-default-config.yml
@@ -4,6 +4,7 @@ vars:
   url: http://{{Hostname}}:{{Port}}
   username: test
   password: test
+  enable_request_tracer: true
 data_stream:
   vars:
     preserve_original_event: true

--- a/packages/windows/data_stream/forwarded/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/forwarded/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: "2"
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 {{#unless token}}
 {{#if username}}
 {{#if password}}

--- a/packages/windows/data_stream/powershell/_dev/test/system/test-default-config.yml
+++ b/packages/windows/data_stream/powershell/_dev/test/system/test-default-config.yml
@@ -4,6 +4,7 @@ vars:
   url: http://{{Hostname}}:{{Port}}
   username: test
   password: test
+  enable_request_tracer: true
 data_stream:
   vars:
     preserve_original_event: true

--- a/packages/windows/data_stream/powershell/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/powershell/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: "2"
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 {{#unless token}}
 {{#if username}}
 {{#if password}}

--- a/packages/windows/data_stream/powershell_operational/_dev/test/system/test-default-config.yml
+++ b/packages/windows/data_stream/powershell_operational/_dev/test/system/test-default-config.yml
@@ -4,6 +4,7 @@ vars:
   url: http://{{Hostname}}:{{Port}}
   username: test
   password: test
+  enable_request_tracer: true
 data_stream:
   vars:
     preserve_original_event: true

--- a/packages/windows/data_stream/powershell_operational/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/powershell_operational/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: "2"
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 {{#unless token}}
 {{#if username}}
 {{#if password}}

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/system/test-default-config.yml
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/system/test-default-config.yml
@@ -4,6 +4,7 @@ vars:
   url: http://{{Hostname}}:{{Port}}
   username: test
   password: test
+  enable_request_tracer: true
 data_stream:
   vars:
     preserve_original_event: true

--- a/packages/windows/data_stream/sysmon_operational/agent/stream/httpjson.yml.hbs
+++ b/packages/windows/data_stream/sysmon_operational/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: "2"
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 {{#unless token}}
 {{#if username}}
 {{#if password}}

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.20.1
+version: 1.21.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:
@@ -15,7 +15,7 @@ format_version: 1.0.0
 license: basic
 release: ga
 conditions:
-  kibana.version: "^8.4.0"
+  kibana.version: "^8.7.1"
 screenshots:
   - src: /img/metricbeat-windows-service.png
     title: metricbeat windows service
@@ -43,6 +43,13 @@ policy_templates:
             show_user: true
             required: true
             default: https://server.example.com:8089
+          - name: enable_request_tracer
+            type: bool
+            title: Enable request tracing
+            multi: false
+            required: false
+            show_user: false
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: username
             type: text
             title: Splunk REST API Username

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -49,7 +49,7 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. The logs are part of agent's diagnostics dump. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: username
             type: text
             title: Splunk REST API Username

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -49,7 +49,7 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. The logs are part of agent's diagnostics dump. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. The logs are part of agent's diagnostics dump under `logs/httpjson/http-request-trace-<InputInstanceId>.ndjson`. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
           - name: username
             type: text
             title: Splunk REST API Username


### PR DESCRIPTION
## What does this PR do?

This PR enables request tracer on integrations with `httpjson` input. 

Sets the minimum Kibana version to `8.7.1`

Enables the request tracer in system tests.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Reviewer's checklist
- [ ] system
- [ ] windows

## Related

- https://github.com/elastic/integrations/pull/5641
