### PR TITLE
[AWS] Fix typo in field name causing erroneous timestamp detection on s3access

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.6"
+  changes:
+    - description: Fix typo in field name causing erroneous timestamp detection on the s3access data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6213
 - version: "1.34.5"
   changes:
     - description: Migrate AWS Lambda metrics dashboard visualizations to lenses.

--- a/packages/aws/data_stream/s3access/_dev/test/pipeline/test-s3-server-access.log-expected.json
+++ b/packages/aws/data_stream/s3access/_dev/test/pipeline/test-s3-server-access.log-expected.json
@@ -1,6 +1,7 @@
 {
     "expected": [
         {
+            "@timestamp": "2019-08-01T00:24:41.000Z",
             "aws": {
                 "s3access": {
                     "authentication_type": "AuthHeader",
@@ -108,6 +109,7 @@
             }
         },
         {
+            "@timestamp": "2019-08-01T00:24:42.000Z",
             "aws": {
                 "s3access": {
                     "authentication_type": "AuthHeader",
@@ -215,6 +217,7 @@
             }
         },
         {
+            "@timestamp": "2019-08-01T00:24:43.000Z",
             "aws": {
                 "s3access": {
                     "authentication_type": "AuthHeader",
@@ -323,6 +326,7 @@
             }
         },
         {
+            "@timestamp": "2019-08-01T00:24:43.000Z",
             "aws": {
                 "s3access": {
                     "authentication_type": "AuthHeader",
@@ -430,6 +434,7 @@
             }
         },
         {
+            "@timestamp": "2019-09-10T15:11:07.000Z",
             "aws": {
                 "s3access": {
                     "authentication_type": "AuthHeader",
@@ -509,6 +514,7 @@
             }
         },
         {
+            "@timestamp": "2019-09-19T17:06:39.000Z",
             "aws": {
                 "s3access": {
                     "authentication_type": "AuthHeader",
@@ -588,6 +594,7 @@
             }
         },
         {
+            "@timestamp": "2021-07-14T18:57:31.000Z",
             "aws": {
                 "s3access": {
                     "authentication_type": "AuthHeader",

--- a/packages/aws/data_stream/s3access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/s3access/elasticsearch/ingest_pipeline/default.yml
@@ -83,7 +83,7 @@ processors:
   # Parse the date included in s3 access logs
   #
   - date:
-      field: _temp_.s3access_time'
+      field: _temp_.s3access_time
       target_field: '@timestamp'
       ignore_failure: true
       formats:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.34.5
+version: 1.34.6
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Fix a small typo in a field name.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
## Author's Checklist

- [ ]
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
## How to test this PR locally
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
## Related issues

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-
-->


<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
## Screenshots

-->
