### PR TITLE
Update urls in prometheues input package readme

### DIFF
--- a/packages/prometheus_input/changelog.yml
+++ b/packages/prometheus_input/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update the url's in README
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/6298
+      link: https://github.com/elastic/integrations/pull/6331
 - version: "0.1.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/prometheus_input/changelog.yml
+++ b/packages/prometheus_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Update the url's in README
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6298
 - version: "0.1.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/prometheus_input/docs/README.md
+++ b/packages/prometheus_input/docs/README.md
@@ -1,8 +1,6 @@
 # Prometheus Input Package
 
-This input package can collect metrics from:
-- [Prometheus Exporters (Collectors)](#prometheus-exporters-collectors).
-It gives users the flexibility to add custom mappings and ingest pipelines.
+This input package can collect metrics from [Prometheus Exporters (Collectors)](https://prometheus.io/docs/instrumenting/exporters/). It gives users the flexibility to add custom mappings and ingest pipelines.
 
 ## Metrics
 
@@ -17,7 +15,7 @@ Example Host Configuration: `http://localhost:9090/metrics`
 #### Histograms and types
 
 `Use Types` parameter (default: `true`) enables a different layout for metrics storage, leveraging Elasticsearch
-types, including {{ url "elasticsearch-histograms" "histograms" }}.
+types, including [histograms](https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html)
 
 `Rate Counters` parameter (default: `true`) enables calculating a rate out of Prometheus counters. When enabled, integration stores
 the counter increment since the last collection. This metric provides better aggregation. 

--- a/packages/prometheus_input/manifest.yml
+++ b/packages/prometheus_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: prometheus_input
 title: "Promethues Input"
-version: "0.1.0"
+version: "0.1.1"
 description: "Collects Metrics from Prometheus Exporter"
 type: input
 categories:


### PR DESCRIPTION

- Bug

## What does this PR do?

This PR fixes broken url's in prometheus input package readme. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/6324
