### PR TITLE
[ti_misp] Fix threat_attributes pagination loop

### DIFF
--- a/packages/ti_misp/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_misp/_dev/deploy/docker/files/config.yml
@@ -505,5 +505,7 @@ rules:
       - status_code: 200
         body: |-
           {
-            "response": []
-          }
+            "response": {
+              "Attribute": []
+            }
+          }  

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.3"
+  changes:
+    - description: Fix bug where the threat_attributes data stream would not stop paginating after an empty response.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6512
 - version: "1.15.2"
   changes:
     - description: Prevent duplicate requests for the first page while paginating.

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -49,7 +49,7 @@ response.pagination:
 - set:
     target: body.page
     # Add 2 because the httpjson page counter is zero-based while the MISP page parameter starts at 1.
-    value: '[[if (ne (len .last_response.body.response) 0)]][[add .last_response.page 2]][[end]]'
+    value: '[[if (gt (len .last_response.body.response.Attribute) 0)]][[add .last_response.page 2]][[end]]'
     fail_on_template_error: true
 cursor:
   timestamp:

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -49,7 +49,7 @@ response.pagination:
 - set:
     target: body.page
     # Add 2 because the httpjson page counter is zero-based while the MISP page parameter starts at 1.
-    value: '[[if (gt (len .last_response.body.response.Attribute) 0)]][[add .last_response.page 2]][[end]]'
+    value: '[[if (ne (len .last_response.body.response.Attribute) 0)]][[add .last_response.page 2]][[end]]'
     fail_on_template_error: true
 cursor:
   timestamp:

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.15.2"
+version: "1.15.3"
 release: ga
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

The threat_attributes data stream was not breaking out of its pagination loop when an empty response was returned.

Fixes #6510

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
