### PR TITLE
[Cloud Posture] remove preview from 1.3.0 after release

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -7,7 +7,7 @@
     - description: Send short notation of ElasticAgentVersion
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6034
-- version: "1.3.0-preview9"
+- version: "1.3.0"
   changes:
     - description: New vulnerability management integration
       type: enhancement


### PR DESCRIPTION
Changing the development version to 1.3.0