### PR TITLE
[Fleet] Fix fleet server integration to avoid server:null in template

### DIFF
--- a/packages/fleet_server/agent/input/agent.yml.hbs
+++ b/packages/fleet_server/agent/input/agent.yml.hbs
@@ -1,4 +1,9 @@
+unused_key: not_used # Unused key as Fleet do not not support empty agent template
+{{#if max_connections}}
 server:
+{{else if max_agents}}
+server:
+{{/if}}
 {{#if max_connections}}
   limits.max_connections: {{max_connections}}
 {{/if}}

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix agent template to avoid server:null
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/5896
+      link: https://github.com/elastic/integrations/pull/6555
 - version: "1.3.0"
   changes:
     - description: Remove host and port

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.3.1"
   changes:
-    - description: Fix agent template to avoid server:null
+    - description: Fix agent template to avoid server:null that caused an invalid policy
       type: bugfix
       link: https://github.com/elastic/integrations/pull/6555
 - version: "1.3.0"

--- a/packages/fleet_server/changelog.yml
+++ b/packages/fleet_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Fix agent template to avoid server:null
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/5896
 - version: "1.3.0"
   changes:
     - description: Remove host and port

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 1.3.0
+version: 1.3.1
 release: ga
 description: Centrally manage Elastic Agents with the Fleet Server integration.
 type: integration


### PR DESCRIPTION
Resolve https://github.com/elastic/fleet-server/issues/2689 

Fix fleet server integration to avoid `server:null` in template and allow to configure APM

I tried the following integration config and got APM working:
<img width="943" alt="Screenshot 2023-06-13 at 10 46 15 AM" src="https://github.com/elastic/integrations/assets/1336873/b91b2c59-0255-42aa-8ea9-f4fb621c33ef">
<img width="1241" alt="Screenshot 2023-06-13 at 10 47 58 AM" src="https://github.com/elastic/integrations/assets/1336873/fbc77679-8c79-4e83-8cb5-f65a39b6e4fe">

