### PR TITLE
[O11y][AWS] Fix Incorrect fields in AWS Metrics Overview dashboard 

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix incorrect fields on multiple visualizations.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #FIXME
+      link: https://github.com/elastic/integrations/pull/6353 #FIXME
 - version: "1.37.2"
   changes:
     - description: Migrate AWS RDS metrics dashboard to lenses.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix incorrect fields on multiple visualizations.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/6353 #FIXME
+      link: https://github.com/elastic/integrations/pull/6353
 - version: "1.37.2"
   changes:
     - description: Migrate AWS RDS metrics dashboard to lenses.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.37.3"
+  changes:
+    - description: Fix incorrect fields on multiple visualizations.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #FIXME
 - version: "1.37.2"
   changes:
     - description: Migrate AWS RDS metrics dashboard to lenses.

--- a/packages/aws/data_stream/kinesis/fields/fields.yml
+++ b/packages/aws/data_stream/kinesis/fields/fields.yml
@@ -8,7 +8,6 @@
           dimension: true
           type: keyword
           description: The name of the Kinesis stream. All available statistics are filtered by StreamName.
-
     - name: kinesis.metrics
       type: group
       fields:
@@ -89,7 +88,6 @@
           metric_type: gauge
           description: >
             The total number of PutRecords operations where at least one record succeeded, per Kinesis stream, measured over the specified time period.
-
 
         - name: PutRecords_TotalRecords.sum
           type: long

--- a/packages/aws/kibana/dashboard/aws-fac28650-7349-11e9-816b-07687310a99a.json
+++ b/packages/aws/kibana/dashboard/aws-fac28650-7349-11e9-816b-07687310a99a.json
@@ -199,7 +199,7 @@
                                     "line_width": 1,
                                     "metrics": [
                                         {
-                                            "field": "aws.ec2.cpu.total.pct",
+                                            "field": "host.cpu.usage",
                                             "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                             "type": "avg"
                                         }
@@ -636,7 +636,7 @@
                                     "line_width": 1,
                                     "metrics": [
                                         {
-                                            "field": "aws.elb.metrics.Latency",
+                                            "field": "aws.elb.metrics.Latency.avg",
                                             "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                             "type": "avg"
                                         }
@@ -713,7 +713,7 @@
                                     "line_width": 1,
                                     "metrics": [
                                         {
-                                            "field": "aws.elb.metrics.UnHealthyHostCount",
+                                            "field": "aws.elb.metrics.UnHealthyHostCount.max",
                                             "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                             "type": "sum"
                                         }
@@ -789,7 +789,7 @@
                                     "line_width": 1,
                                     "metrics": [
                                         {
-                                            "field": "aws.lambda.metrics.Invocations",
+                                            "field": "aws.lambda.metrics.Invocations.avg",
                                             "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                             "type": "avg"
                                         }
@@ -1017,12 +1017,12 @@
                                     "line_width": 1,
                                     "metrics": [
                                         {
-                                            "field": "aws.ecs.metrics.CPUUtilization",
+                                            "field": "aws.ecs.metrics.CPUUtilization.avg",
                                             "id": "17f8ddf0-830d-11e9-9f3d-ed346f48a007",
                                             "type": "sum"
                                         },
                                         {
-                                            "field": "aws.ecs.metrics.CPUReservation",
+                                            "field": "aws.ecs.metrics.CPUReservation.avg",
                                             "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                             "type": "sum"
                                         },
@@ -1114,12 +1114,12 @@
                                     "line_width": 1,
                                     "metrics": [
                                         {
-                                            "field": "aws.ecs.metrics.MemoryUtilization",
+                                            "field": "aws.ecs.metrics.MemoryUtilization.avg",
                                             "id": "17f8ddf0-830d-11e9-9f3d-ed346f48a007",
                                             "type": "sum"
                                         },
                                         {
-                                            "field": "aws.ecs.metrics.MemoryReservation",
+                                            "field": "aws.ecs.metrics.MemoryReservation.avg",
                                             "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                             "type": "sum"
                                         },

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.37.2
+version: 1.37.3
 license: basic
 description: Collect logs and metrics from Amazon Web Services with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?
Update AWS Metric visualizations with correct field names.
<html>
<body>
<!--StartFragment-->

Old Field | New Field
-- | --
aws.ec2.cpu.total.pct | host.cpu.usage
aws.elb.metrics.Latency | aws.elb.metrics.Latency.avg
aws.elb.metrics.UnHealthyHostCount | aws.elb.metrics.UnHealthyHostCount.max
aws.lambda.metrics.Invocations | aws.lambda.metrics.Invocations.avg
aws.ecs.metrics.CPUUtilization | aws.ecs.metrics.CPUUtilization.avg
aws.ecs.metrics.CPUReservation | aws.ecs.metrics.CPUReservation.avg

<!--EndFragment-->
</body>
</html>
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/issues/6338
- https://github.com/elastic/integrations/issues/6222

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
