### PR TITLE
[IIS] Add dimension field mapping for application_pool datastream to …

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Add dimension field mapping for application_pool datastream to support tsdb.
+      type: enhancement
+      link: tbd
 - version: "1.11.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add dimension field mapping for application_pool datastream to support tsdb.
       type: enhancement
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/6460
 - version: "1.11.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/iis/data_stream/application_pool/fields/agent.yml
+++ b/packages/iis/data_stream/application_pool/fields/agent.yml
@@ -8,6 +8,7 @@
     - name: account.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
 
@@ -16,12 +17,14 @@
     - name: availability_zone
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
     - name: instance.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
@@ -39,12 +42,14 @@
     - name: provider
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
@@ -65,6 +70,7 @@
     - name: id
       level: core
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Unique container id.
     - name: image.name
@@ -133,6 +139,7 @@
     - name: name
       level: core
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: 'Name of the host.
 
@@ -196,3 +203,11 @@
       description: >
         OS codename, if any.
 
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/iis/data_stream/application_pool/fields/ecs.yml
+++ b/packages/iis/data_stream/application_pool/fields/ecs.yml
@@ -2,5 +2,6 @@
   name: ecs.version
 - external: ecs
   name: service.address
+  dimension: true
 - external: ecs
   name: service.type

--- a/packages/iis/data_stream/application_pool/fields/fields.yml
+++ b/packages/iis/data_stream/application_pool/fields/fields.yml
@@ -3,6 +3,7 @@
   fields:
     - name: name
       type: keyword
+      dimension: true
       description: |
         application pool name
     - name: process

--- a/packages/iis/docs/README.md
+++ b/packages/iis/docs/README.md
@@ -368,6 +368,7 @@ The fields reported are:
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| agent.id |  | keyword |  |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
 | cloud.availability_zone | Availability zone in which this host is running. | keyword |  |  |
 | cloud.image.id | Image ID for the cloud instance. | keyword |  |  |

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: "1.11.0"
+version: "1.12.0"
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
- Enhancement


## What does this PR do?

This PR adds dimension fields mapping for the application_pool data stream of IIS to support TSDB enablement.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues

- Relates #6267 

