### PR TITLE
[fortinet_fortigate] Simplify split script into a kv

### DIFF
--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Simplify script to split syslog message into a KV processor
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.11.0"
   changes:
     - description: Lowercase host.name field and add event.type denied when action is deny

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -27,51 +27,14 @@ processors:
       field: syslog5424_sd
       pattern: "\u0000"
       replacement: ""
-  - script:
-      lang: painless
-      if: ctx.syslog5424_sd != null
-      description: |
-        Splits syslog5424_sd KV list by space and then each by "=" taking into account quoted values.
-      source: |
-        def splitUnquoted(String input, String sep) {
-          def tokens = [];
-          def startPosition = 0;
-          def isInQuotes = false;
-          char quote = (char)"\"";
-          for (def currentPosition = 0; currentPosition < input.length(); currentPosition++) {
-              if (input.charAt(currentPosition) == quote) {
-                  isInQuotes = !isInQuotes;
-              }
-              else if (input.charAt(currentPosition) == (char)sep && !isInQuotes) {
-                  def token = input.substring(startPosition, currentPosition).trim();
-                  if (!token.equals("")) {
-                    tokens.add(token);
-                  }
-                  startPosition = currentPosition + 1;
-              }
-          }
-
-          def lastToken = input.substring(startPosition);
-          if (!lastToken.equals(sep) && !lastToken.equals("")) {
-              tokens.add(lastToken.trim());
-          }
-          return tokens;
-        }
-
-        def arr = splitUnquoted(ctx.syslog5424_sd, " ");
-
-        Map map = new HashMap();
-        Pattern pattern = /^\"|\"$/;
-        for (def i = 0; i < arr?.length; i++) {
-          def kv = splitUnquoted(arr[i], "=");
-          if (kv.length == 2) {
-            map[kv[0]] = pattern.matcher(kv[1]).replaceAll("");
-          }
-        }
-        if (ctx.fortinet == null) {
-          ctx.fortinet = new HashMap();
-        }
-        ctx.fortinet.firewall = map;
+  - kv:
+      field: syslog5424_sd
+      field_split: \s+(?=(?:[^"]*"[^"]*")*[^"]*$)
+      value_split: '='
+      prefix: "fortinet.firewall."
+      ignore_missing: true
+      ignore_failure: false
+      trim_value: "\""
   - script:
       lang: painless
       source: |

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: "1.11.0"
+version: "1.12.0"
 release: ga
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Simplifies the script used to split the syslog message into a KV processor.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

