### PR TITLE
[Kubernetes][Dashboard] Update volume dashboard

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.40.0-beta.2"
+  changes:
+    - description: Fix volume dashboard.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6221
 - version: "1.40.0-beta.1"
   changes:
     - description: Fix proxy and scheduler visualization with missing sort field.

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix volume dashboard.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/6221
+      link: https://github.com/elastic/integrations/pull/6292
 - version: "1.40.0-beta.1"
   changes:
     - description: Fix proxy and scheduler visualization with missing sort field.

--- a/packages/kubernetes/kibana/dashboard/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013.json
@@ -147,10 +147,15 @@
                                                 "a52b3682-8595-4cff-89b2-590cd5c3e6c2": {
                                                     "customLabel": true,
                                                     "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.volume.fs.used.pct: *"
+                                                    },
                                                     "isBucketed": false,
                                                     "label": "Fs Usage Pct",
-                                                    "operationType": "median",
+                                                    "operationType": "average",
                                                     "params": {
+                                                        "emptyAsNull": true,
                                                         "format": {
                                                             "id": "percent",
                                                             "params": {

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.40.0-beta.1
+version: 1.40.0-beta.2
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent (TSDB Beta).
 type: integration


### PR DESCRIPTION
## What does this PR do?

When TSDB is disabled, there is a visualization that appears like this:

![image](https://github.com/elastic/integrations/assets/113898685/9e8279d9-e6e4-499f-ba59-d72f03e350d1)

However, when enabling TSDB, the visualization stops working since "it is not possible to filter by `kubernetes.volume.fs.used.pct: *`". This PR fixes that so the visualization works the same in both modes.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
