### PR TITLE
[infoblox_nios] Fix dns.answers processing

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Fix dns.answers processing.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6262
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log
@@ -23,3 +23,4 @@
 <30>Apr 14 16:16:05 10.50.1.227 named[2588]: queries: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query: ocsp.digicert.com IN A + (192.168.1.10)
 <30>Apr 14 16:16:05 10.50.1.227 named[2588]: query-errors: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query failed (REFUSED) for ocsp.digicert.com/IN/A at query.c:10288
 <30>Oct 4 10:18:07 a1.foo.com 89.160.20.112 named[10750]: 04-Oct-2022 10:18:07.834 client 89.160.20.128#59605: UDP: query: 89.160.20.128.a1.foo.com IN PTR response: NOERROR + 89.160.20.128.a1.foo.com. 21801 IN PTR 089.160.20.112.a1.foo.com.;
+<30>May 9 11:54:36 a1.foo.com 89.160.20.112 named[12261]: 09-May-2023 11:54:36.185 client 89.160.20.128#59605: view 12: UDP: query: settings-win.data.microsoft.com IN TXT response: NOERROR + settings-win.data.microsoft.com. 3600 IN TXT "k=rsa; p=abc" "def" "ghi" "jkl" "AB";

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -1409,6 +1409,90 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2023-05-09T11:54:36.185Z",
+            "client": {
+                "ip": "89.160.20.128",
+                "port": 59605
+            },
+            "dns": {
+                "answers": {
+                    "class": [
+                        "IN"
+                    ],
+                    "data": [
+                        "\"k=rsa; p=abc\"",
+                        "\"def\"",
+                        "\"ghi\"",
+                        "\"jkl\"",
+                        "\"AB\""
+                    ],
+                    "name": [
+                        "settings-win.data.microsoft.com"
+                    ],
+                    "ttl": [
+                        3600
+                    ],
+                    "type": [
+                        "TXT"
+                    ]
+                },
+                "header_flags": [
+                    "RA"
+                ],
+                "question": {
+                    "class": "IN",
+                    "name": "settings-win.data.microsoft.com",
+                    "type": "TXT"
+                },
+                "response_code": "NOERROR"
+            },
+            "ecs": {
+                "version": "8.7.0"
+            },
+            "event": {
+                "created": "2023-05-09T11:54:36.000Z",
+                "original": "\u003c30\u003eMay 9 11:54:36 a1.foo.com 89.160.20.112 named[12261]: 09-May-2023 11:54:36.185 client 89.160.20.128#59605: view 12: UDP: query: settings-win.data.microsoft.com IN TXT response: NOERROR + settings-win.data.microsoft.com. 3600 IN TXT \"k=rsa; p=abc\" \"def\" \"ghi\" \"jkl\" \"AB\";"
+            },
+            "host": {
+                "domain": "a1.foo.com",
+                "ip": "89.160.20.112"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "header_flags": "+"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "09-May-2023 11:54:36.185 client 89.160.20.128#59605: view 12: UDP: query: settings-win.data.microsoft.com IN TXT response: NOERROR + settings-win.data.microsoft.com. 3600 IN TXT \"k=rsa; p=abc\" \"def\" \"ghi\" \"jkl\" \"AB\";",
+            "network": {
+                "transport": "view 12: udp"
+            },
+            "process": {
+                "pid": 12261
+            },
+            "related": {
+                "hosts": [
+                    "settings-win.data.microsoft.com",
+                    "a1.foo.com"
+                ],
+                "ip": [
+                    "89.160.20.128",
+                    "89.160.20.112"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -45,21 +45,42 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
-  - split:
-      field: repeat_message
-      if: ctx.repeat_message != null
-      separator: ';'
-      ignore_missing: true
-  - trim:
-      field: repeat_message
-      ignore_missing: true
-      ignore_failure: true
   - script:
       lang: painless
       if: ctx.repeat_message != null
+      description: |
+        Process dns.answers data by splitting repeat_message by ';'
+        and then each of the elements by space. It takes into account
+        quoted strings.
       source:
+        def splitUnquoted(String input, String sep) {
+          def tokens = [];
+          def startPosition = 0;
+          def isInQuotes = false;
+          char quote = (char)"\"";
+          for (def currentPosition = 0; currentPosition < input.length(); currentPosition++) {
+              if (input.charAt(currentPosition) == quote) {
+                  isInQuotes = !isInQuotes;
+              }
+              else if (input.charAt(currentPosition) == (char)sep && !isInQuotes) {
+                  def token = input.substring(startPosition, currentPosition).trim();
+                  if (!token.equals("")) {
+                    tokens.add(token);
+                  }
+                  startPosition = currentPosition + 1;
+              }
+          }
+
+          def lastToken = input.substring(startPosition);
+          if (!lastToken.equals(sep) && !lastToken.equals("")) {
+              tokens.add(lastToken.trim());
+          }
+          return tokens;
+        }
+
+        def arr = splitUnquoted(ctx.repeat_message, ";");
+        ctx.repeat_message = arr;
         Map map = new HashMap();
-        def arr = ctx.repeat_message;
         map.put('name', new ArrayList());
         map.put('ttl', new ArrayList());
         map.put('class', new ArrayList());
@@ -67,13 +88,14 @@ processors:
         map.put('data', new ArrayList());
 
         for (def i = 0; i < arr?.length; i++) {
-          def response = arr[i].splitOnToken(' ');
+          def response = splitUnquoted(arr[i], " ");
           map['name'].add(response[0]);
           map['ttl'].add(response[1]);
           map['class'].add(response[2]);
           map['type'].add(response[3]);
-          map['data'].add(response[4]);
+          map['data'].addAll(response.subList(4, response.length));
         }
+
         ctx.dns.answers = map;
   - convert:
       field: dns.answers.ttl

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.7.0"
+version: "1.7.1"
 license: basic
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Fixes the way we split dns messages to take into account quoted values of the split character.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
