### PR TITLE
[Infoblox NIOS] use YAML literal for script source

### DIFF
--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -52,7 +52,7 @@ processors:
         Process dns.answers data by splitting repeat_message by ';'
         and then each of the elements by space. It takes into account
         quoted strings.
-      source:
+      source: |
         def splitUnquoted(String input, String sep) {
           def tokens = [];
           def startPosition = 0;
@@ -110,7 +110,7 @@ processors:
       description: Remove last Full Stop('.') from `dns.answers.data` field.
       lang: painless
       if: ctx.dns?.answers?.data instanceof List
-      source:
+      source: |
         def hash = new ArrayList();
         for(data in ctx.dns?.answers?.data){
           def n = data.length();
@@ -127,7 +127,7 @@ processors:
       description: Remove last Full Stop('.') from `dns.answers.name` field.
       lang: painless
       if: ctx.dns?.answers?.name instanceof List
-      source:
+      source: |
         def hash = new ArrayList();
         for(name in ctx.dns?.answers?.name){
           def n = name.length();


### PR DESCRIPTION
## What does this PR do?

All (indented) characters are considered to be content, including white space characters. This causes the source in the YAML to match the source in the ingest processor.

https://yaml.org/spec/1.2.2/#812-literal-style

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] ~I have added an entry to my package's `changelog.yml` file.~ No user facing changes. Does not change function.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related

- Works around: https://github.com/goccy/go-yaml/issues/374
