### PR TITLE
ActiveMQ Added dimension fields for queue datastream

### DIFF
--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.9.1"
   changes:
-    - description: Added dimension fields for broker datastream for TSDB enablement
+    - description: Added dimension fields for queue datastream for TSDB enablement
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6491
 - version: "0.9.0"

--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.1"
+  changes:
+    - description: Added dimension fields for broker datastream for TSDB enablement
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.9.0"
   changes:
     - description: Added dimension fields for broker datastream for TSDB enablement

--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added dimension fields for broker datastream for TSDB enablement
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6491
 - version: "0.9.0"
   changes:
     - description: Added dimension fields for broker datastream for TSDB enablement

--- a/packages/activemq/data_stream/queue/fields/ecs.yml
+++ b/packages/activemq/data_stream/queue/fields/ecs.yml
@@ -18,7 +18,32 @@
   name: event.type
 - external: ecs
   name: service.address
+  dimension: true
 - external: ecs
   name: service.type
 - external: ecs
   name: tags
+- external: ecs
+  name: agent.id
+  dimension: true
+- external: ecs
+  name: cloud.account.id
+  dimension: true
+- external: ecs
+  name: cloud.region
+  dimension: true
+- external: ecs
+  name: cloud.availability_zone
+  dimension: true
+- external: ecs
+  name: cloud.instance.id
+  dimension: true
+- external: ecs
+  name: cloud.provider
+  dimension: true
+- external: ecs
+  name: container.id
+  dimension: true
+- external: ecs
+  name: host.name
+  dimension: true

--- a/packages/activemq/data_stream/queue/fields/fields.yml
+++ b/packages/activemq/data_stream/queue/fields/fields.yml
@@ -7,6 +7,7 @@
     - name: mbean
       type: keyword
       # Reason to add as a dimension field : Unique identifier
+      dimension: true
       description: MBean that this event is related to.
     - name: memory.broker.pct
       type: float
@@ -50,8 +51,8 @@
           description: Average message size on this destination.
     - name: name
       type: keyword
-      dimension: true
       # Reason to add as a dimension field : Multiple queue name can exist
+      dimension: true
       description: Queue name
     - name: producers.count
       type: long

--- a/packages/activemq/data_stream/queue/fields/fields.yml
+++ b/packages/activemq/data_stream/queue/fields/fields.yml
@@ -6,6 +6,7 @@
       description: Number of consumers subscribed to this destination.
     - name: mbean
       type: keyword
+      # Reason to add as a dimension field : Unique identifier
       description: MBean that this event is related to.
     - name: memory.broker.pct
       type: float
@@ -49,6 +50,8 @@
           description: Average message size on this destination.
     - name: name
       type: keyword
+      dimension: true
+      # Reason to add as a dimension field : Multiple queue name can exist
       description: Queue name
     - name: producers.count
       type: long

--- a/packages/activemq/docs/README.md
+++ b/packages/activemq/docs/README.md
@@ -524,6 +524,13 @@ An example event for `queue` looks as following:
 | activemq.queue.name | Queue name | keyword |  |
 | activemq.queue.producers.count | Number of producers attached to this destination. | long |  |
 | activemq.queue.size | Queue size | long |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |
+| container.id | Unique container id. | keyword |  |
 | data_stream.dataset | Data stream dataset. | constant_keyword |  |
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |
 | data_stream.type | Data stream type. | constant_keyword |  |
@@ -536,6 +543,7 @@ An example event for `queue` looks as following:
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |  |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |  |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 | tags | List of keywords used to tag each event. | keyword |  |

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,6 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: "0.9.0"
+version: "0.9.1"
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
- Enhancement

## What does this PR do?
Added TSDB dimensions for queue datastream of ActiveMQ package

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

