### PR TITLE
[hid_bravura_monitor] - Format ingest pipeline YAML

### DIFF
--- a/packages/hid_bravura_monitor/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hid_bravura_monitor/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -66,7 +66,7 @@ processors:
         -> m.put(k.toLowerCase(), v));
         ctx['hid_bravura_monitor'].remove('perf');
         ctx['hid_bravura_monitor']['perf'] = new HashMap(); m.forEach((k,v) ->
-        ctx['hid_bravura_monitor']['perf'][k] = v ); 
+        ctx['hid_bravura_monitor']['perf'][k] = v );
       description: lowercase perf fields
   - set:
       if: ctx?.hid_bravura_monitor?.perf?.kind == 'PerfExe'

--- a/packages/hid_bravura_monitor/data_stream/winlog/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hid_bravura_monitor/data_stream/winlog/elasticsearch/ingest_pipeline/default.yml
@@ -17,10 +17,9 @@ processors:
 
   - grok:
       field: event.original
-      patterns: 
-        - >-
-          %{DATA:winlog.event_data.Message}\|%{GREEDYDATA:kvpairs}
-  
+      patterns:
+        - '%{DATA:winlog.event_data.Message}\|%{GREEDYDATA:kvpairs}'
+
   - kv:
       field: kvpairs
       field_split: '\|'
@@ -379,18 +378,17 @@ processors:
       ignore_missing: true
 
   - remove:
-      field: [
-        "winlog.event_data.Value1",
-        "winlog.event_data.Value2",
-        "winlog.event_data.Value3",
-        "winlog.event_data.Value4",
-        "winlog.event_data.Value5",
-        "winlog.event_data.Value6",
-        "winlog.event_data.Value7",
-        "winlog.event_data.Value8",
-        "winlog.event_data.Value9"
-      ]
       ignore_missing: true
+      field:
+        - winlog.event_data.Value1
+        - winlog.event_data.Value2
+        - winlog.event_data.Value3
+        - winlog.event_data.Value4
+        - winlog.event_data.Value5
+        - winlog.event_data.Value6
+        - winlog.event_data.Value7
+        - winlog.event_data.Value8
+        - winlog.event_data.Value9
 
 on_failure:
   - set:


### PR DESCRIPTION
## What does this PR do?

Remove trailing spaces. And use a block sequence instead of a flow sequence for remove processor. This was causing some issues when round-tripping the YAML while doing some programmatic edits to the integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] ~I have added an entry to my package's `changelog.yml` file.~ No user facing changes. Just formatting.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

