### PR TITLE
[symantec_endpoint] Parse all times relative to configured TZ offset

### DIFF
--- a/packages/symantec_endpoint/changelog.yml
+++ b/packages/symantec_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.1"
+  changes:
+    - description: Parse all times relative to the configuretimezone offset.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6509
 - version: "2.6.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/symantec_endpoint/changelog.yml
+++ b/packages/symantec_endpoint/changelog.yml
@@ -1,7 +1,10 @@
 # newer versions go on top
 - version: "2.6.1"
   changes:
-    - description: Parse all times relative to the configuretimezone offset.
+    - description: Parse all times relative to the configured timezone offset.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6509
+    - description: Rename group_name in policy logs to group for consistency across log types.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/6509
 - version: "2.6.0"

--- a/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-policy-rfc3164-sep14-3ru7.log
+++ b/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-policy-rfc3164-sep14-3ru7.log
@@ -1,0 +1,1 @@
+<54>Jun 7 09:16:10 SERVER SymantecServer: DESKTOP,Category: 0,Smc,Event Description: Received a new policy with serial number AB13-05/30/2023 23:01:52 031 from Symantec Endpoint Protection Manager.,Event time: 2023-06-07 09:09:54,Group Name: My Group

--- a/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-policy-rfc3164-sep14-3ru7.log-expected.json
+++ b/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-policy-rfc3164-sep14-3ru7.log-expected.json
@@ -1,0 +1,40 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2023-06-07T09:09:54.000Z",
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "kind": "event",
+                "original": "\u003c54\u003eJun 7 09:16:10 SERVER SymantecServer: DESKTOP,Category: 0,Smc,Event Description: Received a new policy with serial number AB13-05/30/2023 23:01:52 031 from Symantec Endpoint Protection Manager.,Event time: 2023-06-07 09:09:54,Group Name: My Group"
+            },
+            "host": {
+                "hostname": "DESKTOP",
+                "name": "DESKTOP"
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "SERVER",
+                    "priority": 54,
+                    "process": {
+                        "name": "SymantecServer"
+                    }
+                }
+            },
+            "message": "Received a new policy with serial number AB13-05/30/2023 23:01:52 031 from Symantec Endpoint Protection Manager.",
+            "symantec_endpoint": {
+                "log": {
+                    "category": "0",
+                    "event_description": "Received a new policy with serial number AB13-05/30/2023 23:01:52 031 from Symantec Endpoint Protection Manager.",
+                    "event_time": "2023-06-07T09:09:54.000Z",
+                    "group": "My Group"
+                }
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/symantec_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/symantec_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -139,6 +139,7 @@ processors:
         'computer': 'computer_name',
         'domain': 'domain_name',
         'end_time': 'end',
+        'group_name': 'group',
         'local': 'local_host_ip',
         'local_host': 'local_host_ip',
         'server_name': 'server',

--- a/packages/symantec_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/symantec_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -412,6 +412,7 @@ processors:
     ignore_failure: true
     formats:
       - yyyy-MM-dd HH:mm:ss
+    timezone: '{{{_conf.tz_offset}}}'
 
 # Caller MD-5
 - dissect:
@@ -514,6 +515,7 @@ processors:
     ignore_failure: true
     formats:
       - yyyy-MM-dd HH:mm:ss
+    timezone: '{{{_conf.tz_offset}}}'
 
 # Event Description
 - set:
@@ -529,6 +531,7 @@ processors:
     ignore_failure: true
     formats:
       - yyyy-MM-dd HH:mm:ss
+    timezone: '{{{_conf.tz_offset}}}'
     on_failure:
       - remove:
           field: symantec_endpoint.log.event_time
@@ -568,6 +571,7 @@ processors:
     ignore_failure: true
     formats:
       - yyyy-MM-dd HH:mm:ss
+    timezone: '{{{_conf.tz_offset}}}'
     on_failure:
       - remove:
           field: symantec_endpoint.log.inserted
@@ -600,6 +604,7 @@ processors:
     target_field: symantec_endpoint.log.last_update_time
     formats:
       - yyyy-MM-dd HH:mm:ss
+    timezone: '{{{_conf.tz_offset}}}'
     on_failure:
       - remove:
           field: symantec_endpoint.log.last_update_time

--- a/packages/symantec_endpoint/data_stream/log/manifest.yml
+++ b/packages/symantec_endpoint/data_stream/log/manifest.yml
@@ -48,7 +48,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting timestamps without a time zone.
       - name: udp_options
         type: yaml
         title: Custom UDP Options
@@ -134,7 +134,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting timestamps without a time zone.
       - name: processors
         type: yaml
         title: Processors
@@ -190,7 +190,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting timestamps without a time zone.
       - name: remove_mapped_fields
         required: true
         show_user: false

--- a/packages/symantec_endpoint/manifest.yml
+++ b/packages/symantec_endpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: symantec_endpoint
 title: Symantec Endpoint Protection
-version: "2.6.0"
+version: "2.6.1"
 description: Collect logs from Symantec Endpoint Protection with Elastic Agent.
 type: integration
 format_version: 2.7.0


### PR DESCRIPTION
## What does this PR do?

Use the configured time zone offset when interpreting all times. Previously only the syslog header and log export header were interpreted using the time zone offset and other times within the event were treated as if the were UTC. Based on new information we now assume that all times are relative to the time zone offset.

Fixes #6499

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
