### PR TITLE
[Docker][Diskio] Add metric type

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Add metric type to diskio data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5586
 - version: "2.4.3"
   changes:
     - description: Added link to docs for condition filter

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add metric type to diskio data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5586
+      link: https://github.com/elastic/integrations/pull/6392
 - version: "2.4.3"
   changes:
     - description: Added link to docs for condition filter

--- a/packages/docker/data_stream/diskio/fields/fields.yml
+++ b/packages/docker/data_stream/diskio/fields/fields.yml
@@ -12,6 +12,7 @@
       fields:
         - name: ops
           type: long
+          metric_type: counter
           description: |
             Number of reads during the life of the container
         - name: bytes

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -365,7 +365,7 @@ The Docker `diskio` data stream collects disk I/O metrics.
 | data_stream.type | Data stream type. | constant_keyword |  |  |
 | docker.container.labels.\* | Container labels | object |  |  |
 | docker.diskio.read.bytes | Bytes read during the life of the container | long |  | counter |
-| docker.diskio.read.ops | Number of reads during the life of the container | long |  |  |
+| docker.diskio.read.ops | Number of reads during the life of the container | long |  | counter |
 | docker.diskio.read.queued | Total number of queued requests | long |  | gauge |
 | docker.diskio.read.rate | Number of current reads per second | long |  | gauge |
 | docker.diskio.read.service_time | Total time to service IO requests, in nanoseconds | long |  | counter |

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.4.3
+version: 2.5.0
 release: ga
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add counter metric type to `docker.diskio.reads.ops`, since it is a cumulative value. All others metrics already have a type.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
