### PR TITLE
[Kubernetes][Dashboards] Fix missing sort field on proxy and scheduler dashboards

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.39.1"
+  changes:
+    - description: Fix proxy and scheduler visualization with missing sort field.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6221
 - version: "1.39.0"
   changes:
     - description: Remove container.name as a dimension.

--- a/packages/kubernetes/kibana/dashboard/kubernetes-5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
@@ -1581,11 +1581,15 @@
                                                 "43097f7a-e478-47bc-81c1-7541bd899d46X0": {
                                                     "customLabel": true,
                                                     "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.proxy.client.request.duration.us.sum: *"
+                                                    },
                                                     "isBucketed": false,
                                                     "label": "Part of Average latency s",
                                                     "operationType": "last_value",
                                                     "params": {
-                                                        "emptyAsNull": false
+                                                        "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "kubernetes.proxy.client.request.duration.us.sum"
@@ -1593,11 +1597,15 @@
                                                 "43097f7a-e478-47bc-81c1-7541bd899d46X1": {
                                                     "customLabel": true,
                                                     "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.proxy.client.request.duration.us.count: *"
+                                                    },
                                                     "isBucketed": false,
                                                     "label": "Part of Average latency s",
                                                     "operationType": "last_value",
                                                     "params": {
-                                                        "emptyAsNull": false
+                                                        "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "kubernetes.proxy.client.request.duration.us.count"
@@ -1622,7 +1630,7 @@
                                                                 1000
                                                             ],
                                                             "location": {
-                                                                "max": 112,
+                                                                "max": 126,
                                                                 "min": 0
                                                             },
                                                             "name": "divide",

--- a/packages/kubernetes/kibana/dashboard/kubernetes-f5ab5510-9c94-11e9-94fd-c91206cd5249.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-f5ab5510-9c94-11e9-94fd-c91206cd5249.json
@@ -341,9 +341,6 @@
                 "type": "lens",
                 "version": "8.6.0"
             },
-
-
-
             {
                 "embeddableConfig": {
                     "attributes": {
@@ -3345,11 +3342,15 @@
                                                 "43097f7a-e478-47bc-81c1-7541bd899d46X0": {
                                                     "customLabel": true,
                                                     "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.scheduler.client.request.duration.us.sum: *"
+                                                    },
                                                     "isBucketed": false,
                                                     "label": "Part of Average latency in ms",
                                                     "operationType": "last_value",
                                                     "params": {
-                                                        "emptyAsNull": false
+                                                        "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "kubernetes.scheduler.client.request.duration.us.sum"
@@ -3357,11 +3358,15 @@
                                                 "43097f7a-e478-47bc-81c1-7541bd899d46X1": {
                                                     "customLabel": true,
                                                     "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.scheduler.client.request.duration.us.count: *"
+                                                    },
                                                     "isBucketed": false,
                                                     "label": "Part of Average latency in ms",
                                                     "operationType": "last_value",
                                                     "params": {
-                                                        "emptyAsNull": false
+                                                        "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "kubernetes.scheduler.client.request.duration.us.count"
@@ -3386,7 +3391,7 @@
                                                                 1000
                                                             ],
                                                             "location": {
-                                                                "max": 120,
+                                                                "max": 134,
                                                                 "min": 0
                                                             },
                                                             "name": "divide",

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.39.0
+version: 1.39.1
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Backport the fix https://github.com/elastic/integrations/pull/6221 to the 1.39 version as was suggested in https://github.com/elastic/integrations/pull/6221#discussion_r1195115705

steps used to create this backport PR:
```
git branch backport-kubernetes-1.39 a02e91e0a7a63d4b94f421f770c7c9b68acdc98f
git cherry-pick 2e7c914d3cfc86020f9e6c6432e183448bbae5f3
<fix conflicts>
git cherry-pick --continue
git push -u origin backport-kubernetes-1.39             
<create remote branch - did it manually from the a02e91e0a7a63d4b94f421f770c7c9b68acdc98f commit>
open a PR against elastic/backport-kubernetes-1.39 
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

Proxy visualisation after this commit:
<img width="1282" alt="Screenshot 2023-05-17 at 15 51 12" src="https://github.com/elastic/integrations/assets/28299531/5fd83555-d802-45ef-b97e-272ed1a849d9">

scheduler:
<img width="1278" alt="Screenshot 2023-05-17 at 15 53 24" src="https://github.com/elastic/integrations/assets/28299531/9e389385-235e-4a48-9a95-155aa3b55c72">

