### PR TITLE
checkpoint: avoid data loss from loguid collisions

### DIFF
--- a/packages/checkpoint/_dev/build/docs/README.md
+++ b/packages/checkpoint/_dev/build/docs/README.md
@@ -39,6 +39,8 @@ This integration has been tested against Check Point Log Exporter on R80.X and R
 For step-by-step instructions on how to set up an integration, see the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
+In some instances firewall events may have the same Checkpoint `loguid` and arrive during the same timestamp resulting in a fingerprint collision. To avoid this [enable semi-unified logging](https://sc1.checkpoint.com/documents/R81/WebAdminGuides/EN/CP_R81_LoggingAndMonitoring_AdminGuide/Topics-LMG/Log-Exporter-Appendix.htm?TocPath=Log%20Exporter%7C_____9) in the Checkpoint dashboard.
+
 ## Logs reference
 
 ### Firewall

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Avoid data loss from updates with colliding loguid and timestamp.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6483
 - version: "1.21.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/checkpoint/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/checkpoint/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -171,6 +171,7 @@ processors:
         - '@timestamp'
         - checkpoint.loguid
         - checkpoint.time
+        - checkpoint.segment_time
       target_field: "_id"
       ignore_missing: true
   - append:

--- a/packages/checkpoint/docs/README.md
+++ b/packages/checkpoint/docs/README.md
@@ -39,6 +39,8 @@ This integration has been tested against Check Point Log Exporter on R80.X and R
 For step-by-step instructions on how to set up an integration, see the
 [Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
 
+In some instances firewall events may have the same Checkpoint `loguid` and arrive during the same timestamp resulting in a fingerprint collision. To avoid this [enable semi-unified logging](https://sc1.checkpoint.com/documents/R81/WebAdminGuides/EN/CP_R81_LoggingAndMonitoring_AdminGuide/Topics-LMG/Log-Exporter-Appendix.htm?TocPath=Log%20Exporter%7C_____9) in the Checkpoint dashboard.
+
 ## Logs reference
 
 ### Firewall

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: checkpoint
 title: Check Point
-version: "1.21.0"
+version: "1.22.0"
 description: Collect logs from Check Point with Elastic Agent.
 type: integration
 format_version: 2.7.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Because Checkpoint reuse loguids, it is possible for two logged events to be given the same fingerprint. So use the segment_time as well in the fingerprint args. Also document that if collisions are important, the user should enable semi-unified logging on the device's dashboard.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #6355

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
