### PR TITLE
Osquery_manager: Resolve mapping conflicts for user.id, user.group.id, group.id

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.3"
+  changes:
+    - description: Resolve mapping conflicts for user.id, user.group.id, group.id
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10000
 - version: "1.7.2"
   changes:
     - description: Fix mapping conflicts

--- a/packages/osquery_manager/data_stream/result/fields/ecs.yml
+++ b/packages/osquery_manager/data_stream/result/fields/ecs.yml
@@ -126,6 +126,8 @@
 - external: ecs
   name: file.x509.public_key_size
 - external: ecs
+  name: group.id
+- external: ecs
   name: host.disk.read.bytes
 - external: ecs
   name: host.disk.write.bytes
@@ -162,9 +164,9 @@
 - external: ecs
   name: network.forwarded_ip
 - external: ecs
-  name: network.packets
-- external: ecs
   name: network.iana_number
+- external: ecs
+  name: network.packets
 - external: ecs
   name: network.type
 - external: ecs
@@ -451,6 +453,10 @@
   name: tls.server.x509.public_key_size
 - external: ecs
   name: url.port
+- external: ecs
+  name: user.group.id
+- external: ecs
+  name: user.id
 - external: ecs
   name: vulnerability.score.base
 - external: ecs

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.7.2
+version: 1.7.3
 license: basic
 description: Deploy osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds mappings for ECS user.id, user.group.id, group.id

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/4507


## Screenshots

Ran the ```select * from users``` query with default ECS mappings, verified no more mapping conflicts 

<img width="1660" alt="Screenshot 2023-05-12 at 3 24 50 PM" src="https://github.com/elastic/integrations/assets/872351/4b049c3e-7dab-46ad-ac16-576b8078f026">

The fields are mapped to ```keyword``` type
<img width="518" alt="Screenshot 2023-05-12 at 3 20 45 PM" src="https://github.com/elastic/integrations/assets/872351/f7ff7feb-c27d-431a-9d76-5f458e88e748">

The documents are stored with all the data
<img width="468" alt="Screenshot 2023-05-12 at 3 21 18 PM" src="https://github.com/elastic/integrations/assets/872351/0244494d-7361-47d5-b194-ae1cb80b5400">
