### PR TITLE
Adds processor configuration support for AWS cloudwatch metrics

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.44.0"
+  changes:
+    - description: Add processor support for AWS cloudwatch metrics.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6535
 - version: "1.43.0"
   changes:
     - description: Add include_linked_accounts config parameter for metrics data streams.

--- a/packages/aws/data_stream/cloudwatch_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_metrics/agent/stream/stream.yml.hbs
@@ -42,3 +42,7 @@ metrics: {{metrics}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/aws/data_stream/cloudwatch_metrics/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_metrics/manifest.yml
@@ -58,7 +58,7 @@ streams:
             # tags:
               # - key: created-by
                 # value: foo
-       - name: processors
+      - name: processors
         type: yaml
         title: Processors
         multi: false

--- a/packages/aws/data_stream/cloudwatch_metrics/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_metrics/manifest.yml
@@ -58,5 +58,13 @@ streams:
             # tags:
               # - key: created-by
                 # value: foo
+       - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: AWS CloudWatch metrics
     description: Collect AWS CloudWatch metrics

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.43.0
+version: 1.44.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION


## What does this PR do?

Adds processor configuration support for AWS cloudwatch metrics

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

