### PR TITLE
windows: set host.os.type and host.os.family in forwarded events

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Set `host.os.type` and `host.os.family` in forwarded events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.1"
   changes:
     - description: Improve regular expression search efficiency to allow parsing large events.

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-powershell-events.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-powershell-events.json-expected.json
@@ -14,7 +14,11 @@
                 "type": "start"
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "verbose"
@@ -72,7 +76,11 @@
                 "type": "info"
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -174,7 +182,11 @@
                 "type": "end"
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "verbose"
@@ -225,7 +237,11 @@
                 "type": "info"
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "verbose"

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-powershell-operational-events.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-powershell-operational-events.json-expected.json
@@ -14,7 +14,11 @@
                 "type": "start"
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "verbose"
@@ -72,7 +76,11 @@
                 "type": "info"
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -174,7 +182,11 @@
                 "type": "end"
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "verbose"
@@ -225,7 +237,11 @@
                 "type": "info"
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "verbose"

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1100.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1100.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1102.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1102.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1104.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1104.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1105.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-1105.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4670-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4670-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4674.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4674.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "DC01.contoso.local"
+                "name": "DC01.contoso.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "input": {
                 "type": "log"
@@ -115,7 +119,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4706-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4706-windowssrv2016.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4707-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4707-windowssrv2016.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4713-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4713-windowssrv2016.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4716-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4716-windowssrv2016.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4717-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4717-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6"
+                "name": "WIN-BVM4LI1L1Q6",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4718-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4718-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6"
+                "name": "WIN-BVM4LI1L1Q6",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4719-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4719-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4719.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4719.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4738.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4738.json-expected.json
@@ -20,7 +20,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12"
+                "name": "DC_TEST2k12",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4739-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4739-windowssrv2016.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4742.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4742.json-expected.json
@@ -20,7 +20,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST."
+                "name": "DC_TEST2k12.TEST.",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4743.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4743.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4744.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4744.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testdistlocal"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4745.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4745.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testdistlocal1"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4746.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4746.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testdistlocal1"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4747.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4747.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testdistlocal1"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4748.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4748.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testdistlocal1"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4749.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4749.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testglobal"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4750.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4750.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testglobal1"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4751.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4751.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testglobal1"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4752.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4752.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testglobal1"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4753.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4753.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testglobal1"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4759.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4759.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testuni"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4760.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4760.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testuni2"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4761.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4761.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testuni2"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4762.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4762.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testuni2"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4763.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4763.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "testuni2"
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4817-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4817-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4902-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4902-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4904-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4904-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4905-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4905-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4906-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4906-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4907-windowssrv2016.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-4907-windowssrv2016.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-BVM4LI1L1Q6.TEST.local"
+                "name": "WIN-BVM4LI1L1Q6.TEST.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4673.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4673.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4697.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4697.json-expected.json
@@ -28,7 +28,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4768.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4768.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4769.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4769.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4770.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4770.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4771.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4771.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4776.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4776.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4778.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4778.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4779.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012-4779.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "DC_TEST2k12.TEST.SAAS"
+                "name": "DC_TEST2k12.TEST.SAAS",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012r2-logon.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2012r2-logon.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -123,7 +127,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -220,7 +228,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -323,7 +335,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -420,7 +436,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -516,7 +536,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -612,7 +636,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -708,7 +736,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -804,7 +836,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -903,7 +939,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -1000,7 +1040,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -1103,7 +1147,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -1200,7 +1248,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -1297,7 +1349,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -1394,7 +1450,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -1491,7 +1551,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -1588,7 +1652,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -1685,7 +1753,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4722-account-enabled.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4722-account-enabled.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -108,7 +112,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4723-password-change.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4723-password-change.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -108,7 +112,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4724-password-reset.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4724-password-reset.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -108,7 +112,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4725-account-disabled.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4725-account-disabled.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -108,7 +112,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4726-account-deleted.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4726-account-deleted.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -109,7 +113,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4727.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4727.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "DnsUpdateProxy"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4728.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4728.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4729.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4729.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group2v2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4730.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4730.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group2v2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4731.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4731.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group1"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4732.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4732.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group1"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4733.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4733.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group1"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4734.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4734.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group1v1"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4735.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4735.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group1v1"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4737.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4737.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group2v2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4738-account-changed.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4738-account-changed.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4740-account-locked-out.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4740-account-locked-out.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4754.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4754.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "Test_group3"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4755.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4755.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "Test_group3v2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4756.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4756.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "Test_group3v2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4757.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4757.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "Test_group3v2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4758.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4758.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "Test_group3v2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4764.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4764.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "test_group2v2"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR.wlbeat.local"
+                "name": "WIN-41OB2LO92CR.wlbeat.local",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4767-account-unlocked.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4767-account-unlocked.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4781-account-renamed.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4781-account-renamed.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -111,7 +115,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4798.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4798.json-expected.json
@@ -27,7 +27,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4799.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-4799.json-expected.json
@@ -32,7 +32,11 @@
                 "name": "Administrators"
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-logoff.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2016-logoff.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -103,7 +107,11 @@
                 ]
             },
             "host": {
-                "name": "WIN-41OB2LO92CR"
+                "name": "WIN-41OB2LO92CR",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2019-4688-process-created.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2019-4688-process-created.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2019-4689-process-exited.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-windows2019-4689-process-exited.json-expected.json
@@ -26,7 +26,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -107,7 +111,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {
@@ -188,7 +196,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant"
+                "name": "vagrant",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "file": {

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-operational-events.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-operational-events.json-expected.json
@@ -64,7 +64,11 @@
                 ]
             },
             "host": {
-                "name": "Win2018Eval"
+                "name": "Win2018Eval",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "input": {
                 "type": "winlog"
@@ -169,6 +173,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -264,6 +274,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -337,6 +353,12 @@
                 "extension": "exe",
                 "name": "test.test.exe",
                 "path": "C:\\Users\\vagrant\\AppData\\Local\\Temp\\1\\go-build583768550\\b001\\test.test.exe"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -439,6 +461,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -538,6 +566,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -606,6 +640,12 @@
                 "type": [
                     "change"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -677,6 +717,12 @@
                 "extension": "dat",
                 "name": "lastalive0.dat",
                 "path": "C:\\Windows\\ServiceProfiles\\LocalService\\AppData\\Local\\lastalive0.dat"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -773,6 +819,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -876,6 +928,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -964,6 +1022,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -1064,6 +1128,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -1150,6 +1220,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -1251,6 +1327,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -1389,6 +1471,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -1487,6 +1575,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -1580,6 +1674,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -1681,6 +1781,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -1767,6 +1873,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -1867,6 +1979,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -1934,6 +2052,12 @@
                 "type": [
                     "change"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -2020,6 +2144,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -2116,6 +2246,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -2185,6 +2321,12 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -2250,6 +2392,12 @@
                 "type": [
                     "change"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -2364,6 +2512,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -2463,6 +2617,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -2609,6 +2769,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -2746,6 +2912,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -2895,6 +3067,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -3008,6 +3186,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -3157,6 +3341,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -3312,6 +3502,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -3405,6 +3601,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -3541,6 +3743,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -3637,6 +3845,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -3774,6 +3988,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -3866,6 +4086,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -3955,6 +4181,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -4085,6 +4317,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -4204,6 +4442,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -4276,6 +4520,12 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -4345,6 +4595,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -4470,6 +4726,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -4610,6 +4872,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -4755,6 +5023,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -4854,6 +5128,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -4994,6 +5274,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -5139,6 +5425,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -5215,6 +5507,12 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -5286,6 +5584,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -5373,6 +5677,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -5438,6 +5748,12 @@
                 "type": [
                     "start"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -5578,6 +5894,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -5710,6 +6032,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -5786,7 +6114,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -5954,6 +6286,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -6060,6 +6398,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -6204,6 +6548,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -6309,6 +6659,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -6430,6 +6786,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -6530,6 +6892,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -6621,6 +6989,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -6698,6 +7072,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -6771,6 +7151,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -6833,6 +7219,12 @@
                 "type": [
                     "end"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -6952,6 +7344,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -7060,6 +7458,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -7151,6 +7555,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -7217,6 +7627,12 @@
                 "type": [
                     "end"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -7336,6 +7752,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -7411,6 +7833,12 @@
                 "type": [
                     "start"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -7517,6 +7945,12 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -7593,6 +8027,12 @@
                     "connection",
                     "protocol"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -7673,6 +8113,12 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -7751,6 +8197,12 @@
                     "connection",
                     "protocol"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -7856,6 +8308,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -7993,6 +8451,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -8074,6 +8538,12 @@
                     "connection",
                     "protocol"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -8170,6 +8640,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -8250,6 +8726,12 @@
                     "connection",
                     "protocol"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -8360,6 +8842,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -8432,6 +8920,12 @@
                     "connection",
                     "protocol"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -8512,6 +9006,12 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -8589,6 +9089,12 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -8665,6 +9171,12 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -8740,6 +9252,12 @@
                     "connection",
                     "protocol"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -8819,6 +9337,12 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -8897,7 +9421,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -8978,7 +9506,11 @@
                 ]
             },
             "host": {
-                "name": "vagrant-2012-r2"
+                "name": "vagrant-2012-r2",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -9057,6 +9589,12 @@
                     "connection",
                     "protocol"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -9168,6 +9706,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -9258,6 +9802,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -9392,6 +9942,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -9542,6 +10098,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -9691,6 +10253,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -9835,6 +10403,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -9943,6 +10517,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -10049,6 +10629,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -10138,6 +10724,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -10273,6 +10865,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -10425,6 +11023,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -10566,6 +11170,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -10641,6 +11251,12 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -10713,6 +11329,12 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -10762,6 +11384,12 @@
                 "type": [
                     "end"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -10818,6 +11446,12 @@
                 "extension": "tmp",
                 "name": "fe823684-c940-49f2-a940-14b02cbafba9.tmp",
                 "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\fe823684-c940-49f2-a940-14b02cbafba9.tmp"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -10879,6 +11513,12 @@
                 "name": "162d4140-cfab-4d05-9c92-bca60515a622.tmp",
                 "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\162d4140-cfab-4d05-9c92-bca60515a622.tmp"
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -10939,6 +11579,12 @@
                 "name": "1450fedf-ac4c-4e35-b371-ed5d3bbe4776.tmp",
                 "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\1450fedf-ac4c-4e35-b371-ed5d3bbe4776.tmp"
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -10998,6 +11644,12 @@
                 "extension": "tmp",
                 "name": "37ed32e9-3c5f-4663-8457-c70743e9456d.tmp",
                 "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\37ed32e9-3c5f-4663-8457-c70743e9456d.tmp"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -11060,6 +11712,12 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -11115,6 +11773,12 @@
                 "extension": "tmp",
                 "name": "ecb9c915-c4c2-4600-a920-f2bc302990a8.tmp",
                 "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\nmmhkkegccagdldgiimedpiccmgmieda\\def\\ecb9c915-c4c2-4600-a920-f2bc302990a8.tmp"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -11196,6 +11860,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -11338,6 +12008,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -11438,6 +12114,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -11580,6 +12262,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -11718,6 +12406,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -11839,6 +12533,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -11983,6 +12683,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -12108,6 +12814,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -12193,6 +12905,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -12328,6 +13046,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -12442,6 +13166,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -12526,6 +13256,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -12660,6 +13396,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -12806,6 +13548,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -12929,6 +13677,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -13065,6 +13819,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -13190,6 +13950,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -13318,6 +14084,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -13470,6 +14242,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -13610,6 +14388,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -13747,6 +14531,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -13890,6 +14680,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -14035,6 +14831,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -14137,6 +14939,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -14279,6 +15087,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -14374,6 +15188,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -14481,6 +15301,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -14575,6 +15401,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -14671,6 +15503,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -14764,6 +15602,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -14861,6 +15705,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -14950,6 +15800,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -15050,6 +15906,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -15144,6 +16006,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -15251,6 +16119,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -15347,6 +16221,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -15442,6 +16322,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -15536,6 +16422,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -15679,6 +16571,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -15794,6 +16692,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -15897,6 +16801,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -16033,6 +16943,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -16128,6 +17044,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -16220,6 +17142,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -16362,6 +17290,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -16459,6 +17393,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -16552,6 +17492,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -16691,6 +17637,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -16839,6 +17791,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -16936,6 +17894,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -17077,6 +18041,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -17221,6 +18191,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -17368,6 +18344,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -17506,6 +18488,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -17646,6 +18634,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -18001,6 +18995,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -18178,6 +19178,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -18277,6 +19283,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -18375,6 +19387,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -18453,6 +19471,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -18543,6 +19567,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -18685,6 +19715,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -18833,6 +19869,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -18933,6 +19975,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -19069,6 +20117,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -19221,6 +20275,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -19364,6 +20424,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -19489,6 +20555,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -19597,6 +20669,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -19698,6 +20776,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -19835,6 +20919,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -19949,6 +21039,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -20095,6 +21191,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -20192,6 +21294,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -20286,6 +21394,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -20377,6 +21491,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -20454,6 +21574,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -20524,6 +21650,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -20593,6 +21725,12 @@
                     "protocol",
                     "info"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -20688,6 +21826,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -20780,6 +21924,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -20846,6 +21996,12 @@
                 "type": [
                     "start"
                 ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -20945,7 +22101,11 @@
                 ]
             },
             "host": {
-                "name": "DESKTOP-I9CQVAQ"
+                "name": "DESKTOP-I9CQVAQ",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -21002,6 +22162,12 @@
                 "directory": "C:\\Windows\\System32\\LogFiles\\Scm",
                 "name": "8b34f644-f627-47e7-98e0-957ba1c5eb6d",
                 "path": "C:\\Windows\\System32\\LogFiles\\Scm\\8b34f644-f627-47e7-98e0-957ba1c5eb6d"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -21096,6 +22262,12 @@
                     "product": "Microsoft« Windows« Operating System"
                 }
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -21164,6 +22336,12 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -21221,7 +22399,11 @@
                 ]
             },
             "host": {
-                "name": "DESKTOP-I9CQVAQ"
+                "name": "DESKTOP-I9CQVAQ",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -21295,6 +22477,12 @@
                 "extension": "tmp",
                 "name": "ee4a6e45-bffd-49f4-98ae-32aebcc890b5.tmp",
                 "path": "C:\\Users\\vagrant\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Storage\\ext\\gfdkimpbcpahaombhbimeihdjnejgicl\\def\\ee4a6e45-bffd-49f4-98ae-32aebcc890b5.tmp"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"
@@ -21407,6 +22595,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -21487,6 +22681,12 @@
                 "name": "lastalive1.dat",
                 "path": "C:\\Windows\\ServiceState\\EventLog\\Data\\lastalive1.dat"
             },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
             "log": {
                 "level": "information"
             },
@@ -21560,6 +22760,12 @@
                 "extension": "000",
                 "name": "OLDCACHE.000",
                 "path": "C:\\ProgramData\\Microsoft\\Windows\\DeviceMetadataCache\\OLDCACHE.000"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
             },
             "log": {
                 "level": "information"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
@@ -14,6 +14,15 @@ processors:
       name: '{{ IngestPipeline "sysmon_operational" }}'
       if: ctx?.winlog?.channel != null && ctx?.winlog?.channel == "Microsoft-Windows-Sysmon/Operational"
 
+  - set:
+      field: host.os.type
+      value: windows
+      override: false
+  - set:
+      field: host.os.family
+      value: windows
+      override: false
+
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:

--- a/packages/windows/data_stream/forwarded/sample_event.json
+++ b/packages/windows/data_stream/forwarded/sample_event.json
@@ -1,12 +1,11 @@
 {
     "@timestamp": "2020-05-13T09:04:04.755Z",
     "agent": {
-        "ephemeral_id": "17601e61-e945-4f5c-aec5-4a2d491f3b00",
-        "hostname": "docker-fleet-agent",
-        "id": "0d57cbc7-6410-455a-840c-08fd44507a26",
+        "ephemeral_id": "5c17ad81-b99e-42f1-93f6-bbbe10bbb567",
+        "id": "3456d621-8d2b-4347-9f0d-c80061df73d7",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "7.17.0"
+        "version": "8.7.1"
     },
     "data_stream": {
         "dataset": "windows.forwarded",
@@ -17,24 +16,28 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "0d57cbc7-6410-455a-840c-08fd44507a26",
+        "id": "3456d621-8d2b-4347-9f0d-c80061df73d7",
         "snapshot": false,
-        "version": "7.17.0"
+        "version": "8.7.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "process",
         "code": "4105",
-        "created": "2022-03-31T08:40:37.999Z",
+        "created": "2023-05-12T02:24:42.259Z",
         "dataset": "windows.forwarded",
-        "ingested": "2022-03-31T08:40:39Z",
+        "ingested": "2023-05-12T02:24:43Z",
         "kind": "event",
         "original": "\u003cEvent xmlns='http://schemas.microsoft.com/win/2004/08/events/event'\u003e\u003cSystem\u003e\u003cProvider Name='Microsoft-Windows-PowerShell' Guid='{a0c1853b-5c40-4b15-8766-3cf1c58f985a}'/\u003e\u003cEventID\u003e4105\u003c/EventID\u003e\u003cVersion\u003e1\u003c/Version\u003e\u003cLevel\u003e5\u003c/Level\u003e\u003cTask\u003e102\u003c/Task\u003e\u003cOpcode\u003e15\u003c/Opcode\u003e\u003cKeywords\u003e0x0\u003c/Keywords\u003e\u003cTimeCreated SystemTime='2020-05-13T09:04:04.755232500Z'/\u003e\u003cEventRecordID\u003e790\u003c/EventRecordID\u003e\u003cCorrelation ActivityID='{dd68516a-2930-0000-5962-68dd3029d601}'/\u003e\u003cExecution ProcessID='4204' ThreadID='1476'/\u003e\u003cChannel\u003eMicrosoft-Windows-PowerShell/Operational\u003c/Channel\u003e\u003cComputer\u003evagrant\u003c/Computer\u003e\u003cSecurity UserID='S-1-5-21-1350058589-2282154016-2764056528-1000'/\u003e\u003c/System\u003e\u003cEventData\u003e\u003cData Name='ScriptBlockId'\u003ef4a378ab-b74f-41a7-a5ef-6dd55562fdb9\u003c/Data\u003e\u003cData Name='RunspaceId'\u003e9c031e5c-8d5a-4b91-a12e-b3624970b623\u003c/Data\u003e\u003c/EventData\u003e\u003c/Event\u003e",
         "provider": "Microsoft-Windows-PowerShell",
         "type": "start"
     },
     "host": {
-        "name": "vagrant"
+        "name": "vagrant",
+        "os": {
+            "family": "windows",
+            "type": "windows"
+        }
     },
     "input": {
         "type": "httpjson"

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.21.1
+version: 1.22.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Set `host.os.type` and `host.os.family` to windows in forwarded events.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6162

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
