### PR TITLE
[sophos_central] Fix timestamp parsing and update package-spec version to 2.7.0

### DIFF
--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Fix timestamp parsing and update package-spec version to 2.7.0.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.2.1"
   changes:
     - description: Handle failure for grok pattern.

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix timestamp parsing and update package-spec version to 2.7.0.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6309
 - version: "1.2.1"
   changes:
     - description: Handle failure for grok pattern.

--- a/packages/sophos_central/data_stream/alert/_dev/test/pipeline/test-pipeline-activity.log-expected.json
+++ b/packages/sophos_central/data_stream/alert/_dev/test/pipeline/test-pipeline-activity.log-expected.json
@@ -59,7 +59,7 @@
                             ],
                             "total_items": 1
                         },
-                        "created_at": "2023-01-01T00:00:00.085Z",
+                        "created_at": "2022-11-24T07:07:52.085Z",
                         "endpoint": {
                             "id": "0320820b-84b4-41ea-95fd-5893fb17e420",
                             "java_id": "0320820b-84b4-41ea-95fd-5893fb17e420",
@@ -81,7 +81,7 @@
                             "uid": "344b9a0b-2271-0e14-0c61-0fa89122c6ad",
                             "version": "2.13.7"
                         },
-                        "inserted_at": "2023-01-01T00:00:00.085Z",
+                        "inserted_at": "2022-11-24T07:07:52.085Z",
                         "ips_threat": {
                             "detection_type": 1,
                             "executable": {
@@ -118,28 +118,28 @@
                             },
                             "tech_support_id": "2019052901.77863414.5"
                         },
-                        "make_actionable_at": "2023-01-01T00:00:00.751Z",
+                        "make_actionable_at": "2023-01-24T04:11:59.751Z",
                         "policy_type": 30,
                         "source_app_id": "CORE",
                         "source_info_ip": "67.43.156.0",
                         "threat_id": {
                             "counter": 5044432,
-                            "date": "2023-01-01T00:00:00.000Z",
+                            "date": "2022-11-24T07:07:52.000Z",
                             "machine_identifier": 13006844,
                             "process_identifier": 3865,
-                            "time": "2023-01-01T00:00:00.000Z",
-                            "time_sec": "2023-01-01T00:00:00.000Z",
-                            "timestamp": "2023-01-01T00:00:00.000Z"
+                            "time": "2022-11-24T07:07:52.000Z",
+                            "time_sec": "2022-11-24T07:07:52.000Z",
+                            "timestamp": "2022-11-24T07:07:52.000Z"
                         },
                         "threat_status": "NONE",
                         "user_match_id": {
                             "counter": 5199272,
-                            "date": "2023-01-01T00:00:00.000Z",
+                            "date": "2022-11-03T08:15:33.000Z",
                             "machine_identifier": 14271215,
                             "process_identifier": 3997,
-                            "time": "2023-01-01T00:00:00.000Z",
-                            "time_sec": "2023-01-01T00:00:00.000Z",
-                            "timestamp": "2023-01-01T00:00:00.000Z"
+                            "time": "2022-11-03T08:15:33.000Z",
+                            "time_sec": "2022-11-03T08:15:33.000Z",
+                            "timestamp": "2022-11-03T08:15:33.000Z"
                         },
                         "user_match_uuid": {
                             "data": "SltcnDmTSoSky+G00P5iTQ==",

--- a/packages/sophos_central/data_stream/alert/_dev/test/pipeline/test-user-formats.log-expected.json
+++ b/packages/sophos_central/data_stream/alert/_dev/test/pipeline/test-user-formats.log-expected.json
@@ -59,7 +59,7 @@
                             ],
                             "total_items": 1
                         },
-                        "created_at": "2023-01-01T00:00:00.085Z",
+                        "created_at": "2022-11-24T07:07:52.085Z",
                         "endpoint": {
                             "id": "0320820b-84b4-41ea-95fd-5893fb17e420",
                             "java_id": "0320820b-84b4-41ea-95fd-5893fb17e420",
@@ -81,7 +81,7 @@
                             "uid": "344b9a0b-2271-0e14-0c61-0fa89122c6ad",
                             "version": "2.13.7"
                         },
-                        "inserted_at": "2023-01-01T00:00:00.085Z",
+                        "inserted_at": "2022-11-24T07:07:52.085Z",
                         "ips_threat": {
                             "detection_type": 1,
                             "executable": {
@@ -118,28 +118,28 @@
                             },
                             "tech_support_id": "2019052901.77863414.5"
                         },
-                        "make_actionable_at": "2023-01-01T00:00:00.751Z",
+                        "make_actionable_at": "2023-01-24T04:11:59.751Z",
                         "policy_type": 30,
                         "source_app_id": "CORE",
                         "source_info_ip": "67.43.156.0",
                         "threat_id": {
                             "counter": 5044432,
-                            "date": "2023-01-01T00:00:00.000Z",
+                            "date": "2022-11-24T07:07:52.000Z",
                             "machine_identifier": 13006844,
                             "process_identifier": 3865,
-                            "time": "2023-01-01T00:00:00.000Z",
-                            "time_sec": "2023-01-01T00:00:00.000Z",
-                            "timestamp": "2023-01-01T00:00:00.000Z"
+                            "time": "2022-11-24T07:07:52.000Z",
+                            "time_sec": "2022-11-24T07:07:52.000Z",
+                            "timestamp": "2022-11-24T07:07:52.000Z"
                         },
                         "threat_status": "NONE",
                         "user_match_id": {
                             "counter": 5199272,
-                            "date": "2023-01-01T00:00:00.000Z",
+                            "date": "2022-11-03T08:15:33.000Z",
                             "machine_identifier": 14271215,
                             "process_identifier": 3997,
-                            "time": "2023-01-01T00:00:00.000Z",
-                            "time_sec": "2023-01-01T00:00:00.000Z",
-                            "timestamp": "2023-01-01T00:00:00.000Z"
+                            "time": "2022-11-03T08:15:33.000Z",
+                            "time_sec": "2022-11-03T08:15:33.000Z",
+                            "timestamp": "2022-11-03T08:15:33.000Z"
                         },
                         "user_match_uuid": {
                             "data": "SltcnDmTSoSky+G00P5iTQ==",
@@ -239,7 +239,7 @@
                             ],
                             "total_items": 1
                         },
-                        "created_at": "2023-01-01T00:00:00.085Z",
+                        "created_at": "2022-11-24T07:07:52.085Z",
                         "endpoint": {
                             "id": "0320820b-84b4-41ea-95fd-5893fb17e420",
                             "java_id": "0320820b-84b4-41ea-95fd-5893fb17e420",
@@ -261,7 +261,7 @@
                             "uid": "344b9a0b-2271-0e14-0c61-0fa89122c6ad",
                             "version": "2.13.7"
                         },
-                        "inserted_at": "2023-01-01T00:00:00.085Z",
+                        "inserted_at": "2022-11-24T07:07:52.085Z",
                         "ips_threat": {
                             "detection_type": 1,
                             "executable": {
@@ -298,28 +298,28 @@
                             },
                             "tech_support_id": "2019052901.77863414.5"
                         },
-                        "make_actionable_at": "2023-01-01T00:00:00.751Z",
+                        "make_actionable_at": "2023-01-24T04:11:59.751Z",
                         "policy_type": 30,
                         "source_app_id": "CORE",
                         "source_info_ip": "67.43.156.0",
                         "threat_id": {
                             "counter": 5044432,
-                            "date": "2023-01-01T00:00:00.000Z",
+                            "date": "2022-11-24T07:07:52.000Z",
                             "machine_identifier": 13006844,
                             "process_identifier": 3865,
-                            "time": "2023-01-01T00:00:00.000Z",
-                            "time_sec": "2023-01-01T00:00:00.000Z",
-                            "timestamp": "2023-01-01T00:00:00.000Z"
+                            "time": "2022-11-24T07:07:52.000Z",
+                            "time_sec": "2022-11-24T07:07:52.000Z",
+                            "timestamp": "2022-11-24T07:07:52.000Z"
                         },
                         "threat_status": "NONE",
                         "user_match_id": {
                             "counter": 5199272,
-                            "date": "2023-01-01T00:00:00.000Z",
+                            "date": "2022-11-03T08:15:33.000Z",
                             "machine_identifier": 14271215,
                             "process_identifier": 3997,
-                            "time": "2023-01-01T00:00:00.000Z",
-                            "time_sec": "2023-01-01T00:00:00.000Z",
-                            "timestamp": "2023-01-01T00:00:00.000Z"
+                            "time": "2022-11-03T08:15:33.000Z",
+                            "time_sec": "2022-11-03T08:15:33.000Z",
+                            "timestamp": "2022-11-03T08:15:33.000Z"
                         },
                         "user_match_uuid": {
                             "data": "SltcnDmTSoSky+G00P5iTQ==",
@@ -415,7 +415,7 @@
                             ],
                             "total_items": 1
                         },
-                        "created_at": "2023-01-01T00:00:00.085Z",
+                        "created_at": "2022-11-24T07:07:52.085Z",
                         "endpoint": {
                             "id": "0320820b-84b4-41ea-95fd-5893fb17e420",
                             "java_id": "0320820b-84b4-41ea-95fd-5893fb17e420",
@@ -437,7 +437,7 @@
                             "uid": "344b9a0b-2271-0e14-0c61-0fa89122c6ad",
                             "version": "2.13.7"
                         },
-                        "inserted_at": "2023-01-01T00:00:00.085Z",
+                        "inserted_at": "2022-11-24T07:07:52.085Z",
                         "ips_threat": {
                             "detection_type": 1,
                             "executable": {
@@ -474,28 +474,28 @@
                             },
                             "tech_support_id": "2019052901.77863414.5"
                         },
-                        "make_actionable_at": "2023-01-01T00:00:00.751Z",
+                        "make_actionable_at": "2023-01-24T04:11:59.751Z",
                         "policy_type": 30,
                         "source_app_id": "CORE",
                         "source_info_ip": "67.43.156.0",
                         "threat_id": {
                             "counter": 5044432,
-                            "date": "2023-01-01T00:00:00.000Z",
+                            "date": "2022-11-24T07:07:52.000Z",
                             "machine_identifier": 13006844,
                             "process_identifier": 3865,
-                            "time": "2023-01-01T00:00:00.000Z",
-                            "time_sec": "2023-01-01T00:00:00.000Z",
-                            "timestamp": "2023-01-01T00:00:00.000Z"
+                            "time": "2022-11-24T07:07:52.000Z",
+                            "time_sec": "2022-11-24T07:07:52.000Z",
+                            "timestamp": "2022-11-24T07:07:52.000Z"
                         },
                         "threat_status": "NONE",
                         "user_match_id": {
                             "counter": 5199272,
-                            "date": "2023-01-01T00:00:00.000Z",
+                            "date": "2022-11-03T08:15:33.000Z",
                             "machine_identifier": 14271215,
                             "process_identifier": 3997,
-                            "time": "2023-01-01T00:00:00.000Z",
-                            "time_sec": "2023-01-01T00:00:00.000Z",
-                            "timestamp": "2023-01-01T00:00:00.000Z"
+                            "time": "2022-11-03T08:15:33.000Z",
+                            "time_sec": "2022-11-03T08:15:33.000Z",
+                            "timestamp": "2022-11-03T08:15:33.000Z"
                         },
                         "user_match_uuid": {
                             "data": "SltcnDmTSoSky+G00P5iTQ==",

--- a/packages/sophos_central/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos_central/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -262,7 +262,7 @@ processors:
       target_field: sophos_central.alert.data.inserted_at
       if: ctx.json?.data?.inserted_at != null
       formats:
-        - epoch_millis
+        - UNIX_MS
       on_failure:
         - append:
             field: error.message
@@ -386,7 +386,7 @@ processors:
       target_field: sophos_central.alert.data.threat_id.timestamp
       if: ctx.json?.data?.threat_id?.timestamp != null
       formats:
-        - epoch_second
+        - UNIX
       on_failure:
         - append:
             field: error.message
@@ -423,7 +423,7 @@ processors:
       target_field: sophos_central.alert.data.threat_id.time
       if: ctx.json?.data?.threat_id?.time != null
       formats:
-        - epoch_millis
+        - UNIX_MS
       on_failure:
         - append:
             field: error.message
@@ -433,7 +433,7 @@ processors:
       target_field: sophos_central.alert.data.threat_id.date
       if: ctx.json?.data?.threat_id?.date != null
       formats:
-        - epoch_second
+        - UNIX_MS
       on_failure:
         - append:
             field: error.message
@@ -443,7 +443,7 @@ processors:
       target_field: sophos_central.alert.data.threat_id.time_sec
       if: ctx.json?.data?.threat_id?.timeSecond != null
       formats:
-        - epoch_second
+        - UNIX
       on_failure:
         - append:
             field: error.message
@@ -457,7 +457,7 @@ processors:
       target_field: sophos_central.alert.data.user_match_id.timestamp
       if: ctx.json?.data?.user_match_id?.timestamp != null
       formats:
-        - epoch_second
+        - UNIX
       on_failure:
         - append:
             field: error.message
@@ -494,7 +494,7 @@ processors:
       target_field: sophos_central.alert.data.user_match_id.time
       if: ctx.json?.data?.user_match_id?.time != null
       formats:
-        - epoch_millis
+        - UNIX_MS
       on_failure:
         - append:
             field: error.message
@@ -504,7 +504,7 @@ processors:
       target_field: sophos_central.alert.data.user_match_id.date
       if: ctx.json?.data?.threat_id?.date != null
       formats:
-        - epoch_millis
+        - UNIX_MS
       on_failure:
         - append:
             field: error.message
@@ -514,7 +514,7 @@ processors:
       target_field: sophos_central.alert.data.user_match_id.time_sec
       if: ctx.json?.data?.user_match_id?.timeSecond != null
       formats:
-        - epoch_second
+        - UNIX
       on_failure:
         - append:
             field: error.message
@@ -524,7 +524,7 @@ processors:
       target_field: sophos_central.alert.data.created_at
       if: ctx.json?.data?.created_at != null
       formats:
-        - epoch_millis
+        - UNIX_MS
       on_failure:
         - append:
             field: error.message
@@ -581,7 +581,7 @@ processors:
       target_field: sophos_central.alert.data.make_actionable_at
       if: ctx.json?.data?.make_actionable_at != null
       formats:
-        - epoch_millis
+        - UNIX_MS
       on_failure:
         - append:
             field: error.message

--- a/packages/sophos_central/data_stream/alert/sample_event.json
+++ b/packages/sophos_central/data_stream/alert/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2022-11-24T07:07:48.000Z",
     "agent": {
-        "ephemeral_id": "213f75e5-c952-4ef7-9f30-5ff0fad3bdfc",
-        "id": "a223e78b-6283-4820-8f7a-8c9664c9a73e",
+        "ephemeral_id": "f0294025-e37d-4210-bda4-eaf14642e17e",
+        "id": "cf659b85-d5b7-4b0d-8b9a-4ea2e187d862",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.7.1"
@@ -20,7 +20,7 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "a223e78b-6283-4820-8f7a-8c9664c9a73e",
+        "id": "cf659b85-d5b7-4b0d-8b9a-4ea2e187d862",
         "snapshot": false,
         "version": "8.7.1"
     },
@@ -33,7 +33,7 @@
         "created": "2022-11-24T07:07:52.094Z",
         "dataset": "sophos_central.alert",
         "id": "8bbd989a-6cab-407f-a586-c5064b94f76a",
-        "ingested": "2023-05-12T09:02:27Z",
+        "ingested": "2023-05-24T14:37:54Z",
         "kind": [
             "alert"
         ],
@@ -79,7 +79,7 @@
                     ],
                     "total_items": 1
                 },
-                "created_at": "2023-01-01T00:00:00.085Z",
+                "created_at": "2022-11-24T07:07:52.085Z",
                 "endpoint": {
                     "id": "0320820b-84b4-41ea-95fd-5893fb17e420",
                     "java_id": "0320820b-84b4-41ea-95fd-5893fb17e420",
@@ -101,7 +101,7 @@
                     "uid": "344b9a0b-2271-0e14-0c61-0fa89122c6ad",
                     "version": "2.13.7"
                 },
-                "inserted_at": "2023-01-01T00:00:00.085Z",
+                "inserted_at": "2022-11-24T07:07:52.085Z",
                 "ips_threat": {
                     "detection_type": 1,
                     "executable": {
@@ -138,28 +138,28 @@
                     },
                     "tech_support_id": "2019052901.77863414.5"
                 },
-                "make_actionable_at": "2023-01-01T00:00:00.751Z",
+                "make_actionable_at": "2023-01-24T04:11:59.751Z",
                 "policy_type": 30,
                 "source_app_id": "CORE",
                 "source_info_ip": "10.1.39.32",
                 "threat_id": {
                     "counter": 5044432,
-                    "date": "2023-01-01T00:00:00.000Z",
+                    "date": "2022-11-24T07:07:52.000Z",
                     "machine_identifier": 13006844,
                     "process_identifier": 3865,
-                    "time": "2023-01-01T00:00:00.000Z",
-                    "time_sec": "2023-01-01T00:00:00.000Z",
-                    "timestamp": "2023-01-01T00:00:00.000Z"
+                    "time": "2022-11-24T07:07:52.000Z",
+                    "time_sec": "2022-11-24T07:07:52.000Z",
+                    "timestamp": "2022-11-24T07:07:52.000Z"
                 },
                 "threat_status": "NONE",
                 "user_match_id": {
                     "counter": 5199272,
-                    "date": "2023-01-01T00:00:00.000Z",
+                    "date": "2022-11-03T08:15:33.000Z",
                     "machine_identifier": 14271215,
                     "process_identifier": 3997,
-                    "time": "2023-01-01T00:00:00.000Z",
-                    "time_sec": "2023-01-01T00:00:00.000Z",
-                    "timestamp": "2023-01-01T00:00:00.000Z"
+                    "time": "2022-11-03T08:15:33.000Z",
+                    "time_sec": "2022-11-03T08:15:33.000Z",
+                    "timestamp": "2022-11-03T08:15:33.000Z"
                 },
                 "user_match_uuid": {
                     "data": "SltcnDmTSoSky+G00P5iTQ==",

--- a/packages/sophos_central/data_stream/event/sample_event.json
+++ b/packages/sophos_central/data_stream/event/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2022-12-06T12:27:28.094Z",
     "agent": {
-        "ephemeral_id": "f20783ea-c472-4191-bf96-2ba0f079ae27",
-        "id": "a223e78b-6283-4820-8f7a-8c9664c9a73e",
+        "ephemeral_id": "5347e925-6d9e-4a32-bda5-1785fd44709f",
+        "id": "cf659b85-d5b7-4b0d-8b9a-4ea2e187d862",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.7.1"
@@ -20,7 +20,7 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "a223e78b-6283-4820-8f7a-8c9664c9a73e",
+        "id": "cf659b85-d5b7-4b0d-8b9a-4ea2e187d862",
         "snapshot": false,
         "version": "8.7.1"
     },
@@ -33,7 +33,7 @@
         "created": "2022-12-06T12:27:31.310Z",
         "dataset": "sophos_central.event",
         "id": "3dab71db-32c9-426a-8616-1e0fd5c9aab9",
-        "ingested": "2023-05-12T09:03:04Z",
+        "ingested": "2023-05-24T14:38:29Z",
         "kind": [
             "event"
         ],

--- a/packages/sophos_central/docs/README.md
+++ b/packages/sophos_central/docs/README.md
@@ -51,8 +51,8 @@ An example event for `alert` looks as following:
 {
     "@timestamp": "2022-11-24T07:07:48.000Z",
     "agent": {
-        "ephemeral_id": "213f75e5-c952-4ef7-9f30-5ff0fad3bdfc",
-        "id": "a223e78b-6283-4820-8f7a-8c9664c9a73e",
+        "ephemeral_id": "f0294025-e37d-4210-bda4-eaf14642e17e",
+        "id": "cf659b85-d5b7-4b0d-8b9a-4ea2e187d862",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.7.1"
@@ -70,7 +70,7 @@ An example event for `alert` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "a223e78b-6283-4820-8f7a-8c9664c9a73e",
+        "id": "cf659b85-d5b7-4b0d-8b9a-4ea2e187d862",
         "snapshot": false,
         "version": "8.7.1"
     },
@@ -83,7 +83,7 @@ An example event for `alert` looks as following:
         "created": "2022-11-24T07:07:52.094Z",
         "dataset": "sophos_central.alert",
         "id": "8bbd989a-6cab-407f-a586-c5064b94f76a",
-        "ingested": "2023-05-12T09:02:27Z",
+        "ingested": "2023-05-24T14:37:54Z",
         "kind": [
             "alert"
         ],
@@ -129,7 +129,7 @@ An example event for `alert` looks as following:
                     ],
                     "total_items": 1
                 },
-                "created_at": "2023-01-01T00:00:00.085Z",
+                "created_at": "2022-11-24T07:07:52.085Z",
                 "endpoint": {
                     "id": "0320820b-84b4-41ea-95fd-5893fb17e420",
                     "java_id": "0320820b-84b4-41ea-95fd-5893fb17e420",
@@ -151,7 +151,7 @@ An example event for `alert` looks as following:
                     "uid": "344b9a0b-2271-0e14-0c61-0fa89122c6ad",
                     "version": "2.13.7"
                 },
-                "inserted_at": "2023-01-01T00:00:00.085Z",
+                "inserted_at": "2022-11-24T07:07:52.085Z",
                 "ips_threat": {
                     "detection_type": 1,
                     "executable": {
@@ -188,28 +188,28 @@ An example event for `alert` looks as following:
                     },
                     "tech_support_id": "2019052901.77863414.5"
                 },
-                "make_actionable_at": "2023-01-01T00:00:00.751Z",
+                "make_actionable_at": "2023-01-24T04:11:59.751Z",
                 "policy_type": 30,
                 "source_app_id": "CORE",
                 "source_info_ip": "10.1.39.32",
                 "threat_id": {
                     "counter": 5044432,
-                    "date": "2023-01-01T00:00:00.000Z",
+                    "date": "2022-11-24T07:07:52.000Z",
                     "machine_identifier": 13006844,
                     "process_identifier": 3865,
-                    "time": "2023-01-01T00:00:00.000Z",
-                    "time_sec": "2023-01-01T00:00:00.000Z",
-                    "timestamp": "2023-01-01T00:00:00.000Z"
+                    "time": "2022-11-24T07:07:52.000Z",
+                    "time_sec": "2022-11-24T07:07:52.000Z",
+                    "timestamp": "2022-11-24T07:07:52.000Z"
                 },
                 "threat_status": "NONE",
                 "user_match_id": {
                     "counter": 5199272,
-                    "date": "2023-01-01T00:00:00.000Z",
+                    "date": "2022-11-03T08:15:33.000Z",
                     "machine_identifier": 14271215,
                     "process_identifier": 3997,
-                    "time": "2023-01-01T00:00:00.000Z",
-                    "time_sec": "2023-01-01T00:00:00.000Z",
-                    "timestamp": "2023-01-01T00:00:00.000Z"
+                    "time": "2022-11-03T08:15:33.000Z",
+                    "time_sec": "2022-11-03T08:15:33.000Z",
+                    "timestamp": "2022-11-03T08:15:33.000Z"
                 },
                 "user_match_uuid": {
                     "data": "SltcnDmTSoSky+G00P5iTQ==",
@@ -367,8 +367,8 @@ An example event for `event` looks as following:
 {
     "@timestamp": "2022-12-06T12:27:28.094Z",
     "agent": {
-        "ephemeral_id": "f20783ea-c472-4191-bf96-2ba0f079ae27",
-        "id": "a223e78b-6283-4820-8f7a-8c9664c9a73e",
+        "ephemeral_id": "5347e925-6d9e-4a32-bda5-1785fd44709f",
+        "id": "cf659b85-d5b7-4b0d-8b9a-4ea2e187d862",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.7.1"
@@ -386,7 +386,7 @@ An example event for `event` looks as following:
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "a223e78b-6283-4820-8f7a-8c9664c9a73e",
+        "id": "cf659b85-d5b7-4b0d-8b9a-4ea2e187d862",
         "snapshot": false,
         "version": "8.7.1"
     },
@@ -399,7 +399,7 @@ An example event for `event` looks as following:
         "created": "2022-12-06T12:27:31.310Z",
         "dataset": "sophos_central.event",
         "id": "3dab71db-32c9-426a-8616-1e0fd5c9aab9",
-        "ingested": "2023-05-12T09:03:04Z",
+        "ingested": "2023-05-24T14:38:29Z",
         "kind": [
             "event"
         ],

--- a/packages/sophos_central/manifest.yml
+++ b/packages/sophos_central/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 2.3.0
+format_version: 2.7.0
 name: sophos_central
 title: Sophos Central
-version: "1.2.1"
+version: "1.3.0"
 description: This Elastic integration collects logs from Sophos Central with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Switch formats from epoch_* to UNIX*
- Switch one instance of UNIX to UNIX_MS (sophos_central.alert.data.threat_id.date), as incoming value was expressed in milliseconds
- Update package-spec version to 2.7.0
- Regen test expected files

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
elastic-package test
```

## Related issues

- Relates elastic/security-team#5870
