### PR TITLE
Fix mongodb logs overview dashboard and default logs path

### DIFF
--- a/packages/mongodb/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mongodb/_dev/deploy/docker/docker-compose.yml
@@ -15,5 +15,4 @@ services:
     volumes:
       - ${SERVICE_LOGS_DIR}:/var/log/mongodb
     entrypoint: >
-      bash -c "chmod a+wx /var/log/mongodb && chmod a+r -R /var/log/mongodb && touch /var/log/mongodb/mongodb.log && chmod 644 /var/log/mongodb/mongodb.log && mongod --replSet beats --logpath /var/log/mongodb/mongodb.log --logappend"
-
+      bash -c "chmod a+wx /var/log/mongodb && chmod a+r -R /var/log/mongodb && touch /var/log/mongodb/mongod.log && chmod 644 /var/log/mongodb/mongod.log && mongod --replSet beats --logpath /var/log/mongodb/mongod.log --logappend"

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix mongodb logs overview dashboard and default path
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/6360
 - version: "1.10.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.10.1"
+  changes:
+    - description: Fix mongodb logs overview dashboard and default path
+      type: bugfix
+      link: tbd
 - version: "1.10.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,6 +1,6 @@
 - version: "1.10.1"
   changes:
-    - description: Fix mongodb logs overview dashboard and default path
+    - description: Fix mongodb logs overview dashboard and default log path
       type: bugfix
       link: https://github.com/elastic/integrations/pull/6360
 - version: "1.10.0"

--- a/packages/mongodb/data_stream/log/manifest.yml
+++ b/packages/mongodb/data_stream/log/manifest.yml
@@ -10,7 +10,7 @@ streams:
         required: true
         show_user: true
         default:
-          - /var/log/mongodb/mongodb.log
+          - /var/log/mongodb/mongod.log
       - name: tags
         type: text
         title: Tags

--- a/packages/mongodb/kibana/search/mongodb-bfc96a60-0a80-11e8-bffe-ff7d4f68cf94.json
+++ b/packages/mongodb/kibana/search/mongodb-bfc96a60-0a80-11e8-bffe-ff7d4f68cf94.json
@@ -16,7 +16,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "log.level: *"
+                    "query": "data_stream.dataset:mongodb.log"
                 },
                 "version": true
             }
@@ -27,7 +27,7 @@
                 "asc"
             ]
         ],
-        "title": "All logs",
+        "title": "Logs MongoDB",
         "version": 1
     },
     "coreMigrationVersion": "8.1.0",

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: "1.10.0"
+version: "1.10.1"
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Bug


## What does this PR do?

This PR updates the default path for mongoldb logs and also fix the dashboard to filter logs data specific to mongodb.log dataset.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## How to test this PR locally


## Related issues


- Closes #6114



## Screenshots

<img width="933" alt="image" src="https://github.com/elastic/integrations/assets/102972658/b239cb19-67b9-4f55-9081-f85bddcd62a9">

<img width="1690" alt="image" src="https://github.com/elastic/integrations/assets/102972658/0a8d9d97-fe4a-4131-9c9d-dffc235e601b">

