### PR TITLE
[Kubernetes] Update version to fix bug on scheduler and proxy dashboards

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -8,7 +8,7 @@
   changes:
     - description: Fix proxy and scheduler visualization with missing sort field.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/6221
+      link: https://github.com/elastic/integrations/pull/6233
 - version: "1.39.0"
   changes:
     - description: Remove container.name as a dimension.

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,9 +1,4 @@
 # newer versions go on top
-- version: "1.40.0-beta"
-  changes:
-    - description: Enable TSDS for metrics data_streams, except events for beta testing
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/6159
 - version: "1.39.1"
   changes:
     - description: Fix proxy and scheduler visualization with missing sort field.

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,14 +1,14 @@
 # newer versions go on top
-- version: "1.40.0-beta.1"
-  changes:
-    - description: Fix proxy and scheduler visualization with missing sort field.
-      type: bugfix
-      link: https://github.com/elastic/integrations/pull/6221
 - version: "1.40.0-beta"
   changes:
     - description: Enable TSDS for metrics data_streams, except events for beta testing
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6159
+- version: "1.39.1"
+  changes:
+    - description: Fix proxy and scheduler visualization with missing sort field.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6221
 - version: "1.39.0"
   changes:
     - description: Remove container.name as a dimension.

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.40.0-beta
+version: 1.39.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent (TSDB Beta).
 type: integration

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.40.0-beta.1
+version: 1.40.0-beta
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent (TSDB Beta).
 type: integration


### PR DESCRIPTION
## What does this PR do?

This is the follow up to https://github.com/elastic/integrations/pull/6221

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
