### PR TITLE
[O11y] [Couchbase] Make sync-gateway host optional

### DIFF
--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Make sync-gateway host optional.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link
+      link: https://github.com/elastic/integrations/pull/6404 # FIXME Replace with the real PR link
 - version: "0.15.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -1,6 +1,6 @@
 - version: "0.15.1"
   changes:
-    - description: Make sync-gateway host optional.
+    - description: Fix sync-gateway host configuration.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/6404
 - version: "0.15.0"

--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Make sync-gateway host optional.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/6404 # FIXME Replace with the real PR link
+      link: https://github.com/elastic/integrations/pull/6404
 - version: "0.15.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.15.1"
+  changes:
+    - description: Make sync-gateway host optional.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link
 - version: "0.15.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/couchbase/manifest.yml
+++ b/packages/couchbase/manifest.yml
@@ -76,49 +76,6 @@ vars:
     multi: false
     required: false
     show_user: false
-  - name: host_sync_gateway
-    type: text
-    title: Hosts for Sync Gateway prometheus exporter
-    multi: true
-    required: false
-    show_user: true
-    description: "Hosts for Sync Gateway prometheus exporter (Format: `http[s]://[username:password@]hostname[:port]`)."
-    default:
-      - http://username:password@localhost:9421
-  - name: ssl_sync_gateway
-    type: yaml
-    title: SSL Configuration for Sync Gateway prometheus exporter hosts
-    default: |
-      # certificate_authorities:
-      # - |
-      #   -----BEGIN CERTIFICATE-----
-      #   MIID+jCCAuKgAwIBAgIGAJJMzlxLMA0GCSqGSIb3DQEBCwUAMHoxCzAJBgNVBAYT
-      #   AlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHROb2RlMDExFjAUBgNV
-      #   BAsTDURlZmF1bHRDZWxsMDExGTAXBgNVBAsTEFJvb3QgQ2VydGlmaWNhdGUxEjAQ
-      #   BgNVBAMTCWxvY2FsaG9zdDAeFw0yMTEyMTQyMjA3MTZaFw0yMjEyMTQyMjA3MTZa
-      #   MF8xCzAJBgNVBAYTAlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHRO
-      #   b2RlMDExFjAUBgNVBAsTDURlZmF1bHRDZWxsMDExEjAQBgNVBAMTCWxvY2FsaG9z
-      #   dDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMv5HCsJZIpI5zCy+jXV
-      #   z6lmzNc9UcVSEEHn86h6zT6pxuY90TYeAhlZ9hZ+SCKn4OQ4GoDRZhLPTkYDt+wW
-      #   CV3NTIy9uCGUSJ6xjCKoxClJmgSQdg5m4HzwfY4ofoEZ5iZQ0Zmt62jGRWc0zuxj
-      #   hegnM+eO2reBJYu6Ypa9RPJdYJsmn1RNnC74IDY8Y95qn+WZj//UALCpYfX41hko
-      #   i7TWD9GKQO8SBmAxhjCDifOxVBokoxYrNdzESl0LXvnzEadeZTd9BfUtTaBHhx6t
-      #   njqqCPrbTY+3jAbZFd4RiERPnhLVKMytw5ot506BhPrUtpr2lusbN5svNXjuLeea
-      #   MMUCAwEAAaOBoDCBnTATBgNVHSMEDDAKgAhOatpLwvJFqjAdBgNVHSUEFjAUBggr
-      #   BgEFBQcDAQYIKwYBBQUHAwIwVAYDVR0RBE0wS4E+UHJvZmlsZVVVSUQ6QXBwU3J2
-      #   MDEtQkFTRS05MDkzMzJjMC1iNmFiLTQ2OTMtYWI5NC01Mjc1ZDI1MmFmNDiCCWxv
-      #   Y2FsaG9zdDARBgNVHQ4ECgQITzqhA5sO8O4wDQYJKoZIhvcNAQELBQADggEBAKR0
-      #   gY/BM69S6BDyWp5dxcpmZ9FS783FBbdUXjVtTkQno+oYURDrhCdsfTLYtqUlP4J4
-      #   CHoskP+MwJjRIoKhPVQMv14Q4VC2J9coYXnePhFjE+6MaZbTjq9WaekGrpKkMaQA
-      #   iQt5b67jo7y63CZKIo9yBvs7sxODQzDn3wZwyux2vPegXSaTHR/rop/s/mPk3YTS
-      #   hQprs/IVtPoWU4/TsDN3gIlrAYGbcs29CAt5q9MfzkMmKsuDkTZD0ry42VjxjAmk
-      #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
-      #   7RhLQyWn2u00L7/9Omw=
-      #   -----END CERTIFICATE-----
-    description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
-    multi: false
-    required: false
-    show_user: false
 policy_templates:
   - name: couchbase
     title: Couchbase metrics
@@ -133,5 +90,49 @@ policy_templates:
       - type: prometheus/metrics
         title: Collect Couchbase metrics using Sync Gateway
         description: Collect Couchbase metrics using Sync Gateway prometheus exporter.
+        vars:
+          - name: host_sync_gateway
+            type: text
+            title: Hosts for Sync Gateway prometheus exporter
+            multi: true
+            required: true
+            show_user: true
+            description: "Hosts for Sync Gateway prometheus exporter (Format: `http[s]://[username:password@]hostname[:port]`)."
+            default:
+              - http://username:password@localhost:9421
+          - name: ssl_sync_gateway
+            type: yaml
+            title: SSL Configuration for Sync Gateway prometheus exporter hosts
+            default: |
+              # certificate_authorities:
+              # - |
+              #   -----BEGIN CERTIFICATE-----
+              #   MIID+jCCAuKgAwIBAgIGAJJMzlxLMA0GCSqGSIb3DQEBCwUAMHoxCzAJBgNVBAYT
+              #   AlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHROb2RlMDExFjAUBgNV
+              #   BAsTDURlZmF1bHRDZWxsMDExGTAXBgNVBAsTEFJvb3QgQ2VydGlmaWNhdGUxEjAQ
+              #   BgNVBAMTCWxvY2FsaG9zdDAeFw0yMTEyMTQyMjA3MTZaFw0yMjEyMTQyMjA3MTZa
+              #   MF8xCzAJBgNVBAYTAlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHRO
+              #   b2RlMDExFjAUBgNVBAsTDURlZmF1bHRDZWxsMDExEjAQBgNVBAMTCWxvY2FsaG9z
+              #   dDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMv5HCsJZIpI5zCy+jXV
+              #   z6lmzNc9UcVSEEHn86h6zT6pxuY90TYeAhlZ9hZ+SCKn4OQ4GoDRZhLPTkYDt+wW
+              #   CV3NTIy9uCGUSJ6xjCKoxClJmgSQdg5m4HzwfY4ofoEZ5iZQ0Zmt62jGRWc0zuxj
+              #   hegnM+eO2reBJYu6Ypa9RPJdYJsmn1RNnC74IDY8Y95qn+WZj//UALCpYfX41hko
+              #   i7TWD9GKQO8SBmAxhjCDifOxVBokoxYrNdzESl0LXvnzEadeZTd9BfUtTaBHhx6t
+              #   njqqCPrbTY+3jAbZFd4RiERPnhLVKMytw5ot506BhPrUtpr2lusbN5svNXjuLeea
+              #   MMUCAwEAAaOBoDCBnTATBgNVHSMEDDAKgAhOatpLwvJFqjAdBgNVHSUEFjAUBggr
+              #   BgEFBQcDAQYIKwYBBQUHAwIwVAYDVR0RBE0wS4E+UHJvZmlsZVVVSUQ6QXBwU3J2
+              #   MDEtQkFTRS05MDkzMzJjMC1iNmFiLTQ2OTMtYWI5NC01Mjc1ZDI1MmFmNDiCCWxv
+              #   Y2FsaG9zdDARBgNVHQ4ECgQITzqhA5sO8O4wDQYJKoZIhvcNAQELBQADggEBAKR0
+              #   gY/BM69S6BDyWp5dxcpmZ9FS783FBbdUXjVtTkQno+oYURDrhCdsfTLYtqUlP4J4
+              #   CHoskP+MwJjRIoKhPVQMv14Q4VC2J9coYXnePhFjE+6MaZbTjq9WaekGrpKkMaQA
+              #   iQt5b67jo7y63CZKIo9yBvs7sxODQzDn3wZwyux2vPegXSaTHR/rop/s/mPk3YTS
+              #   hQprs/IVtPoWU4/TsDN3gIlrAYGbcs29CAt5q9MfzkMmKsuDkTZD0ry42VjxjAmk
+              #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
+              #   7RhLQyWn2u00L7/9Omw=
+              #   -----END CERTIFICATE-----
+            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            multi: false
+            required: false
+            show_user: false
 owner:
   github: elastic/obs-infraobs-integrations

--- a/packages/couchbase/manifest.yml
+++ b/packages/couchbase/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: couchbase
 title: Couchbase
-version: "0.15.0"
+version: "0.15.1"
 license: basic
 description: Collect metrics from Couchbase databases with Elastic Agent.
 type: integration
@@ -80,7 +80,7 @@ vars:
     type: text
     title: Hosts for Sync Gateway prometheus exporter
     multi: true
-    required: true
+    required: false
     show_user: true
     description: "Hosts for Sync Gateway prometheus exporter (Format: `http[s]://[username:password@]hostname[:port]`)."
     default:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:

- Enhancement
- Breaking change
- Deprecation
-->
- Bug

## What does this PR do?

Making the Sync gateway parameter optional, so user won't be forced to configure the Sync gateway host parameter if they are not using it.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Checked for  data collection without Syncgateway configuration.
- [x] Checked for the data collection with Syncgateway configuration.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #6248 
