### PR TITLE
[fortinet_fortigate] use YAML literal for script source

### DIFF
--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -32,7 +32,7 @@ processors:
       if: ctx.syslog5424_sd != null
       description: |
         Splits syslog5424_sd KV list by space and then each by "=" taking into account quoted values.
-      source:
+      source: |
         def splitUnquoted(String input, String sep) {
           def tokens = [];
           def startPosition = 0;


### PR DESCRIPTION
## What does this PR do?

All (indented) characters are considered to be content, including white space characters. This causes the source in the YAML to match the source in the ingest processor.

https://yaml.org/spec/1.2.2/#812-literal-style

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] ~I have added an entry to my package's `changelog.yml` file.~ No user facing changes. Just formatting.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related

- Works around: https://github.com/goccy/go-yaml/issues/374