### PR TITLE
[aws] fix image link in README

### DIFF
--- a/packages/aws/_dev/build/docs/README.md
+++ b/packages/aws/_dev/build/docs/README.md
@@ -206,7 +206,7 @@ current timestamp to see what's the difference. This difference can be used as l
 For example, the screenshot below is taken at `2023-05-09 22:30 UTC` and the timestamp for the last data point is
 `2023-05-09 22:15 UTC`. This means there is a 15min delay between the current time and CloudWatch. With this information,
 we should add a `latency` configuration for `15m` when adding the integration.
-![alt text](../img/metricbeat-aws-cloudwatch-latency.png "CloudWatch Last Data Point Timestamp")
+![CloudWatch Last Data Point Timestamp](../img/metricbeat-aws-cloudwatch-latency.png)
 
 ## Reference
 

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.44.2"
+  changes:
+    - description: Fix image link in readme
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6561
 - version: "1.44.1"
   changes:
     - description: Migrate AWS TransitGateway metrics dashboard to lenses.

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -206,7 +206,7 @@ current timestamp to see what's the difference. This difference can be used as l
 For example, the screenshot below is taken at `2023-05-09 22:30 UTC` and the timestamp for the last data point is
 `2023-05-09 22:15 UTC`. This means there is a 15min delay between the current time and CloudWatch. With this information,
 we should add a `latency` configuration for `15m` when adding the integration.
-![alt text](../img/metricbeat-aws-cloudwatch-latency.png "CloudWatch Last Data Point Timestamp")
+![CloudWatch Last Data Point Timestamp](../img/metricbeat-aws-cloudwatch-latency.png)
 
 ## Reference
 

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.44.1
+version: 1.44.2
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to fix image link in AWS readme file: https://github.com/elastic/integrations/blob/db7028b3383c325063a473e45d45b51ddf628f73/packages/aws/docs/README.md#debug

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

