### PR TITLE
statsd_input: Fix config to take `host` instead of `hosts`

### DIFF
--- a/packages/statsd_input/agent/input/input.yml.hbs
+++ b/packages/statsd_input/agent/input/input.yml.hbs
@@ -1,8 +1,5 @@
 metricsets: ["server"]
-hosts:
-{{#each hosts}}
-  - {{this}}
-{{/each}}
+host: {{host}}
 port: {{port}}
 data_stream:
   dataset: {{data_stream.dataset}}

--- a/packages/statsd_input/agent/input/input.yml.hbs
+++ b/packages/statsd_input/agent/input/input.yml.hbs
@@ -1,5 +1,5 @@
 metricsets: ["server"]
-host: {{host}}
-port: {{port}}
+host: {{listen_address}}
+port: {{listen_port}}
 data_stream:
   dataset: {{data_stream.dataset}}

--- a/packages/statsd_input/changelog.yml
+++ b/packages/statsd_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Fix config to take `host` instead of `hosts`
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6451
 - version: "0.2.0"
   changes:
     - description: Update Kibana version to 8.8.0

--- a/packages/statsd_input/changelog.yml
+++ b/packages/statsd_input/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix config to take `host` instead of `hosts`
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/6451
+      link: https://github.com/elastic/integrations/pull/6592
 - version: "0.2.0"
   changes:
     - description: Update Kibana version to 8.8.0

--- a/packages/statsd_input/manifest.yml
+++ b/packages/statsd_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: statsd_input
 title: Statsd Input
-version: "0.2.0"
+version: "0.2.1"
 description: Statsd Input Package
 type: input
 categories:
@@ -22,14 +22,12 @@ policy_templates:
     input: statsd/metrics
     template_path: input.yml.hbs
     vars:
-      - name: hosts
+      - name: host
         type: text
-        title: Hosts
-        multi: true
+        title: Host
         required: true
         show_user: true
-        default:
-          - http://127.0.0.1
+        default: 0.0.0.0
       - name: port
         type: text
         title: Port

--- a/packages/statsd_input/manifest.yml
+++ b/packages/statsd_input/manifest.yml
@@ -1,8 +1,8 @@
 format_version: 2.0.0
 name: statsd_input
-title: Statsd Input
+title: StatsD Input
 version: "0.2.1"
-description: Statsd Input Package
+description: StatsD Input Package
 type: input
 categories:
   - observability
@@ -17,20 +17,24 @@ icons:
 policy_templates:
   - name: statsd
     type: metrics
-    title: Statsd Metrics
-    description: Collect metrics from Statsd instances
+    title: StatsD Metrics
+    description: Collect metrics from StatsD instances
     input: statsd/metrics
     template_path: input.yml.hbs
     vars:
-      - name: host
+      - name: listen_address
         type: text
-        title: Host
+        title: Listen Address
+        description: |
+          Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.
         required: true
         show_user: true
-        default: 0.0.0.0
-      - name: port
+        default: localhost
+      - name: listen_port
         type: text
-        title: Port
+        title: Listen Port
+        description: |
+          Bind port for the listener.
         required: true
         show_user: true
         default: 8125


### PR DESCRIPTION
- Bug

## What does this PR do?

While debugging why the client is not able to send data to the statsd_input's spawned server, I found that the configuration used is incorrect making the server listen on a default IP which is not always correct unless someone uses the standalone elastic-agent. Also, accepting multiple hosts for a server doesn't make sense and that's why also only one host is considered in metricbeat module side of beats. Also, the IP shouldn't have `http://` prefix and it should be without it.

Found this when trying to send data using a statsd client from a different container which is part of the same network as of elastic-agent's container. Also made a toy UDP server to check if it receiving the packets in the same container but metricbeat was not receiving them.  When checking with tcpdump, I noticed that UDP packets are reaching the correct destination but the server always running on localhost where the packet is destined for another IP and that is the reason for metricbeat module not receiving the packets. But if we run the client on the same container as elastic-agent then it's possible to send it to its localhost directly and it is even true locally and that's why it was working there before.

Ref:

- https://github.com/elastic/beats/blob/main/x-pack/metricbeat/module/statsd/server/server.go#L85
- https://github.com/elastic/beats/blob/main/metricbeat/helper/server/udp/config.go#L20

metricbeat's statsd module is dependent on the UDP helper package and from this we can see that it accepts `host` and `hosts`.

Update:
- Based on review comments from @andrewkroh, made it more like UDP input because field names, defaults, description etc. there makes more sense.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- Start the integration
- Try sending using a statsd_client from a container or host
- Check logs of elastic-agent if the server is spawned on the correct host and port
- Check if data is coming to Elasticsearch