### PR TITLE
Add CRC support to the Zoom integration

### DIFF
--- a/packages/zoom/_dev/build/docs/README.md
+++ b/packages/zoom/_dev/build/docs/README.md
@@ -4,7 +4,7 @@ This integration creates an HTTP listener that accepts incoming webhook
 callbacks from Zoom.
 
 To configure Zoom to send webhooks to this integration, please follow the
-[Zoom Documentation](https://marketplace.zoom.us/docs/guides/build/webhook-only-app).
+[Zoom Documentation](https://developers.zoom.us/docs/api/rest/webhook-only-app).
 
 The agent running this integration must be able to accept requests from the
 Internet in order for Zoom to be able connect. Zoom requires that the webhook

--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Add CRC validation support.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/12345
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.7.0.

--- a/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
+++ b/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
@@ -2,6 +2,7 @@ listen_address: {{listen_address}}
 listen_port: {{listen_port}}
 url: {{url}}
 prefix: zoom
+crc.provider: zoom
 content_type: "" # force ignoring content-type checks
 {{#if preserve_original_event}}
 preserve_original_event: true
@@ -16,13 +17,13 @@ ssl: {{ssl}}
 {{/if}}
 tags:
 {{#if preserve_original_event}}
- - preserve_original_event
+- preserve_original_event
 {{/if}}
 {{#each tags as |tag i|}}
- - {{tag}}
+- {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-  - add_locale: ~
+- add_locale: ~

--- a/packages/zoom/docs/README.md
+++ b/packages/zoom/docs/README.md
@@ -4,7 +4,7 @@ This integration creates an HTTP listener that accepts incoming webhook
 callbacks from Zoom.
 
 To configure Zoom to send webhooks to this integration, please follow the
-[Zoom Documentation](https://marketplace.zoom.us/docs/guides/build/webhook-only-app).
+[Zoom Documentation](https://developers.zoom.us/docs/api/rest/webhook-only-app).
 
 The agent running this integration must be able to accept requests from the
 Internet in order for Zoom to be able connect. Zoom requires that the webhook

--- a/packages/zoom/manifest.yml
+++ b/packages/zoom/manifest.yml
@@ -1,6 +1,6 @@
 name: zoom
 title: Zoom
-version: "1.8.0"
+version: "1.9.0"
 release: ga
 description: Collect logs from Zoom with Elastic Agent.
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: ["security", "productivity_security"]
 conditions:
-  kibana.version: ^7.14.0 || ^8.0.0
+  kibana.version: ^8.9.0
 policy_templates:
   - name: zoom
     title: Zoom logs


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This pull request adds the possibility for the Zoom integration of supporting CRC requests and validating its webhook as is required from Zoom for newer webhooks. More information about this validation is available [here](https://developers.zoom.us/docs/api/rest/webhook-reference/#validate-your-webhook-endpoint).

Changes in the input related to this CRC validation can be found at https://github.com/elastic/beats/pull/35204.

It also fixes two outdated links in the documentation.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Related to https://github.com/elastic/beats/issues/35100

## Screenshots

**Integration config**
<img width="845" alt="image" src="https://github.com/elastic/integrations/assets/29475387/df7ada12-6ef5-4700-a364-0989bd2f7d16">

**CRC request response**
```
root@docker-fleet-agent:~# curl -X POST http://localhost:8181/zoom-webhook -H 'Content-Type: application/json' -H 'Authorization: secret123' -d '{"event_ts":1654503849680,"event":"endpoint.url_validation","payload":{"plainToken":"qgg8vlvZRS6UYooatFL8Aw"}}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8181...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8181 (#0)
> POST /zoom-webhook HTTP/1.1
> Host: localhost:8181
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Type: application/json
> Authorization: secret123
> Content-Length: 110
>
* upload completely sent off: 110 out of 110 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Mon, 22 May 2023 15:06:44 GMT
< Content-Length: 123
<
* Connection #0 to host localhost left intact
{"encryptedToken":"ec1ef6227291f8e16a3ac1ad6167e86557df46bd0e06a0f3acd2bdb2be34baa4","plainToken":"qgg8vlvZRS6UYooatFL8Aw"}
```
**Event ingested**
```
root@docker-fleet-agent:~# curl -X POST http://localhost:8181/zoom-webhook -H 'Content-Type: application/json' -H 'Authorization: secret123' -d '{"event":"account.created","payload":{"account_id":"lq8KK_EoRCq6ByEyA73qCA","operator":"youramazingemailhere@somemail.com","operator_id":"uLohghhRgfgrbTayCX6r2Q_qQsQ","object":{"id":"aIxE1yiRR8WghhUIO6eu9L","owner_id":"e2ZHO5RSGqyfrmFnElxw","owner_email":"thesubaccountowneremail@somemail.com"}}}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8181...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8181 (#0)
> POST /zoom-webhook HTTP/1.1
> Host: localhost:8181
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Type: application/json
> Authorization: secret123
> Content-Length: 296
>
* upload completely sent off: 296 out of 296 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Mon, 22 May 2023 15:09:28 GMT
< Content-Length: 22
<
* Connection #0 to host localhost left intact
{"message": "success"}
```

<img width="906" alt="image" src="https://github.com/elastic/integrations/assets/29475387/27d2b819-528d-401e-a90c-630d9c937dc9">
