### PR TITLE
[dfg]*: ensure event.kind is correctly set for pipeline errors

### DIFF
--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "1.4.0"
   changes:
     - description: Update package to pkg-spec 2.7.0.

--- a/packages/darktrace/data_stream/ai_analyst_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/ai_analyst_alert/elasticsearch/ingest_pipeline/default.yml
@@ -852,6 +852,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/darktrace/data_stream/model_breach_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/model_breach_alert/elasticsearch/ingest_pipeline/default.yml
@@ -1442,6 +1442,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/darktrace/data_stream/system_status_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/system_status_alert/elasticsearch/ingest_pipeline/default.yml
@@ -231,6 +231,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/darktrace/manifest.yml
+++ b/packages/darktrace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: darktrace
 title: Darktrace
-version: "1.4.0"
+version: "1.5.0"
 description: Collect logs from Darktrace with Elastic Agent.
 type: integration
 categories:

--- a/packages/f5/changelog.yml
+++ b/packages/f5/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.16.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "0.15.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/f5/data_stream/bigipafm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/f5/data_stream/bigipafm/elasticsearch/ingest_pipeline/default.yml
@@ -87,6 +87,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/f5/data_stream/bigipapm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/f5/data_stream/bigipapm/elasticsearch/ingest_pipeline/default.yml
@@ -87,6 +87,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
-        field: error.message
-        value: "{{ _ingest.on_failure_message }}"
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/f5/manifest.yml
+++ b/packages/f5/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: f5
 title: F5 Logs
-version: "0.15.0"
+version: "0.16.0"
 description: Collect and parse logs from F5 devices with Elastic Agent.
 categories: ["observability", "load_balancer"]
 release: experimental

--- a/packages/f5_bigip/changelog.yml
+++ b/packages/f5_bigip/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -83,6 +83,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipafm.yml
+++ b/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipafm.yml
@@ -384,6 +384,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipapm.yml
+++ b/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipapm.yml
@@ -190,6 +190,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipasm.yml
+++ b/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipasm.yml
@@ -550,6 +550,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipavr.yml
+++ b/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipavr.yml
@@ -1329,6 +1329,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipltm.yml
+++ b/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipltm.yml
@@ -292,6 +292,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/f5_bigip/manifest.yml
+++ b/packages/f5_bigip/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: f5_bigip
 title: F5 BIG-IP
-version: "1.3.0"
+version: "1.4.0"
 description: Collect logs from F5 BIG-IP with Elastic Agent.
 type: integration
 categories:

--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/fim/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fim/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -6,5 +6,8 @@ processors:
       value: '8.8.0'
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: fim
 title: "File Integrity Monitoring"
-version: "1.7.0"
+version: "1.8.0"
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."
 type: integration
 categories:

--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.13.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "1.12.0"
   changes:
     - description: Update package to pkg-spec 2.7.0.

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/default.yml
@@ -181,5 +181,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
@@ -460,5 +460,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fireeye/manifest.yml
+++ b/packages/fireeye/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: fireeye
 title: "FireEye Network Security"
-version: "1.12.0"
+version: "1.13.0"
 description: Collect logs from FireEye NX with Elastic Agent.
 type: integration
 categories:

--- a/packages/forcepoint_web/changelog.yml
+++ b/packages/forcepoint_web/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "0.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/forcepoint_web/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/forcepoint_web/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
@@ -352,6 +352,9 @@ processors:
         handleMap(ctx);
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/forcepoint_web/manifest.yml
+++ b/packages/forcepoint_web/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: forcepoint_web
 title: "Forcepoint Web Security"
-version: "0.3.0"
+version: "0.4.0"
 source:
   license: "Elastic-2.0"
 description: "Forcepoint Web Security"

--- a/packages/fortinet_forticlient/changelog.yml
+++ b/packages/fortinet_forticlient/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/fortinet_forticlient/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_forticlient/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -71,6 +71,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_forticlient/manifest.yml
+++ b/packages/fortinet_forticlient/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_forticlient
 title: Fortinet FortiClient Logs
-version: "1.6.0"
+version: "1.7.0"
 description: Collect logs from Fortinet FortiClient instances with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/fortinet_fortiedr/changelog.yml
+++ b/packages/fortinet_fortiedr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/fortinet_fortiedr/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortiedr/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -235,6 +235,9 @@ processors:
         - _temp_
       ignore_failure: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortiedr/manifest.yml
+++ b/packages/fortinet_fortiedr/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortiedr
 title: Fortinet FortiEDR Logs
-version: "1.7.0"
+version: "1.8.0"
 description: Collect logs from Fortinet FortiEDR instances with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "1.13.0"
   changes:
     - description: Update package to package-spec 2.7.0.

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -571,5 +571,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/event.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/event.yml
@@ -261,5 +261,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/traffic.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/traffic.yml
@@ -228,5 +228,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/utm.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/utm.yml
@@ -382,5 +382,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: "1.13.0"
+version: "1.14.0"
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "2.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_antispam.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_antispam.yml
@@ -102,3 +102,10 @@ processors:
       field: temp.endpoint
       target_field: fortinet_fortimail.log.endpoint
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_antivirus.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_antivirus.yml
@@ -57,3 +57,10 @@ processors:
       field: temp.session_id
       target_field: fortinet_fortimail.log.session_id
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_encryption.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_encryption.yml
@@ -53,3 +53,10 @@ processors:
       value: '{{{temp.subject}}}'
       allow_duplicates: false
       if: ctx.temp?.subject != null
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_history.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_history.yml
@@ -232,3 +232,10 @@ processors:
       field: temp.read_status
       target_field: fortinet_fortimail.log.read_status
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_mail.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_mail.yml
@@ -132,3 +132,10 @@ processors:
   - lowercase:
       field: network.protocol
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_system.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_system.yml
@@ -172,3 +172,10 @@ processors:
   - lowercase:
       field: network.protocol
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/fortinet_fortimail/manifest.yml
+++ b/packages/fortinet_fortimail/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortimail
 title: Fortinet FortiMail
-version: "2.3.0"
+version: "2.4.0"
 description: Collect logs from Fortinet FortiMail instances with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.22.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "2.21.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -402,5 +402,8 @@ processors:
         drop(ctx);
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/cloudrun_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/cloudrun_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -51,9 +51,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
-      field: error.message
-      value: '{{ _ingest.on_failure_message }}'
-  - append:
       field: event.kind
       value: pipeline_error
-      allow_duplicates: false
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/compute/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/compute/elasticsearch/ingest_pipeline/default.yml
@@ -83,5 +83,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/dataproc/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/dataproc/elasticsearch/ingest_pipeline/default.yml
@@ -96,5 +96,8 @@ processors:
     
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -371,5 +371,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/firestore/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/firestore/elasticsearch/ingest_pipeline/default.yml
@@ -19,5 +19,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -406,5 +406,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/gke/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/gke/elasticsearch/ingest_pipeline/default.yml
@@ -167,5 +167,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/loadbalancing_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/loadbalancing_logs/elasticsearch/ingest_pipeline/default.yml
@@ -211,5 +211,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/loadbalancing_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -123,5 +123,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/pubsub/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/pubsub/elasticsearch/ingest_pipeline/default.yml
@@ -203,5 +203,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/redis/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/redis/elasticsearch/ingest_pipeline/default.yml
@@ -127,5 +127,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/storage/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/storage/elasticsearch/ingest_pipeline/default.yml
@@ -43,5 +43,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
@@ -367,5 +367,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.21.0"
+version: "2.22.0"
 release: ga
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "1.12.2"
   changes:
     - description: Fix documentation for audit log prerequisites

--- a/packages/github/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/github/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -178,5 +178,8 @@ processors:
       handleMap(ctx);
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/github/data_stream/code_scanning/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/github/data_stream/code_scanning/elasticsearch/ingest_pipeline/default.yml
@@ -274,5 +274,8 @@ processors:
       handleMap(ctx);
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/github/data_stream/dependabot/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/github/data_stream/dependabot/elasticsearch/ingest_pipeline/default.yml
@@ -311,5 +311,8 @@ processors:
       handleMap(ctx);
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/github/data_stream/issues/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/github/data_stream/issues/elasticsearch/ingest_pipeline/default.yml
@@ -235,6 +235,9 @@ processors:
       }
       handleMap(ctx);
 on_failure:
+- set:
+    field: event.kind
+    value: pipeline_error
 - append:
     field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/github/data_stream/secret_scanning/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/github/data_stream/secret_scanning/elasticsearch/ingest_pipeline/default.yml
@@ -292,5 +292,8 @@ processors:
       handleMap(ctx);
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: "1.12.2"
+version: "1.13.0"
 release: ga
 description: Collect logs from GitHub with Elastic Agent.
 type: integration

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "2.9.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -794,5 +794,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/google_workspace/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -1037,6 +1037,9 @@ processors:
           }
           dropEmptyFields(ctx);
 on_failure:
-- append:
-    field: error.message
-    value: '{{{ _ingest.on_failure_message }}}'
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
@@ -272,5 +272,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
@@ -304,5 +304,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
@@ -262,5 +262,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/google_workspace/data_stream/rules/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/rules/elasticsearch/ingest_pipeline/default.yml
@@ -528,6 +528,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
@@ -185,5 +185,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
@@ -180,5 +180,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.9.0"
+version: "2.10.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Modify darktrace, f5, f5_bigip, fim, fireeye, forcepoint_web, fortinet_forticlient, fortinet_fortiedr, fortinet_fortigate, fortinet_fortimail, gcp, github and google_workspace  to correctly set `event.kind` for pipeline errors and ensure `error.message` is an array.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6582

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
