### PR TITLE
[AWS] Add dimensions to firewall, transit gateway and vpn data streams

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.36.9"
+  changes:
+    - description: Add dimension fields to firewall, transit gateway and vpn data streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6213
 - version: "1.36.8"
   changes:
     - description: Add dimension fields to usage, dynamoDB and ELB data streams.

--- a/packages/aws/data_stream/firewall_metrics/fields/ecs.yml
+++ b/packages/aws/data_stream/firewall_metrics/fields/ecs.yml
@@ -2,6 +2,7 @@
   name: cloud
 - external: ecs
   name: cloud.account.id
+  dimension: true
 - external: ecs
   name: cloud.account.name
 - external: ecs
@@ -14,6 +15,7 @@
   name: cloud.provider
 - external: ecs
   name: cloud.region
+  dimension: true
 - external: ecs
   name: ecs.version
 - external: ecs

--- a/packages/aws/data_stream/firewall_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/firewall_metrics/fields/fields.yml
@@ -21,15 +21,19 @@
       fields:
         - name: AvailabilityZone
           type: keyword
+          dimension: true
           description: Availability Zone in the Region where the Network Firewall firewall is active.
         - name: CustomAction
           type: keyword
+          dimension: true
           description: Dimension for a publish metrics custom action that you defined. You can define this for a rule action in a stateless rule group or for a stateless default action in a firewall policy.
         - name: Engine
           type: keyword
+          dimension: true
           description: Rules engine that processed the packet. The value for this is either Stateful or Stateless.
         - name: FirewallName
           type: keyword
+          dimension: true
           description: Name that you specified for the Network Firewall firewall.
     - name: cloudwatch
       type: group

--- a/packages/aws/data_stream/transitgateway/fields/ecs.yml
+++ b/packages/aws/data_stream/transitgateway/fields/ecs.yml
@@ -2,6 +2,7 @@
   name: cloud
 - external: ecs
   name: cloud.account.id
+  dimension: true
 - external: ecs
   name: cloud.account.name
 - external: ecs
@@ -18,6 +19,7 @@
   name: cloud.provider
 - external: ecs
   name: cloud.region
+  dimension: true
 - external: ecs
   name: ecs.version
 - external: ecs

--- a/packages/aws/data_stream/transitgateway/fields/fields.yml
+++ b/packages/aws/data_stream/transitgateway/fields/fields.yml
@@ -5,9 +5,11 @@
       type: group
       fields:
         - name: TransitGateway
+          dimension: true
           type: keyword
           description: Filters the metric data by transit gateway.
         - name: TransitGatewayAttachment
+          dimension: true
           type: keyword
           description: Filters the metric data by transit gateway attachment.
     - name: transitgateway

--- a/packages/aws/data_stream/vpn/fields/ecs.yml
+++ b/packages/aws/data_stream/vpn/fields/ecs.yml
@@ -2,6 +2,7 @@
   name: cloud
 - external: ecs
   name: cloud.account.id
+  dimension: true
 - external: ecs
   name: cloud.account.name
 - external: ecs
@@ -18,6 +19,7 @@
   name: cloud.provider
 - external: ecs
   name: cloud.region
+  dimension: true
 - external: ecs
   name: ecs.version
 - external: ecs

--- a/packages/aws/data_stream/vpn/fields/fields.yml
+++ b/packages/aws/data_stream/vpn/fields/fields.yml
@@ -21,9 +21,11 @@
       fields:
         - name: VpnId
           type: keyword
+          dimension: true
           description: Filters the metric data by the Site-to-Site VPN connection ID.
         - name: TunnelIpAddress
           type: keyword
+          dimension: true
           description: Filters the metric data by the IP address of the tunnel for the virtual private gateway.
     - name: cloudwatch
       type: group

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.36.8
+version: 1.36.9
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add dimensions to firewall, transit gateway and vpn data streams.

**Transit gateway**: A transit gateway can have more than one attachment, so it needs to be set as dimensions as well. A transit gateway is unique per AWS account.

**VPN**: Each tunnel belongs to a VPN. Combination tunnel id + vpn id is unique within the AWS scope account (account id + region).
 _**Note**_: for each VPN site to site connection, there are four documents sent to ES. Is this expected?
![image](https://github.com/elastic/integrations/assets/113898685/c7d584f9-204a-4724-adf1-093e764c9660)


**Firewall**: The firewall name is unique per region in an account. A firewall can have more than one engine and one Availability Zone, so both need to be set as dimension to avoid documents being overwritten. Since we can have more than one custom action in the same firewall, we also set that as dimension.
**_Question:_** `CustomAction` fields holds the name of the action. Since a firewall can have different groups (names are unique, but we don't have access to that field in this data stream), then we can also have different custom actions with the exact same name associated with one firewall. I tried to reproduce this, but even with multiple rules with the same name I kept receiving just one document for each rule. Without considering TSDB, can we receive two documents for the same action at the same time? If so, dimensions are not enough for this data stream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

 - [x] Verification of the count of documents (before & after TSDB enablement) in Discover Interface
 - [x] Verify if field mapping is correct in the data stream template.

## How to test this PR locally

Refer to https://github.com/elastic/integrations/issues/6293.

## Related issues

Relates to https://github.com/elastic/integrations/issues/6293.