### PR TITLE
Add CRC options when configuring Zoom integration

### DIFF
--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.9.1"
+- version: "1.10.0"
   changes:
     - description: Make CRC validation configurable.
       type: enhancement

--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Make CRC validation configurable.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6411
 - version: "1.9.0"
   changes:
     - description: Add CRC validation support.

--- a/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
+++ b/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
@@ -2,10 +2,14 @@ listen_address: {{listen_address}}
 listen_port: {{listen_port}}
 url: {{url}}
 prefix: zoom
-crc.provider: zoom
 content_type: "" # force ignoring content-type checks
 {{#if preserve_original_event}}
 preserve_original_event: true
+{{/if}}
+# Fill CRC settings if enabled
+{{#if crc_enabled}}
+crc.provider: zoom
+crc.secret: "{{crc_secret}}"
 {{/if}}
 # Only set the secret options if a secret.value is set
 {{#if secret_value}}

--- a/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
+++ b/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
@@ -11,11 +11,9 @@ preserve_original_event: true
 crc.provider: zoom
 crc.secret: "{{crc_secret}}"
 {{/if}}
-# Only set the secret options if a secret.value is set
-{{#if secret_value}}
-secret.header: Authorization
+# Secret header and value are mandatory for new integrations
+secret.header: "{{secret_header}}"
 secret.value: "{{secret_value}}"
-{{/if}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}

--- a/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
+++ b/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
@@ -11,9 +11,13 @@ preserve_original_event: true
 crc.provider: zoom
 crc.secret: "{{crc_secret}}"
 {{/if}}
-# Secret header and value are required when configuring a new Zoom integration
+# Only set the secret options if both header and value are set
+{{#if secret_header}}
+{{#if secret_value}}
 secret.header: "{{secret_header}}"
 secret.value: "{{secret_value}}"
+{{/if}}
+{{/if}}
 {{#if ssl}}
 ssl: {{ssl}}
 {{/if}}

--- a/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
+++ b/packages/zoom/data_stream/webhook/agent/stream/http_endpoint.yml.hbs
@@ -11,7 +11,7 @@ preserve_original_event: true
 crc.provider: zoom
 crc.secret: "{{crc_secret}}"
 {{/if}}
-# Secret header and value are mandatory for new integrations
+# Secret header and value are required when configuring a new Zoom integration
 secret.header: "{{secret_header}}"
 secret.value: "{{secret_value}}"
 {{#if ssl}}

--- a/packages/zoom/data_stream/webhook/manifest.yml
+++ b/packages/zoom/data_stream/webhook/manifest.yml
@@ -49,7 +49,7 @@ streams:
         title: Zoom Custom Header
         description: Custom header used to validate the authenticity of incoming Zoom POST requests. It should be created by the user when configuring the webhook on Zoom. See [Verify webhook events](https://developers.zoom.us/docs/api/rest/webhook-reference/#custom-header) for more information.
         multi: false
-        required: true
+        required: false
         show_user: true
         default: Authorization
       - name: secret_value
@@ -57,7 +57,7 @@ streams:
         title: Zoom Custom Header value
         description: Custom header value used to validate the authenticity of incoming Zoom POST requests. It should be created by the user when configuring the webhook on Zoom. See [Verify webhook events](https://developers.zoom.us/docs/api/rest/webhook-reference/#custom-header) for more information.
         multi: false
-        required: true
+        required: false
         show_user: true
       - name: ssl
         type: yaml

--- a/packages/zoom/data_stream/webhook/manifest.yml
+++ b/packages/zoom/data_stream/webhook/manifest.yml
@@ -32,7 +32,7 @@ streams:
       - name: crc_enabled
         type: bool
         title: Enable CRC validation
-        description: CRC validation is used by certain providers to verify the authenticity of a webhook endpoint.
+        description: CRC validation is used by Zoom to verify the authenticity of a webhook endpoint. See [Validate your webhook endpoint](https://developers.zoom.us/docs/api/rest/webhook-reference/#validate-your-webhook-endpoint) for more information.
         multi: false
         required: false
         show_user: true
@@ -40,14 +40,14 @@ streams:
       - name: crc_secret
         type: text
         title: Zoom Secret Token
-        description: Secret token provided by Zoom when configured the webhook. It is used for the CRC validation of the webhook endpoint.
+        description: Secret token provided by Zoom when the webhook was configured. It is used for the CRC validation of the webhook endpoint.
         multi: false
         required: false
         show_user: true
       - name: secret_header
         type: text
         title: Zoom Custom Header
-        description: Custom header used to validate the authenticity of incoming Zoom POST requests. It should be created when configuring the webhook on Zoom. See [this documentation](https://developers.zoom.us/docs/api/rest/webhook-reference/#custom-header) for more information about this process.
+        description: Custom header used to validate the authenticity of incoming Zoom POST requests. It should be created by the user when configuring the webhook on Zoom. See [Verify webhook events](https://developers.zoom.us/docs/api/rest/webhook-reference/#custom-header) for more information.
         multi: false
         required: true
         show_user: true
@@ -55,7 +55,7 @@ streams:
       - name: secret_value
         type: text
         title: Zoom Custom Header value
-        description: Custom header value used to validate the authenticity of incoming Zoom POST requests. It should be created when configuring the webhook on Zoom. See [this documentation](https://developers.zoom.us/docs/api/rest/webhook-reference/#custom-header) for more information about this process.
+        description: Custom header value used to validate the authenticity of incoming Zoom POST requests. It should be created by the user when configuring the webhook on Zoom. See [Verify webhook events](https://developers.zoom.us/docs/api/rest/webhook-reference/#custom-header) for more information.
         multi: false
         required: true
         show_user: true

--- a/packages/zoom/data_stream/webhook/manifest.yml
+++ b/packages/zoom/data_stream/webhook/manifest.yml
@@ -44,10 +44,18 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: secret_header
+        type: text
+        title: Zoom Custom Header
+        description: Custom header used to validate the authenticity of incoming Zoom POST requests. It should be created when configuring the webhook on Zoom. See [this documentation](https://developers.zoom.us/docs/api/rest/webhook-reference/#custom-header) for more information about this process.
+        multi: false
+        required: true
+        show_user: true
+        default: Authorization
       - name: secret_value
         type: text
-        title: Zoom verification token
-        description: Verification token used to validate the authenticity of incoming Zoom POST requests. Zoom sends this as the Authorization header.
+        title: Zoom Custom Header value
+        description: Custom header value used to validate the authenticity of incoming Zoom POST requests. It should be created when configuring the webhook on Zoom. See [this documentation](https://developers.zoom.us/docs/api/rest/webhook-reference/#custom-header) for more information about this process.
         multi: false
         required: true
         show_user: true

--- a/packages/zoom/data_stream/webhook/manifest.yml
+++ b/packages/zoom/data_stream/webhook/manifest.yml
@@ -29,6 +29,21 @@ streams:
         required: true
         show_user: true
         default: /zoom-webhook
+      - name: crc_enabled
+        type: bool
+        title: Enable CRC validation
+        description: CRC validation is used by certain providers to verify the authenticity of a webhook endpoint.
+        multi: false
+        required: false
+        show_user: true
+        default: false
+      - name: crc_secret
+        type: text
+        title: Zoom Secret Token
+        description: Secret token provided by Zoom when configured the webhook. It is used for the CRC validation of the webhook endpoint.
+        multi: false
+        required: false
+        show_user: true
       - name: secret_value
         type: text
         title: Zoom verification token

--- a/packages/zoom/manifest.yml
+++ b/packages/zoom/manifest.yml
@@ -1,6 +1,6 @@
 name: zoom
 title: Zoom
-version: "1.9.1"
+version: "1.10.0"
 release: ga
 description: Collect logs from Zoom with Elastic Agent.
 type: integration

--- a/packages/zoom/manifest.yml
+++ b/packages/zoom/manifest.yml
@@ -1,6 +1,6 @@
 name: zoom
 title: Zoom
-version: "1.9.0"
+version: "1.9.1"
 release: ga
 description: Collect logs from Zoom with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This is an improvement of #6288 adding the following:
- Instead of hardcoding the CRC provider option for the Zoom integration, now it is exposed to users the option to enable it when configuring the integration.
- The reason of this change, is because a new option has been added called `crc.secret` at https://github.com/elastic/beats/pull/35604. This forces the user to add this secret token manually when setting up the integration.
- A new parameter `secret_header` has been added since now, Zoom allows verifying events with a custom header instead of using `Authorization` as a hardcoded one.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Depends on https://github.com/elastic/beats/pull/35604

## Screenshots

<img width="1241" alt="Screenshot 2023-05-31 at 19 19 50" src="https://github.com/elastic/integrations/assets/29475387/52dc5ca3-6b42-4db3-92e6-c5da58fbbbaf">

<img width="391" alt="image" src="https://github.com/elastic/integrations/assets/29475387/959ba19e-4e57-4c22-9422-0be36b684c30">

