### PR TITLE
jamf_compliance_reporter: ensure event.kind is correctly set for pipeline errors

### DIFF
--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6615
 - version: "1.2.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -48,5 +48,8 @@ processors:
         dropEmptyFields(ctx);
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_app_metrics.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_app_metrics.yml
@@ -138,6 +138,9 @@ processors:
         ctx.host.cpu = new HashMap();
         ctx.host.cpu.usage = Math.round(ctx.json?.app_metric_info?.cpu_percentage *10) / 1000.0;
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audio_video_device_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audio_video_device_event.yml
@@ -38,3 +38,10 @@ processors:
       field: json.audio_video_device_info.device_status
       target_field: jamf_compliance_reporter.log.audio_video_device_info.device_status
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
@@ -359,5 +359,8 @@ processors:
       if: ctx.event?.action == 'aue_wait4'
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit_class_verification_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit_class_verification_event.yml
@@ -28,3 +28,10 @@ processors:
       field: json.audit_class_verification_info.status_str
       target_field: jamf_compliance_reporter.log.audit_class_verification_info.status_str
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_accept.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_accept.yml
@@ -58,3 +58,10 @@ processors:
         ctx.jamf_compliance_reporter.log.socket.unix.family = map.get(ctx.json.inet_family);
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_arguments.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_arguments.yml
@@ -9,3 +9,10 @@ processors:
       ignore_failure: true
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_auth.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_auth.yml
@@ -7,3 +7,10 @@ processors:
       field: json.texts
       target_field: jamf_compliance_reporter.log.texts
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_bind_and_aue_connect.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_bind_and_aue_connect.yml
@@ -89,3 +89,10 @@ processors:
         ctx.jamf_compliance_reporter.log.socket.inet.family = map.get(ctx.json.inet_family);
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_chdir.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_chdir.yml
@@ -68,3 +68,10 @@ processors:
       source: |
         int temp = (int)ctx.json?.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_chroot.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_chroot.yml
@@ -70,3 +70,10 @@ processors:
       source: |
         int temp = (int)ctx.json?.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_execve.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_execve.yml
@@ -143,3 +143,10 @@ processors:
       source: |
         int temp = (int)ctx.json?.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_exit.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_exit.yml
@@ -20,3 +20,10 @@ processors:
       type: string
       ignore_missing: true
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_fork.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_fork.yml
@@ -16,3 +16,10 @@ processors:
             value: '{{{_ingest.on_failure_message}}}'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_kill.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_kill.yml
@@ -11,3 +11,10 @@ processors:
       name: '{{ IngestPipeline "pipeline_process_object" }}'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_listen.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_listen.yml
@@ -11,3 +11,10 @@ processors:
       name: '{{ IngestPipeline "pipeline_exec_chain_child_object" }}'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_logout.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_logout.yml
@@ -5,3 +5,10 @@ processors:
       name: '{{ IngestPipeline "pipeline_exec_chain_child_object" }}'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_mount.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_mount.yml
@@ -80,3 +80,10 @@ processors:
       source: |
         int temp = (int)ctx.json?.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_pidfortask.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_pidfortask.yml
@@ -19,3 +19,10 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_posix_spawn.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_posix_spawn.yml
@@ -45,3 +45,10 @@ processors:
         }
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_ptrace.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_ptrace.yml
@@ -29,3 +29,10 @@ processors:
       name: '{{ IngestPipeline "pipeline_exec_chain_child_object" }}'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_remove_from_group_and_aue_mac_set_proc.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_remove_from_group_and_aue_mac_set_proc.yml
@@ -9,3 +9,10 @@ processors:
       name: '{{ IngestPipeline "pipeline_exec_chain_child_object" }}'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_session.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_session.yml
@@ -19,3 +19,10 @@ processors:
       type: string
       ignore_missing: true
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_setpriority.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_setpriority.yml
@@ -24,3 +24,10 @@ processors:
       type: string
       ignore_missing: true
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_socketpair.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_socketpair.yml
@@ -21,3 +21,10 @@ processors:
       type: string
       ignore_missing: true
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_ssauthint.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_ssauthint.yml
@@ -17,3 +17,10 @@ processors:
       field: json.arguments
       target_field: jamf_compliance_reporter.log.arguments.flattened
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_taskforpid.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_taskforpid.yml
@@ -21,3 +21,10 @@ processors:
             value: '{{{_ingest.on_failure_message}}}'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_process_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_tasknameforpid.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_tasknameforpid.yml
@@ -25,3 +25,10 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_unmount.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_unmount.yml
@@ -70,3 +70,10 @@ processors:
       source: |
         int temp = (int)ctx.json?.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_wait4.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_wait4.yml
@@ -12,3 +12,10 @@ processors:
             value: '{{{_ingest.on_failure_message}}}'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_compliance_reporter_tamper_event_and_file_event_info.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_compliance_reporter_tamper_event_and_file_event_info.yml
@@ -231,3 +231,10 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_event.yml
@@ -124,6 +124,9 @@ processors:
       name: '{{ IngestPipeline "pipeline_xprotect_event_log" }}'
       if: ctx.event?.action == 'xprotect_event_log'
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_exec_chain_child_object.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_exec_chain_child_object.yml
@@ -18,3 +18,10 @@ processors:
       field: json.exec_chain_child.parent_uuid
       target_field: jamf_compliance_reporter.log.exec_chain_child.parent.uuid
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_gatekeeper_info_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_gatekeeper_info_event.yml
@@ -27,3 +27,10 @@ processors:
       field: json.event_attributes.version
       target_field: jamf_compliance_reporter.log.event_attributes.version
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_gatekeeper_manual_overrides.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_gatekeeper_manual_overrides.yml
@@ -41,3 +41,10 @@ processors:
       field: json.event_attributes.path
       target_field: jamf_compliance_reporter.log.event_attributes.path
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_gatekeeper_quarantine_log.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_gatekeeper_quarantine_log.yml
@@ -72,3 +72,10 @@ processors:
       field: json.event_attributes.path
       target_field: jamf_compliance_reporter.log.event_attributes.path
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_hardware_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_hardware_event.yml
@@ -84,3 +84,10 @@ processors:
       field: json.hardware_event_info.device_status
       target_field: jamf_compliance_reporter.log.hardware_event_info.device.status
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_identity_object.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_identity_object.yml
@@ -37,3 +37,10 @@ processors:
       type: string
       ignore_missing: true
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_license_info_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_license_info_event.yml
@@ -43,3 +43,10 @@ processors:
       field: json.ComplianceReporter_license_info.version
       target_field: jamf_compliance_reporter.log.compliancereporter_license_info.version
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_preference_list_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_preference_list_event.yml
@@ -139,3 +139,10 @@ processors:
       field: json.event_attributes.Version
       target_field: jamf_compliance_reporter.log.event_attributes.version
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_print_event_information.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_print_event_information.yml
@@ -67,3 +67,10 @@ processors:
       if: ctx.jamf_compliance_reporter?.log?.event_attributes?.job?.user != null
       allow_duplicates: false
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_process_object.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_process_object.yml
@@ -144,3 +144,10 @@ processors:
       if: ctx.jamf_compliance_reporter?.log?.process?.user?.name != null
       allow_duplicates: false
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_prohibited_app_blocked.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_prohibited_app_blocked.yml
@@ -266,3 +266,10 @@ processors:
         for (Map.Entry m : ctx.json?.args.entrySet()) {
           ctx.process?.args.add(m.getValue());
         }
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_signal_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_signal_event.yml
@@ -10,3 +10,10 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_unified_log_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_unified_log_event.yml
@@ -146,3 +146,10 @@ processors:
       type: string
       ignore_missing: true
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_xprotect_definitions_version_info.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_xprotect_definitions_version_info.yml
@@ -25,3 +25,10 @@ processors:
       field: json.event_attributes.SourceVersion
       target_field: jamf_compliance_reporter.log.event_attributes.source_version
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_xprotect_event_log.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_xprotect_event_log.yml
@@ -281,3 +281,10 @@ processors:
       type: string
       ignore_missing: true
       ignore_failure: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/jamf_compliance_reporter/manifest.yml
+++ b/packages/jamf_compliance_reporter/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: jamf_compliance_reporter
 title: Jamf Compliance Reporter
-version: "1.2.0"
+version: "1.3.0"
 license: basic
 description: Collect logs from Jamf Compliance Reporter with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Modify jamf_compliance_reporter to correctly set `event.kind` for pipeline errors and ensure `error.message` is an array.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6582

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
