### PR TITLE
Added additional dimension fields for status datastream

### DIFF
--- a/packages/influxdb/changelog.yml
+++ b/packages/influxdb/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.3"
+  changes:
+    - description: Added additional dimension fields for status datastream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.4.2"
   changes:
     - description: Modifed the dimension field mapping to support public cloud deployment.

--- a/packages/influxdb/data_stream/status/fields/fields.yml
+++ b/packages/influxdb/data_stream/status/fields/fields.yml
@@ -21,6 +21,10 @@
           type: keyword
           # Reason to add as a dimension field: To support multiple orgs
           dimension: true
+        - name: level
+          type: keyword
+          # Reason to add as a dimension field: To support multiple levels
+          dimension: true
         - name: job
           type: keyword
           description: Type of the job

--- a/packages/influxdb/docs/README.md
+++ b/packages/influxdb/docs/README.md
@@ -57,6 +57,7 @@ Status metrics include details of memory usage, OS thread usage, query statistic
 | influxdb.status.label.handler | Request handler. | keyword |  |  |
 | influxdb.status.label.id |  | keyword |  |  |
 | influxdb.status.label.job | Type of the job | keyword |  |  |
+| influxdb.status.label.level |  | keyword |  |  |
 | influxdb.status.label.method | Type of service operation | keyword |  |  |
 | influxdb.status.label.op | Extended information related to various operations | keyword |  |  |
 | influxdb.status.label.quantile | Number that indicates the histogram quantile value. | keyword |  |  |

--- a/packages/influxdb/manifest.yml
+++ b/packages/influxdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: influxdb
 title: "InfluxDb"
-version: 0.4.2
+version: 0.4.3
 license: basic
 description: "Collect metrics from Influxdb database"
 type: integration


### PR DESCRIPTION

- Bug

## What does this PR do?

Adds missing dimension files for the influxdb.status datastream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

https://github.com/elastic/integrations/issues/6224


