### PR TITLE
[darktrace] - Update to package-spec 2.7.0

### DIFF
--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package to pkg-spec 2.7.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6581
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Update package to pkg-spec 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/darktrace/data_stream/ai_analyst_alert/_dev/test/pipeline/test-ai-analyst-alert.log-expected.json
+++ b/packages/darktrace/data_stream/ai_analyst_alert/_dev/test/pipeline/test-ai-analyst-alert.log-expected.json
@@ -157,7 +157,7 @@
                     "2021-08-03T10:08:18.683Z"
                 ],
                 "type": [
-                    "info"
+                    "indicator"
                 ]
             },
             "host": {
@@ -431,7 +431,7 @@
                     "2022-07-13T21:17:00.967Z"
                 ],
                 "type": [
-                    "info"
+                    "indicator"
                 ],
                 "url": "https://www.example.com/#aiaincidentevent/eabcdef0-1234-1234-1234-cabcdefghij9"
             },

--- a/packages/darktrace/data_stream/ai_analyst_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/ai_analyst_alert/elasticsearch/ingest_pipeline/default.yml
@@ -39,7 +39,8 @@ processors:
       if: ctx.event?.kind == 'alert'
   - set:
       field: event.type
-      value: [info]
+      value: [indicator]
+      if: ctx.event?.category != null && ctx.event.category.contains('threat')
   - rename:
       field: json.activityId
       target_field: darktrace.ai_analyst_alert.activity_id

--- a/packages/darktrace/data_stream/ai_analyst_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/ai_analyst_alert/elasticsearch/ingest_pipeline/default.yml
@@ -40,7 +40,7 @@ processors:
   - set:
       field: event.type
       value: [indicator]
-      if: ctx.event?.category != null && ctx.event.category.contains('threat')
+      if: ctx.event?.category instanceof Collection && ctx.event.category.contains('threat')
   - rename:
       field: json.activityId
       target_field: darktrace.ai_analyst_alert.activity_id

--- a/packages/darktrace/data_stream/ai_analyst_alert/sample_event.json
+++ b/packages/darktrace/data_stream/ai_analyst_alert/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-08-03T14:48:09.240Z",
     "agent": {
-        "ephemeral_id": "82482032-e103-4c45-a00e-103ac604f4ae",
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
+        "ephemeral_id": "315a1a3f-bc7a-4a11-9540-c316f1ec95ee",
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.1"
+        "version": "8.9.0"
     },
     "darktrace": {
         "ai_analyst_alert": {
@@ -147,9 +147,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
-        "snapshot": false,
-        "version": "8.2.1"
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
+        "snapshot": true,
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -164,7 +164,7 @@
             "2021-08-03T14:15:41.220Z"
         ],
         "id": "eabc0011-1234-1234-1234-cabcdefg0011",
-        "ingested": "2022-09-30T11:36:06Z",
+        "ingested": "2023-06-14T17:00:35Z",
         "kind": "alert",
         "original": "{\"summariser\":\"AdminConnSummary\",\"acknowledged\":false,\"pinned\":true,\"createdAt\":1628002089240,\"attackPhases\":[5],\"title\":\"Extensive Unusual SSH Connections\",\"id\":\"eabc0011-1234-1234-1234-cabcdefg0011\",\"children\":[\"eabcdef0-1234-1234-1234-cabcdefghij9\"],\"category\":\"critical\",\"currentGroup\":\"eabc1234-1234-1234-1234-cabcdefg0011\",\"groupCategory\":\"critical\",\"groupScore\":\"72.9174234\",\"groupPreviousGroups\":null,\"activityId\":\"abcd1234\",\"groupingIds\":[\"abcdef12\"],\"groupByActivity\":false,\"userTriggered\":false,\"externalTriggered\":false,\"aiaScore\":98,\"summary\":\"The device 175.16.199.1 was observed making unusual internal SSH connections to a wide range of devices.\\n\\nThough this behaviour could be the result of legitimate remote access or administration, it could also be a sign of attempted lateral movement by a compromised machine.\\n\\nConsequently, if this activity was not expected, the security team may wish to investigate further.\",\"periods\":[{\"start\":1627985298683,\"end\":1628000141220}],\"breachDevices\":[{\"identifier\":null,\"hostname\":null,\"ip\":\"81.2.69.144\",\"mac\":null,\"subnet\":\"VPN\",\"did\":10,\"sid\":12}],\"relatedBreaches\":[{\"modelName\":\"Unusual Activity / Unusual Activity from Re-Activated Device\",\"pbid\":1234,\"threatScore\":37,\"timestamp\":1627997157000}],\"details\":[[{\"header\":\"Breaching Device\",\"contents\":[{\"key\":null,\"type\":\"device\",\"values\":[{\"identifier\":null,\"hostname\":null,\"ip\":\"175.16.199.1\",\"mac\":null,\"subnet\":\"VPN\",\"did\":10,\"sid\":12}]}]}],[{\"header\":\"SSH Activity\",\"contents\":[{\"key\":\"Time\",\"type\":\"timestampRange\",\"values\":[{\"start\":1627985298683,\"end\":1628000141220}]},{\"key\":\"Number of unique IPs\",\"type\":\"integer\",\"values\":[16]},{\"key\":\"Targeted IP ranges include\",\"type\":\"device\",\"values\":[{\"identifier\":null,\"hostname\":null,\"ip\":\"81.2.69.192\",\"mac\":null,\"subnet\":null,\"did\":null,\"sid\":null},{\"identifier\":null,\"hostname\":null,\"ip\":\"175.16.199.1\",\"mac\":null,\"subnet\":null,\"did\":null,\"sid\":null},{\"identifier\":null,\"hostname\":null,\"ip\":\"175.16.199.3\",\"mac\":null,\"subnet\":null,\"did\":null,\"sid\":null}]},{\"key\":\"Destination port\",\"type\":\"integer\",\"values\":[22]},{\"key\":\"Connection count\",\"type\":\"integer\",\"values\":[40]},{\"key\":\"Percentage successful\",\"type\":\"percentage\",\"values\":[100]}]}]]}",
         "reason": "Extensive Unusual SSH Connections",
@@ -174,7 +174,7 @@
             "2021-08-03T10:08:18.683Z"
         ],
         "type": [
-            "info"
+            "indicator"
         ]
     },
     "host": {
@@ -186,11 +186,11 @@
         ]
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "source": {
-            "address": "192.168.128.5:49066"
+            "address": "172.31.0.4:53890"
         },
         "syslog": {
             "facility": {

--- a/packages/darktrace/data_stream/model_breach_alert/_dev/test/pipeline/test-model-breach-alert.log-expected.json
+++ b/packages/darktrace/data_stream/model_breach_alert/_dev/test/pipeline/test-model-breach-alert.log-expected.json
@@ -156,7 +156,9 @@
                 ]
             },
             "rule": {
-                "author": "System",
+                "author": [
+                    "System"
+                ],
                 "category": "Informational",
                 "description": "An issue with the system has been detected. This system alert is generated for system information that may merit further investigation. This may be due to things like probes failing to connect.\\n\\nAction: Review the system message. Use the status page to see additional system information that may help with diagnostics.",
                 "name": "System::System",
@@ -555,7 +557,9 @@
                 ]
             },
             "rule": {
-                "author": "System",
+                "author": [
+                    "System"
+                ],
                 "category": "Suspicious",
                 "description": "A device is using common penetration testing tools.\\n\\nAction: Review the device to see if it a security device, these can be tagged as such to exclude them from future breaches. Activity from non security devices merit further investigation into what else the device is doing and could be a significant risk within the network.",
                 "name": "Device::Attack and Recon Tools",
@@ -1106,7 +1110,9 @@
                 ]
             },
             "rule": {
-                "author": "System",
+                "author": [
+                    "System"
+                ],
                 "category": "Informational",
                 "description": "A device has been repeatedly connecting to a rare external location with a beacon score. A beacon score is added when Darktrace identifies that a device is regularly communicating with an endpoint, for example, if a device connects to a rare external endpoint every 12 minutes this would get a beacon score. This model is designed to identify beaconing at a lower threshold and be protocol agnostic.\\n\\nAction: Review the external domains and IPs being connected to to see if they are legitimate and would be expected for business purposes.",
                 "name": "Compromise::Beaconing Activity To External Rare",
@@ -1272,7 +1278,9 @@
                 ]
             },
             "rule": {
-                "author": "System",
+                "author": [
+                    "System"
+                ],
                 "description": "Test model used for testing alerting configuration.",
                 "name": "Unrestricted Test Model"
             },

--- a/packages/darktrace/data_stream/model_breach_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/model_breach_alert/elasticsearch/ingest_pipeline/default.yml
@@ -664,10 +664,11 @@ processors:
       value: '{{{darktrace.model_breach_alert.model.created.by}}}'
       allow_duplicates: false
       ignore_failure: true
-  - set:
+  - append:
       field: rule.author
-      copy_from: darktrace.model_breach_alert.model.created.by
-      ignore_failure: true
+      value: '{{{darktrace.model_breach_alert.model.created.by}}}'
+      allow_duplicates: false
+      if: ctx.darktrace?.model_breach_alert?.model?.created?.by != null
   - foreach:
       field: json.model.defeats
       if: ctx.json?.model?.defeats instanceof List

--- a/packages/darktrace/data_stream/model_breach_alert/sample_event.json
+++ b/packages/darktrace/data_stream/model_breach_alert/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-07-11T13:04:08.000Z",
     "agent": {
-        "ephemeral_id": "572d7663-c480-491f-b06f-96f0330cf942",
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
+        "ephemeral_id": "4d6d9ea0-9819-41c2-92ea-85ae0db8f2e7",
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.1"
+        "version": "8.9.0"
     },
     "darktrace": {
         "model_breach_alert": {
@@ -502,9 +502,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
-        "snapshot": false,
-        "version": "8.2.1"
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
+        "snapshot": true,
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -513,7 +513,7 @@
         ],
         "created": "2022-07-11T13:04:19.000Z",
         "dataset": "darktrace.model_breach_alert",
-        "ingested": "2022-09-30T11:39:13Z",
+        "ingested": "2023-06-14T17:03:48Z",
         "kind": "event",
         "original": "{\"commentCount\":0,\"pbid\":1,\"time\":1657544648000,\"creationTime\":1657544659000,\"aianalystData\":[{\"uuid\":\"1234abcd-1234-1234-1234-123456abcdef\",\"related\":[1],\"summariser\":\"BeaconSummary\"}],\"model\":{\"name\":\"Compromise::Beaconing Activity To External Rare\",\"pid\":156,\"phid\":1072,\"uuid\":\"1234abcd-1234-1234-1234-123456abcdef\",\"logic\":{\"data\":[{\"cid\":2026,\"weight\":1},{\"cid\":2024,\"weight\":1},{\"cid\":2025,\"weight\":-100}],\"targetScore\":1,\"type\":\"weightedComponentList\",\"version\":1},\"throttle\":10800,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[\"AP: C2 Comms\"],\"interval\":10800,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2022-07-11 11:47:37\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"A device has been repeatedly connecting to a rare external location with a beacon score. A beacon score is added when Darktrace identifies that a device is regularly communicating with an endpoint, for example, if a device connects to a rare external endpoint every 12 minutes this would get a beacon score. This model is designed to identify beaconing at a lower threshold and be protocol agnostic.\\\\n\\\\nAction: Review the external domains and IPs being connected to to see if they are legitimate and would be expected for business purposes.\",\"behaviour\":\"incdec1\",\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"version\":23,\"priority\":2,\"category\":\"Informational\",\"compliance\":false},\"triggeredComponents\":[{\"time\":1657544648000,\"cbid\":1,\"cid\":2026,\"chid\":2113,\"size\":11,\"threshold\":10,\"interval\":3600,\"logic\":{\"data\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"AA\",\"operator\":\"AND\",\"right\":{\"left\":\"AC\",\"operator\":\"AND\",\"right\":{\"left\":\"AD\",\"operator\":\"AND\",\"right\":{\"left\":\"AF\",\"operator\":\"AND\",\"right\":{\"left\":\"AG\",\"operator\":\"AND\",\"right\":{\"left\":\"AH\",\"operator\":\"AND\",\"right\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":{\"left\":\"K\",\"operator\":\"AND\",\"right\":{\"left\":\"L\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"S\",\"operator\":\"AND\",\"right\":{\"left\":\"U\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"X\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"AA\",\"operator\":\"AND\",\"right\":{\"left\":\"AB\",\"operator\":\"AND\",\"right\":{\"left\":\"AE\",\"operator\":\"AND\",\"right\":{\"left\":\"AF\",\"operator\":\"AND\",\"right\":{\"left\":\"AG\",\"operator\":\"AND\",\"right\":{\"left\":\"AH\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":{\"left\":\"K\",\"operator\":\"AND\",\"right\":{\"left\":\"L\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"S\",\"operator\":\"AND\",\"right\":{\"left\":\"U\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"X\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}}}}}}}}}}}},\"version\":\"v0.1\"},\"metric\":{\"mlid\":1,\"name\":\"externalconnections\",\"label\":\"External Connections\"},\"triggeredFilters\":[{\"cfid\":23426,\"id\":\"A\",\"filterType\":\"Beaconing score\",\"arguments\":{\"value\":60},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":23427,\"id\":\"AA\",\"filterType\":\"Individual size up\",\"arguments\":{\"value\":0},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"4382\"}},{\"cfid\":23428,\"id\":\"AB\",\"filterType\":\"Rare domain\",\"arguments\":{\"value\":95},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":23430,\"id\":\"AD\",\"filterType\":\"Age of destination\",\"arguments\":{\"value\":1209600},\"comparatorType\":\"\u003c\",\"trigger\":{\"value\":\"558\"}},{\"cfid\":23431,\"id\":\"AE\",\"filterType\":\"Age of external hostname\",\"arguments\":{\"value\":1209600},\"comparatorType\":\"\u003c\",\"trigger\":{\"value\":\"558\"}},{\"cfid\":23432,\"id\":\"AF\",\"filterType\":\"Connection hostname\",\"arguments\":{\"value\":\"examples\"},\"comparatorType\":\"does not match regular expression\",\"trigger\":{\"value\":\"example.com\"}},{\"cfid\":23433,\"id\":\"AG\",\"filterType\":\"ASN\",\"arguments\":{\"value\":\"examples\"},\"comparatorType\":\"does not match regular expression\",\"trigger\":{\"value\":\"AS12345 LOCAL-02\"}},{\"cfid\":23434,\"id\":\"AH\",\"filterType\":\"JA3 hash\",\"arguments\":{\"value\":\"5d41402abc4b2a76b9719d911017c592\"},\"comparatorType\":\"does not match\",\"trigger\":{\"value\":\"5d41402abc4b2a76b9719d911017c592\"}},{\"cfid\":23435,\"id\":\"B\",\"filterType\":\"Rare external IP\",\"arguments\":{\"value\":95},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":23436,\"id\":\"C\",\"filterType\":\"Application protocol\",\"arguments\":{\"value\":\"1003\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"1004\"}},{\"cfid\":23437,\"id\":\"D\",\"filterType\":\"Destination port\",\"arguments\":{\"value\":53},\"comparatorType\":\"!=\",\"trigger\":{\"value\":\"443\"}},{\"cfid\":23438,\"id\":\"E\",\"filterType\":\"Direction\",\"arguments\":{\"value\":\"out\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"out\"}},{\"cfid\":23439,\"id\":\"H\",\"filterType\":\"Destination port\",\"arguments\":{\"value\":137},\"comparatorType\":\"!=\",\"trigger\":{\"value\":\"443\"}},{\"cfid\":23440,\"id\":\"I\",\"filterType\":\"Destination port\",\"arguments\":{\"value\":161},\"comparatorType\":\"!=\",\"trigger\":{\"value\":\"443\"}},{\"cfid\":23441,\"id\":\"J\",\"filterType\":\"Protocol\",\"arguments\":{\"value\":\"6\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23442,\"id\":\"K\",\"filterType\":\"ASN\",\"arguments\":{\"value\":\"Company\"},\"comparatorType\":\"does not contain\",\"trigger\":{\"value\":\"AS12345 LOCAL-02\"}},{\"cfid\":23443,\"id\":\"L\",\"filterType\":\"ASN\",\"arguments\":{\"value\":\"Company\"},\"comparatorType\":\"does not contain\",\"trigger\":{\"value\":\"AS12345 LOCAL-02\"}},{\"cfid\":23444,\"id\":\"M\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"13\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23445,\"id\":\"N\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"5\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23446,\"id\":\"O\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"9\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23447,\"id\":\"P\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"12\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23448,\"id\":\"S\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"30\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23449,\"id\":\"U\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"4\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23450,\"id\":\"V\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"3\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23451,\"id\":\"X\",\"filterType\":\"Trusted hostname\",\"arguments\":{\"value\":\"false\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"false\"}},{\"cfid\":23452,\"id\":\"Y\",\"filterType\":\"Tagged internal source\",\"arguments\":{\"value\":26},\"comparatorType\":\"does not have tag\",\"trigger\":{\"value\":\"26\",\"tag\":{\"tid\":26,\"expiry\":0,\"thid\":26,\"name\":\"No Device Tracking\",\"restricted\":false,\"data\":{\"auto\":false,\"color\":5,\"description\":\"\",\"visibility\":\"Public\"},\"isReferenced\":true}}},{\"cfid\":23453,\"id\":\"Z\",\"filterType\":\"Individual size down\",\"arguments\":{\"value\":0},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"5862\"}},{\"cfid\":23454,\"id\":\"d1\",\"filterType\":\"JA3 hash\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"5d41402abc4b2a76b9719d911017c592\"}},{\"cfid\":23455,\"id\":\"d2\",\"filterType\":\"ASN\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"AS12345 LOCAL-02\"}},{\"cfid\":23456,\"id\":\"d3\",\"filterType\":\"Destination IP\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"81.2.69.192\"}},{\"cfid\":23457,\"id\":\"d4\",\"filterType\":\"Connection hostname\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"example.com\"}}]}],\"score\":0.674,\"device\":{\"did\":3,\"ip\":\"81.2.69.142\",\"sid\":1,\"firstSeen\":1657544089000,\"lastSeen\":1657544418000,\"typename\":\"desktop\",\"typelabel\":\"Desktop\"}}",
         "risk_score": 0.674,
@@ -535,11 +535,11 @@
         "type": "desktop"
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "source": {
-            "address": "192.168.128.5:60206"
+            "address": "172.31.0.4:60610"
         },
         "syslog": {
             "facility": {
@@ -564,7 +564,9 @@
         ]
     },
     "rule": {
-        "author": "System",
+        "author": [
+            "System"
+        ],
         "category": "Informational",
         "description": "A device has been repeatedly connecting to a rare external location with a beacon score. A beacon score is added when Darktrace identifies that a device is regularly communicating with an endpoint, for example, if a device connects to a rare external endpoint every 12 minutes this would get a beacon score. This model is designed to identify beaconing at a lower threshold and be protocol agnostic.\\n\\nAction: Review the external domains and IPs being connected to to see if they are legitimate and would be expected for business purposes.",
         "name": "Compromise::Beaconing Activity To External Rare",

--- a/packages/darktrace/data_stream/system_status_alert/_dev/test/pipeline/test-system-status-alert.log-expected.json
+++ b/packages/darktrace/data_stream/system_status_alert/_dev/test/pipeline/test-system-status-alert.log-expected.json
@@ -34,7 +34,9 @@
             },
             "host": {
                 "hostname": "example-vsensor",
-                "ip": "175.16.199.1"
+                "ip": [
+                    "175.16.199.1"
+                ]
             },
             "related": {
                 "hosts": [
@@ -90,7 +92,9 @@
             },
             "host": {
                 "hostname": "local-abc",
-                "ip": "175.16.199.1"
+                "ip": [
+                    "175.16.199.1"
+                ]
             },
             "related": {
                 "hosts": [

--- a/packages/darktrace/data_stream/system_status_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/system_status_alert/elasticsearch/ingest_pipeline/default.yml
@@ -134,13 +134,14 @@ processors:
       target_field: darktrace.system_status_alert._temp_.ip_address
       type: ip
       ignore_failure: true
-  - set:
+  - append:
       field: host.ip
-      copy_from: darktrace.system_status_alert._temp_.ip_address
+      value: '{{{darktrace.system_status_alert._temp_.ip_address}}}'
+      allow_duplicates: false
       ignore_failure: true
   - append:
       field: related.ip
-      value: '{{{host.ip}}}'
+      value: '{{{darktrace.system_status_alert._temp_.ip_address}}}'
       allow_duplicates: false
       ignore_failure: true
   - rename:

--- a/packages/darktrace/data_stream/system_status_alert/sample_event.json
+++ b/packages/darktrace/data_stream/system_status_alert/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-04-18T15:44:11.000Z",
     "agent": {
-        "ephemeral_id": "5b042cea-01fa-47a2-ab0f-ac1f7baa6bd2",
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
+        "ephemeral_id": "b16aba4d-b447-49c7-ac87-7785481b8e51",
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.1"
+        "version": "8.9.0"
     },
     "darktrace": {
         "system_status_alert": {
@@ -32,15 +32,15 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
-        "snapshot": false,
-        "version": "8.2.1"
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
+        "snapshot": true,
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "darktrace.system_status_alert",
         "id": "abcdabcd-1234-1234-1234-3abababcdcd3",
-        "ingested": "2022-09-30T11:41:35Z",
+        "ingested": "2023-06-14T17:06:15Z",
         "kind": "alert",
         "original": "{\"last_updated\":1618760651,\"uuid\":\"abcdabcd-1234-1234-1234-3abababcdcd3\",\"priority\":43,\"priority_level\":\"medium\",\"hostname\":\"example-vsensor\",\"ip_address\":\"175.16.199.1\",\"message\":\"There have been no Advanced Search hits for this instance seen since Sun 18 April 2021 13:20:23 (UTC). If this is not expected behaviour, please open a ticket using the following link or get in touch with your Cyber Technology Specialist. https://example.com/test\",\"name\":\"advanced_search\",\"acknowledge_timeout\":null,\"alert_name\":\"Advanced Search\",\"child_id\":1,\"last_updated_status\":1618760651,\"status\":\"active\"}",
         "reason": "There have been no Advanced Search hits for this instance seen since Sun 18 April 2021 13:20:23 (UTC). If this is not expected behaviour, please open a ticket using the following link or get in touch with your Cyber Technology Specialist. https://example.com/test",
@@ -52,14 +52,16 @@
     },
     "host": {
         "hostname": "example-vsensor",
-        "ip": "175.16.199.1"
+        "ip": [
+            "175.16.199.1"
+        ]
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "source": {
-            "address": "192.168.128.5:36197"
+            "address": "172.31.0.4:43852"
         },
         "syslog": {
             "facility": {

--- a/packages/darktrace/docs/README.md
+++ b/packages/darktrace/docs/README.md
@@ -111,11 +111,11 @@ An example event for `ai_analyst_alert` looks as following:
 {
     "@timestamp": "2021-08-03T14:48:09.240Z",
     "agent": {
-        "ephemeral_id": "82482032-e103-4c45-a00e-103ac604f4ae",
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
+        "ephemeral_id": "315a1a3f-bc7a-4a11-9540-c316f1ec95ee",
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.1"
+        "version": "8.9.0"
     },
     "darktrace": {
         "ai_analyst_alert": {
@@ -257,9 +257,9 @@ An example event for `ai_analyst_alert` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
-        "snapshot": false,
-        "version": "8.2.1"
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
+        "snapshot": true,
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -274,7 +274,7 @@ An example event for `ai_analyst_alert` looks as following:
             "2021-08-03T14:15:41.220Z"
         ],
         "id": "eabc0011-1234-1234-1234-cabcdefg0011",
-        "ingested": "2022-09-30T11:36:06Z",
+        "ingested": "2023-06-14T17:00:35Z",
         "kind": "alert",
         "original": "{\"summariser\":\"AdminConnSummary\",\"acknowledged\":false,\"pinned\":true,\"createdAt\":1628002089240,\"attackPhases\":[5],\"title\":\"Extensive Unusual SSH Connections\",\"id\":\"eabc0011-1234-1234-1234-cabcdefg0011\",\"children\":[\"eabcdef0-1234-1234-1234-cabcdefghij9\"],\"category\":\"critical\",\"currentGroup\":\"eabc1234-1234-1234-1234-cabcdefg0011\",\"groupCategory\":\"critical\",\"groupScore\":\"72.9174234\",\"groupPreviousGroups\":null,\"activityId\":\"abcd1234\",\"groupingIds\":[\"abcdef12\"],\"groupByActivity\":false,\"userTriggered\":false,\"externalTriggered\":false,\"aiaScore\":98,\"summary\":\"The device 175.16.199.1 was observed making unusual internal SSH connections to a wide range of devices.\\n\\nThough this behaviour could be the result of legitimate remote access or administration, it could also be a sign of attempted lateral movement by a compromised machine.\\n\\nConsequently, if this activity was not expected, the security team may wish to investigate further.\",\"periods\":[{\"start\":1627985298683,\"end\":1628000141220}],\"breachDevices\":[{\"identifier\":null,\"hostname\":null,\"ip\":\"81.2.69.144\",\"mac\":null,\"subnet\":\"VPN\",\"did\":10,\"sid\":12}],\"relatedBreaches\":[{\"modelName\":\"Unusual Activity / Unusual Activity from Re-Activated Device\",\"pbid\":1234,\"threatScore\":37,\"timestamp\":1627997157000}],\"details\":[[{\"header\":\"Breaching Device\",\"contents\":[{\"key\":null,\"type\":\"device\",\"values\":[{\"identifier\":null,\"hostname\":null,\"ip\":\"175.16.199.1\",\"mac\":null,\"subnet\":\"VPN\",\"did\":10,\"sid\":12}]}]}],[{\"header\":\"SSH Activity\",\"contents\":[{\"key\":\"Time\",\"type\":\"timestampRange\",\"values\":[{\"start\":1627985298683,\"end\":1628000141220}]},{\"key\":\"Number of unique IPs\",\"type\":\"integer\",\"values\":[16]},{\"key\":\"Targeted IP ranges include\",\"type\":\"device\",\"values\":[{\"identifier\":null,\"hostname\":null,\"ip\":\"81.2.69.192\",\"mac\":null,\"subnet\":null,\"did\":null,\"sid\":null},{\"identifier\":null,\"hostname\":null,\"ip\":\"175.16.199.1\",\"mac\":null,\"subnet\":null,\"did\":null,\"sid\":null},{\"identifier\":null,\"hostname\":null,\"ip\":\"175.16.199.3\",\"mac\":null,\"subnet\":null,\"did\":null,\"sid\":null}]},{\"key\":\"Destination port\",\"type\":\"integer\",\"values\":[22]},{\"key\":\"Connection count\",\"type\":\"integer\",\"values\":[40]},{\"key\":\"Percentage successful\",\"type\":\"percentage\",\"values\":[100]}]}]]}",
         "reason": "Extensive Unusual SSH Connections",
@@ -284,7 +284,7 @@ An example event for `ai_analyst_alert` looks as following:
             "2021-08-03T10:08:18.683Z"
         ],
         "type": [
-            "info"
+            "indicator"
         ]
     },
     "host": {
@@ -296,11 +296,11 @@ An example event for `ai_analyst_alert` looks as following:
         ]
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "source": {
-            "address": "192.168.128.5:49066"
+            "address": "172.31.0.4:53890"
         },
         "syslog": {
             "facility": {
@@ -481,11 +481,11 @@ An example event for `model_breach_alert` looks as following:
 {
     "@timestamp": "2022-07-11T13:04:08.000Z",
     "agent": {
-        "ephemeral_id": "572d7663-c480-491f-b06f-96f0330cf942",
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
+        "ephemeral_id": "4d6d9ea0-9819-41c2-92ea-85ae0db8f2e7",
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.1"
+        "version": "8.9.0"
     },
     "darktrace": {
         "model_breach_alert": {
@@ -982,9 +982,9 @@ An example event for `model_breach_alert` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
-        "snapshot": false,
-        "version": "8.2.1"
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
+        "snapshot": true,
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -993,7 +993,7 @@ An example event for `model_breach_alert` looks as following:
         ],
         "created": "2022-07-11T13:04:19.000Z",
         "dataset": "darktrace.model_breach_alert",
-        "ingested": "2022-09-30T11:39:13Z",
+        "ingested": "2023-06-14T17:03:48Z",
         "kind": "event",
         "original": "{\"commentCount\":0,\"pbid\":1,\"time\":1657544648000,\"creationTime\":1657544659000,\"aianalystData\":[{\"uuid\":\"1234abcd-1234-1234-1234-123456abcdef\",\"related\":[1],\"summariser\":\"BeaconSummary\"}],\"model\":{\"name\":\"Compromise::Beaconing Activity To External Rare\",\"pid\":156,\"phid\":1072,\"uuid\":\"1234abcd-1234-1234-1234-123456abcdef\",\"logic\":{\"data\":[{\"cid\":2026,\"weight\":1},{\"cid\":2024,\"weight\":1},{\"cid\":2025,\"weight\":-100}],\"targetScore\":1,\"type\":\"weightedComponentList\",\"version\":1},\"throttle\":10800,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[\"AP: C2 Comms\"],\"interval\":10800,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2022-07-11 11:47:37\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"A device has been repeatedly connecting to a rare external location with a beacon score. A beacon score is added when Darktrace identifies that a device is regularly communicating with an endpoint, for example, if a device connects to a rare external endpoint every 12 minutes this would get a beacon score. This model is designed to identify beaconing at a lower threshold and be protocol agnostic.\\\\n\\\\nAction: Review the external domains and IPs being connected to to see if they are legitimate and would be expected for business purposes.\",\"behaviour\":\"incdec1\",\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"version\":23,\"priority\":2,\"category\":\"Informational\",\"compliance\":false},\"triggeredComponents\":[{\"time\":1657544648000,\"cbid\":1,\"cid\":2026,\"chid\":2113,\"size\":11,\"threshold\":10,\"interval\":3600,\"logic\":{\"data\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"AA\",\"operator\":\"AND\",\"right\":{\"left\":\"AC\",\"operator\":\"AND\",\"right\":{\"left\":\"AD\",\"operator\":\"AND\",\"right\":{\"left\":\"AF\",\"operator\":\"AND\",\"right\":{\"left\":\"AG\",\"operator\":\"AND\",\"right\":{\"left\":\"AH\",\"operator\":\"AND\",\"right\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":{\"left\":\"K\",\"operator\":\"AND\",\"right\":{\"left\":\"L\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"S\",\"operator\":\"AND\",\"right\":{\"left\":\"U\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"X\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"AA\",\"operator\":\"AND\",\"right\":{\"left\":\"AB\",\"operator\":\"AND\",\"right\":{\"left\":\"AE\",\"operator\":\"AND\",\"right\":{\"left\":\"AF\",\"operator\":\"AND\",\"right\":{\"left\":\"AG\",\"operator\":\"AND\",\"right\":{\"left\":\"AH\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":{\"left\":\"K\",\"operator\":\"AND\",\"right\":{\"left\":\"L\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"S\",\"operator\":\"AND\",\"right\":{\"left\":\"U\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"X\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}}}}}}}}}}}},\"version\":\"v0.1\"},\"metric\":{\"mlid\":1,\"name\":\"externalconnections\",\"label\":\"External Connections\"},\"triggeredFilters\":[{\"cfid\":23426,\"id\":\"A\",\"filterType\":\"Beaconing score\",\"arguments\":{\"value\":60},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":23427,\"id\":\"AA\",\"filterType\":\"Individual size up\",\"arguments\":{\"value\":0},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"4382\"}},{\"cfid\":23428,\"id\":\"AB\",\"filterType\":\"Rare domain\",\"arguments\":{\"value\":95},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":23430,\"id\":\"AD\",\"filterType\":\"Age of destination\",\"arguments\":{\"value\":1209600},\"comparatorType\":\"\u003c\",\"trigger\":{\"value\":\"558\"}},{\"cfid\":23431,\"id\":\"AE\",\"filterType\":\"Age of external hostname\",\"arguments\":{\"value\":1209600},\"comparatorType\":\"\u003c\",\"trigger\":{\"value\":\"558\"}},{\"cfid\":23432,\"id\":\"AF\",\"filterType\":\"Connection hostname\",\"arguments\":{\"value\":\"examples\"},\"comparatorType\":\"does not match regular expression\",\"trigger\":{\"value\":\"example.com\"}},{\"cfid\":23433,\"id\":\"AG\",\"filterType\":\"ASN\",\"arguments\":{\"value\":\"examples\"},\"comparatorType\":\"does not match regular expression\",\"trigger\":{\"value\":\"AS12345 LOCAL-02\"}},{\"cfid\":23434,\"id\":\"AH\",\"filterType\":\"JA3 hash\",\"arguments\":{\"value\":\"5d41402abc4b2a76b9719d911017c592\"},\"comparatorType\":\"does not match\",\"trigger\":{\"value\":\"5d41402abc4b2a76b9719d911017c592\"}},{\"cfid\":23435,\"id\":\"B\",\"filterType\":\"Rare external IP\",\"arguments\":{\"value\":95},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":23436,\"id\":\"C\",\"filterType\":\"Application protocol\",\"arguments\":{\"value\":\"1003\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"1004\"}},{\"cfid\":23437,\"id\":\"D\",\"filterType\":\"Destination port\",\"arguments\":{\"value\":53},\"comparatorType\":\"!=\",\"trigger\":{\"value\":\"443\"}},{\"cfid\":23438,\"id\":\"E\",\"filterType\":\"Direction\",\"arguments\":{\"value\":\"out\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"out\"}},{\"cfid\":23439,\"id\":\"H\",\"filterType\":\"Destination port\",\"arguments\":{\"value\":137},\"comparatorType\":\"!=\",\"trigger\":{\"value\":\"443\"}},{\"cfid\":23440,\"id\":\"I\",\"filterType\":\"Destination port\",\"arguments\":{\"value\":161},\"comparatorType\":\"!=\",\"trigger\":{\"value\":\"443\"}},{\"cfid\":23441,\"id\":\"J\",\"filterType\":\"Protocol\",\"arguments\":{\"value\":\"6\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23442,\"id\":\"K\",\"filterType\":\"ASN\",\"arguments\":{\"value\":\"Company\"},\"comparatorType\":\"does not contain\",\"trigger\":{\"value\":\"AS12345 LOCAL-02\"}},{\"cfid\":23443,\"id\":\"L\",\"filterType\":\"ASN\",\"arguments\":{\"value\":\"Company\"},\"comparatorType\":\"does not contain\",\"trigger\":{\"value\":\"AS12345 LOCAL-02\"}},{\"cfid\":23444,\"id\":\"M\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"13\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23445,\"id\":\"N\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"5\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23446,\"id\":\"O\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"9\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23447,\"id\":\"P\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"12\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23448,\"id\":\"S\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"30\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23449,\"id\":\"U\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"4\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23450,\"id\":\"V\",\"filterType\":\"Internal source device type\",\"arguments\":{\"value\":\"3\"},\"comparatorType\":\"is not\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":23451,\"id\":\"X\",\"filterType\":\"Trusted hostname\",\"arguments\":{\"value\":\"false\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"false\"}},{\"cfid\":23452,\"id\":\"Y\",\"filterType\":\"Tagged internal source\",\"arguments\":{\"value\":26},\"comparatorType\":\"does not have tag\",\"trigger\":{\"value\":\"26\",\"tag\":{\"tid\":26,\"expiry\":0,\"thid\":26,\"name\":\"No Device Tracking\",\"restricted\":false,\"data\":{\"auto\":false,\"color\":5,\"description\":\"\",\"visibility\":\"Public\"},\"isReferenced\":true}}},{\"cfid\":23453,\"id\":\"Z\",\"filterType\":\"Individual size down\",\"arguments\":{\"value\":0},\"comparatorType\":\"\u003e\",\"trigger\":{\"value\":\"5862\"}},{\"cfid\":23454,\"id\":\"d1\",\"filterType\":\"JA3 hash\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"5d41402abc4b2a76b9719d911017c592\"}},{\"cfid\":23455,\"id\":\"d2\",\"filterType\":\"ASN\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"AS12345 LOCAL-02\"}},{\"cfid\":23456,\"id\":\"d3\",\"filterType\":\"Destination IP\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"81.2.69.192\"}},{\"cfid\":23457,\"id\":\"d4\",\"filterType\":\"Connection hostname\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"example.com\"}}]}],\"score\":0.674,\"device\":{\"did\":3,\"ip\":\"81.2.69.142\",\"sid\":1,\"firstSeen\":1657544089000,\"lastSeen\":1657544418000,\"typename\":\"desktop\",\"typelabel\":\"Desktop\"}}",
         "risk_score": 0.674,
@@ -1015,11 +1015,11 @@ An example event for `model_breach_alert` looks as following:
         "type": "desktop"
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "source": {
-            "address": "192.168.128.5:60206"
+            "address": "172.31.0.4:60610"
         },
         "syslog": {
             "facility": {
@@ -1044,7 +1044,9 @@ An example event for `model_breach_alert` looks as following:
         ]
     },
     "rule": {
-        "author": "System",
+        "author": [
+            "System"
+        ],
         "category": "Informational",
         "description": "A device has been repeatedly connecting to a rare external location with a beacon score. A beacon score is added when Darktrace identifies that a device is regularly communicating with an endpoint, for example, if a device connects to a rare external endpoint every 12 minutes this would get a beacon score. This model is designed to identify beaconing at a lower threshold and be protocol agnostic.\\n\\nAction: Review the external domains and IPs being connected to to see if they are legitimate and would be expected for business purposes.",
         "name": "Compromise::Beaconing Activity To External Rare",
@@ -1280,11 +1282,11 @@ An example event for `system_status_alert` looks as following:
 {
     "@timestamp": "2021-04-18T15:44:11.000Z",
     "agent": {
-        "ephemeral_id": "5b042cea-01fa-47a2-ab0f-ac1f7baa6bd2",
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
+        "ephemeral_id": "b16aba4d-b447-49c7-ac87-7785481b8e51",
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.1"
+        "version": "8.9.0"
     },
     "darktrace": {
         "system_status_alert": {
@@ -1311,15 +1313,15 @@ An example event for `system_status_alert` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "95d2bc73-8bc8-47d9-b36e-a21b58255eec",
-        "snapshot": false,
-        "version": "8.2.1"
+        "id": "85270a54-b915-4d11-9305-d004346cb8cf",
+        "snapshot": true,
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "darktrace.system_status_alert",
         "id": "abcdabcd-1234-1234-1234-3abababcdcd3",
-        "ingested": "2022-09-30T11:41:35Z",
+        "ingested": "2023-06-14T17:06:15Z",
         "kind": "alert",
         "original": "{\"last_updated\":1618760651,\"uuid\":\"abcdabcd-1234-1234-1234-3abababcdcd3\",\"priority\":43,\"priority_level\":\"medium\",\"hostname\":\"example-vsensor\",\"ip_address\":\"175.16.199.1\",\"message\":\"There have been no Advanced Search hits for this instance seen since Sun 18 April 2021 13:20:23 (UTC). If this is not expected behaviour, please open a ticket using the following link or get in touch with your Cyber Technology Specialist. https://example.com/test\",\"name\":\"advanced_search\",\"acknowledge_timeout\":null,\"alert_name\":\"Advanced Search\",\"child_id\":1,\"last_updated_status\":1618760651,\"status\":\"active\"}",
         "reason": "There have been no Advanced Search hits for this instance seen since Sun 18 April 2021 13:20:23 (UTC). If this is not expected behaviour, please open a ticket using the following link or get in touch with your Cyber Technology Specialist. https://example.com/test",
@@ -1331,14 +1333,16 @@ An example event for `system_status_alert` looks as following:
     },
     "host": {
         "hostname": "example-vsensor",
-        "ip": "175.16.199.1"
+        "ip": [
+            "175.16.199.1"
+        ]
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "source": {
-            "address": "192.168.128.5:36197"
+            "address": "172.31.0.4:43852"
         },
         "syslog": {
             "facility": {

--- a/packages/darktrace/manifest.yml
+++ b/packages/darktrace/manifest.yml
@@ -1,9 +1,7 @@
-format_version: 1.0.0
+format_version: 2.7.0
 name: darktrace
 title: Darktrace
-version: "1.3.0"
-release: ga
-license: basic
+version: "1.4.0"
 description: Collect logs from Darktrace with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

This updates the darktrace integration to package-spec 2.7.0.

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=8.8 -format-version=2.7.0 packages/darktrace
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/darktrace
elastic-package test
```

## Related issues

- Relates elastic/security-team#5870
