### PR TITLE
mysql: Add script processor to fix grok behaviour of ES 8.7.x+

### DIFF
--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log
@@ -17,9 +17,3 @@ SELECT last_name, MAX(salary) AS salary FROM employees
     GROUP BY last_name
     ORDER BY salary DESC
     LIMIT 10;
-# Time: 2019-03-24T14:04:53.713951Z
-# User@Host: root[root] @ localhost []  Id:    15
-# Query_time: 2.631844  Lock_time: 0.000145 Rows_sent: 10  Rows_examined: 3145718 Thread_id: 16 Errno: 0 Killed: 0 Bytes_received: 0 Bytes_sent: 312 Read_first: 1 Read_last: 0 Read_key: 3144072 Read_next: 2844047 Read_prev: 0 Read_rnd: 10 Read_rnd_next: 301663 Sort_merge_passes: 0 Sort_range_count: 0 Sort_rows: 10 Sort_scan_count: 1 Created_tmp_disk_tables: 0 Created_tmp_tables: 1 Start: 2019-03-24T14:04:51.082107Z End: 2019-03-24T14:04:53.713951Z
-use employees;
-SET timestamp=1553436105;
-SELECT last_name, MAX(salary) AS salary FROM employees INNER JOIN salaries ON employees.emp_no = salaries.emp_no GROUP BY last_name ORDER BY salary DESC LIMIT 10;

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log
@@ -17,3 +17,9 @@ SELECT last_name, MAX(salary) AS salary FROM employees
     GROUP BY last_name
     ORDER BY salary DESC
     LIMIT 10;
+# Time: 2019-03-24T14:04:53.713951Z
+# User@Host: root[root] @ localhost []  Id:    15
+# Query_time: 2.631844  Lock_time: 0.000145 Rows_sent: 10  Rows_examined: 3145718 Thread_id: 16 Errno: 0 Killed: 0 Bytes_received: 0 Bytes_sent: 312 Read_first: 1 Read_last: 0 Read_key: 3144072 Read_next: 2844047 Read_prev: 0 Read_rnd: 10 Read_rnd_next: 301663 Sort_merge_passes: 0 Sort_range_count: 0 Sort_rows: 10 Sort_scan_count: 1 Created_tmp_disk_tables: 0 Created_tmp_tables: 1 Start: 2019-03-24T14:04:51.082107Z End: 2019-03-24T14:04:53.713951Z
+use employees;
+SET timestamp=1553436105;
+SELECT last_name, MAX(salary) AS salary FROM employees INNER JOIN salaries ON employees.emp_no = salaries.emp_no GROUP BY last_name ORDER BY salary DESC LIMIT 10;

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log-expected.json
@@ -95,6 +95,66 @@
             "user": {
                 "name": "root"
             }
+        },
+        null,
+        {
+            "@timestamp": "2019-03-24T14:01:45.000Z",
+            "ecs": {
+                "version": "8.5.1"
+            },
+            "event": {
+                "category": [
+                    "database"
+                ],
+                "duration": 2631844000,
+                "end": "2019-03-24T14:04:53.713951Z",
+                "ingested": "2023-02-02T06:11:55.908780800Z",
+                "kind": "event",
+                "start": "2019-03-24T14:04:51.082107Z",
+                "type": [
+                    "info"
+                ]
+            },
+            "mysql": {
+                "slowlog": {
+                    "bytes_received": 0,
+                    "bytes_sent": 312,
+                    "current_user": "root",
+                    "killed": "0",
+                    "last_errno": "0",
+                    "lock_time": {
+                        "sec": 1.45E-4
+                    },
+                    "query": "SELECT last_name, MAX(salary) AS salary FROM employees INNER JOIN salaries ON employees.emp_no = salaries.emp_no GROUP BY last_name ORDER BY salary DESC LIMIT 10;",
+                    "read_first": 1,
+                    "read_key": 3144072,
+                    "read_last": 0,
+                    "read_next": 2844047,
+                    "read_prev": 0,
+                    "read_rnd": 10,
+                    "read_rnd_next": 301663,
+                    "rows_examined": 3145718,
+                    "rows_sent": 10,
+                    "schema": "employees",
+                    "sort_merge_passes": 0,
+                    "sort_range_count": 0,
+                    "sort_rows": 10,
+                    "sort_scan_count": 1,
+                    "tmp_disk_tables": 0,
+                    "tmp_tables": 1
+                },
+                "thread_id": [
+                    15,
+                    16
+                ]
+            },
+            "source": {
+                "domain": "localhost"
+            },
+            "temp": {},
+            "user": {
+                "name": "root"
+            }
         }
     ]
 }

--- a/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log-expected.json
+++ b/packages/mysql/data_stream/slowlog/_dev/test/pipeline/test-mysql-ubuntu-8-0-15.log-expected.json
@@ -95,66 +95,6 @@
             "user": {
                 "name": "root"
             }
-        },
-        null,
-        {
-            "@timestamp": "2019-03-24T14:01:45.000Z",
-            "ecs": {
-                "version": "8.5.1"
-            },
-            "event": {
-                "category": [
-                    "database"
-                ],
-                "duration": 2631844000,
-                "end": "2019-03-24T14:04:53.713951Z",
-                "ingested": "2023-02-02T06:11:55.908780800Z",
-                "kind": "event",
-                "start": "2019-03-24T14:04:51.082107Z",
-                "type": [
-                    "info"
-                ]
-            },
-            "mysql": {
-                "slowlog": {
-                    "bytes_received": 0,
-                    "bytes_sent": 312,
-                    "current_user": "root",
-                    "killed": "0",
-                    "last_errno": "0",
-                    "lock_time": {
-                        "sec": 1.45E-4
-                    },
-                    "query": "SELECT last_name, MAX(salary) AS salary FROM employees INNER JOIN salaries ON employees.emp_no = salaries.emp_no GROUP BY last_name ORDER BY salary DESC LIMIT 10;",
-                    "read_first": 1,
-                    "read_key": 3144072,
-                    "read_last": 0,
-                    "read_next": 2844047,
-                    "read_prev": 0,
-                    "read_rnd": 10,
-                    "read_rnd_next": 301663,
-                    "rows_examined": 3145718,
-                    "rows_sent": 10,
-                    "schema": "employees",
-                    "sort_merge_passes": 0,
-                    "sort_range_count": 0,
-                    "sort_rows": 10,
-                    "sort_scan_count": 1,
-                    "tmp_disk_tables": 0,
-                    "tmp_tables": 1
-                },
-                "thread_id": [
-                    15,
-                    16
-                ]
-            },
-            "source": {
-                "domain": "localhost"
-            },
-            "temp": {},
-            "user": {
-                "name": "root"
-            }
         }
     ]
 }

--- a/packages/mysql/data_stream/slowlog/elasticsearch/ingest_pipeline/default.json
+++ b/packages/mysql/data_stream/slowlog/elasticsearch/ingest_pipeline/default.json
@@ -33,6 +33,30 @@
       }
     },
     {
+      "script": {
+        "lang": "painless",
+        "if": "ctx?.mysql != null",
+        "source": "for (field in params.fields) { if (ctx.mysql[field] instanceof List) { def vals = ctx.mysql[field]; vals = vals.stream().distinct().collect(Collectors.toList()); if (vals.size() == 1) { ctx.mysql[field] = vals[0] } else { ctx.mysql[field] = vals } } }",
+        "params": {
+          "fields": [
+            "thread_id"
+          ]
+        }
+      }
+    },
+    {
+      "script": {
+        "lang": "painless",
+        "if": "ctx?.mysql?.slowlog != null",
+        "source": "for (field in params.fields) { if (ctx.mysql.slowlog[field] instanceof List) { def vals = ctx.mysql.slowlog[field]; vals = vals.stream().distinct().collect(Collectors.toList()); if (vals.size() == 1) { ctx.mysql.slowlog[field] = vals[0] } else { ctx.mysql.slowlog[field] = vals } } }",
+        "params": {
+          "fields": [
+            "schema"
+          ]
+        }
+      }
+    },
+    {
       "remove": {
         "field": "message"
       }


### PR DESCRIPTION
- Bug

## What does this PR do?

Changes deduplicate the list and only keep the unique elements. After this, if only 1 element remains, then it's added to the result as a single element (a string) and if not, the list is kept in the result with unique elements. This handling is done to manage the new behaviour of the grok processor in 8.7.x+. Read the related issue for more details.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #6016
