### PR TITLE
1password,[ab]*: ensure event.kind is correctly set for pipeline errors

### DIFF
--- a/packages/1password/changelog.yml
+++ b/packages/1password/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "1.13.0"
   changes:
     - description: Update package to ECS 8.8.0 and package-spec 2.7.0.

--- a/packages/1password/data_stream/audit_events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/1password/data_stream/audit_events/elasticsearch/ingest_pipeline/default.yml
@@ -132,4 +132,4 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/1password/data_stream/item_usages/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/1password/data_stream/item_usages/elasticsearch/ingest_pipeline/default.yml
@@ -138,5 +138,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/1password/data_stream/signin_attempts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/1password/data_stream/signin_attempts/elasticsearch/ingest_pipeline/default.yml
@@ -148,5 +148,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/1password/manifest.yml
+++ b/packages/1password/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: 1password
 title: "1Password"
-version: "1.13.0"
+version: "1.14.0"
 description: Collect logs from 1Password with Elastic Agent.
 type: integration
 categories:

--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "2.9.1"
   changes:
     - description: Fix sign of initial interval for start time offset calculation.

--- a/packages/akamai/data_stream/siem/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/akamai/data_stream/siem/elasticsearch/ingest_pipeline/default.yml
@@ -452,5 +452,8 @@ processors:
       handleMap(ctx);
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.9.1"
+version: "2.10.0"
 description: Collect logs from Akamai with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/atlassian_bitbucket/changelog.yml
+++ b/packages/atlassian_bitbucket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/atlassian_bitbucket/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_bitbucket/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -462,5 +462,8 @@ processors:
       handleMap(ctx);
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: atlassian_bitbucket
 title: Atlassian Bitbucket
-version: "1.10.0"
+version: "1.11.0"
 description: Collect logs from Atlassian Bitbucket with Elastic Agent.
 type: integration
 categories:

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/cloud.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/cloud.yml
@@ -82,5 +82,8 @@ processors:
         }
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}' 
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -439,4 +439,4 @@ on_failure:
     value: pipeline_error
 - append:
     field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -435,5 +435,8 @@ on_failure:
       - _tmp
     ignore_failure: true
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}' 
+    value: "{{ _ingest.on_failure_message }}"

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/self-hosted.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/self-hosted.yml
@@ -79,5 +79,8 @@ processors:
     if: ctx._tmp?.service?.domain != null
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}' 
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.11.0"
+version: "1.12.0"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/atlassian_jira/data_stream/audit/elasticsearch/ingest_pipeline/cloud.yml
+++ b/packages/atlassian_jira/data_stream/audit/elasticsearch/ingest_pipeline/cloud.yml
@@ -77,5 +77,8 @@ processors:
         }
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}' 
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/atlassian_jira/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_jira/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -414,5 +414,8 @@ processors:
       handleMap(ctx);
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/atlassian_jira/data_stream/audit/elasticsearch/ingest_pipeline/self-hosted.yml
+++ b/packages/atlassian_jira/data_stream/audit/elasticsearch/ingest_pipeline/self-hosted.yml
@@ -90,5 +90,8 @@ processors:
     if: ctx._tmp?.service?.domain != null
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.11.0"
+version: "1.12.0"
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration
 categories:

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "3.9.0"
   changes:
     - description: Add permissions to reroute events to logs-*-* for log datastream.

--- a/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2239,5 +2239,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd Logs
-version: "3.9.0"
+version: "3.10.0"
 description: Collect logs from Linux audit daemon with Elastic Agent.
 type: integration
 icons:

--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/auditd_manager/data_stream/auditd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auditd_manager/data_stream/auditd/elasticsearch/ingest_pipeline/default.yml
@@ -234,5 +234,8 @@ processors:
         handleMap(ctx);
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: auditd_manager
 title: "Auditd Manager"
-version: "1.9.0"
+version: "1.10.0"
 description: "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel."
 type: integration
 categories:

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auth0/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
@@ -1101,5 +1101,8 @@ processors:
 
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: auth0
 title: "Auth0"
-version: "1.7.0"
+version: "1.8.0"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:

--- a/packages/azure_frontdoor/changelog.yml
+++ b/packages/azure_frontdoor/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.4.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "0.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/azure_frontdoor/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure_frontdoor/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -182,5 +182,8 @@ processors:
 
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/azure_frontdoor/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure_frontdoor/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
@@ -121,5 +121,8 @@ processors:
 
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/azure_frontdoor/manifest.yml
+++ b/packages/azure_frontdoor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: azure_frontdoor
 title: "Azure Frontdoor"
-version: "0.3.0"
+version: "0.4.0"
 description: "This Elastic integration collects logs from Azure Frontdoor."
 type: integration
 categories:

--- a/packages/barracuda/data_stream/waf/elasticsearch/ingest_pipeline/audit.yml
+++ b/packages/barracuda/data_stream/waf/elasticsearch/ingest_pipeline/audit.yml
@@ -48,4 +48,4 @@ on_failure:
       value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/barracuda_cloudgen_firewall/changelog.yml
+++ b/packages/barracuda_cloudgen_firewall/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/barracuda_cloudgen_firewall/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/barracuda_cloudgen_firewall/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -180,6 +180,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/barracuda_cloudgen_firewall/data_stream/log/elasticsearch/ingest_pipeline/firewall.yml
+++ b/packages/barracuda_cloudgen_firewall/data_stream/log/elasticsearch/ingest_pipeline/firewall.yml
@@ -203,6 +203,9 @@ processors:
       allow_duplicates: false
       if: ctx.event.action == 'End'
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/barracuda_cloudgen_firewall/data_stream/log/elasticsearch/ingest_pipeline/threat.yml
+++ b/packages/barracuda_cloudgen_firewall/data_stream/log/elasticsearch/ingest_pipeline/threat.yml
@@ -121,6 +121,9 @@ processors:
       allow_duplicates: false
       if: ctx.event.action == 'allow'
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/barracuda_cloudgen_firewall/data_stream/log/elasticsearch/ingest_pipeline/web.yml
+++ b/packages/barracuda_cloudgen_firewall/data_stream/log/elasticsearch/ingest_pipeline/web.yml
@@ -121,6 +121,9 @@ processors:
       allow_duplicates: false
       if: ctx.event.action == '0'
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/barracuda_cloudgen_firewall/manifest.yml
+++ b/packages/barracuda_cloudgen_firewall/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: barracuda_cloudgen_firewall
 title: Barracuda CloudGen Firewall Logs
-version: "1.3.0"
+version: "1.4.0"
 description: Collect logs from Barracuda CloudGen Firewall devices with Elastic Agent.
 categories: ["network", "security", "firewall_security"]
 type: integration

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "0.2.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/bitdefender/data_stream/push_configuration/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitdefender/data_stream/push_configuration/elasticsearch/ingest_pipeline/default.yml
@@ -34,6 +34,9 @@ processors:
     ignore_failure: true
     ignore_missing: true
 on_failure:
-- set:
-    field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/bitdefender/data_stream/push_statistics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitdefender/data_stream/push_statistics/elasticsearch/ingest_pipeline/default.yml
@@ -35,5 +35,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: bitdefender
 title: "BitDefender"
-version: "0.2.0"
+version: "0.3.0"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"

--- a/packages/bluecoat/changelog.yml
+++ b/packages/bluecoat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.16.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "0.15.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/bluecoat/data_stream/director/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bluecoat/data_stream/director/elasticsearch/ingest_pipeline/default.yml
@@ -62,6 +62,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
-        field: error.message
-        value: "{{ _ingest.on_failure_message }}"
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/bluecoat/manifest.yml
+++ b/packages/bluecoat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: bluecoat
 title: Blue Coat Director Logs
-version: "0.15.0"
+version: "0.16.0"
 description: Collect director logs from Blue Coat devices with Elastic Agent.
 categories: ["network", "security", "proxy_security"]
 type: integration

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6599
 - version: "1.4.0"
   changes:
     - description: Sanitise IP values.

--- a/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -1223,5 +1223,8 @@ processors:
         dropEmptyFields(ctx);
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: box_events
 title: Box Events
-version: "1.4.0"
+version: "1.5.0"
 release: ga
 license: basic
 description: "Collect logs from Box with Elastic Agent"

--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -18,7 +18,7 @@
   changes:
     - description: Honor `preserve_original_event` setting.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/5205
 - version: "0.4.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -18,7 +18,7 @@
   changes:
     - description: Honor `preserve_original_event` setting.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/5205
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.6.0.

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -18,7 +18,7 @@
   changes:
     - description: Honor `preserve_original_event` setting.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/5205
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.6.0.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Modify 1password, akamai, atlassian_*, auditd*, auth0, azure_frontdoor, barracuda_cloudgen_firewall, bitdefender, bluecoat, box_events to correctly set `event.kind` for pipeline errors and ensure `error.message` is an array.

Also fixes changelog links for ti_cif3, ti_otx. and ti_threatq.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6582

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
