### PR TITLE
Add support for processors on all mysql integrations

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Add processor support
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6394
 - version: "1.12.1"
   changes:
     - description: Add system test cases for performance datastream

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add processor support
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6394
+      link: https://github.com/elastic/integrations/pull/6538
 - version: "1.12.1"
   changes:
     - description: Add system test cases for performance datastream

--- a/packages/mysql/data_stream/error/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/error/agent/stream/stream.yml.hbs
@@ -10,3 +10,7 @@ multiline:
   match: after
 processors:
 - add_locale: ~
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/mysql/data_stream/error/manifest.yml
+++ b/packages/mysql/data_stream/error/manifest.yml
@@ -12,5 +12,14 @@ streams:
         default:
           - /var/log/mysql/error.log*
           - /var/log/mysqld.log*
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: MySQL error logs
     description: Collect MySQL error logs

--- a/packages/mysql/data_stream/galera_status/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/galera_status/agent/stream/stream.yml.hbs
@@ -13,3 +13,7 @@ raw: {{raw}}
 {{#if username}}
 username: {{username}}
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/mysql/data_stream/galera_status/manifest.yml
+++ b/packages/mysql/data_stream/galera_status/manifest.yml
@@ -15,7 +15,15 @@ streams:
         title: Raw
         description: >
           When enabled, in addition to the existing data structure, all fields available from the mysql service through "SHOW /*!50002 GLOBAL */ STATUS;" will be added to the event.
-
         default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: MySQL galera_status metrics
     description: Collect MySQL galera_status metrics

--- a/packages/mysql/data_stream/performance/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/performance/agent/stream/stream.yml.hbs
@@ -13,3 +13,7 @@ raw: {{raw}}
 {{#if username}}
 username: {{username}}
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/mysql/data_stream/performance/manifest.yml
+++ b/packages/mysql/data_stream/performance/manifest.yml
@@ -19,3 +19,11 @@ streams:
         required: true
         show_user: true
         default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/mysql/data_stream/slowlog/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/slowlog/agent/stream/stream.yml.hbs
@@ -8,3 +8,7 @@ multiline:
   negate: true
   match: after
 exclude_lines: ['^[\/\w\.]+, Version: .* started with:.*', '^# Time:.*']   # Exclude the header and time
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/mysql/data_stream/slowlog/manifest.yml
+++ b/packages/mysql/data_stream/slowlog/manifest.yml
@@ -12,5 +12,14 @@ streams:
         default:
           - /var/log/mysql/*-slow.log*
           - /var/lib/mysql/*-slow.log*
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
     title: MySQL slowlog logs (log)
     description: Collect MySQL slowlog logs using log input

--- a/packages/mysql/data_stream/status/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/status/agent/stream/stream.yml.hbs
@@ -13,3 +13,7 @@ raw: {{raw}}
 {{#if username}}
 username: {{username}}
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/mysql/data_stream/status/manifest.yml
+++ b/packages/mysql/data_stream/status/manifest.yml
@@ -17,5 +17,13 @@ streams:
         required: true
         show_user: true
         default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
     title: MySQL status metrics
     description: Collect MySQL status metrics

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: "1.12.1"
+version: "1.13.0"
 license: basic
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adds support for the processors on all mysql integrations.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

