### PR TITLE
[O11y][MySQL] Update system test cases

### DIFF
--- a/packages/mysql/_dev/deploy/docker/Dockerfile
+++ b/packages/mysql/_dev/deploy/docker/Dockerfile
@@ -1,6 +1,7 @@
-ARG IMAGE=${IMAGE:-mysql:5.7.34}
+ARG IMAGE=${IMAGE}
 FROM ${IMAGE}
 
+USER root
 ENV MYSQL_ROOT_PASSWORD test
 
 HEALTHCHECK --interval=1s --retries=90 CMD /healthcheck.sh

--- a/packages/mysql/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mysql/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,17 @@
 version: '2.3'
 services:
   mysql:
-    build: .
+    build:
+      context: .
+      args:
+        IMAGE: ${IMAGE:-mysql:8.0.13}
     ports:
       - 3306
     volumes:
       - ${SERVICE_LOGS_DIR}/mysql:/var/log/mysql
       - mysqldata:/var/lib/mysql
+    environment:
+      - IMAGE=${IMAGE:-mysql:8.0.13}
   mysql_is_ready:
     image: tianon/true
     depends_on:

--- a/packages/mysql/_dev/deploy/docker/entrypoint.sh
+++ b/packages/mysql/_dev/deploy/docker/entrypoint.sh
@@ -9,7 +9,28 @@ chown mysql:mysql /var/log/mysql/*.log
 chmod a+wx /var/log/mysql
 chmod a+r -R /var/log/mysql
 
+if [[ "$IMAGE" == "percona:8.0.13-4" ]]; then
+# Write "test.cnf" config
+cat << EOF > /etc/my.cnf.d/test.cnf
+[mysqld]
+user=root
+bind-address = 0.0.0.0
+log-error = /var/log/mysql/$HOSTNAME-error.log
+EOF
 
+# Write "slow-log.cnf" config (/var/lib/mysql/<hostname>-slow.log, but in the shared log directory).
+cat << EOF > /etc/my.cnf.d/slow-log.cnf
+[mysqld]
+user=root
+slow-query-log=ON
+slow-query-log-file=/var/log/mysql/$HOSTNAME-slow.log
+long-query-time=0
+EOF
+
+exec bash /docker-entrypoint.sh mysqld
+fi
+
+if [[ "$IMAGE" == "mysql:8.0.13" ]]; then
 # Write "test.cnf" config
 cat << EOF > /etc/mysql/conf.d/test.cnf
 [mysqld]
@@ -26,3 +47,4 @@ long-query-time=0
 EOF
 
 exec bash /entrypoint.sh mysqld
+fi

--- a/packages/mysql/_dev/deploy/variants.yml
+++ b/packages/mysql/_dev/deploy/variants.yml
@@ -1,16 +1,6 @@
 variants:
-  mysql_5_7_12:
-    IMAGE: mysql:5.7.12
   mysql_8_0_13:
     IMAGE: mysql:8.0.13
-  percona_5_7_24:
-    IMAGE: percona:5.7.24
   percona_8_0_13:
     IMAGE: percona:8.0.13-4
-  mariadb_10_2_23:
-    IMAGE: mariadb:10.2.23
-  mariadb_10_3_14:
-    IMAGE: mariadb:10.3.14
-  mariadb_10_4_4:
-    IMAGE: mariadb:10.4.4
-default: mysql_5_7_12
+default: mysql_8_0_13

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.1"
+  changes:
+    - description: Add system test cases for performance datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIXME
 - version: "1.12.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add system test cases for performance datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIXME
+      link: https://github.com/elastic/integrations/pull/6394
 - version: "1.12.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/mysql/data_stream/performance/_dev/test/system/test-default-config.yml
+++ b/packages/mysql/data_stream/performance/_dev/test/system/test-default-config.yml
@@ -1,0 +1,7 @@
+vars:
+  hosts:
+    - tcp({{Hostname}}:{{Port}})/
+  username: root
+  password: test
+data_stream:
+  vars: ~

--- a/packages/mysql/data_stream/performance/sample_event.json
+++ b/packages/mysql/data_stream/performance/sample_event.json
@@ -1,52 +1,51 @@
 {
-    "@timestamp": "2023-01-25T14:23:17.060Z",
+    "@timestamp": "2023-05-30T09:51:54.708Z",
     "agent": {
+        "ephemeral_id": "7e7fea68-fc17-44df-9a8e-6ceb55e55348",
+        "id": "c5ef7e66-470c-4ff7-aca5-4a28b7a75618",
         "name": "docker-fleet-agent",
-        "id": "39205dfa-169a-4567-a887-12b5974403f0",
         "type": "metricbeat",
-        "ephemeral_id": "57fc2e5d-6672-4ed3-a0cf-b70093c1f0dc",
-        "version": "8.5.3"
+        "version": "8.0.0"
     },
     "data_stream": {
-        "namespace": "default",
-        "type": "metrics",
-        "dataset": "mysql.performance"
+        "dataset": "mysql.performance",
+        "namespace": "ep",
+        "type": "metrics"
     },
     "ecs": {
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "39205dfa-169a-4567-a887-12b5974403f0",
-        "version": "8.5.3",
-        "snapshot": false
+        "id": "c5ef7e66-470c-4ff7-aca5-4a28b7a75618",
+        "snapshot": false,
+        "version": "8.0.0"
     },
     "event": {
-        "duration": 2867042,
         "agent_id_status": "verified",
-        "ingested": "2023-01-25T14:23:18Z",
-        "module": "mysql",
-        "dataset": "mysql.performance"
+        "dataset": "mysql.performance",
+        "duration": 2102127,
+        "ingested": "2023-05-30T09:51:58Z",
+        "module": "mysql"
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "589e678e8f3f457d81e3a530d3ae6011",
         "ip": [
-            "172.24.0.7"
+            "192.168.244.7"
         ],
         "mac": [
-            "02-42-AC-18-00-07"
+            "02:42:c0:a8:f4:07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.104-linuxkit",
+            "kernel": "3.10.0-1160.88.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.3 LTS (Focal Fossa)"
         }
     },
     "metricset": {
@@ -58,7 +57,7 @@
             "events_statements": {
                 "avg": {
                     "timer": {
-                        "wait": 3722000000
+                        "wait": 2884186000
                     }
                 },
                 "count": {
@@ -68,21 +67,21 @@
                     "text": "SELECT `digest_text` , `count_star` , `avg_timer_wait` , `max_timer_wait` , `last_seen` , `quantile_95` FROM `performance_schema` . `events_statements_summary_by_digest` ORDER BY `avg_timer_wait` DESC LIMIT ?"
                 },
                 "last": {
-                    "seen": "2023-01-25T14:23:07.055308"
+                    "seen": "2023-05-30T09:51:49.233295"
                 },
                 "max": {
                     "timer": {
-                        "wait": 3722000000
+                        "wait": 2884186000
                     }
                 },
                 "quantile": {
-                    "95": 3801893963
+                    "95": 3019951720
                 }
             }
         }
     },
     "service": {
-        "address": "tcp(host.docker.internal:52767)/?readTimeout=10s&timeout=10s&writeTimeout=10s",
+        "address": "tcp(elastic-package-service_mysql_1:3306)/?readTimeout=10s\u0026timeout=10s\u0026writeTimeout=10s",
         "type": "mysql"
     }
 }

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: "1.12.0"
+version: "1.12.1"
 license: basic
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement


## What does this PR do?

- This PR updates system test cases for the MySQL package.
- System tests are done in the supported versions mentioned in the `variants.yml` due to this [issue](https://github.com/elastic/beats/issues/25069).
Conversation for the same:- [Link](https://github.com/elastic/integrations/issues/4372#issuecomment-1567776226)
- Updated `sample_event.json` for the performance data stream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.


## How to test this PR locally

- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/mysql directory.
- Run the following command to run the system tests. elastic-package test system

## Related issues


- Closes #4372

![image](https://github.com/elastic/integrations/assets/124054599/64e192ca-1511-4531-b5cc-2b62a54db180)
![image](https://github.com/elastic/integrations/assets/124054599/acf74947-6085-4daa-bef3-04c9c3a1c524)
![image](https://github.com/elastic/integrations/assets/124054599/3f8c3670-ceb3-4c00-aa84-037cd5bc752f)

