### PR TITLE
Fix dashboard issue with integration nginx_ingress_controller

### DIFF
--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix dashboard by replacing type for nginx_ingress_controller.access.upstream.name from `text` to `keyword`.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6249
 - version: "1.7.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.2"
+  changes:
+    - description: Fix dashboard by replacing type for nginx_ingress_controller.access.upstream.name from `text` to `keyword`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.1"
   changes:
     - description: Added categories and/or subcategories.

--- a/packages/nginx_ingress_controller/data_stream/access/fields/fields.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/fields/fields.yml
@@ -16,7 +16,7 @@
       description: |
         Time elapsed since the first bytes were read from the client
     - name: upstream.name
-      type: text
+      type: keyword
       description: |
         The name of the upstream.
     - name: upstream.alternative_name

--- a/packages/nginx_ingress_controller/docs/README.md
+++ b/packages/nginx_ingress_controller/docs/README.md
@@ -206,7 +206,7 @@ An example event for `access` looks as following:
 | nginx_ingress_controller.access.remote_ip_list | An array of remote IP addresses. It is a list because it is common to include, besides the client IP address, IP addresses from headers like `X-Forwarded-For`. Real source IP is restored to `source.ip`. | array |
 | nginx_ingress_controller.access.upstream.alternative_name | The name of the alternative upstream. | text |
 | nginx_ingress_controller.access.upstream.ip | The IP address of the upstream server. If several servers were contacted during request processing, their addresses are separated by commas. | ip |
-| nginx_ingress_controller.access.upstream.name | The name of the upstream. | text |
+| nginx_ingress_controller.access.upstream.name | The name of the upstream. | keyword |
 | nginx_ingress_controller.access.upstream.port | The port of the upstream server. | long |
 | nginx_ingress_controller.access.upstream.response.length | The length of the response obtained from the upstream server | long |
 | nginx_ingress_controller.access.upstream.response.length_list | An array of upstream response lengths. It is a list because it is common that several upstream servers were contacted during request processing. | keyword |

--- a/packages/nginx_ingress_controller/manifest.yml
+++ b/packages/nginx_ingress_controller/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx_ingress_controller
 title: Nginx Ingress Controller Logs
-version: 1.7.1
+version: 1.7.2
 license: basic
 description: Collect Nginx Ingress Controller logs.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Change the mapping type of the field nginx_ingress_controller.access.upstream.name to fix an error on the overview dashboard of the integration `nginx_ingress_controller`. 

This error was preventing the `top upstreams` panel to correctly display any value

## Checklist

- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

## Author's Checklist

- [x] the package correctly builds and all tests pass

## How to test this PR locally

1. Setup a dev environment with elastic stack, fleet and kubernetes integration installe
2. install ingress-nginx helm chart from https://kubernetes.github.io/ingress-nginx
3. Add a demo application with the following manifests

deployment.yaml

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name:  demo
  namespace: default
  labels:
    app:  demo
spec:
  selector:
    matchLabels:
      app: demo
  replicas: 1
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      labels:
        app:  demo
    spec:
      # initContainers:
        # Init containers are exactly like regular containers, except:
          # - Init containers always run to completion.
          # - Each init container must complete successfully before the next one starts.
      containers:
      - name:  demo
        image:  nginx:1.23.1-alpine
        resources:
          requests:
            cpu: 100m
            memory: 100Mi
          limits:
            cpu: 100m
            memory: 100Mi
        livenessProbe:
          tcpSocket:
            port: 80
          initialDelaySeconds: 5
          timeoutSeconds: 5
          successThreshold: 1
          failureThreshold: 3
          periodSeconds: 10
        ports:
        - containerPort:  80
          name:  http
        volumeMounts:
        - name: localtime
          mountPath: /etc/localtime
      volumes:
        - name: localtime
          hostPath:
            path: /usr/share/zoneinfo/Europe/London
      restartPolicy: Always
```

service.yaml

```yaml
apiVersion: v1
kind: Service
metadata:
  name: demo
  namespace: default
spec:
  selector:
    app: demo
  type: ClusterIP
  sessionAffinity: None
  sessionAffinityConfig:
    clientIP:
      timeoutSeconds: 10800
  ports:
  - name: demo
    protocol: TCP
    port: 8080
    targetPort: 80
    # If you set the `spec.type` field to `NodePort` and you want a specific port number,
    # you can specify a value in the `spec.ports[*].nodePort` field.
    # nodePort: 8080
```

ingress.yaml to add an ingress rule to expose the service

```yaml
apiVersion: networking.k8s.io/v1                                                                                                                                                                                   
kind: Ingress                                                                                                                                                                                                      
metadata:                                                                                                                                                                                                          
  name: demo-localhost                                                                                                                                                                                             
  namespace: default                                                                                                                                                                                               
spec:                                                                                                                                                                                                              
  ingressClassName: nginx                                                                                                                                                                                          
  rules:                                                                                                                                                                                                           
  - host: demo.localdev.me                                                                                                                                                                                         
    http:                                                                                                                                                                                                          
      paths:                                                                                                                                                                                                       
      - backend:                                                                                                                                                                                                   
          service:                                                                                                                                                                                                 
            name: demo                                                                                                                                                                                             
            port:                                                                                                                                                                                                  
              number: 80                                                                                                                                                                                           
        path: /                                                                                                                                                                                                    
        pathType: Prefix
```

client.yaml to simulate traffic

```yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: demo-client
  namespace: default
spec:
  schedule: "*/1 * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - name: demo-client
            image: curlimages/curl:7.86.0
            args: ['/bin/sh', '-c', ' curl --header "Host: demo.localdev.me"  ingress-nginx-controller.ingress-nginx.svc.cluster.local']
          restartPolicy: OnFailure
```

## Related issues

- Closes #5943 

## Screenshots
The following screenshot shows that the panl `top upstreams` is now being filled. It was showing `error` before.

<img width="353" alt="Screenshot 2023-05-18 at 13 44 31" src="https://github.com/elastic/integrations/assets/2378291/b33c5e7b-86df-4553-9c34-3de55eede4f9">

