### PR TITLE
[cisco_meraki] - Update to package-spec 2.7.0

### DIFF
--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Update package-spec version to 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec version to 2.7.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6439
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/cisco_meraki/data_stream/events/_dev/test/pipeline/test-mx-events.json-expected.json
+++ b/packages/cisco_meraki/data_stream/events/_dev/test/pipeline/test-mx-events.json-expected.json
@@ -46,7 +46,9 @@
                 "name": "Main Office"
             },
             "observer": {
-                "mac": "00-11-22-33-44-55",
+                "mac": [
+                    "00-11-22-33-44-55"
+                ],
                 "name": "My appliance",
                 "product": "MX",
                 "serial_number": "Q234-ABCD-5678",
@@ -95,7 +97,9 @@
                 "name": "Main Office"
             },
             "observer": {
-                "mac": "00-11-22-33-44-55",
+                "mac": [
+                    "00-11-22-33-44-55"
+                ],
                 "serial_number": "Q234-ABCD-5678",
                 "vendor": "Cisco"
             },
@@ -153,7 +157,9 @@
                 "name": "Main Office"
             },
             "observer": {
-                "mac": "00-11-22-33-44-55",
+                "mac": [
+                    "00-11-22-33-44-55"
+                ],
                 "name": "My switch",
                 "product": "MS",
                 "serial_number": "Q234-ABCD-5678",

--- a/packages/cisco_meraki/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_meraki/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -9,9 +9,13 @@ processors:
     copy_from: json.deviceSerial
 - gsub:
     field: json.deviceMac
-    target_field: observer.mac
+    target_field: _tmp.observer.mac
     pattern: '[-:.]'
     replacement: '-'
+- append:
+    field: observer.mac
+    value: '{{{_tmp.observer.mac}}}'
+    if: ctx?._tmp?.observer?.mac != null
 - set:
     field: observer.name
     copy_from: json.deviceName
@@ -262,6 +266,7 @@ processors:
       - cisco_meraki.event.organizationName
       - cisco_meraki.event.alertType
       - cisco_meraki.event.alertLevel
+      - _tmp
     ignore_missing: true
 - remove:
     field: event.original

--- a/packages/cisco_meraki/data_stream/events/sample_event.json
+++ b/packages/cisco_meraki/data_stream/events/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2018-02-11T00:00:00.123Z",
     "agent": {
-        "ephemeral_id": "6c6d06ce-b090-4f7c-a7e1-ac4ea241dc4b",
-        "id": "c5f4a269-fab9-4c19-9b0f-2f270ed03375",
+        "ephemeral_id": "077a2d93-4b1d-4908-b2d5-7c3a0218df3a",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.8.0"
     },
     "cisco_meraki": {
         "event": {
@@ -40,9 +40,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "c5f4a269-fab9-4c19-9b0f-2f270ed03375",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.8.0"
     },
     "event": {
         "action": "Cellular came up",
@@ -51,7 +51,7 @@
             "network"
         ],
         "dataset": "cisco_meraki.events",
-        "ingested": "2023-01-30T01:28:32Z",
+        "ingested": "2023-06-01T20:29:21Z",
         "original": "{\"alertData\":{\"connection\":\"LTE\",\"local\":\"192.168.1.2\",\"model\":\"UML290VW\",\"provider\":\"Purview Wireless\",\"remote\":\"1.2.3.5\"},\"alertId\":\"0000000000000000\",\"alertLevel\":\"informational\",\"alertType\":\"Cellular came up\",\"alertTypeId\":\"cellular_up\",\"deviceMac\":\"00:11:22:33:44:55\",\"deviceModel\":\"MX\",\"deviceName\":\"My appliance\",\"deviceSerial\":\"Q234-ABCD-5678\",\"deviceTags\":[\"tag1\",\"tag2\"],\"deviceUrl\":\"https://n1.meraki.com//n//manage/nodes/new_list/000000000000\",\"networkId\":\"N_24329156\",\"networkName\":\"Main Office\",\"networkTags\":[],\"networkUrl\":\"https://n1.meraki.com//n//manage/nodes/list\",\"occurredAt\":\"2018-02-11T00:00:00.123450Z\",\"organizationId\":\"2930418\",\"organizationName\":\"My organization\",\"organizationUrl\":\"https://dashboard.meraki.com/o/VjjsAd/manage/organization/overview\",\"sentAt\":\"2021-10-07T08:42:00.926325Z\",\"sharedSecret\":\"secret\",\"version\":\"0.1\"}",
         "type": [
             "info",
@@ -68,7 +68,9 @@
         "name": "Main Office"
     },
     "observer": {
-        "mac": "00-11-22-33-44-55",
+        "mac": [
+            "00-11-22-33-44-55"
+        ],
         "name": "My appliance",
         "product": "MX",
         "serial_number": "Q234-ABCD-5678",

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-airmarshal-events.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-airmarshal-events.log-expected.json
@@ -35,7 +35,9 @@
             },
             "observer": {
                 "hostname": "MX84_5",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -80,7 +82,9 @@
             },
             "observer": {
                 "hostname": "MX84_2",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-D8-51"
@@ -125,7 +129,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-DF-FD"
@@ -213,7 +219,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -259,7 +267,9 @@
             },
             "observer": {
                 "hostname": "MX84_5",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-D8-51"
@@ -304,7 +314,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E2-9D"
@@ -349,7 +361,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -394,7 +408,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E2-9D"
@@ -482,7 +498,9 @@
             },
             "observer": {
                 "hostname": "MX84_5",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-D8-51"
@@ -527,7 +545,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-DF-FD"
@@ -573,7 +593,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-D8-51"
@@ -618,7 +640,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-D8-51"
@@ -663,7 +687,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-E2-9D"
@@ -708,7 +734,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E2-9D"
@@ -753,7 +781,9 @@
             },
             "observer": {
                 "hostname": "MX84_5",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-D8-51"
@@ -798,7 +828,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E2-9D"
@@ -844,7 +876,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-DF-FD"
@@ -932,7 +966,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-DF-FD"
@@ -978,7 +1014,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E2-9D"
@@ -1024,7 +1062,9 @@
             },
             "observer": {
                 "hostname": "MX84_5",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-D8-51"
@@ -1070,7 +1110,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-D8-51"
@@ -1115,7 +1157,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-DF-FD"
@@ -1161,7 +1205,9 @@
             },
             "observer": {
                 "hostname": "MX84_1",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-D8-51"
@@ -1206,7 +1252,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-E1-41"
@@ -1252,7 +1300,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-D8-51"
@@ -1297,7 +1347,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-DF-FD"
@@ -1385,7 +1437,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-E2-9D"
@@ -1430,7 +1484,9 @@
             },
             "observer": {
                 "hostname": "MX84_1",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-D8-51"
@@ -1475,7 +1531,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-D8-51"
@@ -1521,7 +1579,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-DF-FD"
@@ -1566,7 +1626,9 @@
             },
             "observer": {
                 "hostname": "MX84_2",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-D8-51"
@@ -1654,7 +1716,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-D8-51"
@@ -1699,7 +1763,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-E2-9D"
@@ -1744,7 +1810,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-E2-9D"
@@ -1789,7 +1857,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-D8-51"
@@ -1834,7 +1904,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E2-9D"
@@ -1879,7 +1951,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -1925,7 +1999,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E2-9D"
@@ -1970,7 +2046,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-DF-FD"
@@ -2015,7 +2093,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-DF-FD"
@@ -2146,7 +2226,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E2-9D"
@@ -2191,7 +2273,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E1-41"
@@ -2236,7 +2320,9 @@
             },
             "observer": {
                 "hostname": "MX84_1",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-D8-51"
@@ -2281,7 +2367,9 @@
             },
             "observer": {
                 "hostname": "MX84_4",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -2326,7 +2414,9 @@
             },
             "observer": {
                 "hostname": "MX84_2",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -2371,7 +2461,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-D8-51"
@@ -2459,7 +2551,9 @@
             },
             "observer": {
                 "hostname": "MX84_4",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -2505,7 +2599,9 @@
             },
             "observer": {
                 "hostname": "MX84_2",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-D8-51"
@@ -2550,7 +2646,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E2-9D"
@@ -2595,7 +2693,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E2-9D"
@@ -2640,7 +2740,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-DF-FD"
@@ -2729,7 +2831,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-E1-41"
@@ -2775,7 +2879,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-D8-51"
@@ -2821,7 +2927,9 @@
             },
             "observer": {
                 "hostname": "MX84_2",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-D8-51"
@@ -2866,7 +2974,9 @@
             },
             "observer": {
                 "hostname": "MX84_2",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-DF-FD"
@@ -2911,7 +3021,9 @@
             },
             "observer": {
                 "hostname": "MX84_2",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -2956,7 +3068,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-E1-41"
@@ -3002,7 +3116,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-D8-51"
@@ -3047,7 +3163,9 @@
             },
             "observer": {
                 "hostname": "MX84_1",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-D8-51"
@@ -3092,7 +3210,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-DF-FD"
@@ -3137,7 +3257,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E2-9D"
@@ -3225,7 +3347,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E1-41"
@@ -3270,7 +3394,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-DF-FD"
@@ -3316,7 +3442,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E2-9D"
@@ -3362,7 +3490,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E2-9D"
@@ -3408,7 +3538,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-E2-9D"
@@ -3496,7 +3628,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-DF-FD"
@@ -3541,7 +3675,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E2-9D"
@@ -3586,7 +3722,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-D8-51"
@@ -3631,7 +3769,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-DF-FD"
@@ -3676,7 +3816,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -3721,7 +3863,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-DF-FD"
@@ -3767,7 +3911,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-D8-51"
@@ -3812,7 +3958,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-D8-51"
@@ -3857,7 +4005,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-D8-51"
@@ -3903,7 +4053,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E1-41"
@@ -3949,7 +4101,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-D8-51"
@@ -3995,7 +4149,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-E2-9D"
@@ -4041,7 +4197,9 @@
             },
             "observer": {
                 "hostname": "MX84_2",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-D8-51"
@@ -4086,7 +4244,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -4131,7 +4291,9 @@
             },
             "observer": {
                 "hostname": "MX84_1",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -4176,7 +4338,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-DF-FD"
@@ -4221,7 +4385,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E2-9D"
@@ -4309,7 +4475,9 @@
             },
             "observer": {
                 "hostname": "MX84_4",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-E1-41"
@@ -4354,7 +4522,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-E2-9D"
@@ -4442,7 +4612,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E2-9D"
@@ -4488,7 +4660,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-E2-9D"
@@ -4533,7 +4707,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-DF-FD"
@@ -4621,7 +4797,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-DF-FD"
@@ -4666,7 +4844,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-E2-9D"
@@ -4712,7 +4892,9 @@
             },
             "observer": {
                 "hostname": "MX84_4",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E2-9D"
@@ -4800,7 +4982,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-D8-51"
@@ -4888,7 +5072,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-D8-51"
@@ -4933,7 +5119,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E1-41"
@@ -4978,7 +5166,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-E1-41"
@@ -5023,7 +5213,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-E2-9D"
@@ -5068,7 +5260,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-E1-41"
@@ -5113,7 +5307,9 @@
             },
             "observer": {
                 "hostname": "MX84_4",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E2-9D"
@@ -5158,7 +5354,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-E2-9D"
@@ -5204,7 +5402,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-E2-9D"
@@ -5249,7 +5449,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-E1-41"
@@ -5295,7 +5497,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E2-9D"
@@ -5340,7 +5544,9 @@
             },
             "observer": {
                 "hostname": "MX84_8",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-E1-41"
@@ -5385,7 +5591,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-DF-FD"
@@ -5430,7 +5638,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-E1-41"
@@ -5475,7 +5685,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-D8-51"
@@ -5520,7 +5732,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -5565,7 +5779,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-E2-9D"
@@ -5610,7 +5826,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-D8-51"
@@ -5655,7 +5873,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -5700,7 +5920,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E2-9D"
@@ -5745,7 +5967,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -5833,7 +6057,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-D8-51"
@@ -5878,7 +6104,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-DF-FD"
@@ -5923,7 +6151,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E2-9D"
@@ -5968,7 +6198,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-D8-51"
@@ -6013,7 +6245,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-DF-FD"
@@ -6058,7 +6292,9 @@
             },
             "observer": {
                 "hostname": "MX84_4",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-D8-51"
@@ -6104,7 +6340,9 @@
             },
             "observer": {
                 "hostname": "MX84_7",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E2-9D"
@@ -6149,7 +6387,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -6194,7 +6434,9 @@
             },
             "observer": {
                 "hostname": "MX84_6",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-D8-51"
@@ -6239,7 +6481,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E1-41"
@@ -6284,7 +6528,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-E2-9D"
@@ -6329,7 +6575,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-D8-51"
@@ -6375,7 +6623,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-D8-51"
@@ -6420,7 +6670,9 @@
             },
             "observer": {
                 "hostname": "MX84_5",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-D8-51"
@@ -6465,7 +6717,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E2-9D"
@@ -6510,7 +6764,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -6555,7 +6811,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -6600,7 +6858,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E1-41"
@@ -6645,7 +6905,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-C8-C7-D8-51"
@@ -6690,7 +6952,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-C8-C7-D8-51"
@@ -6735,7 +6999,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-D8-51"
@@ -6780,7 +7046,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-D8-51"
@@ -6826,7 +7094,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-D8-51"
@@ -6872,7 +7142,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-D8-51"
@@ -6918,7 +7190,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-DF-FD"
@@ -6964,7 +7238,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-DF-FD"
@@ -7009,7 +7285,9 @@
             },
             "observer": {
                 "hostname": "MX84_5",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E1-41"
@@ -7054,7 +7332,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-DF-FD"
+                "mac": [
+                    "AC-17-C8-C7-DF-FD"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-DF-FD"
@@ -7099,7 +7379,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E2-9D"
@@ -7144,7 +7426,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E2-9D"
@@ -7189,7 +7473,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-E1-41"
@@ -7234,7 +7520,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E1-41"
@@ -7280,7 +7568,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-E1-41"
@@ -7326,7 +7616,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E1-41"
@@ -7371,7 +7663,9 @@
             },
             "observer": {
                 "hostname": "MX84_4",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-E2-9D"
@@ -7416,7 +7710,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-C8-C7-D8-51"
@@ -7461,7 +7757,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-D8-51"
@@ -7506,7 +7804,9 @@
             },
             "observer": {
                 "hostname": "MX84_3",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "BE-17-D8-C7-D8-51"
@@ -7552,7 +7852,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-D8-51"
@@ -7598,7 +7900,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-D8-51"
@@ -7644,7 +7948,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-D8-51"
+                "mac": [
+                    "AC-17-C8-C7-D8-51"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-D8-51"
@@ -7690,7 +7996,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AA-17-D8-C7-E2-9D"
@@ -7735,7 +8043,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E2-9D"
@@ -7781,7 +8091,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AE-17-D8-C7-E2-9D"
@@ -7826,7 +8138,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E2-9D"
+                "mac": [
+                    "AC-17-C8-C7-E2-9D"
+                ]
             },
             "source": {
                 "mac": "AC-17-C8-C7-E2-9D"
@@ -7871,7 +8185,9 @@
             },
             "observer": {
                 "hostname": "MX84",
-                "mac": "AC-17-C8-C7-E1-41"
+                "mac": [
+                    "AC-17-C8-C7-E1-41"
+                ]
             },
             "source": {
                 "mac": "92-17-D8-C7-E1-41"

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/airmarshal.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/airmarshal.yml
@@ -44,10 +44,14 @@ processors:
     replacement: '-'
 - gsub:
     field: _temp.kv.wired_mac
-    target_field: observer.mac
+    target_field: _temp.observer.mac
     pattern: '[-:.]'
     replacement: '-'
     if: ctx?.cisco_meraki?.event_subtype == 'rogue_ssid_detected'
+- append:
+    field: observer.mac
+    value: '{{{_temp.observer.mac}}}'
+    if: ctx?._temp?.observer?.mac != null
 - rename:
     field: _temp.kv.vlan_id
     target_field: network.vlan.id

--- a/packages/cisco_meraki/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_meraki/data_stream/log/fields/ecs.yml
@@ -251,8 +251,6 @@
 - external: ecs
   name: user_agent.version
 - external: ecs
-  name: user_agent.device.name
-- external: ecs
   name: user_agent.os.name
 - external: ecs
   name: user_agent.os.version

--- a/packages/cisco_meraki/data_stream/log/sample_event.json
+++ b/packages/cisco_meraki/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-11-23T18:13:18.348Z",
     "agent": {
-        "ephemeral_id": "6c6d06ce-b090-4f7c-a7e1-ac4ea241dc4b",
-        "id": "c5f4a269-fab9-4c19-9b0f-2f270ed03375",
+        "ephemeral_id": "eedc7205-9a4a-44e7-8574-3c9450a28434",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.8.0"
     },
     "cisco_meraki": {
         "event_subtype": "ids_alerted",
@@ -30,9 +30,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "c5f4a269-fab9-4c19-9b0f-2f270ed03375",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.8.0"
     },
     "event": {
         "action": "ids-signature-matched",
@@ -42,7 +42,7 @@
             "threat"
         ],
         "dataset": "cisco_meraki.log",
-        "ingested": "2023-01-30T01:30:34Z",
+        "ingested": "2023-06-01T20:31:15Z",
         "original": "\u003c134\u003e1 1637691198.348361125 MX84 security_event ids_alerted signature=1:29708:4 priority=1 timestamp=1637691198.330873 dhost=D0:AB:D5:7B:43:73 direction=ingress protocol=tcp/ip src=67.43.156.12:80 dst=10.0.3.162:56391 decision=allowed message: BROWSER-IE Microsoft Internet Explorer CSS uninitialized object access attempt detected",
         "type": [
             "info",
@@ -54,7 +54,7 @@
     },
     "log": {
         "source": {
-            "address": "172.24.0.4:59574"
+            "address": "192.168.224.4:50508"
         }
     },
     "network": {

--- a/packages/cisco_meraki/docs/README.md
+++ b/packages/cisco_meraki/docs/README.md
@@ -297,11 +297,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2021-11-23T18:13:18.348Z",
     "agent": {
-        "ephemeral_id": "6c6d06ce-b090-4f7c-a7e1-ac4ea241dc4b",
-        "id": "c5f4a269-fab9-4c19-9b0f-2f270ed03375",
+        "ephemeral_id": "eedc7205-9a4a-44e7-8574-3c9450a28434",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.8.0"
     },
     "cisco_meraki": {
         "event_subtype": "ids_alerted",
@@ -326,9 +326,9 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "c5f4a269-fab9-4c19-9b0f-2f270ed03375",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.8.0"
     },
     "event": {
         "action": "ids-signature-matched",
@@ -338,7 +338,7 @@ An example event for `log` looks as following:
             "threat"
         ],
         "dataset": "cisco_meraki.log",
-        "ingested": "2023-01-30T01:30:34Z",
+        "ingested": "2023-06-01T20:31:15Z",
         "original": "\u003c134\u003e1 1637691198.348361125 MX84 security_event ids_alerted signature=1:29708:4 priority=1 timestamp=1637691198.330873 dhost=D0:AB:D5:7B:43:73 direction=ingress protocol=tcp/ip src=67.43.156.12:80 dst=10.0.3.162:56391 decision=allowed message: BROWSER-IE Microsoft Internet Explorer CSS uninitialized object access attempt detected",
         "type": [
             "info",
@@ -350,7 +350,7 @@ An example event for `log` looks as following:
     },
     "log": {
         "source": {
-            "address": "172.24.0.4:59574"
+            "address": "192.168.224.4:50508"
         }
     },
     "network": {
@@ -622,11 +622,11 @@ An example event for `events` looks as following:
 {
     "@timestamp": "2018-02-11T00:00:00.123Z",
     "agent": {
-        "ephemeral_id": "6c6d06ce-b090-4f7c-a7e1-ac4ea241dc4b",
-        "id": "c5f4a269-fab9-4c19-9b0f-2f270ed03375",
+        "ephemeral_id": "077a2d93-4b1d-4908-b2d5-7c3a0218df3a",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.8.0"
     },
     "cisco_meraki": {
         "event": {
@@ -661,9 +661,9 @@ An example event for `events` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "c5f4a269-fab9-4c19-9b0f-2f270ed03375",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.8.0"
     },
     "event": {
         "action": "Cellular came up",
@@ -672,7 +672,7 @@ An example event for `events` looks as following:
             "network"
         ],
         "dataset": "cisco_meraki.events",
-        "ingested": "2023-01-30T01:28:32Z",
+        "ingested": "2023-06-01T20:29:21Z",
         "original": "{\"alertData\":{\"connection\":\"LTE\",\"local\":\"192.168.1.2\",\"model\":\"UML290VW\",\"provider\":\"Purview Wireless\",\"remote\":\"1.2.3.5\"},\"alertId\":\"0000000000000000\",\"alertLevel\":\"informational\",\"alertType\":\"Cellular came up\",\"alertTypeId\":\"cellular_up\",\"deviceMac\":\"00:11:22:33:44:55\",\"deviceModel\":\"MX\",\"deviceName\":\"My appliance\",\"deviceSerial\":\"Q234-ABCD-5678\",\"deviceTags\":[\"tag1\",\"tag2\"],\"deviceUrl\":\"https://n1.meraki.com//n//manage/nodes/new_list/000000000000\",\"networkId\":\"N_24329156\",\"networkName\":\"Main Office\",\"networkTags\":[],\"networkUrl\":\"https://n1.meraki.com//n//manage/nodes/list\",\"occurredAt\":\"2018-02-11T00:00:00.123450Z\",\"organizationId\":\"2930418\",\"organizationName\":\"My organization\",\"organizationUrl\":\"https://dashboard.meraki.com/o/VjjsAd/manage/organization/overview\",\"sentAt\":\"2021-10-07T08:42:00.926325Z\",\"sharedSecret\":\"secret\",\"version\":\"0.1\"}",
         "type": [
             "info",
@@ -689,7 +689,9 @@ An example event for `events` looks as following:
         "name": "Main Office"
     },
     "observer": {
-        "mac": "00-11-22-33-44-55",
+        "mac": [
+            "00-11-22-33-44-55"
+        ],
         "name": "My appliance",
         "product": "MX",
         "serial_number": "Q234-ABCD-5678",

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,14 +1,12 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.8.0"
-license: basic
+version: "1.9.0"
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration
 categories:
   - network
   - security
-release: ga
 conditions:
   kibana.version: ^7.17.0 || ^8.0.0
 screenshots:


### PR DESCRIPTION
## What does this PR do?

Updates package-spec version to 2.7.0

- Normalized `observer.mac` to array.

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=8.8 -format-version=2.7.0 packages/cisco_meraki
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_meraki
elastic-package test
```

## Related issues

- Relates elastic/security-team#5870
