### PR TITLE
Map message field to match_only_text for custom logs input package

### DIFF
--- a/packages/log/_dev/build/build.yml
+++ b/packages/log/_dev/build/build.yml
@@ -1,0 +1,4 @@
+dependencies:
+  ecs:
+    reference: git@8.8
+    import_mappings: true

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.0"
+  changes:
+    - description: Add mapping for message field
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.0.0"
   changes:
     - description: Change from type "integration" to "input"

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -4,7 +4,7 @@ title: Custom Logs
 description: >-
   Collect custom logs with Elastic Agent.
 type: input
-version: 2.0.0
+version: 2.1.0
 categories:
   - custom
   - custom_logs


### PR DESCRIPTION
## What does this PR do?

Add support for ECS dynamic templates in the custom logs integration defined in the `log` input package

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Install the new version of the package in elastic-package
- check that the field `message` has mapping `match_only_text` instead of `keyword`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #6566 6566

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
