### PR TITLE
[network_traffic] Fix to index events with memcached stats responses

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Fix indexing of memcached stats responses.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6539
 - version: "1.19.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/network_traffic/data_stream/memcached/_dev/test/pipeline/test-common-config.yml
+++ b/packages/network_traffic/data_stream/memcached/_dev/test/pipeline/test-common-config.yml
@@ -1,0 +1,3 @@
+fields:
+  tags:
+    - preserve_original_event

--- a/packages/network_traffic/data_stream/memcached/_dev/test/pipeline/test-stats-responses.json
+++ b/packages/network_traffic/data_stream/memcached/_dev/test/pipeline/test-stats-responses.json
@@ -1,0 +1,658 @@
+{
+  "events": [
+    {
+      "_conf": {
+        "geoip_enrich": true
+      },
+      "agent": {
+        "ephemeral_id": "1dc3d6c4-48d7-4268-968a-04bd7c3fd84a",
+        "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",
+        "name": "docker-fleet-agent",
+        "type": "packetbeat",
+        "version": "8.7.1"
+      },
+      "client": {
+        "bytes": 2005,
+        "ip": "192.168.188.37",
+        "port": 55322
+      },
+      "data_stream": {
+        "dataset": "network_traffic.memcached",
+        "namespace": "ep",
+        "type": "logs"
+      },
+      "destination": {
+        "bytes": 24,
+        "ip": "192.168.188.38",
+        "port": 11211
+      },
+      "ecs": {
+        "version": "8.0.0"
+      },
+      "elastic_agent": {
+        "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",
+        "snapshot": false,
+        "version": "8.7.1"
+      },
+      "event": {
+        "category": [
+          "network"
+        ],
+        "dataset": "network_traffic.memcached",
+        "duration": 79472,
+        "end": "2023-06-08T14:58:19.574Z",
+        "kind": "event",
+        "start": "2023-06-08T14:58:19.574Z",
+        "type": [
+          "connection",
+          "protocol"
+        ]
+      },
+      "event.action": "memcache.stats",
+      "event.outcome": "success",
+      "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "fd2c4b0943e444508c12855a04d117c7",
+        "ip": [
+          "172.20.0.6"
+        ],
+        "mac": [
+          "02-42-AC-14-00-06"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+          "codename": "focal",
+          "family": "debian",
+          "kernel": "6.3.6-arch1-1",
+          "name": "Ubuntu",
+          "platform": "ubuntu",
+          "type": "linux",
+          "version": "20.04.6 LTS (Focal Fossa)"
+        }
+      },
+      "memcache": {
+        "protocol_type": "binary",
+        "request": {
+          "command": "stats",
+          "opaque": 196608,
+          "opcode": "Stat",
+          "opcode_value": 16,
+          "quiet": false,
+          "type": "Stats",
+          "vbucket": 0
+        },
+        "response": {
+          "command": "stats",
+          "keys": [
+            "pid"
+          ],
+          "opaque": 196608,
+          "opcode": "Stat",
+          "opcode_value": 16,
+          "stats": [
+            {
+              "name": "pid",
+              "value": "1"
+            },
+            {
+              "name": "uptime",
+              "value": "183329"
+            },
+            {
+              "name": "time",
+              "value": "1440267261"
+            },
+            {
+              "name": "version",
+              "value": "1.4.24"
+            },
+            {
+              "name": "libevent",
+              "value": "2.0.21-stable"
+            },
+            {
+              "name": "pointer_size",
+              "value": "64"
+            },
+            {
+              "name": "rusage_user",
+              "value": "4.000000"
+            },
+            {
+              "name": "rusage_system",
+              "value": "5.450000"
+            },
+            {
+              "name": "curr_connections",
+              "value": "10"
+            },
+            {
+              "name": "total_connections",
+              "value": "148"
+            },
+            {
+              "name": "connection_structures",
+              "value": "11"
+            },
+            {
+              "name": "reserved_fds",
+              "value": "20"
+            },
+            {
+              "name": "cmd_get",
+              "value": "248"
+            },
+            {
+              "name": "cmd_set",
+              "value": "252"
+            },
+            {
+              "name": "cmd_flush",
+              "value": "0"
+            },
+            {
+              "name": "cmd_touch",
+              "value": "0"
+            },
+            {
+              "name": "get_hits",
+              "value": "192"
+            },
+            {
+              "name": "get_misses",
+              "value": "56"
+            },
+            {
+              "name": "delete_misses",
+              "value": "0"
+            },
+            {
+              "name": "delete_hits",
+              "value": "28"
+            },
+            {
+              "name": "incr_misses",
+              "value": "7"
+            },
+            {
+              "name": "incr_hits",
+              "value": "26"
+            },
+            {
+              "name": "decr_misses",
+              "value": "0"
+            },
+            {
+              "name": "decr_hits",
+              "value": "21"
+            },
+            {
+              "name": "cas_misses",
+              "value": "0"
+            },
+            {
+              "name": "cas_hits",
+              "value": "0"
+            },
+            {
+              "name": "cas_badval",
+              "value": "0"
+            },
+            {
+              "name": "touch_hits",
+              "value": "0"
+            },
+            {
+              "name": "touch_misses",
+              "value": "0"
+            },
+            {
+              "name": "auth_cmds",
+              "value": "0"
+            },
+            {
+              "name": "auth_errors",
+              "value": "0"
+            },
+            {
+              "name": "bytes_read",
+              "value": "191781"
+            },
+            {
+              "name": "bytes_written",
+              "value": "196745"
+            },
+            {
+              "name": "limit_maxbytes",
+              "value": "67108864"
+            },
+            {
+              "name": "accepting_conns",
+              "value": "1"
+            },
+            {
+              "name": "listen_disabled_num",
+              "value": "0"
+            },
+            {
+              "name": "threads",
+              "value": "4"
+            },
+            {
+              "name": "conn_yields",
+              "value": "0"
+            },
+            {
+              "name": "hash_power_level",
+              "value": "16"
+            },
+            {
+              "name": "hash_bytes",
+              "value": "524288"
+            },
+            {
+              "name": "hash_is_expanding",
+              "value": "0"
+            },
+            {
+              "name": "malloc_fails",
+              "value": "0"
+            },
+            {
+              "name": "bytes",
+              "value": "2885"
+            },
+            {
+              "name": "curr_items",
+              "value": "10"
+            },
+            {
+              "name": "total_items",
+              "value": "252"
+            },
+            {
+              "name": "expired_unfetched",
+              "value": "0"
+            },
+            {
+              "name": "evicted_unfetched",
+              "value": "0"
+            },
+            {
+              "name": "evictions",
+              "value": "0"
+            },
+            {
+              "name": "reclaimed",
+              "value": "0"
+            },
+            {
+              "name": "crawler_reclaimed",
+              "value": "0"
+            },
+            {
+              "name": "crawler_items_checked",
+              "value": "0"
+            },
+            {
+              "name": "lrutail_reflocked",
+              "value": "0"
+            }
+          ],
+          "status": "Success",
+          "status_code": 0,
+          "type": "Stats"
+        }
+      },
+      "network": {
+        "bytes": 2029,
+        "community_id": "1:60niiGfWxMl9SEmb67FS023acOU=",
+        "direction": "unknown",
+        "protocol": "memcache",
+        "transport": "tcp",
+        "type": "ipv4"
+      },
+      "related": {
+        "ip": [
+          "192.168.188.37",
+          "192.168.188.38"
+        ]
+      },
+      "server": {
+        "bytes": 24,
+        "ip": "192.168.188.38",
+        "port": 11211
+      },
+      "source": {
+        "bytes": 2005,
+        "ip": "192.168.188.37",
+        "port": 55322
+      },
+      "status": "OK",
+      "type": "memcache"
+    },
+    {
+      "_conf": {
+        "geoip_enrich": true
+      },
+      "agent": {
+        "ephemeral_id": "c580a71e-34de-454b-96b9-30272e2e1fe0",
+        "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",
+        "name": "docker-fleet-agent",
+        "type": "packetbeat",
+        "version": "8.7.1"
+      },
+      "client": {
+        "bytes": 1154,
+        "ip": "192.168.188.37",
+        "port": 55321
+      },
+      "data_stream": {
+        "dataset": "network_traffic.memcached",
+        "namespace": "ep",
+        "type": "logs"
+      },
+      "destination": {
+        "bytes": 8,
+        "ip": "192.168.188.38",
+        "port": 11211
+      },
+      "ecs": {
+        "version": "8.0.0"
+      },
+      "elastic_agent": {
+        "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",
+        "snapshot": false,
+        "version": "8.7.1"
+      },
+      "event": {
+        "category": [
+          "network"
+        ],
+        "dataset": "network_traffic.memcached",
+        "duration": 39088,
+        "end": "2023-06-08T14:59:25.702Z",
+        "kind": "event",
+        "start": "2023-06-08T14:59:25.701Z",
+        "type": [
+          "connection",
+          "protocol"
+        ]
+      },
+      "event.action": "memcache.stats",
+      "event.outcome": "success",
+      "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "fd2c4b0943e444508c12855a04d117c7",
+        "ip": [
+          "172.20.0.6"
+        ],
+        "mac": [
+          "02-42-AC-14-00-06"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+          "codename": "focal",
+          "family": "debian",
+          "kernel": "6.3.6-arch1-1",
+          "name": "Ubuntu",
+          "platform": "ubuntu",
+          "type": "linux",
+          "version": "20.04.6 LTS (Focal Fossa)"
+        }
+      },
+      "memcache": {
+        "protocol_type": "text",
+        "request": {
+          "command": "stats",
+          "raw_args": "",
+          "type": "Stats"
+        },
+        "response": {
+          "command": "STAT",
+          "stats": [
+            {
+              "name": "pid",
+              "value": "1"
+            },
+            {
+              "name": "uptime",
+              "value": "183323"
+            },
+            {
+              "name": "time",
+              "value": "1440267255"
+            },
+            {
+              "name": "version",
+              "value": "1.4.24"
+            },
+            {
+              "name": "libevent",
+              "value": "2.0.21-stable"
+            },
+            {
+              "name": "pointer_size",
+              "value": "64"
+            },
+            {
+              "name": "rusage_user",
+              "value": "4.000000"
+            },
+            {
+              "name": "rusage_system",
+              "value": "5.450000"
+            },
+            {
+              "name": "curr_connections",
+              "value": "10"
+            },
+            {
+              "name": "total_connections",
+              "value": "147"
+            },
+            {
+              "name": "connection_structures",
+              "value": "11"
+            },
+            {
+              "name": "reserved_fds",
+              "value": "20"
+            },
+            {
+              "name": "cmd_get",
+              "value": "247"
+            },
+            {
+              "name": "cmd_set",
+              "value": "251"
+            },
+            {
+              "name": "cmd_flush",
+              "value": "0"
+            },
+            {
+              "name": "cmd_touch",
+              "value": "0"
+            },
+            {
+              "name": "get_hits",
+              "value": "191"
+            },
+            {
+              "name": "get_misses",
+              "value": "56"
+            },
+            {
+              "name": "delete_misses",
+              "value": "0"
+            },
+            {
+              "name": "delete_hits",
+              "value": "28"
+            },
+            {
+              "name": "incr_misses",
+              "value": "7"
+            },
+            {
+              "name": "incr_hits",
+              "value": "26"
+            },
+            {
+              "name": "decr_misses",
+              "value": "0"
+            },
+            {
+              "name": "decr_hits",
+              "value": "21"
+            },
+            {
+              "name": "cas_misses",
+              "value": "0"
+            },
+            {
+              "name": "cas_hits",
+              "value": "0"
+            },
+            {
+              "name": "cas_badval",
+              "value": "0"
+            },
+            {
+              "name": "touch_hits",
+              "value": "0"
+            },
+            {
+              "name": "touch_misses",
+              "value": "0"
+            },
+            {
+              "name": "auth_cmds",
+              "value": "0"
+            },
+            {
+              "name": "auth_errors",
+              "value": "0"
+            },
+            {
+              "name": "bytes_read",
+              "value": "191686"
+            },
+            {
+              "name": "bytes_written",
+              "value": "195533"
+            },
+            {
+              "name": "limit_maxbytes",
+              "value": "67108864"
+            },
+            {
+              "name": "accepting_conns",
+              "value": "1"
+            },
+            {
+              "name": "listen_disabled_num",
+              "value": "0"
+            },
+            {
+              "name": "threads",
+              "value": "4"
+            },
+            {
+              "name": "conn_yields",
+              "value": "0"
+            },
+            {
+              "name": "hash_power_level",
+              "value": "16"
+            },
+            {
+              "name": "hash_bytes",
+              "value": "524288"
+            },
+            {
+              "name": "hash_is_expanding",
+              "value": "0"
+            },
+            {
+              "name": "malloc_fails",
+              "value": "0"
+            },
+            {
+              "name": "bytes",
+              "value": "2885"
+            },
+            {
+              "name": "curr_items",
+              "value": "10"
+            },
+            {
+              "name": "total_items",
+              "value": "251"
+            },
+            {
+              "name": "expired_unfetched",
+              "value": "0"
+            },
+            {
+              "name": "evicted_unfetched",
+              "value": "0"
+            },
+            {
+              "name": "evictions",
+              "value": "0"
+            },
+            {
+              "name": "reclaimed",
+              "value": "0"
+            },
+            {
+              "name": "crawler_reclaimed",
+              "value": "0"
+            },
+            {
+              "name": "crawler_items_checked",
+              "value": "0"
+            },
+            {
+              "name": "lrutail_reflocked",
+              "value": "0"
+            }
+          ],
+          "type": "Stats"
+        }
+      },
+      "network": {
+        "bytes": 1162,
+        "community_id": "1:PB7vEs4V/pEYgD41A4BnjbXNw+w=",
+        "direction": "unknown",
+        "protocol": "memcache",
+        "transport": "tcp",
+        "type": "ipv4"
+      },
+      "related": {
+        "ip": [
+          "192.168.188.37",
+          "192.168.188.38"
+        ]
+      },
+      "server": {
+        "bytes": 8,
+        "ip": "192.168.188.38",
+        "port": 11211
+      },
+      "source": {
+        "bytes": 1154,
+        "ip": "192.168.188.37",
+        "port": 55321
+      },
+      "status": "OK",
+      "type": "memcache"
+    }
+  ]
+}

--- a/packages/network_traffic/data_stream/memcached/_dev/test/pipeline/test-stats-responses.json
+++ b/packages/network_traffic/data_stream/memcached/_dev/test/pipeline/test-stats-responses.json
@@ -1,9 +1,6 @@
 {
   "events": [
     {
-      "_conf": {
-        "geoip_enrich": true
-      },
       "agent": {
         "ephemeral_id": "1dc3d6c4-48d7-4268-968a-04bd7c3fd84a",
         "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",

--- a/packages/network_traffic/data_stream/memcached/_dev/test/pipeline/test-stats-responses.json-expected.json
+++ b/packages/network_traffic/data_stream/memcached/_dev/test/pipeline/test-stats-responses.json-expected.json
@@ -1,0 +1,346 @@
+{
+  "expected": [
+    {
+      "agent": {
+        "ephemeral_id": "1dc3d6c4-48d7-4268-968a-04bd7c3fd84a",
+        "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",
+        "name": "docker-fleet-agent",
+        "type": "packetbeat",
+        "version": "8.7.1"
+      },
+      "client": {
+        "bytes": 2005,
+        "ip": "192.168.188.37",
+        "port": 55322
+      },
+      "data_stream": {
+        "dataset": "network_traffic.memcached",
+        "namespace": "ep",
+        "type": "logs"
+      },
+      "destination": {
+        "bytes": 24,
+        "ip": "192.168.188.38",
+        "port": 11211
+      },
+      "ecs": {
+        "version": "8.8.0"
+      },
+      "elastic_agent": {
+        "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",
+        "snapshot": false,
+        "version": "8.7.1"
+      },
+      "event": {
+        "category": [
+          "network"
+        ],
+        "dataset": "network_traffic.memcached",
+        "duration": 79472,
+        "end": "2023-06-08T14:58:19.574Z",
+        "kind": "event",
+        "start": "2023-06-08T14:58:19.574Z",
+        "type": [
+          "connection",
+          "protocol"
+        ]
+      },
+      "event.action": "memcache.stats",
+      "event.outcome": "success",
+      "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "fd2c4b0943e444508c12855a04d117c7",
+        "ip": [
+          "172.20.0.6"
+        ],
+        "mac": [
+          "02-42-AC-14-00-06"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+          "codename": "focal",
+          "family": "debian",
+          "kernel": "6.3.6-arch1-1",
+          "name": "Ubuntu",
+          "platform": "ubuntu",
+          "type": "linux",
+          "version": "20.04.6 LTS (Focal Fossa)"
+        }
+      },
+      "memcache": {
+        "protocol_type": "binary",
+        "request": {
+          "command": "stats",
+          "opaque": 196608,
+          "opcode": "Stat",
+          "opcode_value": 16,
+          "quiet": false,
+          "type": "Stats",
+          "vbucket": 0
+        },
+        "response": {
+          "command": "stats",
+          "keys": [
+            "pid"
+          ],
+          "opaque": 196608,
+          "opcode": "Stat",
+          "opcode_value": 16,
+          "status": "Success",
+          "status_code": 0,
+          "type": "Stats",
+          "stats": {
+            "pid": "1",
+            "uptime": "183329",
+            "time": "1440267261",
+            "version": "1.4.24",
+            "libevent": "2.0.21-stable",
+            "pointer_size": "64",
+            "rusage_user": "4.000000",
+            "rusage_system": "5.450000",
+            "curr_connections": "10",
+            "total_connections": "148",
+            "connection_structures": "11",
+            "reserved_fds": "20",
+            "cmd_get": "248",
+            "cmd_set": "252",
+            "cmd_flush": "0",
+            "cmd_touch": "0",
+            "get_hits": "192",
+            "get_misses": "56",
+            "delete_misses": "0",
+            "delete_hits": "28",
+            "incr_misses": "7",
+            "incr_hits": "26",
+            "decr_misses": "0",
+            "decr_hits": "21",
+            "cas_misses": "0",
+            "cas_hits": "0",
+            "cas_badval": "0",
+            "touch_hits": "0",
+            "touch_misses": "0",
+            "auth_cmds": "0",
+            "auth_errors": "0",
+            "bytes_read": "191781",
+            "bytes_written": "196745",
+            "limit_maxbytes": "67108864",
+            "accepting_conns": "1",
+            "listen_disabled_num": "0",
+            "threads": "4",
+            "conn_yields": "0",
+            "hash_power_level": "16",
+            "hash_bytes": "524288",
+            "hash_is_expanding": "0",
+            "malloc_fails": "0",
+            "bytes": "2885",
+            "curr_items": "10",
+            "total_items": "252",
+            "expired_unfetched": "0",
+            "evicted_unfetched": "0",
+            "evictions": "0",
+            "reclaimed": "0",
+            "crawler_reclaimed": "0",
+            "crawler_items_checked": "0",
+            "lrutail_reflocked": "0"
+          }
+        }
+      },
+      "network": {
+        "bytes": 2029,
+        "community_id": "1:60niiGfWxMl9SEmb67FS023acOU=",
+        "direction": "unknown",
+        "protocol": "memcache",
+        "transport": "tcp",
+        "type": "ipv4"
+      },
+      "related": {
+        "ip": [
+          "192.168.188.37",
+          "192.168.188.38"
+        ]
+      },
+      "server": {
+        "bytes": 24,
+        "ip": "192.168.188.38",
+        "port": 11211
+      },
+      "source": {
+        "bytes": 2005,
+        "ip": "192.168.188.37",
+        "port": 55322
+      },
+      "status": "OK",
+      "tags": [
+        "preserve_original_event"
+      ],
+      "type": "memcache"
+    },
+    {
+      "agent": {
+        "ephemeral_id": "c580a71e-34de-454b-96b9-30272e2e1fe0",
+        "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",
+        "name": "docker-fleet-agent",
+        "type": "packetbeat",
+        "version": "8.7.1"
+      },
+      "client": {
+        "bytes": 1154,
+        "ip": "192.168.188.37",
+        "port": 55321
+      },
+      "data_stream": {
+        "dataset": "network_traffic.memcached",
+        "namespace": "ep",
+        "type": "logs"
+      },
+      "destination": {
+        "bytes": 8,
+        "ip": "192.168.188.38",
+        "port": 11211
+      },
+      "ecs": {
+        "version": "8.8.0"
+      },
+      "elastic_agent": {
+        "id": "c1bac647-3e5b-4e76-9d6d-ff0be67c3d6e",
+        "snapshot": false,
+        "version": "8.7.1"
+      },
+      "event": {
+        "category": [
+          "network"
+        ],
+        "dataset": "network_traffic.memcached",
+        "duration": 39088,
+        "end": "2023-06-08T14:59:25.702Z",
+        "kind": "event",
+        "start": "2023-06-08T14:59:25.701Z",
+        "type": [
+          "connection",
+          "protocol"
+        ]
+      },
+      "event.action": "memcache.stats",
+      "event.outcome": "success",
+      "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "fd2c4b0943e444508c12855a04d117c7",
+        "ip": [
+          "172.20.0.6"
+        ],
+        "mac": [
+          "02-42-AC-14-00-06"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+          "codename": "focal",
+          "family": "debian",
+          "kernel": "6.3.6-arch1-1",
+          "name": "Ubuntu",
+          "platform": "ubuntu",
+          "type": "linux",
+          "version": "20.04.6 LTS (Focal Fossa)"
+        }
+      },
+      "memcache": {
+        "protocol_type": "text",
+        "request": {
+          "command": "stats",
+          "raw_args": "",
+          "type": "Stats"
+        },
+        "response": {
+          "command": "STAT",
+          "type": "Stats",
+          "stats": {
+            "pid": "1",
+            "uptime": "183323",
+            "time": "1440267255",
+            "version": "1.4.24",
+            "libevent": "2.0.21-stable",
+            "pointer_size": "64",
+            "rusage_user": "4.000000",
+            "rusage_system": "5.450000",
+            "curr_connections": "10",
+            "total_connections": "147",
+            "connection_structures": "11",
+            "reserved_fds": "20",
+            "cmd_get": "247",
+            "cmd_set": "251",
+            "cmd_flush": "0",
+            "cmd_touch": "0",
+            "get_hits": "191",
+            "get_misses": "56",
+            "delete_misses": "0",
+            "delete_hits": "28",
+            "incr_misses": "7",
+            "incr_hits": "26",
+            "decr_misses": "0",
+            "decr_hits": "21",
+            "cas_misses": "0",
+            "cas_hits": "0",
+            "cas_badval": "0",
+            "touch_hits": "0",
+            "touch_misses": "0",
+            "auth_cmds": "0",
+            "auth_errors": "0",
+            "bytes_read": "191686",
+            "bytes_written": "195533",
+            "limit_maxbytes": "67108864",
+            "accepting_conns": "1",
+            "listen_disabled_num": "0",
+            "threads": "4",
+            "conn_yields": "0",
+            "hash_power_level": "16",
+            "hash_bytes": "524288",
+            "hash_is_expanding": "0",
+            "malloc_fails": "0",
+            "bytes": "2885",
+            "curr_items": "10",
+            "total_items": "251",
+            "expired_unfetched": "0",
+            "evicted_unfetched": "0",
+            "evictions": "0",
+            "reclaimed": "0",
+            "crawler_reclaimed": "0",
+            "crawler_items_checked": "0",
+            "lrutail_reflocked": "0"
+          }
+        }
+      },
+      "network": {
+        "bytes": 1162,
+        "community_id": "1:PB7vEs4V/pEYgD41A4BnjbXNw+w=",
+        "direction": "unknown",
+        "protocol": "memcache",
+        "transport": "tcp",
+        "type": "ipv4"
+      },
+      "related": {
+        "ip": [
+          "192.168.188.37",
+          "192.168.188.38"
+        ]
+      },
+      "server": {
+        "bytes": 8,
+        "ip": "192.168.188.38",
+        "port": 11211
+      },
+      "source": {
+        "bytes": 1154,
+        "ip": "192.168.188.37",
+        "port": 55321
+      },
+      "status": "OK",
+      "tags": [
+        "preserve_original_event"
+      ],
+      "type": "memcache"
+    }
+  ]
+}

--- a/packages/network_traffic/data_stream/memcached/_dev/test/system/test-memcached-bin-tcp-stats-config.yml
+++ b/packages/network_traffic/data_stream/memcached/_dev/test/system/test-memcached-bin-tcp-stats-config.yml
@@ -3,3 +3,5 @@ vars:
 input: packet
 data_stream:
   vars: ~
+assert:
+  hit_count: 4

--- a/packages/network_traffic/data_stream/memcached/_dev/test/system/test-memcached-bin-tcp-stats-config.yml
+++ b/packages/network_traffic/data_stream/memcached/_dev/test/system/test-memcached-bin-tcp-stats-config.yml
@@ -3,6 +3,3 @@ vars:
 input: packet
 data_stream:
   vars: ~
-skip:
-  link: https://github.com/elastic/integrations/issues/6230
-  reason: "This integration produces events that cannot be indexed"

--- a/packages/network_traffic/data_stream/memcached/_dev/test/system/test-memcached-text-tcp-stats-config.yml
+++ b/packages/network_traffic/data_stream/memcached/_dev/test/system/test-memcached-text-tcp-stats-config.yml
@@ -3,3 +3,5 @@ vars:
 input: packet
 data_stream:
   vars: ~
+assert:
+  hit_count: 4

--- a/packages/network_traffic/data_stream/memcached/_dev/test/system/test-memcached-text-tcp-stats-config.yml
+++ b/packages/network_traffic/data_stream/memcached/_dev/test/system/test-memcached-text-tcp-stats-config.yml
@@ -3,6 +3,3 @@ vars:
 input: packet
 data_stream:
   vars: ~
-skip:
-  link: https://github.com/elastic/integrations/issues/6230
-  reason: "This integration produces events that cannot be indexed"

--- a/packages/network_traffic/data_stream/memcached/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/network_traffic/data_stream/memcached/elasticsearch/ingest_pipeline/default.yml
@@ -49,6 +49,26 @@ processors:
     field: _conf
     ignore_missing: true
 
+##
+# Reformat memcache stats response data as a single object
+##
+- rename:
+    field: memcache.response.stats
+    target_field: memcache.response.stats_objects
+    ignore_missing: true
+- foreach:
+    description: Build an object for memcache stats response data
+    if: ctx.memcache?.response?.stats_objects instanceof List
+    tag: foreach_memcache_response_stats_objects
+    field: memcache.response.stats_objects
+    processor:
+      set:
+        field: "memcache.response.stats.{{{_ingest._value.name}}}"
+        value: "{{{_ingest._value.value}}}"
+- remove:
+    field: memcache.response.stats_objects
+    ignore_missing: true
+
 on_failure:
   - append:
       field: error.message

--- a/packages/network_traffic/data_stream/memcached/fields/protocol.yml
+++ b/packages/network_traffic/data_stream/memcached/fields/protocol.yml
@@ -204,9 +204,9 @@
         The CAS (compare-and-swap) identifier to be used with CAS-based updates (if present).
 
     - name: response.stats
-      type: keyword
+      type: flattened
       description: >
-        The list of statistic values returned. Each entry is a dictionary with the fields "name" and "value".
+        The statistic values returned.
 
     - name: response.version
       type: keyword

--- a/packages/network_traffic/docs/README.md
+++ b/packages/network_traffic/docs/README.md
@@ -2552,7 +2552,7 @@ Fields published for Memcached packets.
 | memcache.response.opaque | The binary protocol opaque header value used for correlating request with response messages. | long |
 | memcache.response.opcode | The binary protocol message opcode name. | keyword |
 | memcache.response.opcode_value | The binary protocol message opcode value. | long |
-| memcache.response.stats | The list of statistic values returned. Each entry is a dictionary with the fields "name" and "value". | keyword |
+| memcache.response.stats | The statistic values returned. | flattened |
 | memcache.response.status | The textual representation of the response error code (binary protocol only). | keyword |
 | memcache.response.status_code | The status code value returned in the response (binary protocol only). | long |
 | memcache.response.type | The memcache command classification. This value can be "UNKNOWN", "Load", "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler", "Stats", "Success", "Fail", or "Auth". The text based protocol will employ any of these, whereas the binary based protocol will mirror the request commands only (see `memcache.response.status` for binary protocol). | keyword |

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: network_traffic
 title: Network Packet Capture
-version: "1.19.0"
+version: "1.19.1"
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Fixes the Network Packet Capture integration to not drop events with memcached `STATS` response data, by using a flattened field to hold the stats data in a single object.

## Details

The Network Packet Capture integration currently fails to index events with memcached `STATS` response data,
as described in issue https://github.com/elastic/integrations/issues/6230.

The stats data in the event is an array of objects with `name` and `value` keys:
```
{
  "memcache": {
    "response": {
      "stats": [
        {
          "name": "pid",
          "value": "1"
        },
        {
          "name": "uptime",
          "value": "183329"
        },
        ...
      ], ...
    }, ...
  }, ...
}
```

Many stat names are listed in the [memcached documentation](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L1229) (93 general-purpose statistics, and over 100 others). However, actual responses may include fewer, or additional (undocumented) stats.

Since the purpose of the integration is to sniff network packets and dissect known protocols, rather than to support monitoring and operation of memcached clusters, I chose to index the stats data as a single flattened object, which makes the data readable although not easily queryable:

```
{
  "memcache": {
    "response": {
      "stats": {
        "pid": "1",
        "uptime": "183329",
        ...
      }, ...
    }, ...
  }, ...
}
```

Alternative representations could be more queryable, but at the cost of indexing many additional documents (nested), or mapping a large and changeable number of fields.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
## Author's Checklist
- [ ]
-->

<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/6230