### PR TITLE
Add `condition` and `processors` settings to SQL Input

### DIFF
--- a/packages/sql_input/agent/input/input.yml.hbs
+++ b/packages/sql_input/agent/input/input.yml.hbs
@@ -3,6 +3,9 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 driver: {{driver}}
 sql_queries: {{sql_queries}}
 raw_data.enabled: true
@@ -10,3 +13,7 @@ period: {{period}}
 merge_results: {{merge_results}}
 data_stream:
   dataset: {{data_stream.dataset}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/sql_input/changelog.yml
+++ b/packages/sql_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Add `condition` and `processors` settings.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6358
 - version: "0.3.0"
   changes:
     - description: Add merge_results feature

--- a/packages/sql_input/manifest.yml
+++ b/packages/sql_input/manifest.yml
@@ -70,6 +70,6 @@ policy_templates:
         required: false
         show_user: false
         description: >-
-          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/metricbeat/current/filtering-and-enhancing-data.html) for details.
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 owner:
   github: elastic/obs-infraobs-integrations

--- a/packages/sql_input/manifest.yml
+++ b/packages/sql_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: sql
 title: "SQL Input"
-version: "0.3.0"
+version: "0.4.0"
 description: "Collects Metrics by Quering on SQL Databases"
 type: input
 categories:
@@ -56,5 +56,20 @@ policy_templates:
         show_user: false
         default: false
         description: Merge results from multiple queries to a single event (restrictions apply)
+      - name: condition
+        title: Condition
+        description: Condition to filter when to apply this datastream. Refer to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
+        type: text
+        multi: false
+        required: false
+        show_user: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/metricbeat/current/filtering-and-enhancing-data.html) for details.
 owner:
   github: elastic/obs-infraobs-integrations


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- 
- Breaking change
- Deprecation
-->

Enhancement

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adds two (2) new field settings to the SQL Input integration.

1. Adds the ability to set `condition`.
    - The ability to set this value allows for having multiple SQL Input integrations in the same Agent policy while only having them run on specific hosts. (Most likely to be used with the `host` metadata; ex; `host.name` or `host.platform`.
2. Adds the ability to set `processors`.
    - The ability to set `processors` to manipulate collected data before sending to Elasticsearch.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- I added both `condition` and `processors` as "advanced" fields.

<details>
<summary>Before Upgrade</summary>

```yaml
inputs:
  - id: sql/metrics-sql-12f9198a-ae28-48f4-aae6-63b23781e064
    name: sql-1
    revision: 1
    type: sql/metrics
    use_output: default
    meta:
      package:
        name: sql
        version: 0.1.0
    data_stream:
      namespace: default
    package_policy_id: 12f9198a-ae28-48f4-aae6-63b23781e064
    streams:
      - id: sql/metrics-sql.sql-12f9198a-ae28-48f4-aae6-63b23781e064
        data_stream:
          dataset: test
        metricsets:
          - query
        hosts:
          - 'root:test@tcp(127.0.0.1:3306)/'
        driver: mysql
        sql_queries:
          - query: SHOW GLOBAL STATUS LIKE 'Innodb_system%'
            response_format: variables
        raw_data.enabled: true
        period: 10s
```

</details>

<details>
<summary>After Upgrade (with Settings)</summary>

```yaml
inputs:
  - id: sql/metrics-sql-12f9198a-ae28-48f4-aae6-63b23781e064
    name: sql-1
    revision: 3
    type: sql/metrics
    use_output: default
    meta:
      package:
        name: sql
        version: 0.2.0
    data_stream:
      namespace: default
    package_policy_id: 12f9198a-ae28-48f4-aae6-63b23781e064
    streams:
      - id: sql/metrics-sql.sql-12f9198a-ae28-48f4-aae6-63b23781e064
        data_stream:
          dataset: test
        condition: '${host.name} == "mydb-server"'
        period: 10s
        raw_data.enabled: true
        driver: mysql
        sql_queries:
          - response_format: variables
            query: SHOW GLOBAL STATUS LIKE 'Innodb_system%'
        hosts:
          - 'root:test@tcp(127.0.0.1:3306)/'
        metricsets:
          - query
        processors:
          - drop_fields:
              fields:
                - agent
```

</details>

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Install current integration version
2. Upgrade integration to this PR
3. Add/Remove condition values.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- N/A

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

- New fields from Kibana UI
![image](https://github.com/elastic/integrations/assets/8277432/853bfa1b-3d7a-4cae-8c0c-1889309f1467)

