### PR TITLE
windows: allow DNS query responses to have no data

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,9 +1,14 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Allow DNS query responses to have no data.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6508
 - version: "1.22.0"
   changes:
     - description: Set `host.os.type` and `host.os.family` in forwarded events.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6180
 - version: "1.21.1"
   changes:
     - description: Improve regular expression search efficiency to allow parsing large events.

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json
@@ -9483,6 +9483,51 @@
             "log": {
                 "level": "information"
             }
+        },
+        {
+            "event": {
+                "code": "22",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "host": {
+                "name": "internal.network.org"
+            },
+            "log": {
+                "level": "information"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "internal.network.org",
+                "event_data": {
+                    "Image": "C:\\Windows\\System32\\lsass.exe",
+                    "ProcessGuid": "{00000000-0000-0000-0000-000000000000}",
+                    "ProcessId": "500",
+                    "QueryName": "some.other.domain.com",
+                    "QueryResults": "type:  33 ;type:  33 ;81.2.69.144;81.2.69.142;",
+                    "QueryStatus": "0",
+                    "RuleName": "-",
+                    "User": "NT AUTHORITY\\SYSTEM",
+                    "UtcTime": "2000-01-01T00:00:00.000"
+                },
+                "event_id": "22",
+                "level": "information",
+                "opcode": "Info",
+                "process": {
+                    "pid": 1000,
+                    "thread": {
+                        "id": 2000
+                    }
+                },
+                "provider_guid": "{00000000-0000-0000-0000-000000000000}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": 1111,
+                "time_created": "2000-01-01T00:00:00Z",
+                "user": {
+                    "identifier": "A-0-0-00"
+                },
+                "version": 5
+            }
         }
     ]
 }

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
@@ -22758,6 +22758,108 @@
                 },
                 "version": 5
             }
+        },
+        {
+            "dns": {
+                "answers": [
+                    {
+                        "type": "SRV"
+                    },
+                    {
+                        "type": "SRV"
+                    },
+                    {
+                        "data": "81.2.69.144",
+                        "type": "A"
+                    },
+                    {
+                        "data": "81.2.69.142",
+                        "type": "A"
+                    }
+                ],
+                "question": {
+                    "name": "some.other.domain.com",
+                    "registered_domain": "domain.com",
+                    "subdomain": "some.other",
+                    "top_level_domain": "com"
+                },
+                "resolved_ip": [
+                    "81.2.69.144",
+                    "81.2.69.142"
+                ]
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "22",
+                "created": "2000-01-01T00:00:00.000Z",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "connection",
+                    "protocol",
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "internal.network.org"
+            },
+            "log": {
+                "level": "information"
+            },
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "executable": "C:\\Windows\\System32\\lsass.exe",
+                "name": "lsass.exe",
+                "pid": 500
+            },
+            "related": {
+                "hosts": [
+                    "some.other.domain.com"
+                ],
+                "ip": [
+                    "81.2.69.144",
+                    "81.2.69.142"
+                ],
+                "user": [
+                    "SYSTEM"
+                ]
+            },
+            "sysmon": {
+                "dns": {
+                    "status": "SUCCESS"
+                }
+            },
+            "user": {
+                "domain": "NT AUTHORITY",
+                "id": "A-0-0-00",
+                "name": "SYSTEM"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "internal.network.org",
+                "event_id": "22",
+                "opcode": "Info",
+                "process": {
+                    "pid": 1000,
+                    "thread": {
+                        "id": 2000
+                    }
+                },
+                "provider_guid": "{00000000-0000-0000-0000-000000000000}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "1111",
+                "user": {
+                    "identifier": "A-0-0-00"
+                },
+                "version": 5
+            }
         }
     ]
 }

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -788,15 +788,20 @@ processors:
 
           if (answer.startsWith("type:")) {
             def parts = /\s+/.split(answer);
-            if (parts.length != 3) {
+            if (parts.length < 2) {
               throw new Exception("unexpected QueryResult format");
             }
-
-            answers.add([
-              "type": params[parts[1]],
-              "data": parts[2]
-            ]);
-            relatedHosts.add(parts[2]);
+            if (parts.length == 3) {
+              answers.add([
+                "type": params[parts[1]],
+                "data": parts[2]
+              ]);
+              relatedHosts.add(parts[2]);
+            } else {
+              answers.add([
+                "type": params[parts[1]]
+              ]);
+            }
           } else {
             answer = answer.replace("::ffff:", "");
             ips.add(answer);

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.22.0
+version: 1.23.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This allows DNS query responses to have no data as can be seen for example with SRV responses.

Test event provided in elastic/beats#35207.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #elastic/beats#35207

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
