### PR TITLE
trellix_epo_cloud: ensure API keys are not logged

### DIFF
--- a/packages/trellix_epo_cloud/changelog.yml
+++ b/packages/trellix_epo_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Ensure API key does not leak into debug logs.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6179
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/trellix_epo_cloud/data_stream/device/agent/stream/input.yml.hbs
+++ b/packages/trellix_epo_cloud/data_stream/device/agent/stream/input.yml.hbs
@@ -21,6 +21,9 @@ state:
   api_key: {{api_key}}
   batch_size: {{batch_size}}
   want_more: false
+redact:
+  fields:
+    - api_key
 program: |
   request("GET", (
     has(state.want_more) && !state.want_more

--- a/packages/trellix_epo_cloud/data_stream/event/agent/stream/input.yml.hbs
+++ b/packages/trellix_epo_cloud/data_stream/event/agent/stream/input.yml.hbs
@@ -22,6 +22,9 @@ state:
   batch_size: {{batch_size}}
   want_more: false
   initial_interval: {{initial_interval}}
+redact:
+  fields:
+    - api_key
 program: |
   (
     has(state.want_more) && !state.want_more ?

--- a/packages/trellix_epo_cloud/data_stream/group/agent/stream/input.yml.hbs
+++ b/packages/trellix_epo_cloud/data_stream/group/agent/stream/input.yml.hbs
@@ -21,6 +21,9 @@ state:
   api_key: {{api_key}}
   batch_size: {{batch_size}}
   want_more: false
+redact:
+  fields:
+    - api_key
 program: |
   request("GET", (
     has(state.want_more) && !state.want_more

--- a/packages/trellix_epo_cloud/manifest.yml
+++ b/packages/trellix_epo_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.6.0
 name: trellix_epo_cloud
 title: Trellix ePO Cloud
-version: 0.1.0
+version: 0.1.1
 source:
   license: Elastic-2.0
 description: Collect logs from Trellix ePO Cloud with Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

During debug logging complete state is logged. Currently this will include the `api_key` field. So let the redactor know to mask this.

Example log lines:

Relevant text is `"api_key\":\"*\"`

before call to CEL:
```
{"log.level":"debug","@timestamp":"2023-05-12T01:24:30.674Z","message":"request state","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"service.name":"filebeat","id":"cel-trellix_epo_cloud.device-3ea71031-938c-4944-b2e6-bd49efbff32e","input_url":"http://elastic-package-service_trellix_epo_cloud_1:8090","cel":{"ecs.version":"1.6.0","state":"{\"api_key\":\"*\",\"batch_size\":1000,\"url\":\"http://elastic-package-service_trellix_epo_cloud_1:8090\",\"want_more\":false}"},"log.logger":"input.cel","log.origin":{"file.line":209,"file.name":"cel/input.go"},"input_source":"http://elastic-package-service_trellix_epo_cloud_1:8090","ecs.version":"1.6.0"}
```

returned value:
```
{"log.level":"debug","@timestamp":"2023-05-12T01:24:30.678Z","message":"response state","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"log.logger":"input.cel","log.origin":{"file.line":213,"file.name":"cel/input.go"},"service.name":"filebeat","id":"cel-trellix_epo_cloud.device-3ea71031-938c-4944-b2e6-bd49efbff32e","input_url":"http://elastic-package-service_trellix_epo_cloud_1:8090","cel":{"ecs.version":"1.6.0","state":"{\"api_key\":\"*\",\"batch_size\":1000,\"events\":[{\"message\":\"{\\\"attributes\\\":{\\\"agentGuid\\\":\\\"3AF594B1-00A0-AA00-87C6-005056833A00\\\",\\\"agentPlatform\\\":\\\"LINUX\\\",\\\"agentState\\\":0,\\\"agentVersion\\\":\\\"5.7.9.139\\\",\\\"computerName\\\":\\\"localhost\\\",\\\"cpuSpeed\\\":2100,\\\"cpuType\\\":\\\"Intel(R) Xeon(R) CPU E5-2620 v2 @ 2.10GHz\\\",\\\"domainName\\\":\\\"(none)\\\",\\\"excludedTags\\\":\\\"\\\",\\\"ipAddress\\\":\\\"1.128.0.0\\\",\\\"ipHostName\\\":\\\"localhost\\\",\\\"isPortable\\\":\\\"non-portable\\\",\\\"lastUpdate\\\":\\\"2023-04-17T07:38:35.563+00:00\\\",\\\"macAddress\\\":\\\"00005E005300\\\",\\\"managed\\\":\\\"1\\\",\\\"managedState\\\":1,\\\"name\\\":\\\"localhost\\\",\\\"nodeCreatedDate\\\":\\\"2023-03-29T12:06:05.877+00:00\\\",\\\"nodePath\\\":null,\\\"numOfCpu\\\":4,\\\"osBuildNumber\\\":0,\\\"osPlatform\\\":\\\"Server\\\",\\\"osType\\\":\\\"Linux\\\",\\\"osVersion\\\":\\\"3.10\\\",\\\"parentId\\\":123456,\\\"subnetAddress\\\":\\\"\\\",\\\"systemBootTime\\\":\\\"2023-03-24T16:54:27.000+00:00\\\",\\\"systemManufacturer\\\":\\\"VMware, Inc.\\\",\\\"systemModel\\\":\\\"VMware Virtual Platform\\\",\\\"systemRebootPending\\\":0,\\\"systemSerialNumber\\\":\\\"VMware-12 02 1a a1 1c 31 9c eb-0e a6 00 41 54 14 91 f5\\\",\\\"tags\\\":\\\"Deployment 2, Deployment, Server\\\",\\\"tenantId\\\":12345,\\\"totalPhysicalMemory\\\":12409634816,\\\"userName\\\":\\\"N/A\\\"},\\\"id\\\":\\\"123456\\\",\\\"links\\\":{\\\"self\\\":\\\"https://api.manage.trellix.com/epo/v2/devices/123456\\\"},\\\"relationships\\\":{\\\"installedProducts\\\":{\\\"links\\\":{\\\"related\\\":\\\"https://api.manage.trellix.com/epo/v2/devices/123456/installedProducts\\\",\\\"self\\\":\\\"https://api.manage.trellix.com/epo/v2/devices/123456/relationships/installedProducts\\\"}}},\\\"type\\\":\\\"devices\\\"}\"}],\"url\":\"http://elastic-package-service_trellix_epo_cloud_1:8090\",\"want_more\":false}"},"input_source":"http://elastic-package-service_trellix_epo_cloud_1:8090","ecs.version":"1.6.0"}
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

First set logging to DEBUG then run the system tests with `elastic-package` and obtain a diagnostics bundle to inspect.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #6029

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
