### PR TITLE
Corrections to `ecs.yml` mappings

### DIFF
--- a/packages/cisco_secure_endpoint/data_stream/event/fields/ecs.yml
+++ b/packages/cisco_secure_endpoint/data_stream/event/fields/ecs.yml
@@ -10,64 +10,64 @@
   name: event.code
 - external: ecs
   name: event.ingested
-- name: event.kind
-  external: ecs
+- external: ecs
+  name: event.kind
 - external: ecs
   name: event.original
 - external: ecs
   name: event.outcome
 - external: ecs
   name: event.severity
-- name: event.start
-  external: ecs
+- external: ecs
+  name: event.start
 - external: ecs
   name: event.category
 - external: ecs
   name: event.id
 - external: ecs
   name: event.timezone
-- name: related.ip
-  external: ecs
-- name: related.user
-  external: ecs
+- external: ecs
+  name: related.hash
+- external: ecs
+  name: related.hosts
+- external: ecs
+  name: related.ip
+- external: ecs
+  name: related.user
 - external: ecs
   name: user.name
 - external: ecs
   name: user.domain
 - external: ecs
   name: user.email
-- name: related.hosts
-  external: ecs
-- name: related.hash
-  external: ecs
-- name: process.args
-  external: ecs
-- name: process.args_count
-  external: ecs
-- name: process.command_line
-  external: ecs
-- name: process.executable
-  external: ecs
-- name: process.name
-  external: ecs
-- name: process.pid
-  external: ecs
-- name: process.hash.md5
-  external: ecs
-- name: process.hash.sha1
-  external: ecs
-- name: process.hash.sha256
-  external: ecs
-- name: file.hash.md5
-  external: ecs
-- name: file.hash.sha1
-  external: ecs
-- name: file.hash.sha256
-  external: ecs
-- name: file.name
-  external: ecs
-- name: file.path
-  external: ecs
+- external: ecs
+  name: process.args
+- external: ecs
+  name: process.args_count
+- external: ecs
+  name: process.command_line
+- external: ecs
+  name: process.executable
+- external: ecs
+  name: process.name
+- external: ecs
+  name: process.pid
+- external: ecs
+  name: process.hash.md5
+- external: ecs
+  name: process.hash.sha1
+- external: ecs
+  name: process.hash.sha256
+- external: ecs
+  name: file.hash.md5
+- external: ecs
+  name: file.hash.sha1
+- external: ecs
+  name: file.hash.sha256
+- external: ecs
+  name: file.name
+- external: ecs
+  name: file.path
 - external: ecs
   name: destination.address
 - external: ecs


### PR DESCRIPTION
# Type of change
- Bug

## What does this PR do?

There are quite a few discrepancies with how fields are defined in `ecs.yml`. The PR corrects those and sorts some fields for better readability. Example:

```
- name: event.start
  external: ecs
```

Should be:

```
- external: ecs
  name: event.start
```

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #6430 
