### PR TITLE
[aws] Add tags_filter and include_linked_accounts in missing metric data streams

### DIFF
--- a/packages/aws/_dev/build/docs/README.md
+++ b/packages/aws/_dev/build/docs/README.md
@@ -201,6 +201,7 @@ Visit the page for each individual AWS integration to see details about exported
 
 | Service          | Metrics | Logs    |
 |------------------|:-------:|:-------:|
+| API Gateway      |    x    |         |
 | Billing          |    x    |         |
 | CloudFront       |         |    x    |
 | CloudTrail       |         |    x    |
@@ -215,6 +216,7 @@ Visit the page for each individual AWS integration to see details about exported
 | Network Firewall |    x    |    x    |
 | Lambda           |    x    |         |
 | NAT Gateway      |    x    |         |
+| Redshift         |    x    |         |
 | RDS              |    x    |         |
 | Route 53         |         |    x    |
 | S3               |    x    |    x    |
@@ -226,5 +228,4 @@ Visit the page for each individual AWS integration to see details about exported
 | VPC Flow         |         |    x    |
 | VPN              |    x    |         |
 | WAF              |         |    x    |
-| Redshift         |    x    |         |
 | Custom           |         |    x    |

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add include_linked_accounts config parameter for redshift and apigateway.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6459
+      link: https://github.com/elastic/integrations/pull/6526
 - version: "1.43.0"
   changes:
     - description: Add include_linked_accounts config parameter for metrics data streams.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.43.1"
+  changes:
+    - description: Add include_linked_accounts config parameter for redshift and apigateway.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6459
 - version: "1.43.0"
   changes:
     - description: Add include_linked_accounts config parameter for metrics data streams.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.43.1"
   changes:
-    - description: Add include_linked_accounts config parameter for redshift and apigateway.
+    - description: Add tags_filter and include_linked_accounts config parameter in missing metric data streams.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6526
 - version: "1.43.0"

--- a/packages/aws/data_stream/apigateway_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/apigateway_metrics/agent/stream/stream.yml.hbs
@@ -3,6 +3,9 @@ period: {{period}}
 {{#if data_granularity}}
 data_granularity: {{data_granularity}}
 {{/if}}
+{{#if include_linked_accounts}}
+include_linked_accounts: {{include_linked_accounts}}
+{{/if}}
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}
 {{/if}}

--- a/packages/aws/data_stream/apigateway_metrics/manifest.yml
+++ b/packages/aws/data_stream/apigateway_metrics/manifest.yml
@@ -29,5 +29,13 @@ streams:
         multi: false
         required: false
         show_user: false
+      - name: include_linked_accounts
+        type: bool
+        title: Include Linked Accounts
+        multi: false
+        required: false
+        show_user: false
+        default: false
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
     title: AWS API Gateway metrics
     description: Collect AWS API Gateway metrics

--- a/packages/aws/data_stream/apigateway_metrics/manifest.yml
+++ b/packages/aws/data_stream/apigateway_metrics/manifest.yml
@@ -37,5 +37,14 @@ streams:
         show_user: false
         default: false
         description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+      - name: tags_filter
+        type: yaml
+        title: Tags Filter
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          # - key: "created-by"
+            # value: "foo"
     title: AWS API Gateway metrics
     description: Collect AWS API Gateway metrics

--- a/packages/aws/data_stream/natgateway/manifest.yml
+++ b/packages/aws/data_stream/natgateway/manifest.yml
@@ -36,5 +36,14 @@ streams:
         show_user: false
         default: false
         description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+      - name: tags_filter
+        type: yaml
+        title: Tags Filter
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          # - key: "created-by"
+            # value: "foo"
     title: AWS NAT gateway metrics
     description: Collect AWS NAT gateway metrics

--- a/packages/aws/data_stream/redshift/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/redshift/agent/stream/stream.yml.hbs
@@ -36,6 +36,9 @@ regions:
 {{#if latency}}
 latency: {{latency}}
 {{/if}}
+{{#if tags_filter}}
+tags_filter: {{tags_filter}}
+{{/if}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/aws/data_stream/redshift/manifest.yml
+++ b/packages/aws/data_stream/redshift/manifest.yml
@@ -36,5 +36,14 @@ streams:
         show_user: false
         default: false
         description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+      - name: tags_filter
+        type: yaml
+        title: Tags Filter
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          # - key: "created-by"
+            # value: "foo"
     title: Amazon Redshift metrics
     description: Collect Amazon Redshift metrics

--- a/packages/aws/data_stream/redshift/manifest.yml
+++ b/packages/aws/data_stream/redshift/manifest.yml
@@ -28,5 +28,13 @@ streams:
         multi: false
         required: false
         show_user: false
+      - name: include_linked_accounts
+        type: bool
+        title: Include Linked Accounts
+        multi: false
+        required: false
+        show_user: false
+        default: false
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
     title: Amazon Redshift metrics
     description: Collect Amazon Redshift metrics

--- a/packages/aws/data_stream/transitgateway/manifest.yml
+++ b/packages/aws/data_stream/transitgateway/manifest.yml
@@ -36,5 +36,14 @@ streams:
         show_user: false
         default: false
         description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+      - name: tags_filter
+        type: yaml
+        title: Tags Filter
+        multi: false
+        required: false
+        show_user: false
+        default: |
+          # - key: "created-by"
+            # value: "foo"
     title: AWS Transit Gateway metrics
     description: Collect AWS Transit Gateway metrics

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -201,6 +201,7 @@ Visit the page for each individual AWS integration to see details about exported
 
 | Service          | Metrics | Logs    |
 |------------------|:-------:|:-------:|
+| API Gateway      |    x    |         |
 | Billing          |    x    |         |
 | CloudFront       |         |    x    |
 | CloudTrail       |         |    x    |
@@ -215,6 +216,7 @@ Visit the page for each individual AWS integration to see details about exported
 | Network Firewall |    x    |    x    |
 | Lambda           |    x    |         |
 | NAT Gateway      |    x    |         |
+| Redshift         |    x    |         |
 | RDS              |    x    |         |
 | Route 53         |         |    x    |
 | S3               |    x    |    x    |
@@ -226,5 +228,4 @@ Visit the page for each individual AWS integration to see details about exported
 | VPC Flow         |         |    x    |
 | VPN              |    x    |         |
 | WAF              |         |    x    |
-| Redshift         |    x    |         |
 | Custom           |         |    x    |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.43.0
+version: 1.43.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Add `include_linked_accounts` into redshift and apigateway data streams.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
