### PR TITLE
[zoom] - update ECS to 8.8.0 from 8.7.0

### DIFF
--- a/packages/zoom/_dev/build/build.yml
+++ b/packages/zoom/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.7
+    reference: git@8.8

--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Update package to ECS 8.8.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.9.0"
   changes:
     - description: Add CRC validation support.

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-account.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-account.json-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "account.created",
@@ -49,7 +49,7 @@
         {
             "@timestamp": "2019-07-01T17:03:04.527Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "account.updated",
@@ -103,7 +103,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "account.disassociated",

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-channel.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-channel.json-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-02-10T21:39:50.388Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_channel.created",
@@ -44,7 +44,7 @@
         {
             "@timestamp": "2020-02-10T21:59:05.584Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_channel.updated",
@@ -82,7 +82,7 @@
         {
             "@timestamp": "2020-02-10T21:59:05.584Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_channel.deleted",
@@ -120,7 +120,7 @@
         {
             "@timestamp": "2020-02-10T21:39:50.388Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_channel.member_invited",
@@ -160,7 +160,7 @@
         {
             "@timestamp": "2020-02-10T21:39:50.388Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_channel.member_joined",
@@ -198,7 +198,7 @@
         {
             "@timestamp": "2020-02-10T21:39:50.388Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_channel.member_left",

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-message.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-chat-message.json-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-02-11T22:02:11.930Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_message.sent",
@@ -45,7 +45,7 @@
         {
             "@timestamp": "2020-02-11T23:00:08.594Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_message.updated",
@@ -87,7 +87,7 @@
         {
             "@timestamp": "2020-02-11T23:00:08.594Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "chat_message.updated",

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-meeting.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-meeting.json-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.alert",
@@ -41,7 +41,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.created",
@@ -84,7 +84,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.updated",
@@ -141,7 +141,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.deleted",
@@ -184,7 +184,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.started",
@@ -223,7 +223,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.ended",
@@ -263,7 +263,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.registration_created",
@@ -313,7 +313,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.registration_approved",
@@ -363,7 +363,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.registration_cancelled",
@@ -409,7 +409,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.sharing_started",
@@ -461,7 +461,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.sharing_ended",
@@ -514,7 +514,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.participant_jbh_waiting",
@@ -556,7 +556,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.participant_jbh_joined",
@@ -598,7 +598,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.participant_joined",
@@ -644,7 +644,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "meeting.participant_left",

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-phone.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-phone.json-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.caller_ringing",
@@ -49,7 +49,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.caller_connected",
@@ -97,7 +97,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.caller_ringing",
@@ -148,7 +148,7 @@
                 }
             },
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.callee_answered",
@@ -196,7 +196,7 @@
                 }
             },
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.callee_missed",
@@ -240,7 +240,7 @@
                 }
             },
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.callee_ended",
@@ -288,7 +288,7 @@
                 }
             },
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.caller_ended",
@@ -336,7 +336,7 @@
                 }
             },
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.callee_rejected",
@@ -383,7 +383,7 @@
                 }
             },
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.voicemail_received",
@@ -429,7 +429,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.caller_call_log_completed",
@@ -453,7 +453,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "phone.callee_call_log_completed",

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-recording.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-recording.json-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.started",
@@ -46,7 +46,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.paused",
@@ -89,7 +89,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.resumed",
@@ -132,7 +132,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.stopped",
@@ -177,7 +177,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.completed",
@@ -224,7 +224,7 @@
         {
             "@timestamp": "2019-12-04T23:00:57.395Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.renamed",
@@ -269,7 +269,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.trashed",
@@ -314,7 +314,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.deleted",
@@ -359,7 +359,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.recovered",
@@ -404,7 +404,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.transcript_completed",
@@ -449,7 +449,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.registration_created",
@@ -498,7 +498,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.registration_approved",
@@ -547,7 +547,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "recording.registration_denied",

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-user.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-user.json-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.created",
@@ -45,7 +45,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.invitation_accepted",
@@ -87,7 +87,7 @@
         {
             "@timestamp": "2019-07-19T18:10:54.861Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.updated",
@@ -136,7 +136,7 @@
         {
             "@timestamp": "2019-07-19T21:47:06.929Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.settings_updated",
@@ -194,7 +194,7 @@
         {
             "@timestamp": "2020-06-29T17:32:19.427Z",
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.settings_updated",
@@ -247,7 +247,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.deactivated",
@@ -296,7 +296,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.activated",
@@ -345,7 +345,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.disassociated",
@@ -394,7 +394,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.deleted",
@@ -443,7 +443,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.presence_status_updated",
@@ -482,7 +482,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.personal_notes_updated",
@@ -528,7 +528,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.signed_in",
@@ -568,7 +568,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "user.signed_out",

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-webinar.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-webinar.json-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.created",
@@ -45,7 +45,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.updated",
@@ -99,7 +99,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.deleted",
@@ -142,7 +142,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.started",
@@ -183,7 +183,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.ended",
@@ -224,7 +224,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.alert",
@@ -260,7 +260,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.sharing_started",
@@ -313,7 +313,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.sharing_started",
@@ -366,7 +366,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.registration_created",
@@ -417,7 +417,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.registration_approved",
@@ -470,7 +470,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.registration_denied",
@@ -521,7 +521,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.registration_cancelled",
@@ -571,7 +571,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.participant_joined",
@@ -619,7 +619,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "webinar.participant_left",

--- a/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-zoomroom.json-expected.json
+++ b/packages/zoom/data_stream/webhook/_dev/test/pipeline/test-zoomroom.json-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "zoomroom.alert",
@@ -30,7 +30,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "zoomroom.delayed_alert",
@@ -58,7 +58,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "zoomroom.checked_in",
@@ -90,7 +90,7 @@
         },
         {
             "ecs": {
-                "version": "8.7.0"
+                "version": "8.8.0"
             },
             "event": {
                 "action": "zoomroom.checked_in",

--- a/packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
       value: Webhook
   - set:
       field: ecs.version
-      value: '8.7.0'
+      value: '8.8.0'
   - script:
       description: Drops null/empty values recursively
       lang: painless

--- a/packages/zoom/data_stream/webhook/sample_event.json
+++ b/packages/zoom/data_stream/webhook/sample_event.json
@@ -1,0 +1,85 @@
+{
+    "@timestamp": "2019-07-01T17:03:04.527Z",
+    "agent": {
+        "ephemeral_id": "b49c8a84-f0f6-44ce-ad90-a9886d422c41",
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
+        "name": "docker-fleet-agent",
+        "type": "filebeat",
+        "version": "8.8.0"
+    },
+    "data_stream": {
+        "dataset": "zoom.webhook",
+        "namespace": "ep",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "8.8.0"
+    },
+    "elastic_agent": {
+        "id": "878982e9-a174-4ed8-abe3-19378c1473de",
+        "snapshot": false,
+        "version": "8.8.0"
+    },
+    "event": {
+        "action": "account.updated",
+        "agent_id_status": "verified",
+        "category": [
+            "iam"
+        ],
+        "dataset": "zoom.webhook",
+        "ingested": "2023-06-02T19:23:58Z",
+        "kind": [
+            "event"
+        ],
+        "original": "{\"event\":\"account.updated\",\"payload\":{\"account_id\":\"abKKcd_IGRCq63yEy673lCA\",\"object\":{\"account_alias\":\"MH\",\"account_name\":\"Michael Harris\",\"id\":\"eFs_EGRCq6ByEyA73qCA\"},\"old_object\":{\"account_alias\":\"\",\"account_name\":\"Mike Harris\",\"id\":\"eFs_EGRCq6ByEyA73qCA\"},\"operator\":\"theoperatoremail@someemail.com\",\"operator_id\":\"iKoRgfbaTazDX6r2Q_eQsQL\",\"time_stamp\":1562000584527}}",
+        "timezone": "+00:00",
+        "type": [
+            "user",
+            "change"
+        ]
+    },
+    "input": {
+        "type": "http_endpoint"
+    },
+    "observer": {
+        "product": "Webhook",
+        "vendor": "Zoom"
+    },
+    "related": {
+        "user": [
+            "iKoRgfbaTazDX6r2Q_eQsQL",
+            "eFs_EGRCq6ByEyA73qCA"
+        ]
+    },
+    "tags": [
+        "preserve_original_event",
+        "zoom-webhook",
+        "forwarded"
+    ],
+    "user": {
+        "changes": {
+            "full_name": "Michael Harris",
+            "name": "MH"
+        },
+        "email": "theoperatoremail@someemail.com",
+        "id": "iKoRgfbaTazDX6r2Q_eQsQL",
+        "target": {
+            "full_name": "Mike Harris",
+            "id": "eFs_EGRCq6ByEyA73qCA"
+        }
+    },
+    "zoom": {
+        "account": {
+            "account_alias": "MH",
+            "account_name": "Michael Harris"
+        },
+        "master_account_id": "abKKcd_IGRCq63yEy673lCA",
+        "old_values": {
+            "account_name": "Mike Harris",
+            "id": "eFs_EGRCq6ByEyA73qCA"
+        },
+        "operator": "theoperatoremail@someemail.com",
+        "operator_id": "iKoRgfbaTazDX6r2Q_eQsQL",
+        "sub_account_id": "eFs_EGRCq6ByEyA73qCA"
+    }
+}

--- a/packages/zoom/manifest.yml
+++ b/packages/zoom/manifest.yml
@@ -1,6 +1,6 @@
 name: zoom
 title: Zoom
-version: "1.9.0"
+version: "1.10.0"
 release: ga
 description: Collect logs from Zoom with Elastic Agent.
 type: integration


### PR DESCRIPTION
This updates the zoom integration to ECS 8.8.0.
It was referencing elastic/ecs git@8.7 and using 8.7.0 in ingest pipelines.

[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=8.8packages/zoom

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
