### PR TITLE
[System] Add missing metric_type metadata

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.1"
+  changes:
+    - description: Add missing metric_type metadata
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6256
 - version: "1.29.0"
   changes:
     - description: support ip or domain in sshd messages

--- a/packages/system/data_stream/cpu/fields/fields.yml
+++ b/packages/system/data_stream/cpu/fields/fields.yml
@@ -139,6 +139,7 @@
         The amount of CPU time spent in user space.
     - name: system.ticks
       type: long
+      metric_type: counter
       description: |
         The amount of CPU time spent in kernel space.
     - name: nice.ticks

--- a/packages/system/data_stream/memory/fields/fields.yml
+++ b/packages/system/data_stream/memory/fields/fields.yml
@@ -91,6 +91,7 @@
           description: swap readahead pages
         - name: readahead.cached
           type: long
+          metric_type: counter
           description: swap readahead cache hits
         - name: used.pct
           type: scaled_float

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -1294,7 +1294,7 @@ This data should be available without elevated permissions.
 | system.cpu.steal.ticks | The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix. | long |  | counter |
 | system.cpu.system.norm.pct | The percentage of CPU time spent in kernel space. | scaled_float | percent | gauge |
 | system.cpu.system.pct | The percentage of CPU time spent in kernel space. | scaled_float | percent | gauge |
-| system.cpu.system.ticks | The amount of CPU time spent in kernel space. | long |  |  |
+| system.cpu.system.ticks | The amount of CPU time spent in kernel space. | long |  | counter |
 | system.cpu.total.norm.pct | The percentage of CPU time in states other than Idle and IOWait, normalised by the number of cores. | scaled_float | percent | gauge |
 | system.cpu.total.pct | The percentage of CPU time spent in states other than Idle and IOWait. | scaled_float | percent | gauge |
 | system.cpu.user.norm.pct | The percentage of CPU time spent in user space. | scaled_float | percent | gauge |
@@ -1673,7 +1673,7 @@ This data should be available without elevated permissions.
 | system.memory.swap.free | Available swap memory. | long | byte | gauge |
 | system.memory.swap.in.pages | count of pages swapped in | long |  | gauge |
 | system.memory.swap.out.pages | count of pages swapped out | long |  | counter |
-| system.memory.swap.readahead.cached | swap readahead cache hits | long |  |  |
+| system.memory.swap.readahead.cached | swap readahead cache hits | long |  | counter |
 | system.memory.swap.readahead.pages | swap readahead pages | long |  | counter |
 | system.memory.swap.total | Total swap memory. | long | byte | gauge |
 | system.memory.swap.used.bytes | Used swap memory. | long | byte | gauge |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.29.0
+version: 1.29.1
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Cpu and Memory data_streams already contain the `metric_type`, only those 2 fields were missing for some reason.

In all system package are missing `metric_type` for those 2 fields and for `process.cgroup` metrics - it will be a part for a different PR.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
