### PR TITLE
[fortinet_fortigate] - Update package-spec to 2.7.0

### DIFF
--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Update package to package-spec 2.7.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package to package-spec 2.7.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6591
 - version: "1.12.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/fortinet_fortigate/data_stream/log/_dev/test/pipeline/test-fortinet.log-expected.json
+++ b/packages/fortinet_fortigate/data_stream/log/_dev/test/pipeline/test-fortinet.log-expected.json
@@ -475,7 +475,9 @@
                 "server": {
                     "x509": {
                         "subject": {
-                            "common_name": "test.elastic.co"
+                            "common_name": [
+                                "test.elastic.co"
+                            ]
                         }
                     }
                 }
@@ -604,7 +606,9 @@
                 "server": {
                     "x509": {
                         "subject": {
-                            "common_name": "test.elastic.co"
+                            "common_name": [
+                                "test.elastic.co"
+                            ]
                         }
                     }
                 }
@@ -1330,7 +1334,6 @@
                 "start": "2020-04-18T12:32:48.439-05:00",
                 "timezone": "-0500",
                 "type": [
-                    "user",
                     "start"
                 ]
             },
@@ -1662,7 +1665,6 @@
                 "start": "2020-04-18T12:32:10.109-05:00",
                 "timezone": "-0500",
                 "type": [
-                    "user",
                     "start"
                 ]
             },
@@ -2116,7 +2118,6 @@
                 "start": "2020-04-18T14:16:44.674-03:00",
                 "timezone": "-0300",
                 "type": [
-                    "user",
                     "end"
                 ]
             },
@@ -3123,10 +3124,14 @@
                     "issuer": "DigiCert SHA2 High Assurance Server CA",
                     "x509": {
                         "issuer": {
-                            "common_name": "DigiCert SHA2 High Assurance Server CA"
+                            "common_name": [
+                                "DigiCert SHA2 High Assurance Server CA"
+                            ]
                         },
                         "subject": {
-                            "common_name": "*.dailymotion.com"
+                            "common_name": [
+                                "*.dailymotion.com"
+                            ]
                         }
                     }
                 }

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/event.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/event.yml
@@ -15,13 +15,11 @@ processors:
   - append:
       field: event.type
       value:
-        - user
         - start
       if: "['FSSO-logon', 'auth-logon'].contains(ctx.fortinet?.firewall?.action)"
   - append:
       field: event.type
       value:
-        - user
         - end
       if: "['FSSO-logoff', 'auth-logout'].contains(ctx.fortinet?.firewall?.action)"
   - append:

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/utm.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/utm.yml
@@ -316,26 +316,26 @@ processors:
       field: fortinet.firewall.xid
       target_field: dns.id
       ignore_missing: true
-  - rename:
-      field: fortinet.firewall.scertcname
-      target_field: tls.server.x509.subject.common_name
-      ignore_missing: true
+  - append:
+      field: tls.server.x509.subject.common_name
+      value: "{{{fortinet.firewall.scertcname}}}"
+      if: ctx.fortinet?.firewall?.scertcname != null
   - rename:
       field: fortinet.firewall.scertissuer
       target_field: tls.server.issuer
       ignore_missing: true
-  - set:
+  - append:
       field: tls.server.x509.issuer.common_name
       value: "{{tls.server.issuer}}"
-      ignore_empty_value: true
+      if: ctx.tls?.server?.issuer != null
   - rename:
       field: fortinet.firewall.ccertissuer
       target_field: tls.client.issuer
       ignore_missing: true
-  - set:
+  - append:
       field: tls.client.x509.issuer.common_name
-      value: "{{tls.client.issuer}}"
-      ignore_empty_value: true
+      value: "{{{tls.client.issuer}}}"
+      if: ctx.tls?.client?.issuer != null
   - rename:
       field: fortinet.firewall.sender
       target_field: tls.server.issuer
@@ -372,6 +372,7 @@ processors:
         - fortinet.firewall.dstport
         - fortinet.firewall.rcvdbyte
         - fortinet.firewall.locport
+        - fortinet.firewall.scertcname
         - fortinet.firewall.src_port
         - fortinet.firewall.srcport
         - fortinet.firewall.sentbyte

--- a/packages/fortinet_fortigate/data_stream/log/fields/ecs.yml
+++ b/packages/fortinet_fortigate/data_stream/log/fields/ecs.yml
@@ -99,8 +99,6 @@
 - external: ecs
   name: file.size
 - external: ecs
-  name: host.name
-- external: ecs
   name: log.level
 - external: ecs
   name: log.syslog.facility.code

--- a/packages/fortinet_fortigate/data_stream/log/fields/fields.yml
+++ b/packages/fortinet_fortigate/data_stream/log/fields/fields.yml
@@ -7,7 +7,6 @@
         CRC32 Hash of file
     - name: firewall
       type: group
-      release: beta
       fields:
         - name: acct_stat
           type: keyword

--- a/packages/fortinet_fortigate/data_stream/log/sample_event.json
+++ b/packages/fortinet_fortigate/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2019-05-15T18:03:36.000Z",
     "agent": {
-        "ephemeral_id": "aafd1f24-359a-4baa-b2bb-0e584cdb077e",
-        "id": "4d0a076e-ad1f-4be8-9084-c937ff295789",
+        "ephemeral_id": "7dc43a3d-5d1a-4ba7-8834-fcc613929c0b",
+        "id": "8b10c3ab-9f4b-4ca0-b5ad-b6200b7fe65d",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "fortinet_fortigate.log",
@@ -32,9 +32,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "4d0a076e-ad1f-4be8-9084-c937ff295789",
-        "snapshot": false,
-        "version": "8.3.0"
+        "id": "8b10c3ab-9f4b-4ca0-b5ad-b6200b7fe65d",
+        "snapshot": true,
+        "version": "8.9.0"
     },
     "event": {
         "action": "app-ctrl-all",
@@ -44,7 +44,7 @@
         ],
         "code": "1059028704",
         "dataset": "fortinet_fortigate.log",
-        "ingested": "2023-05-24T08:00:16Z",
+        "ingested": "2023-06-15T20:11:05Z",
         "kind": "event",
         "original": "\u003c190\u003edate=2019-05-15 time=18:03:36 logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1557968615 appid=40568 srcip=10.1.100.22 dstip=67.43.156.14 srcport=50798 dstport=443 srcintf=\"port10\" srcintfrole=\"lan\" dstintf=\"port9\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=4414 applist=\"block-social.media\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"www.dailymotion.com\" incidentserialno=1962906680 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\" scertcname=\"*.dailymotion.com\" scertissuer=\"DigiCert SHA2 High Assurance Server CA\"",
         "outcome": "success",
@@ -73,7 +73,7 @@
     "log": {
         "level": "information",
         "source": {
-            "address": "172.23.0.4:38690"
+            "address": "172.23.0.4:52312"
         },
         "syslog": {
             "facility": {
@@ -134,10 +134,14 @@
             "issuer": "DigiCert SHA2 High Assurance Server CA",
             "x509": {
                 "issuer": {
-                    "common_name": "DigiCert SHA2 High Assurance Server CA"
+                    "common_name": [
+                        "DigiCert SHA2 High Assurance Server CA"
+                    ]
                 },
                 "subject": {
-                    "common_name": "*.dailymotion.com"
+                    "common_name": [
+                        "*.dailymotion.com"
+                    ]
                 }
             }
         }

--- a/packages/fortinet_fortigate/docs/README.md
+++ b/packages/fortinet_fortigate/docs/README.md
@@ -16,11 +16,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2019-05-15T18:03:36.000Z",
     "agent": {
-        "ephemeral_id": "aafd1f24-359a-4baa-b2bb-0e584cdb077e",
-        "id": "4d0a076e-ad1f-4be8-9084-c937ff295789",
+        "ephemeral_id": "7dc43a3d-5d1a-4ba7-8834-fcc613929c0b",
+        "id": "8b10c3ab-9f4b-4ca0-b5ad-b6200b7fe65d",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "fortinet_fortigate.log",
@@ -47,9 +47,9 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "4d0a076e-ad1f-4be8-9084-c937ff295789",
-        "snapshot": false,
-        "version": "8.3.0"
+        "id": "8b10c3ab-9f4b-4ca0-b5ad-b6200b7fe65d",
+        "snapshot": true,
+        "version": "8.9.0"
     },
     "event": {
         "action": "app-ctrl-all",
@@ -59,7 +59,7 @@ An example event for `log` looks as following:
         ],
         "code": "1059028704",
         "dataset": "fortinet_fortigate.log",
-        "ingested": "2023-05-24T08:00:16Z",
+        "ingested": "2023-06-15T20:11:05Z",
         "kind": "event",
         "original": "\u003c190\u003edate=2019-05-15 time=18:03:36 logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1557968615 appid=40568 srcip=10.1.100.22 dstip=67.43.156.14 srcport=50798 dstport=443 srcintf=\"port10\" srcintfrole=\"lan\" dstintf=\"port9\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=4414 applist=\"block-social.media\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"www.dailymotion.com\" incidentserialno=1962906680 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\" scertcname=\"*.dailymotion.com\" scertissuer=\"DigiCert SHA2 High Assurance Server CA\"",
         "outcome": "success",
@@ -88,7 +88,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "information",
         "source": {
-            "address": "172.23.0.4:38690"
+            "address": "172.23.0.4:52312"
         },
         "syslog": {
             "facility": {
@@ -149,10 +149,14 @@ An example event for `log` looks as following:
             "issuer": "DigiCert SHA2 High Assurance Server CA",
             "x509": {
                 "issuer": {
-                    "common_name": "DigiCert SHA2 High Assurance Server CA"
+                    "common_name": [
+                        "DigiCert SHA2 High Assurance Server CA"
+                    ]
                 },
                 "subject": {
-                    "common_name": "*.dailymotion.com"
+                    "common_name": [
+                        "*.dailymotion.com"
+                    ]
                 }
             }
         }

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,11 +1,9 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: "1.12.0"
-release: ga
+version: "1.13.0"
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.7.0
 categories: ["security", "network", "firewall_security"]
 conditions:
   kibana.version: "^8.3.0"


### PR DESCRIPTION
## What does this PR do?

This updates the fortinet_fortigate integration package to package-spec 2.7.0.

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=8.8 -format-version=2.7.0 packages/fortinet_fortigate
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/fortinet_fortigate
elastic-package test
```

## Related issues

- Relates elastic/security-team#5870
