### PR TITLE
Migrate  dashboard "Azure Spring Cloud System Logs" to Lens

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,6 +1,6 @@
 - version: "1.5.15"
   changes:
-    - description: Migration of Spring Cloud System Logs to Lens
+    - description: Migration of Spring Cloud System Logs dashboard to Lens
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6397
 - version: "1.5.14"

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.5.15"
+  changes:
+    - description: Migration of Spring Cloud System Logs to Lens
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6397
 - version: "1.5.14"
   changes:
     - description: Enhancement/Improving performance of the dashboards

--- a/packages/azure/kibana/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43.json
+++ b/packages/azure/kibana/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43.json
@@ -9,30 +9,7 @@
         "description": "[Logs Azure] Azure Spring cloud Logs System Logs",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "data_stream.dataset",
-                            "negate": false,
-                            "params": {
-                                "query": "azure.springcloudlogs"
-                            },
-                            "type": "phrase"
-                        },
-                        "query": {
-                            "match_phrase": {
-                                "data_stream.dataset": "azure.springcloudlogs"
-                            }
-                        }
-                    }
-                ],
+                "filter": [],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -83,7 +60,7 @@
                 "panelIndex": "36cfd9c9-98e2-427a-9f99-3b4406d86841",
                 "title": "Navigation Azure System Logs",
                 "type": "visualization",
-                "version": "8.6.0"
+                "version": "8.7.0"
             },
             {
                 "embeddableConfig": {
@@ -92,6 +69,11 @@
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-59775c31-6a61-4dd7-8004-05462a989a2b",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "52a6c795-a0fd-41e7-a644-83a6b04ac9a2",
                                 "type": "index-pattern"
                             }
                         ],
@@ -141,7 +123,30 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "52a6c795-a0fd-41e7-a644-83a6b04ac9a2",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "azure.springcloudlogs"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "azure.springcloudlogs"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -228,7 +233,7 @@
                 "panelIndex": "dd3bc6e6-219b-46d1-a458-cf79faa14c22",
                 "title": "System Logs Activity",
                 "type": "lens",
-                "version": "8.6.0"
+                "version": "8.7.0"
             },
             {
                 "embeddableConfig": {
@@ -237,6 +242,11 @@
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-442ce462-87f8-44d8-8060-ae99c2af8ff4",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "002814ed-6273-4412-8cac-e594a9425284",
                                 "type": "index-pattern"
                             }
                         ],
@@ -302,6 +312,10 @@
                                                 },
                                                 "d833bce2-53bd-463a-8f3a-99b8241196ef": {
                                                     "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
                                                     "isBucketed": false,
                                                     "label": "Count of records",
                                                     "operationType": "count",
@@ -320,7 +334,30 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "002814ed-6273-4412-8cac-e594a9425284",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "azure.springcloudlogs"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "azure.springcloudlogs"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -408,7 +445,7 @@
                 "panelIndex": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7",
                 "title": "Log Level",
                 "type": "lens",
-                "version": "8.6.0"
+                "version": "8.7.0"
             },
             {
                 "embeddableConfig": {
@@ -417,21 +454,22 @@
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-7574efe2-c9d0-4a05-ab12-0801f59f6aaf",
                                 "type": "index-pattern"
                             },
                             {
                                 "id": "logs-*",
-                                "name": "filter-index-pattern-0",
+                                "name": "51379c8c-15c8-410a-9060-e5e48b17ea53",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "8abed462-4937-4c15-8ad4-8c3034ca4670",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
                                     "layers": {
@@ -484,7 +522,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "filter-index-pattern-0",
+                                        "index": "51379c8c-15c8-410a-9060-e5e48b17ea53",
                                         "key": "azure.springcloudlogs.category",
                                         "negate": false,
                                         "params": {
@@ -497,8 +535,31 @@
                                             "azure.springcloudlogs.category": "SystemLogs"
                                         }
                                     }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "8abed462-4937-4c15-8ad4-8c3034ca4670",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "azure.springcloudlogs"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "azure.springcloudlogs"
+                                        }
+                                    }
                                 }
                             ],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -555,6 +616,7 @@
                             }
                         },
                         "title": "Azure Spring Cloud Logs System Logs Operations [Logs Azure]",
+                        "type": "lens",
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -570,7 +632,7 @@
                 "panelIndex": "748eb38a-92e4-4636-87c4-ca8bde01e6d8",
                 "title": "Operations",
                 "type": "lens",
-                "version": "8.6.0"
+                "version": "8.7.0"
             },
             {
                 "embeddableConfig": {
@@ -579,6 +641,11 @@
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-a12fbd27-f613-4f5c-9a74-13239009bfa9",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "7884311b-8393-4fee-80fe-d645bf2b9574",
                                 "type": "index-pattern"
                             }
                         ],
@@ -663,7 +730,30 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "7884311b-8393-4fee-80fe-d645bf2b9574",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "azure.springcloudlogs"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "azure.springcloudlogs"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -751,7 +841,7 @@
                 "panelIndex": "f10825d9-48e7-4c3b-b225-51ac95988c8a",
                 "title": "Services",
                 "type": "lens",
-                "version": "8.6.0"
+                "version": "8.7.0"
             },
             {
                 "embeddableConfig": {
@@ -765,6 +855,11 @@
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-a4f2e606-7655-45fa-be3d-de35dff5209a",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "d1fefd9d-6ebe-464a-a08f-bd2d4f412c57",
                                 "type": "index-pattern"
                             }
                         ],
@@ -918,7 +1013,30 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "d1fefd9d-6ebe-464a-a08f-bd2d4f412c57",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "azure.springcloudlogs"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "azure.springcloudlogs"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -1027,28 +1145,28 @@
                 "panelIndex": "65014b13-0aa6-488b-9015-5dcb7b0dfe74",
                 "title": "Logger \u0026 Type",
                 "type": "lens",
-                "version": "8.6.0"
+                "version": "8.7.0"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Azure] Azure Spring Cloud Logs System Logs",
         "version": 1
     },
-    "coreMigrationVersion": "8.6.0",
-    "created_at": "2023-05-15T15:24:13.365Z",
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-06-01T13:54:15.714Z",
     "id": "azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43",
     "migrationVersion": {
-        "dashboard": "8.6.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
             "id": "logs-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "name": "dd3bc6e6-219b-46d1-a458-cf79faa14c22:indexpattern-datasource-layer-59775c31-6a61-4dd7-8004-05462a989a2b",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "dd3bc6e6-219b-46d1-a458-cf79faa14c22:indexpattern-datasource-layer-59775c31-6a61-4dd7-8004-05462a989a2b",
+            "name": "dd3bc6e6-219b-46d1-a458-cf79faa14c22:52a6c795-a0fd-41e7-a644-83a6b04ac9a2",
             "type": "index-pattern"
         },
         {
@@ -1058,7 +1176,7 @@
         },
         {
             "id": "logs-*",
-            "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:indexpattern-datasource-current-indexpattern",
+            "name": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7:002814ed-6273-4412-8cac-e594a9425284",
             "type": "index-pattern"
         },
         {
@@ -1068,12 +1186,22 @@
         },
         {
             "id": "logs-*",
-            "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:filter-index-pattern-0",
+            "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:51379c8c-15c8-410a-9060-e5e48b17ea53",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:8abed462-4937-4c15-8ad4-8c3034ca4670",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
             "name": "f10825d9-48e7-4c3b-b225-51ac95988c8a:indexpattern-datasource-layer-a12fbd27-f613-4f5c-9a74-13239009bfa9",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "f10825d9-48e7-4c3b-b225-51ac95988c8a:7884311b-8393-4fee-80fe-d645bf2b9574",
             "type": "index-pattern"
         },
         {
@@ -1084,6 +1212,11 @@
         {
             "id": "logs-*",
             "name": "65014b13-0aa6-488b-9015-5dcb7b0dfe74:indexpattern-datasource-layer-a4f2e606-7655-45fa-be3d-de35dff5209a",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "65014b13-0aa6-488b-9015-5dcb7b0dfe74:d1fefd9d-6ebe-464a-a08f-bd2d4f412c57",
             "type": "index-pattern"
         },
         {

--- a/packages/azure/kibana/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43.json
+++ b/packages/azure/kibana/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43.json
@@ -60,7 +60,7 @@
                 "panelIndex": "36cfd9c9-98e2-427a-9f99-3b4406d86841",
                 "title": "Navigation Azure System Logs",
                 "type": "visualization",
-                "version": "8.7.0"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -233,7 +233,7 @@
                 "panelIndex": "dd3bc6e6-219b-46d1-a458-cf79faa14c22",
                 "title": "System Logs Activity",
                 "type": "lens",
-                "version": "8.7.0"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -445,7 +445,7 @@
                 "panelIndex": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7",
                 "title": "Log Level",
                 "type": "lens",
-                "version": "8.7.0"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -632,7 +632,7 @@
                 "panelIndex": "748eb38a-92e4-4636-87c4-ca8bde01e6d8",
                 "title": "Operations",
                 "type": "lens",
-                "version": "8.7.0"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -841,7 +841,7 @@
                 "panelIndex": "f10825d9-48e7-4c3b-b225-51ac95988c8a",
                 "title": "Services",
                 "type": "lens",
-                "version": "8.7.0"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1145,18 +1145,18 @@
                 "panelIndex": "65014b13-0aa6-488b-9015-5dcb7b0dfe74",
                 "title": "Logger \u0026 Type",
                 "type": "lens",
-                "version": "8.7.0"
+                "version": "8.6.0"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Azure] Azure Spring Cloud Logs System Logs",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.0",
+    "coreMigrationVersion": "8.6.0",
     "created_at": "2023-06-01T13:54:15.714Z",
     "id": "azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43",
     "migrationVersion": {
-        "dashboard": "8.7.0"
+        "dashboard": "8.6.0"
     },
     "references": [
         {

--- a/packages/azure/kibana/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43.json
+++ b/packages/azure/kibana/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43.json
@@ -1,677 +1,1101 @@
 {
-  "id": "azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43",
-  "type": "dashboard",
-  "namespaces": [
-    "default"
-  ],
-  "updated_at": "2023-03-07T09:38:25.166Z",
-  "created_at": "2023-03-07T09:38:25.166Z",
-  "version": "WzExMjc1LDFd",
-  "attributes": {
-    "controlGroupInput": {
-      "chainingSystem": "HIERARCHICAL",
-      "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"5cbc2c45-1213-4bb9-ab65-8dfc0cfbad8a\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription\",\"id\":\"5cbc2c45-1213-4bb9-ab65-8dfc0cfbad8a\",\"enhancements\":{}}},\"35a7fa77-1459-438c-8cb7-28770a0d7374\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.springcloudlogs.category\",\"title\":\"Spring Cloud Logs Type\",\"id\":\"35a7fa77-1459-438c-8cb7-28770a0d7374\",\"enhancements\":{}}}}"
-      },
-    "description": "[Logs Azure] Azure Spring cloud Logs System Logs",
-    "hits": 0,
-    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": {
-        "query": {
-          "query": "",
-          "language": "kuery"
+    "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"5cbc2c45-1213-4bb9-ab65-8dfc0cfbad8a\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription\",\"id\":\"5cbc2c45-1213-4bb9-ab65-8dfc0cfbad8a\",\"enhancements\":{}}},\"35a7fa77-1459-438c-8cb7-28770a0d7374\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.springcloudlogs.category\",\"title\":\"Spring Cloud Logs Type\",\"id\":\"35a7fa77-1459-438c-8cb7-28770a0d7374\",\"enhancements\":{}}}}"
         },
-        "filter": [
-          {
-            "$state": {
-              "store": "appState"
-            },
-            "meta": {
-              "alias": null,
-              "disabled": false,
-              "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-              "key": "data_stream.dataset",
-              "negate": false,
-              "params": {
-                "query": "azure.springcloudlogs"
-              },
-              "type": "phrase"
-            },
-            "query": {
-              "match_phrase": {
-                "data_stream.dataset": "azure.springcloudlogs"
-              }
-            }
-          }
-        ]
-      }
-    },
-    "optionsJSON": {
-      "useMargins": true,
-      "syncColors": false,
-      "hidePanelTitles": false
-    },
-    "panelsJSON": [
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 0,
-          "y": 0,
-          "w": 48,
-          "h": 5,
-          "i": "36cfd9c9-98e2-427a-9f99-3b4406d86841"
-        },
-        "panelIndex": "36cfd9c9-98e2-427a-9f99-3b4406d86841",
-        "embeddableConfig": {
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs Navigation System Logs [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "fontSize": 12,
-              "openLinksInNewTab": false,
-              "markdown": "### Azure Spring Cloud System Logs\n[Overview](#/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43) | [**System Logs**](#/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43) | [Application Console Logs](#/dashboard/azure-32aedb00-f524-11eb-b9f3-73fa29f35762) "
-            },
-            "type": "markdown",
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
-            }
-          },
-          "hidePanelTitles": false,
-          "enhancements": {},
-          "type": "visualization"
-        },
-        "title": "Navigation Azure System Logs"
-      },
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 23,
-          "y": 5,
-          "w": 25,
-          "h": 18,
-          "i": "dd3bc6e6-219b-46d1-a458-cf79faa14c22"
-        },
-        "panelIndex": "dd3bc6e6-219b-46d1-a458-cf79faa14c22",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": false,
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs System Logs Activity [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "time_range_mode": "entire_time_range",
-              "id": "2377e52f-91ef-4ff1-bdad-211ff2c25f0f",
-              "type": "timeseries",
-              "series": [
-                {
-                  "id": "267ec4fa-03f7-4089-b02f-c738d4a0dd04",
-                  "color": "#68BC00",
-                  "split_mode": "everything",
-                  "palette": {
-                    "type": "palette",
-                    "name": "default"
-                  },
-                  "metrics": [
+        "description": "[Logs Azure] Azure Spring cloud Logs System Logs",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
                     {
-                      "id": "737a9957-834d-4a30-8e4c-468cfb3c4905",
-                      "type": "count"
-                    }
-                  ],
-                  "separate_axis": 0,
-                  "axis_position": "right",
-                  "formatter": "number",
-                  "chart_type": "line",
-                  "line_width": 1,
-                  "point_size": 1,
-                  "fill": 0.5,
-                  "stacked": "none"
-                }
-              ],
-              "time_field": "",
-              "use_kibana_indexes": true,
-              "interval": "",
-              "axis_position": "left",
-              "axis_formatter": "number",
-              "axis_scale": "normal",
-              "show_legend": 1,
-              "show_grid": 1,
-              "tooltip_mode": "show_all",
-              "drop_last_bucket": 0,
-              "isModelInvalid": false,
-              "filter": {
-                "query": "data_stream.dataset : \"azure.springcloudlogs\" and azure.springcloudlogs.category : \"SystemLogs\" ",
-                "language": "kuery"
-              },
-              "index_pattern_ref_name": "metrics_0_index_pattern"
-            },
-            "type": "metrics",
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
-            }
-          }
-        },
-        "title": "System Logs Activity"
-      },
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 0,
-          "y": 5,
-          "w": 23,
-          "h": 18,
-          "i": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7"
-        },
-        "panelIndex": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": false,
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs System Logs Level List [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "time_range_mode": "entire_time_range",
-              "id": "e8ae1bbe-9172-4214-986d-7118f06a8f02",
-              "type": "timeseries",
-              "series": [
-                {
-                  "id": "710c298a-93bb-4d00-99c0-605bbd463ac0",
-                  "color": "rgba(170,101,86,1)",
-                  "split_mode": "terms",
-                  "palette": {
-                    "type": "palette",
-                    "name": "default"
-                  },
-                  "metrics": [
-                    {
-                      "id": "10c7e926-cf10-42a7-89f7-0c0018b38c62",
-                      "type": "count"
-                    }
-                  ],
-                  "separate_axis": 0,
-                  "axis_position": "right",
-                  "formatter": "number",
-                  "chart_type": "line",
-                  "line_width": 1,
-                  "point_size": 1,
-                  "fill": 0.5,
-                  "stacked": "none",
-                  "terms_field": "log.level"
-                }
-              ],
-              "time_field": "",
-              "use_kibana_indexes": true,
-              "interval": "",
-              "axis_position": "left",
-              "axis_formatter": "number",
-              "axis_scale": "normal",
-              "show_legend": 1,
-              "show_grid": 1,
-              "tooltip_mode": "show_all",
-              "drop_last_bucket": 0,
-              "isModelInvalid": false,
-              "filter": {
-                "query": "data_stream.dataset : \"azure.springcloudlogs\" and azure.springcloudlogs.category : \"SystemLogs\" ",
-                "language": "kuery"
-              },
-              "index_pattern_ref_name": "metrics_0_index_pattern"
-            },
-            "type": "metrics",
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
-            }
-          }
-        },
-        "title": "Log Level"
-      },
-      {
-        "version": "8.6.0",
-        "type": "lens",
-        "gridData": {
-          "x": 23,
-          "y": 23,
-          "w": 25,
-          "h": 18,
-          "i": "748eb38a-92e4-4636-87c4-ca8bde01e6d8"
-        },
-        "panelIndex": "748eb38a-92e4-4636-87c4-ca8bde01e6d8",
-        "embeddableConfig": {
-          "hidePanelTitles": false,
-          "enhancements": {},
-          "attributes": {
-            "description": "",
-            "state": {
-              "datasourceStates": {
-                "formBased": {
-                  "layers": {
-                    "7574efe2-c9d0-4a05-ab12-0801f59f6aaf": {
-                      "columnOrder": [
-                        "163f071e-4d30-4b2f-a90b-cba1de12ef71",
-                        "52e349f5-8b7c-486f-a5f7-0de1ea532dc5"
-                      ],
-                      "columns": {
-                        "163f071e-4d30-4b2f-a90b-cba1de12ef71": {
-                          "dataType": "string",
-                          "isBucketed": true,
-                          "label": "Top values of azure.springcloudlogs.operation_name",
-                          "operationType": "terms",
-                          "params": {
-                            "missingBucket": false,
-                            "orderBy": {
-                              "columnId": "52e349f5-8b7c-486f-a5f7-0de1ea532dc5",
-                              "type": "column"
-                            },
-                            "orderDirection": "desc",
-                            "otherBucket": true,
-                            "size": 5,
-                            "parentFormat": {
-                              "id": "terms"
-                            }
-                          },
-                          "scale": "ordinal",
-                          "sourceField": "azure.springcloudlogs.operation_name"
+                        "$state": {
+                            "store": "appState"
                         },
-                        "52e349f5-8b7c-486f-a5f7-0de1ea532dc5": {
-                          "dataType": "number",
-                          "isBucketed": false,
-                          "label": "Count of records",
-                          "operationType": "count",
-                          "scale": "ratio",
-                          "sourceField": "___records___"
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "field": "data_stream.dataset",
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "azure.springcloudlogs"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "azure.springcloudlogs"
+                            }
                         }
-                      },
-                      "incompleteColumns": {}
                     }
-                  }
-                }
-              },
-              "filters": [
-                {
-                  "$state": {
-                    "store": "appState"
-                  },
-                  "meta": {
-                    "alias": null,
-                    "disabled": false,
-                    "key": "azure.springcloudlogs.category",
-                    "negate": false,
-                    "params": {
-                      "query": "SystemLogs"
-                    },
-                    "type": "phrase",
-                    "index": "filter-index-pattern-0"
-                  },
-                  "query": {
-                    "match_phrase": {
-                      "azure.springcloudlogs.category": "SystemLogs"
-                    }
-                  }
-                }
-              ],
-              "query": {
-                "language": "kuery",
-                "query": ""
-              },
-              "visualization": {
-                "axisTitlesVisibilitySettings": {
-                  "x": true,
-                  "yLeft": true,
-                  "yRight": true
-                },
-                "fittingFunction": "None",
-                "gridlinesVisibilitySettings": {
-                  "x": true,
-                  "yLeft": true,
-                  "yRight": true
-                },
-                "layers": [
-                  {
-                    "accessors": [
-                      "52e349f5-8b7c-486f-a5f7-0de1ea532dc5"
-                    ],
-                    "layerId": "7574efe2-c9d0-4a05-ab12-0801f59f6aaf",
-                    "position": "top",
-                    "seriesType": "bar_horizontal_stacked",
-                    "showGridlines": false,
-                    "xAccessor": "163f071e-4d30-4b2f-a90b-cba1de12ef71",
-                    "yConfig": [
-                      {
-                        "color": "#5c84ce",
-                        "forAccessor": "52e349f5-8b7c-486f-a5f7-0de1ea532dc5"
-                      }
-                    ],
-                    "layerType": "data"
-                  }
                 ],
-                "legend": {
-                  "isVisible": true,
-                  "position": "right",
-                  "legendSize": "auto"
-                },
-                "preferredSeriesType": "bar_horizontal_stacked",
-                "tickLabelsVisibilitySettings": {
-                  "x": true,
-                  "yLeft": true,
-                  "yRight": true
-                },
-                "valueLabels": "hide",
-                "yLeftExtent": {
-                  "mode": "full"
-                },
-                "yRightExtent": {
-                  "mode": "full"
-                }
-              }
-            },
-            "title": "Azure Spring Cloud Logs System Logs Operations [Logs Azure]",
-            "visualizationType": "lnsXY",
-            "references": [
-              {
-                "id": "logs-*",
-                "name": "indexpattern-datasource-current-indexpattern",
-                "type": "index-pattern"
-              },
-              {
-                "id": "logs-*",
-                "name": "indexpattern-datasource-layer-7574efe2-c9d0-4a05-ab12-0801f59f6aaf",
-                "type": "index-pattern"
-              },
-              {
-                "id": "logs-*",
-                "name": "filter-index-pattern-0",
-                "type": "index-pattern"
-              }
-            ]
-          }
-        },
-        "title": "Operations"
-      },
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 0,
-          "y": 23,
-          "w": 23,
-          "h": 18,
-          "i": "f10825d9-48e7-4c3b-b225-51ac95988c8a"
-        },
-        "panelIndex": "f10825d9-48e7-4c3b-b225-51ac95988c8a",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": false,
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs System Logs Services [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "time_range_mode": "entire_time_range",
-              "id": "aee8223d-7cfa-4776-a006-15876e5bb382",
-              "type": "timeseries",
-              "series": [
-                {
-                  "id": "286b9de2-90e1-48c1-9357-63dc88a0d500",
-                  "color": "rgba(160,165,230,1)",
-                  "split_mode": "terms",
-                  "palette": {
-                    "type": "palette",
-                    "name": "complimentary"
-                  },
-                  "metrics": [
-                    {
-                      "id": "4a944774-8d00-4412-aeae-1a3e978f1a6a",
-                      "type": "count"
-                    }
-                  ],
-                  "separate_axis": 0,
-                  "axis_position": "right",
-                  "formatter": "number",
-                  "chart_type": "line",
-                  "line_width": 1,
-                  "point_size": 1,
-                  "fill": 0.5,
-                  "stacked": "none",
-                  "terms_field": "azure.springcloudlogs.properties.service_name",
-                  "label": "Services",
-                  "split_color_mode": null
-                }
-              ],
-              "time_field": "",
-              "use_kibana_indexes": true,
-              "interval": "",
-              "axis_position": "left",
-              "axis_formatter": "number",
-              "axis_scale": "normal",
-              "show_legend": 1,
-              "show_grid": 1,
-              "tooltip_mode": "show_all",
-              "drop_last_bucket": 0,
-              "isModelInvalid": false,
-              "filter": {
-                "query": "data_stream.dataset : \"azure.springcloudlogs\" and azure.springcloudlogs.category : \"SystemLogs\" ",
-                "language": "kuery"
-              },
-              "index_pattern_ref_name": "metrics_0_index_pattern"
-            },
-            "type": "metrics",
-            "data": {
-              "aggs": [],
-              "searchSource": {
                 "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
-            }
-          }
-        },
-        "title": "Services"
-      },
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 0,
-          "y": 41,
-          "w": 23,
-          "h": 17,
-          "i": "65014b13-0aa6-488b-9015-5dcb7b0dfe74"
-        },
-        "panelIndex": "65014b13-0aa6-488b-9015-5dcb7b0dfe74",
-        "embeddableConfig": {
-          "hidePanelTitles": false,
-          "enhancements": {},
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs System Logs Logger Type [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "time_range_mode": "entire_time_range",
-              "id": "c8b02450-7668-4c2b-9b21-e7d59f0867a7",
-              "type": "timeseries",
-              "series": [
-                {
-                  "id": "901af5fd-96ec-4e96-b35d-7a1941b85a40",
-                  "color": "#68BC00",
-                  "split_mode": "terms",
-                  "palette": {
-                    "type": "palette",
-                    "name": "default"
-                  },
-                  "metrics": [
-                    {
-                      "id": "08168ad0-60ba-492f-a7be-af47252f9cfe",
-                      "type": "count"
-                    }
-                  ],
-                  "separate_axis": 0,
-                  "axis_position": "right",
-                  "formatter": "number",
-                  "chart_type": "line",
-                  "line_width": 1,
-                  "point_size": 1,
-                  "fill": 0.5,
-                  "stacked": "none",
-                  "terms_field": "azure.springcloudlogs.properties.logger",
-                  "label": "Logger"
-                },
-                {
-                  "id": "d9a5e200-f52e-11eb-ba9b-7b2d136782e1",
-                  "color": "rgba(145,112,184,1)",
-                  "split_mode": "terms",
-                  "palette": {
-                    "type": "palette",
-                    "name": "negative"
-                  },
-                  "metrics": [
-                    {
-                      "id": "d9a5e201-f52e-11eb-ba9b-7b2d136782e1",
-                      "type": "count"
-                    }
-                  ],
-                  "separate_axis": 0,
-                  "axis_position": "right",
-                  "formatter": "number",
-                  "chart_type": "line",
-                  "line_width": 1,
-                  "point_size": 1,
-                  "fill": 0.5,
-                  "stacked": "stacked_within_series",
-                  "label": "Type",
-                  "terms_field": "azure.springcloudlogs.properties.type",
-                  "split_color_mode": null
+                    "language": "kuery",
+                    "query": ""
                 }
-              ],
-              "time_field": "",
-              "use_kibana_indexes": true,
-              "interval": "",
-              "axis_position": "left",
-              "axis_formatter": "number",
-              "axis_scale": "normal",
-              "show_legend": 1,
-              "show_grid": 1,
-              "tooltip_mode": "show_all",
-              "drop_last_bucket": 0,
-              "isModelInvalid": false,
-              "filter": {
-                "query": "data_stream.dataset : \"azure.springcloudlogs\" and azure.springcloudlogs.category : \"SystemLogs\" ",
-                "language": "kuery"
-              },
-              "background_color": null,
-              "index_pattern_ref_name": "metrics_0_index_pattern"
-            },
-            "type": "metrics",
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
             }
-          }
         },
-        "title": "Logger & Type"
-      }
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "### Azure Spring Cloud System Logs\n[Overview](#/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43) | [**System Logs**](#/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43) | [Application Console Logs](#/dashboard/azure-32aedb00-f524-11eb-b9f3-73fa29f35762) ",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "Azure Spring Cloud Logs Navigation System Logs [Logs Azure]",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "36cfd9c9-98e2-427a-9f99-3b4406d86841",
+                    "w": 48,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "36cfd9c9-98e2-427a-9f99-3b4406d86841",
+                "title": "Navigation Azure System Logs",
+                "type": "visualization",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-59775c31-6a61-4dd7-8004-05462a989a2b",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "59775c31-6a61-4dd7-8004-05462a989a2b": {
+                                            "columnOrder": [
+                                                "5be6a9c3-c580-44fc-8264-37be57e2ff53",
+                                                "131a2eb4-0e98-4a64-8e83-bdacb6eb2142"
+                                            ],
+                                            "columns": {
+                                                "131a2eb4-0e98-4a64-8e83-bdacb6eb2142": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "5be6a9c3-c580-44fc-8264-37be57e2ff53": {
+                                                    "customLabel": true,
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": " ",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "131a2eb4-0e98-4a64-8e83-bdacb6eb2142"
+                                        ],
+                                        "layerId": "59775c31-6a61-4dd7-8004-05462a989a2b",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "xAccessor": "5be6a9c3-c580-44fc-8264-37be57e2ff53",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "131a2eb4-0e98-4a64-8e83-bdacb6eb2142"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs System Logs Activity [Logs Azure] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 18,
+                    "i": "dd3bc6e6-219b-46d1-a458-cf79faa14c22",
+                    "w": 25,
+                    "x": 23,
+                    "y": 5
+                },
+                "panelIndex": "dd3bc6e6-219b-46d1-a458-cf79faa14c22",
+                "title": "System Logs Activity",
+                "type": "lens",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-442ce462-87f8-44d8-8060-ae99c2af8ff4",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "442ce462-87f8-44d8-8060-ae99c2af8ff4": {
+                                            "columnOrder": [
+                                                "05dfecff-f42d-46a1-8a17-701500dea5df",
+                                                "128f2d76-3a6c-4944-b799-1a399e088f3b",
+                                                "d833bce2-53bd-463a-8f3a-99b8241196ef"
+                                            ],
+                                            "columns": {
+                                                "05dfecff-f42d-46a1-8a17-701500dea5df": {
+                                                    "customLabel": true,
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": " ",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "128f2d76-3a6c-4944-b799-1a399e088f3b": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of log.level",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "log.level"
+                                                },
+                                                "d833bce2-53bd-463a-8f3a-99b8241196ef": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "d833bce2-53bd-463a-8f3a-99b8241196ef"
+                                        ],
+                                        "layerId": "442ce462-87f8-44d8-8060-ae99c2af8ff4",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "splitAccessor": "128f2d76-3a6c-4944-b799-1a399e088f3b",
+                                        "xAccessor": "05dfecff-f42d-46a1-8a17-701500dea5df",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "rgba(170,101,86,1)",
+                                                "forAccessor": "d833bce2-53bd-463a-8f3a-99b8241196ef"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs System Logs Level List [Logs Azure] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 18,
+                    "i": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7",
+                    "w": 23,
+                    "x": 0,
+                    "y": 5
+                },
+                "panelIndex": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7",
+                "title": "Log Level",
+                "type": "lens",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-7574efe2-c9d0-4a05-ab12-0801f59f6aaf",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "filter-index-pattern-0",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "7574efe2-c9d0-4a05-ab12-0801f59f6aaf": {
+                                            "columnOrder": [
+                                                "163f071e-4d30-4b2f-a90b-cba1de12ef71",
+                                                "52e349f5-8b7c-486f-a5f7-0de1ea532dc5"
+                                            ],
+                                            "columns": {
+                                                "163f071e-4d30-4b2f-a90b-cba1de12ef71": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of azure.springcloudlogs.operation_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "52e349f5-8b7c-486f-a5f7-0de1ea532dc5",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.springcloudlogs.operation_name"
+                                                },
+                                                "52e349f5-8b7c-486f-a5f7-0de1ea532dc5": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "filter-index-pattern-0",
+                                        "key": "azure.springcloudlogs.category",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "SystemLogs"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "azure.springcloudlogs.category": "SystemLogs"
+                                        }
+                                    }
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "52e349f5-8b7c-486f-a5f7-0de1ea532dc5"
+                                        ],
+                                        "layerId": "7574efe2-c9d0-4a05-ab12-0801f59f6aaf",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal_stacked",
+                                        "showGridlines": false,
+                                        "xAccessor": "163f071e-4d30-4b2f-a90b-cba1de12ef71",
+                                        "yConfig": [
+                                            {
+                                                "color": "#5c84ce",
+                                                "forAccessor": "52e349f5-8b7c-486f-a5f7-0de1ea532dc5"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_horizontal_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs System Logs Operations [Logs Azure]",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 18,
+                    "i": "748eb38a-92e4-4636-87c4-ca8bde01e6d8",
+                    "w": 25,
+                    "x": 23,
+                    "y": 23
+                },
+                "panelIndex": "748eb38a-92e4-4636-87c4-ca8bde01e6d8",
+                "title": "Operations",
+                "type": "lens",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-a12fbd27-f613-4f5c-9a74-13239009bfa9",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a12fbd27-f613-4f5c-9a74-13239009bfa9": {
+                                            "columnOrder": [
+                                                "e047e0c9-01b0-4225-9b07-363c64668db8",
+                                                "a3bc61a6-865f-4004-9b74-cc81207dee8a",
+                                                "8.6.033e-f56c-4f42-b315-20e4779f0f76"
+                                            ],
+                                            "columns": {
+                                                "8.6.033e-f56c-4f42-b315-20e4779f0f76": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Services",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "a3bc61a6-865f-4004-9b74-cc81207dee8a": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.springcloudlogs.properties.service_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.springcloudlogs.properties.service_name"
+                                                },
+                                                "e047e0c9-01b0-4225-9b07-363c64668db8": {
+                                                    "customLabel": true,
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": " ",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "8.6.033e-f56c-4f42-b315-20e4779f0f76"
+                                        ],
+                                        "layerId": "a12fbd27-f613-4f5c-9a74-13239009bfa9",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "complimentary",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "splitAccessor": "a3bc61a6-865f-4004-9b74-cc81207dee8a",
+                                        "xAccessor": "e047e0c9-01b0-4225-9b07-363c64668db8",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "rgba(160,165,230,1)",
+                                                "forAccessor": "8.6.033e-f56c-4f42-b315-20e4779f0f76"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs System Logs Services [Logs Azure] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 18,
+                    "i": "f10825d9-48e7-4c3b-b225-51ac95988c8a",
+                    "w": 23,
+                    "x": 0,
+                    "y": 23
+                },
+                "panelIndex": "f10825d9-48e7-4c3b-b225-51ac95988c8a",
+                "title": "Services",
+                "type": "lens",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-28eeaf80-51d5-41a2-bf3b-ca86e238a636",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-a4f2e606-7655-45fa-be3d-de35dff5209a",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "28eeaf80-51d5-41a2-bf3b-ca86e238a636": {
+                                            "columnOrder": [
+                                                "609e7071-f6c9-4a26-a16f-0f853d9c3070",
+                                                "0971061b-f0fa-4736-807c-5a4f86716f5d",
+                                                "2d97d84c-c53f-4c4a-b073-f6fa2d4d70a1"
+                                            ],
+                                            "columns": {
+                                                "0971061b-f0fa-4736-807c-5a4f86716f5d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.springcloudlogs.properties.logger",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.springcloudlogs.properties.logger"
+                                                },
+                                                "2d97d84c-c53f-4c4a-b073-f6fa2d4d70a1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Logger",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "609e7071-f6c9-4a26-a16f-0f853d9c3070": {
+                                                    "customLabel": true,
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": " ",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        },
+                                        "a4f2e606-7655-45fa-be3d-de35dff5209a": {
+                                            "columnOrder": [
+                                                "22eae8f6-d187-42a4-b5a5-9b969383c9c5",
+                                                "3ba577f3-d574-4990-8c47-b7ae8f4e2450",
+                                                "d51d05fa-d6e2-4e4b-8451-885dee936c44"
+                                            ],
+                                            "columns": {
+                                                "22eae8f6-d187-42a4-b5a5-9b969383c9c5": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "3ba577f3-d574-4990-8c47-b7ae8f4e2450": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.springcloudlogs.properties.type",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.springcloudlogs.properties.type"
+                                                },
+                                                "d51d05fa-d6e2-4e4b-8451-885dee936c44": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Type",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "2d97d84c-c53f-4c4a-b073-f6fa2d4d70a1"
+                                        ],
+                                        "layerId": "28eeaf80-51d5-41a2-bf3b-ca86e238a636",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "splitAccessor": "0971061b-f0fa-4736-807c-5a4f86716f5d",
+                                        "xAccessor": "609e7071-f6c9-4a26-a16f-0f853d9c3070",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "2d97d84c-c53f-4c4a-b073-f6fa2d4d70a1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "accessors": [
+                                            "d51d05fa-d6e2-4e4b-8451-885dee936c44"
+                                        ],
+                                        "layerId": "a4f2e606-7655-45fa-be3d-de35dff5209a",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "negative",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area_stacked",
+                                        "splitAccessor": "3ba577f3-d574-4990-8c47-b7ae8f4e2450",
+                                        "xAccessor": "22eae8f6-d187-42a4-b5a5-9b969383c9c5",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "rgba(145,112,184,1)",
+                                                "forAccessor": "d51d05fa-d6e2-4e4b-8451-885dee936c44"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs System Logs Logger Type [Logs Azure] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 17,
+                    "i": "65014b13-0aa6-488b-9015-5dcb7b0dfe74",
+                    "w": 23,
+                    "x": 0,
+                    "y": 41
+                },
+                "panelIndex": "65014b13-0aa6-488b-9015-5dcb7b0dfe74",
+                "title": "Logger \u0026 Type",
+                "type": "lens",
+                "version": "8.6.0"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Logs Azure] Azure Spring Cloud Logs System Logs",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.6.0",
+    "created_at": "2023-05-15T15:24:13.365Z",
+    "id": "azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43",
+    "migrationVersion": {
+        "dashboard": "8.6.0"
+    },
+    "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "dd3bc6e6-219b-46d1-a458-cf79faa14c22:indexpattern-datasource-layer-59775c31-6a61-4dd7-8004-05462a989a2b",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7:indexpattern-datasource-layer-442ce462-87f8-44d8-8060-ae99c2af8ff4",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:indexpattern-datasource-layer-7574efe2-c9d0-4a05-ab12-0801f59f6aaf",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:filter-index-pattern-0",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "f10825d9-48e7-4c3b-b225-51ac95988c8a:indexpattern-datasource-layer-a12fbd27-f613-4f5c-9a74-13239009bfa9",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "65014b13-0aa6-488b-9015-5dcb7b0dfe74:indexpattern-datasource-layer-28eeaf80-51d5-41a2-bf3b-ca86e238a636",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "65014b13-0aa6-488b-9015-5dcb7b0dfe74:indexpattern-datasource-layer-a4f2e606-7655-45fa-be3d-de35dff5209a",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "controlGroup_5cbc2c45-1213-4bb9-ab65-8dfc0cfbad8a:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "controlGroup_35a7fa77-1459-438c-8cb7-28770a0d7374:optionsListDataView",
+            "type": "index-pattern"
+        }
     ],
-    "timeRestore": false,
-    "title": "[Logs Azure] Azure Spring Cloud Logs System Logs",
-    "version": 1
-  },
-  "references": [
-    {
-      "id": "logs-*",
-      "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-      "type": "index-pattern"
-    },
-    {
-      "type": "index-pattern",
-      "name": "5cbc2c45-1213-4bb9-ab65-8dfc0cfbad8a:control_0_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "5cbc2c45-1213-4bb9-ab65-8dfc0cfbad8a:control_1_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "dd3bc6e6-219b-46d1-a458-cf79faa14c22:metrics_0_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "6c53434c-d1f9-4210-a0fe-0e406cffb1a7:metrics_0_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:indexpattern-datasource-current-indexpattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:indexpattern-datasource-layer-7574efe2-c9d0-4a05-ab12-0801f59f6aaf",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "748eb38a-92e4-4636-87c4-ca8bde01e6d8:filter-index-pattern-0",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "f10825d9-48e7-4c3b-b225-51ac95988c8a:metrics_0_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "65014b13-0aa6-488b-9015-5dcb7b0dfe74:metrics_0_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "name": "controlGroup_5cbc2c45-1213-4bb9-ab65-8dfc0cfbad8a:optionsListDataView",
-      "type": "index-pattern",
-      "id": "logs-*"
-    },
-    {
-      "name": "controlGroup_35a7fa77-1459-438c-8cb7-28770a0d7374:optionsListDataView",
-      "type": "index-pattern",
-      "id": "logs-*"
-    }
-  ],
-  "migrationVersion": {
-    "dashboard": "8.6.0"
-  },
-  "coreMigrationVersion": "8.6.1"
+    "type": "dashboard"
 }

--- a/packages/azure/kibana/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43.json
+++ b/packages/azure/kibana/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43.json
@@ -6,7 +6,7 @@
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
             "panelsJSON": "{\"a71b2a03-663d-4897-a3c2-4a363a5cd13c\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription\",\"id\":\"a71b2a03-663d-4897-a3c2-4a363a5cd13c\",\"enhancements\":{}}},\"19286679-ff18-4cb1-b048-e32dd60c3ff9\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.springcloudlogs.category\",\"title\":\"Spring Cloud Logs Type\",\"id\":\"19286679-ff18-4cb1-b048-e32dd60c3ff9\",\"enhancements\":{}}}}"
         },
-        "description": "Logs Azure] Azure Spring Cloud logs Overview",
+        "description": "[Logs Azure] Azure Spring Cloud logs Overview",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [

--- a/packages/azure/kibana/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43.json
+++ b/packages/azure/kibana/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43.json
@@ -117,9 +117,10 @@
                                                     "sourceField": "___records___"
                                                 },
                                                 "4f5e6d42-879e-4b95-9f0f-87eff4520dc4": {
+                                                    "customLabel": true,
                                                     "dataType": "date",
                                                     "isBucketed": true,
-                                                    "label": "@timestamp",
+                                                    "label": " ",
                                                     "operationType": "date_histogram",
                                                     "params": {
                                                         "dropPartials": false,
@@ -147,7 +148,7 @@
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
                                     "x": true,
-                                    "yLeft": true,
+                                    "yLeft": false,
                                     "yRight": true
                                 },
                                 "fillOpacity": 0.5,
@@ -189,7 +190,7 @@
                                     "maxLines": 1,
                                     "position": "right",
                                     "shouldTruncate": true,
-                                    "showSingleSeries": true
+                                    "showSingleSeries": false
                                 },
                                 "preferredSeriesType": "bar_stacked",
                                 "tickLabelsVisibilitySettings": {
@@ -409,9 +410,10 @@
                                             ],
                                             "columns": {
                                                 "6a7e169e-2680-4dc8-abbf-d398365f537b": {
+                                                    "customLabel": true,
                                                     "dataType": "date",
                                                     "isBucketed": true,
-                                                    "label": "@timestamp",
+                                                    "label": " ",
                                                     "operationType": "date_histogram",
                                                     "params": {
                                                         "dropPartials": false,
@@ -524,11 +526,12 @@
                                     }
                                 ],
                                 "legend": {
+                                    "isInside": false,
                                     "isVisible": true,
                                     "maxLines": 1,
                                     "position": "right",
                                     "shouldTruncate": true,
-                                    "showSingleSeries": true
+                                    "showSingleSeries": false
                                 },
                                 "preferredSeriesType": "bar_stacked",
                                 "tickLabelsVisibilitySettings": {
@@ -757,9 +760,10 @@
                                                     "sourceField": "log.level"
                                                 },
                                                 "b042daa1-e88f-48d5-a850-4fc4a373376d": {
+                                                    "customLabel": true,
                                                     "dataType": "date",
                                                     "isBucketed": true,
-                                                    "label": "@timestamp",
+                                                    "label": " ",
                                                     "operationType": "date_histogram",
                                                     "params": {
                                                         "dropPartials": false,
@@ -798,7 +802,7 @@
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
                                     "x": true,
-                                    "yLeft": true,
+                                    "yLeft": false,
                                     "yRight": true
                                 },
                                 "fillOpacity": 0.5,
@@ -885,7 +889,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.0",
-    "created_at": "2023-05-15T14:55:56.863Z",
+    "created_at": "2023-05-15T15:10:43.345Z",
     "id": "azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43",
     "migrationVersion": {
         "dashboard": "8.6.0"

--- a/packages/azure/kibana/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43.json
+++ b/packages/azure/kibana/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43.json
@@ -6,7 +6,7 @@
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
             "panelsJSON": "{\"a71b2a03-663d-4897-a3c2-4a363a5cd13c\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription\",\"id\":\"a71b2a03-663d-4897-a3c2-4a363a5cd13c\",\"enhancements\":{}}},\"19286679-ff18-4cb1-b048-e32dd60c3ff9\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.springcloudlogs.category\",\"title\":\"Spring Cloud Logs Type\",\"id\":\"19286679-ff18-4cb1-b048-e32dd60c3ff9\",\"enhancements\":{}}}}"
         },
-        "description": "[Logs Azure] Azure Spring Cloud logs Overview",
+        "description": "Logs Azure] Azure Spring Cloud logs Overview",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -223,6 +223,7 @@
                     "y": 0
                 },
                 "panelIndex": "c9d5c763-5ee4-4fa2-8694-5678a33ca7ab",
+                "title": "Azure Spring Cloud Logs Activity Level [Logs Azure]",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -381,6 +382,7 @@
                     "y": 6
                 },
                 "panelIndex": "8ed7ced5-a053-4d6c-99f0-09ec2c3d5933",
+                "title": "Azure Spring Cloud Logs Top Resource Groups [Logs Azure]",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -873,6 +875,7 @@
                     "y": 29
                 },
                 "panelIndex": "e0d96ed1-5839-4e7a-bf04-8757614b8503",
+                "title": "Azure Spring Cloud Logs Overview Level [Logs Azure]",
                 "type": "lens",
                 "version": "8.6.0"
             }
@@ -882,7 +885,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.6.0",
-    "created_at": "2023-05-15T14:06:04.021Z",
+    "created_at": "2023-05-15T14:55:56.863Z",
     "id": "azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43",
     "migrationVersion": {
         "dashboard": "8.6.0"

--- a/packages/azure/kibana/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43.json
+++ b/packages/azure/kibana/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43.json
@@ -1,673 +1,938 @@
 {
-  "id": "azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43",
-  "type": "dashboard",
-  "namespaces": [
-    "default"
-  ],
-  "updated_at": "2023-03-07T09:38:25.166Z",
-  "created_at": "2023-03-07T09:38:25.166Z",
-  "version": "WzExMjgxLDFd",
-  "attributes": {
-    "controlGroupInput": {
-      "chainingSystem": "HIERARCHICAL",
-      "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"a71b2a03-663d-4897-a3c2-4a363a5cd13c\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription\",\"id\":\"a71b2a03-663d-4897-a3c2-4a363a5cd13c\",\"enhancements\":{}}},\"19286679-ff18-4cb1-b048-e32dd60c3ff9\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.springcloudlogs.category\",\"title\":\"Spring Cloud Logs Type\",\"id\":\"19286679-ff18-4cb1-b048-e32dd60c3ff9\",\"enhancements\":{}}}}"
-      },
-    "description": "Logs Azure] Azure Spring Cloud logs Overview",
-    "hits": 0,
-    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": {
-        "query": {
-          "query": "",
-          "language": "kuery"
+    "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"a71b2a03-663d-4897-a3c2-4a363a5cd13c\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription\",\"id\":\"a71b2a03-663d-4897-a3c2-4a363a5cd13c\",\"enhancements\":{}}},\"19286679-ff18-4cb1-b048-e32dd60c3ff9\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"azure.springcloudlogs.category\",\"title\":\"Spring Cloud Logs Type\",\"id\":\"19286679-ff18-4cb1-b048-e32dd60c3ff9\",\"enhancements\":{}}}}"
         },
-        "filter": [
-           {
-            "$state": {
-              "store": "appState"
-            },
-            "meta": {
-              "alias": null,
-              "disabled": false,
-              "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-              "key": "data_stream.dataset",
-              "negate": false,
-              "params": {
-                "query": "azure.springcloudlogs"
-              },
-              "type": "phrase"
-            },
-            "query": {
-              "match_phrase": {
-                "data_stream.dataset": "azure.springcloudlogs"
-              }
-            }
-          }
-        ]
-      }
-    },
-    "optionsJSON": {
-      "useMargins": true,
-      "syncColors": false,
-      "hidePanelTitles": false
-    },
-    "panelsJSON": [
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 0,
-          "y": 0,
-          "w": 20,
-          "h": 6,
-          "i": "5139d9b1-5d42-4157-8c19-9f5480da0741"
-        },
-        "panelIndex": "5139d9b1-5d42-4157-8c19-9f5480da0741",
-        "embeddableConfig": {
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs Navigation Overview [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "fontSize": 12,
-              "openLinksInNewTab": false,
-              "markdown": "### Azure Spring Cloud  Overview Logs\n\n[**Overview**](#/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43) | [System Logs](#/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43) | [Application Console Logs](#/dashboard/azure-32aedb00-f524-11eb-b9f3-73fa29f35762) "
-            },
-            "type": "markdown",
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
-            }
-          },
-          "hidePanelTitles": false,
-          "enhancements": {},
-          "type": "visualization"
-        },
-        "title": "Navigation Azure Spring Cloud Logs"
-      },
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 20,
-          "y": 0,
-          "w": 28,
-          "h": 14,
-          "i": "c9d5c763-5ee4-4fa2-8694-5678a33ca7ab"
-        },
-        "panelIndex": "c9d5c763-5ee4-4fa2-8694-5678a33ca7ab",
-        "embeddableConfig": {
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs Activity Level [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "time_range_mode": "entire_time_range",
-              "id": "6e9eef83-a185-439a-984f-66145d3836a8",
-              "type": "timeseries",
-              "series": [
-                {
-                  "id": "cde434f5-35d6-49e2-8730-ef347d66c57d",
-                  "color": "#68BC00",
-                  "split_mode": "everything",
-                  "palette": {
-                    "type": "palette",
-                    "name": "default"
-                  },
-                  "metrics": [
+        "description": "Logs Azure] Azure Spring Cloud logs Overview",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
                     {
-                      "id": "41bce31f-658c-4580-adfd-9fb86fe623db",
-                      "type": "count"
-                    }
-                  ],
-                  "separate_axis": 0,
-                  "axis_position": "right",
-                  "formatter": "number",
-                  "chart_type": "line",
-                  "line_width": 1,
-                  "point_size": 1,
-                  "fill": 0.5,
-                  "stacked": "none"
-                }
-              ],
-              "time_field": "",
-              "use_kibana_indexes": true,
-              "interval": "",
-              "axis_position": "left",
-              "axis_formatter": "number",
-              "axis_scale": "normal",
-              "show_legend": 1,
-              "show_grid": 1,
-              "tooltip_mode": "show_all",
-              "drop_last_bucket": 0,
-              "isModelInvalid": false,
-              "filter": {
-                "query": "data_stream.dataset :\"azure.springcloudlogs\"",
-                "language": "kuery"
-              },
-              "index_pattern_ref_name": "metrics_0_index_pattern"
-            },
-            "type": "metrics",
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
-            }
-          },
-          "hidePanelTitles": false,
-          "enhancements": {},
-          "type": "visualization"
-        },
-        "title": "Spring Cloud Logs Activity"
-      },
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 0,
-          "y": 6,
-          "w": 20,
-          "h": 20,
-          "i": "8ed7ced5-a053-4d6c-99f0-09ec2c3d5933"
-        },
-        "panelIndex": "8ed7ced5-a053-4d6c-99f0-09ec2c3d5933",
-        "embeddableConfig": {
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs Top Resource Groups [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "type": "histogram",
-              "grid": {
-                "categoryLines": false
-              },
-              "categoryAxes": [
-                {
-                  "id": "CategoryAxis-1",
-                  "type": "category",
-                  "position": "left",
-                  "show": true,
-                  "scale": {
-                    "type": "linear"
-                  },
-                  "labels": {
-                    "show": true,
-                    "rotate": 0,
-                    "filter": false,
-                    "truncate": 200
-                  },
-                  "title": {},
-                  "style": {}
-                }
-              ],
-              "valueAxes": [
-                {
-                  "id": "ValueAxis-1",
-                  "name": "LeftAxis-1",
-                  "type": "value",
-                  "position": "bottom",
-                  "show": true,
-                  "scale": {
-                    "type": "linear",
-                    "mode": "normal"
-                  },
-                  "labels": {
-                    "show": true,
-                    "rotate": 75,
-                    "filter": true,
-                    "truncate": 100
-                  },
-                  "title": {
-                    "text": "Count"
-                  },
-                  "style": {}
-                }
-              ],
-              "seriesParams": [
-                {
-                  "show": true,
-                  "type": "histogram",
-                  "mode": "normal",
-                  "data": {
-                    "label": "Count",
-                    "id": "1"
-                  },
-                  "interpolate": "linear",
-                  "valueAxis": "ValueAxis-1",
-                  "drawLinesBetweenPoints": true,
-                  "lineWidth": 2,
-                  "showCircles": true,
-                  "circlesRadius": 3
-                }
-              ],
-              "addTooltip": true,
-              "detailedTooltip": true,
-              "palette": {
-                "type": "palette",
-                "name": "default"
-              },
-              "addLegend": true,
-              "legendPosition": "right",
-              "times": [],
-              "addTimeMarker": false,
-              "labels": {},
-              "radiusRatio": 0,
-              "thresholdLine": {
-                "show": false,
-                "value": 10,
-                "width": 1,
-                "style": "full",
-                "color": "#E7664C"
-              },
-              "legendSize": "auto"
-            },
-            "type": "horizontal_bar",
-            "data": {
-              "aggs": [
-                {
-                  "id": "1",
-                  "enabled": true,
-                  "type": "count",
-                  "params": {},
-                  "schema": "metric"
-                },
-                {
-                  "id": "2",
-                  "enabled": true,
-                  "type": "terms",
-                  "params": {
-                    "field": "azure.resource.group",
-                    "orderBy": "1",
-                    "order": "desc",
-                    "size": 10,
-                    "otherBucket": false,
-                    "otherBucketLabel": "Other",
-                    "missingBucket": false,
-                    "missingBucketLabel": "Missing"
-                  },
-                  "schema": "segment"
-                }
-              ],
-              "searchSource": {
-                "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": [],
-                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index"
-              }
-            }
-          },
-          "hidePanelTitles": false,
-          "enhancements": {},
-          "type": "visualization"
-        },
-        "title": "Top Resource Groups"
-      },
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 20,
-          "y": 14,
-          "w": 28,
-          "h": 15,
-          "i": "8a69029b-054e-4adc-b20b-b2052cdaed73"
-        },
-        "panelIndex": "8a69029b-054e-4adc-b20b-b2052cdaed73",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": false,
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs Service  List [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "time_range_mode": "entire_time_range",
-              "id": "136ddaa9-9a6d-423b-b399-29018f0ea01b",
-              "type": "timeseries",
-              "series": [
-                {
-                  "id": "c99c6393-738a-452b-a68f-2cf1e7580ba0",
-                  "color": "rgba(231,102,76,1)",
-                  "split_mode": "terms",
-                  "palette": {
-                    "type": "palette",
-                    "name": "default"
-                  },
-                  "metrics": [
-                    {
-                      "id": "7c304953-51fe-4c51-8007-0c0035eb39da",
-                      "type": "count"
-                    }
-                  ],
-                  "separate_axis": 0,
-                  "axis_position": "right",
-                  "formatter": "number",
-                  "chart_type": "line",
-                  "line_width": 1,
-                  "point_size": 1,
-                  "fill": 0.5,
-                  "stacked": "none",
-                  "terms_field": "azure.springcloudlogs.properties.service_name",
-                  "label": "Service name"
-                }
-              ],
-              "time_field": "",
-              "use_kibana_indexes": true,
-              "interval": "",
-              "axis_position": "left",
-              "axis_formatter": "number",
-              "axis_scale": "normal",
-              "show_legend": 1,
-              "show_grid": 1,
-              "tooltip_mode": "show_all",
-              "drop_last_bucket": 0,
-              "isModelInvalid": false,
-              "filter": {
-                "query": "data_stream.dataset : \"azure.springcloudlogs\" ",
-                "language": "kuery"
-              },
-              "index_pattern_ref_name": "metrics_0_index_pattern"
-            },
-            "type": "metrics",
-            "data": {
-              "aggs": [],
-              "searchSource": {
-                "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
-            }
-          }
-        },
-        "title": "Services"
-      },
-      {
-        "version": "8.6.0",
-        "type": "lens",
-        "gridData": {
-          "x": 0,
-          "y": 26,
-          "w": 20,
-          "h": 19,
-          "i": "08b8beb6-9b26-461b-9a04-3560916952d0"
-        },
-        "panelIndex": "08b8beb6-9b26-461b-9a04-3560916952d0",
-        "embeddableConfig": {
-          "enhancements": {},
-          "hidePanelTitles": false,
-          "attributes": {
-            "description": null,
-            "state": {
-              "datasourceStates": {
-                "formBased": {
-                  "layers": {
-                    "8f78ff58-39ee-47eb-8e7a-46a2bec850d1": {
-                      "columnOrder": [
-                        "cf83f6bc-ad85-4bc7-834a-afe71367eea8",
-                        "c10116a8-f001-4e5f-8796-1a81c8408211"
-                      ],
-                      "columns": {
-                        "c10116a8-f001-4e5f-8796-1a81c8408211": {
-                          "dataType": "number",
-                          "isBucketed": false,
-                          "label": "Count of records",
-                          "operationType": "count",
-                          "scale": "ratio",
-                          "sourceField": "___records___"
+                        "$state": {
+                            "store": "appState"
                         },
-                        "cf83f6bc-ad85-4bc7-834a-afe71367eea8": {
-                          "dataType": "string",
-                          "isBucketed": true,
-                          "label": "Top values of azure.resource.name",
-                          "operationType": "terms",
-                          "params": {
-                            "missingBucket": false,
-                            "orderBy": {
-                              "columnId": "c10116a8-f001-4e5f-8796-1a81c8408211",
-                              "type": "column"
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "azure.springcloudlogs"
                             },
-                            "orderDirection": "desc",
-                            "otherBucket": true,
-                            "size": 5,
-                            "parentFormat": {
-                              "id": "terms"
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "azure.springcloudlogs"
                             }
-                          },
-                          "scale": "ordinal",
-                          "sourceField": "azure.resource.name"
                         }
-                      },
-                      "incompleteColumns": {}
                     }
-                  }
-                }
-              },
-              "filters": [],
-              "query": {
-                "language": "kuery",
-                "query": ""
-              },
-              "visualization": {
-                "axisTitlesVisibilitySettings": {
-                  "x": true,
-                  "yLeft": true,
-                  "yRight": true
-                },
-                "fittingFunction": "None",
-                "gridlinesVisibilitySettings": {
-                  "x": true,
-                  "yLeft": true,
-                  "yRight": true
-                },
-                "layers": [
-                  {
-                    "accessors": [
-                      "c10116a8-f001-4e5f-8796-1a81c8408211"
-                    ],
-                    "layerId": "8f78ff58-39ee-47eb-8e7a-46a2bec850d1",
-                    "position": "top",
-                    "seriesType": "bar_horizontal_stacked",
-                    "showGridlines": false,
-                    "xAccessor": "cf83f6bc-ad85-4bc7-834a-afe71367eea8",
-                    "yConfig": [
-                      {
-                        "color": "#da8b45",
-                        "forAccessor": "c10116a8-f001-4e5f-8796-1a81c8408211"
-                      }
-                    ],
-                    "layerType": "data"
-                  }
                 ],
-                "legend": {
-                  "isVisible": true,
-                  "position": "right",
-                  "legendSize": "auto"
-                },
-                "preferredSeriesType": "bar_horizontal_stacked",
-                "tickLabelsVisibilitySettings": {
-                  "x": true,
-                  "yLeft": true,
-                  "yRight": true
-                },
-                "valueLabels": "hide",
-                "yLeftExtent": {
-                  "mode": "full"
-                },
-                "yRightExtent": {
-                  "mode": "full"
-                }
-              }
-            },
-            "title": "Azure Spring Cloud Logs Overview Top Resources [Logs Azure]",
-            "visualizationType": "lnsXY",
-            "references": [
-              {
-                "id": "logs-*",
-                "name": "indexpattern-datasource-current-indexpattern",
-                "type": "index-pattern"
-              },
-              {
-                "id": "logs-*",
-                "name": "indexpattern-datasource-layer-8f78ff58-39ee-47eb-8e7a-46a2bec850d1",
-                "type": "index-pattern"
-              }
-            ]
-          }
-        },
-        "title": "Top Resources"
-      },
-      {
-        "version": "8.5.0",
-        "type": "visualization",
-        "gridData": {
-          "x": 20,
-          "y": 29,
-          "w": 28,
-          "h": 16,
-          "i": "e0d96ed1-5839-4e7a-bf04-8757614b8503"
-        },
-        "panelIndex": "e0d96ed1-5839-4e7a-bf04-8757614b8503",
-        "embeddableConfig": {
-          "hidePanelTitles": false,
-          "enhancements": {},
-          "savedVis": {
-            "title": "Azure Spring Cloud Logs Overview Level [Logs Azure]",
-            "description": "",
-            "uiState": {},
-            "params": {
-              "time_range_mode": "entire_time_range",
-              "id": "ccbe1aec-ac1e-4ec8-85af-24aa0b31530d",
-              "type": "timeseries",
-              "series": [
-                {
-                  "id": "8f3fef78-506e-48d0-b365-2c2824d09876",
-                  "color": "#68BC00",
-                  "split_mode": "terms",
-                  "palette": {
-                    "type": "palette",
-                    "name": "default"
-                  },
-                  "metrics": [
-                    {
-                      "id": "48e32be1-95d1-41a0-89e4-ed62cc73a459",
-                      "type": "count"
-                    }
-                  ],
-                  "separate_axis": 0,
-                  "axis_position": "right",
-                  "formatter": "number",
-                  "chart_type": "line",
-                  "line_width": 1,
-                  "point_size": 1,
-                  "fill": 0.5,
-                  "stacked": "none",
-                  "label": "",
-                  "type": "timeseries",
-                  "terms_field": "log.level"
-                }
-              ],
-              "time_field": "",
-              "use_kibana_indexes": true,
-              "interval": "",
-              "axis_position": "left",
-              "axis_formatter": "number",
-              "axis_scale": "normal",
-              "show_legend": 1,
-              "show_grid": 1,
-              "tooltip_mode": "show_all",
-              "drop_last_bucket": 0,
-              "isModelInvalid": false,
-              "filter": {
-                "query": "data_stream.dataset : \"azure.springcloudlogs\"",
-                "language": "kuery"
-              },
-              "index_pattern_ref_name": "metrics_0_index_pattern"
-            },
-            "type": "metrics",
-            "data": {
-              "aggs": [],
-              "searchSource": {
                 "query": {
-                  "query": "",
-                  "language": "kuery"
-                },
-                "filter": []
-              }
+                    "language": "kuery",
+                    "query": ""
+                }
             }
-          }
         },
-        "title": "Log Level"
-      }
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "### Azure Spring Cloud  Overview Logs\n\n[**Overview**](#/dashboard/azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43) | [System Logs](#/dashboard/azure-1adf52d0-f50f-11eb-a831-732d3e9bbd43) | [Application Console Logs](#/dashboard/azure-32aedb00-f524-11eb-b9f3-73fa29f35762) ",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "Azure Spring Cloud Logs Navigation Overview [Logs Azure]",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "5139d9b1-5d42-4157-8c19-9f5480da0741",
+                    "w": 20,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "5139d9b1-5d42-4157-8c19-9f5480da0741",
+                "title": "Navigation Azure Spring Cloud Logs",
+                "type": "visualization",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-0421bd38-ee0f-4ace-bab7-561904ed1950",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "0421bd38-ee0f-4ace-bab7-561904ed1950": {
+                                            "columnOrder": [
+                                                "4f5e6d42-879e-4b95-9f0f-87eff4520dc4",
+                                                "2e76a868-b041-4a8f-952a-af542bd1aea8"
+                                            ],
+                                            "columns": {
+                                                "2e76a868-b041-4a8f-952a-af542bd1aea8": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "4f5e6d42-879e-4b95-9f0f-87eff4520dc4": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "2e76a868-b041-4a8f-952a-af542bd1aea8"
+                                        ],
+                                        "layerId": "0421bd38-ee0f-4ace-bab7-561904ed1950",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "xAccessor": "4f5e6d42-879e-4b95-9f0f-87eff4520dc4",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "2e76a868-b041-4a8f-952a-af542bd1aea8"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs Activity Level [Logs Azure] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "c9d5c763-5ee4-4fa2-8694-5678a33ca7ab",
+                    "w": 28,
+                    "x": 20,
+                    "y": 0
+                },
+                "panelIndex": "c9d5c763-5ee4-4fa2-8694-5678a33ca7ab",
+                "type": "lens",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-398c425f-92c4-4e6c-be4b-48fffc5ecda1",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "398c425f-92c4-4e6c-be4b-48fffc5ecda1": {
+                                            "columnOrder": [
+                                                "389212f7-27a9-4503-9f9b-2a0b730d033d",
+                                                "de6d0ade-500d-44ac-b256-d243e125ecf8"
+                                            ],
+                                            "columns": {
+                                                "389212f7-27a9-4503-9f9b-2a0b730d033d": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "azure.resource.group: Descending",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "de6d0ade-500d-44ac-b256-d243e125ecf8",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.resource.group"
+                                                },
+                                                "de6d0ade-500d-44ac-b256-d243e125ecf8": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "curveType": "LINEAR",
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": -45,
+                                    "yRight": -90
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "de6d0ade-500d-44ac-b256-d243e125ecf8"
+                                        ],
+                                        "isHistogram": false,
+                                        "layerId": "398c425f-92c4-4e6c-be4b-48fffc5ecda1",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "bar_horizontal",
+                                        "simpleView": false,
+                                        "xAccessor": "389212f7-27a9-4503-9f9b-2a0b730d033d",
+                                        "xScaleType": "ordinal",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "forAccessor": "de6d0ade-500d-44ac-b256-d243e125ecf8"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": false,
+                                "yLeftExtent": {
+                                    "enforce": true,
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightScale": "linear",
+                                "yTitle": "Count"
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs Top Resource Groups [Logs Azure] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 20,
+                    "i": "8ed7ced5-a053-4d6c-99f0-09ec2c3d5933",
+                    "w": 20,
+                    "x": 0,
+                    "y": 6
+                },
+                "panelIndex": "8ed7ced5-a053-4d6c-99f0-09ec2c3d5933",
+                "type": "lens",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-0b4182ad-689e-4911-ac97-5a79c3a78ef7",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "0b4182ad-689e-4911-ac97-5a79c3a78ef7": {
+                                            "columnOrder": [
+                                                "6a7e169e-2680-4dc8-abbf-d398365f537b",
+                                                "8563389a-dd9c-4c14-9b6f-b64163ff22b7",
+                                                "8321534a-85a0-43a3-9372-77c37d21ac0a"
+                                            ],
+                                            "columns": {
+                                                "6a7e169e-2680-4dc8-abbf-d398365f537b": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "8321534a-85a0-43a3-9372-77c37d21ac0a": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Service name",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "8563389a-dd9c-4c14-9b6f-b64163ff22b7": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.springcloudlogs.properties.service_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.springcloudlogs.properties.service_name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "8321534a-85a0-43a3-9372-77c37d21ac0a"
+                                        ],
+                                        "layerId": "0b4182ad-689e-4911-ac97-5a79c3a78ef7",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "splitAccessor": "8563389a-dd9c-4c14-9b6f-b64163ff22b7",
+                                        "xAccessor": "6a7e169e-2680-4dc8-abbf-d398365f537b",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "rgba(231,102,76,1)",
+                                                "forAccessor": "8321534a-85a0-43a3-9372-77c37d21ac0a"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs Service  List [Logs Azure] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "8a69029b-054e-4adc-b20b-b2052cdaed73",
+                    "w": 28,
+                    "x": 20,
+                    "y": 14
+                },
+                "panelIndex": "8a69029b-054e-4adc-b20b-b2052cdaed73",
+                "type": "lens",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": null,
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-8f78ff58-39ee-47eb-8e7a-46a2bec850d1",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "8f78ff58-39ee-47eb-8e7a-46a2bec850d1": {
+                                            "columnOrder": [
+                                                "cf83f6bc-ad85-4bc7-834a-afe71367eea8",
+                                                "c10116a8-f001-4e5f-8796-1a81c8408211"
+                                            ],
+                                            "columns": {
+                                                "c10116a8-f001-4e5f-8796-1a81c8408211": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "cf83f6bc-ad85-4bc7-834a-afe71367eea8": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of azure.resource.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "c10116a8-f001-4e5f-8796-1a81c8408211",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.resource.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "c10116a8-f001-4e5f-8796-1a81c8408211"
+                                        ],
+                                        "layerId": "8f78ff58-39ee-47eb-8e7a-46a2bec850d1",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal_stacked",
+                                        "showGridlines": false,
+                                        "xAccessor": "cf83f6bc-ad85-4bc7-834a-afe71367eea8",
+                                        "yConfig": [
+                                            {
+                                                "color": "#da8b45",
+                                                "forAccessor": "c10116a8-f001-4e5f-8796-1a81c8408211"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_horizontal_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs Overview Top Resources [Logs Azure]",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 19,
+                    "i": "08b8beb6-9b26-461b-9a04-3560916952d0",
+                    "w": 20,
+                    "x": 0,
+                    "y": 26
+                },
+                "panelIndex": "08b8beb6-9b26-461b-9a04-3560916952d0",
+                "title": "Top Resources",
+                "type": "lens",
+                "version": "8.6.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-cb0ceeef-76e7-4d8c-afdc-af12519e45d2",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "cb0ceeef-76e7-4d8c-afdc-af12519e45d2": {
+                                            "columnOrder": [
+                                                "b042daa1-e88f-48d5-a850-4fc4a373376d",
+                                                "1b30a891-8f67-4355-b653-26b3d6943c65",
+                                                "cf2b5754-60d0-4d62-92e2-c14aa2bbcd47"
+                                            ],
+                                            "columns": {
+                                                "1b30a891-8f67-4355-b653-26b3d6943c65": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of log.level",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "log.level"
+                                                },
+                                                "b042daa1-e88f-48d5-a850-4fc4a373376d": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cf2b5754-60d0-4d62-92e2-c14aa2bbcd47": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "cf2b5754-60d0-4d62-92e2-c14aa2bbcd47"
+                                        ],
+                                        "layerId": "cb0ceeef-76e7-4d8c-afdc-af12519e45d2",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "splitAccessor": "1b30a891-8f67-4355-b653-26b3d6943c65",
+                                        "xAccessor": "b042daa1-e88f-48d5-a850-4fc4a373376d",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "cf2b5754-60d0-4d62-92e2-c14aa2bbcd47"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Azure Spring Cloud Logs Overview Level [Logs Azure] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "e0d96ed1-5839-4e7a-bf04-8757614b8503",
+                    "w": 28,
+                    "x": 20,
+                    "y": 29
+                },
+                "panelIndex": "e0d96ed1-5839-4e7a-bf04-8757614b8503",
+                "type": "lens",
+                "version": "8.6.0"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Logs Azure] Azure Spring Cloud logs Overview",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.6.0",
+    "created_at": "2023-05-15T14:06:04.021Z",
+    "id": "azure-5ad41d90-f50e-11eb-a831-732d3e9bbd43",
+    "migrationVersion": {
+        "dashboard": "8.6.0"
+    },
+    "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "c9d5c763-5ee4-4fa2-8694-5678a33ca7ab:indexpattern-datasource-layer-0421bd38-ee0f-4ace-bab7-561904ed1950",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "8ed7ced5-a053-4d6c-99f0-09ec2c3d5933:indexpattern-datasource-layer-398c425f-92c4-4e6c-be4b-48fffc5ecda1",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "8a69029b-054e-4adc-b20b-b2052cdaed73:indexpattern-datasource-layer-0b4182ad-689e-4911-ac97-5a79c3a78ef7",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "08b8beb6-9b26-461b-9a04-3560916952d0:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "08b8beb6-9b26-461b-9a04-3560916952d0:indexpattern-datasource-layer-8f78ff58-39ee-47eb-8e7a-46a2bec850d1",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e0d96ed1-5839-4e7a-bf04-8757614b8503:indexpattern-datasource-layer-cb0ceeef-76e7-4d8c-afdc-af12519e45d2",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "controlGroup_a71b2a03-663d-4897-a3c2-4a363a5cd13c:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "controlGroup_19286679-ff18-4cb1-b048-e32dd60c3ff9:optionsListDataView",
+            "type": "index-pattern"
+        }
     ],
-    "timeRestore": false,
-    "title": "[Logs Azure] Azure Spring Cloud logs Overview",
-    "version": 1
-  },
-  "references": [
-    {
-      "id": "logs-*",
-      "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-      "type": "index-pattern"
-    },
-    {
-      "type": "index-pattern",
-      "name": "c9d5c763-5ee4-4fa2-8694-5678a33ca7ab:metrics_0_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "8ed7ced5-a053-4d6c-99f0-09ec2c3d5933:kibanaSavedObjectMeta.searchSourceJSON.index",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "8a69029b-054e-4adc-b20b-b2052cdaed73:metrics_0_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "08b8beb6-9b26-461b-9a04-3560916952d0:indexpattern-datasource-current-indexpattern",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "08b8beb6-9b26-461b-9a04-3560916952d0:indexpattern-datasource-layer-8f78ff58-39ee-47eb-8e7a-46a2bec850d1",
-      "id": "logs-*"
-    },
-    {
-      "type": "index-pattern",
-      "name": "e0d96ed1-5839-4e7a-bf04-8757614b8503:metrics_0_index_pattern",
-      "id": "logs-*"
-    },
-    {
-      "name": "controlGroup_a71b2a03-663d-4897-a3c2-4a363a5cd13c:optionsListDataView",
-      "type": "index-pattern",
-      "id": "logs-*"
-    },
-    {
-      "name": "controlGroup_19286679-ff18-4cb1-b048-e32dd60c3ff9:optionsListDataView",
-      "type": "index-pattern",
-      "id": "logs-*"
-    }
-  ],
-  "migrationVersion": {
-    "dashboard": "8.6.0"
-  },
-  "coreMigrationVersion": "8.6.1"
+    "type": "dashboard"
 }

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 1.5.14
+version: 1.5.15
 release: ga
 description: This Elastic integration collects logs from Azure
 type: integration


### PR DESCRIPTION
## What does this PR do?

Migrating dashboard "Azure Spring Cloud System Logs" to Lens

Note: I have observed some issues with area plots, "Top 10 values" and "Hide zero values" options not taking effect in the latest stack versions, I am currently investigating why, seems like an issue on the visualization side so far. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

## How to test this PR locally

## Related issues

## Screenshots 

Screenshot before migration:

![BEFORE](https://github.com/elastic/integrations/assets/122360116/4102e32a-f205-4720-979f-d468d6ba61e8)

Screenshot after migration:
![AFTER_31_05](https://github.com/elastic/integrations/assets/122360116/cd37e599-6c40-435a-858e-1db7ea69aead)



<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
