### PR TITLE
Add beta flag to nginx

### DIFF
--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1-beta"
+  changes:
+    - description: Add beta flag 
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6298
 - version: "1.14.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nginx
 title: Nginx
-version: "1.14.0"
+version: "1.14.1-beta"
 license: basic
 description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent (TSDB Beta).
 type: integration


### PR DESCRIPTION

- Bug

## What does this PR do?

Add beta flag to NGINX 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues


- Relates https://github.com/elastic/obs-infraobs-team/issues/1043