### PR TITLE
Disable buildkite comments in PR until pipeline is ready

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -55,8 +55,9 @@ spec:
       cancel_intermediate_builds_branch_filter: '!main'
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
-      env:
-        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+      # TODO set as true ELASTIC_PR_COMMENTS_ENABLED when pipeline is ready
+      # env:
+      #   ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## What does this PR do?

This PR disable comments in PR from Buildkite until that pipeline is ready. That would avoid possible contradictory messages in case Jenkins fails, since Buildkite pipeline is just an echo for the time being.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

