### PR TITLE
[zeek] Ensure event.kind is correctly set for pipeline errors

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.45.2"
+  changes:
+    - description: Add AWS EMR metrics dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6606
 - version: "1.45.1"
   changes:
     - description: Add AWS API Gateway dashboard.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.45.1"
+  changes:
+    - description: Add AWS API Gateway dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6476
 - version: "1.45.0"
   changes:
     - description: Add AWS EMR metrics data stream.

--- a/packages/aws/kibana/dashboard/aws-98f85120-0ea4-11ee-9c37-e55025c0278a.json
+++ b/packages/aws/kibana/dashboard/aws-98f85120-0ea4-11ee-9c37-e55025c0278a.json
@@ -1,0 +1,2286 @@
+{
+    "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"939bbdd4-5843-4f44-bd0a-cc15f4f4efe8\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":false,\"width\":\"medium\",\"explicitInput\":{\"id\":\"939bbdd4-5843-4f44-bd0a-cc15f4f4efe8\",\"fieldName\":\"cloud.region\",\"title\":\"AWS Region\",\"enhancements\":{}}},\"a5ba1a06-889c-4758-b15b-b22263411798\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":false,\"width\":\"medium\",\"explicitInput\":{\"id\":\"a5ba1a06-889c-4758-b15b-b22263411798\",\"fieldName\":\"aws.dimensions.JobFlowId\",\"title\":\"Job Flow ID\",\"enhancements\":{}}}}"
+        },
+        "description": "Overview of AWS EMR Metrics",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "HDFSUtilization",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.HDFSUtilization.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "layerType": "data",
+                                "metricAccessor": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                "showBar": false
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "927fa50c-bf7d-4f7b-8679-518aa7f51262",
+                    "w": 6,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "927fa50c-bf7d-4f7b-8679-518aa7f51262",
+                "title": "HDFS Utilization",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Apps Failed",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.AppsFailed.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "layerType": "data",
+                                "metricAccessor": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "ef158595-61d2-4e7e-a55a-b6fd0fa8214d",
+                    "w": 6,
+                    "x": 6,
+                    "y": 0
+                },
+                "panelIndex": "ef158595-61d2-4e7e-a55a-b6fd0fa8214d",
+                "title": "Apps Failed",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.elasticmapreduce.metrics.S3BytesRead.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.S3BytesRead.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "c3ce6c26-e55a-44e2-907c-1d2aab3529b7",
+                    "w": 36,
+                    "x": 12,
+                    "y": 0
+                },
+                "panelIndex": "c3ce6c26-e55a-44e2-907c-1d2aab3529b7",
+                "title": "S3 Bytes Read",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "YARN Memory Available Percentage",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.YARNMemoryAvailablePercentage.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "layerType": "data",
+                                "metricAccessor": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "9e85d781-6cf2-4e95-ac2f-385711c74765",
+                    "w": 6,
+                    "x": 0,
+                    "y": 5
+                },
+                "panelIndex": "9e85d781-6cf2-4e95-ac2f-385711c74765",
+                "title": "YARN Memory Available Percentage",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Apps Completed",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.AppsCompleted.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "layerType": "data",
+                                "metricAccessor": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "53377d5a-7df3-4634-9300-293ce2fbbd64",
+                    "w": 6,
+                    "x": 6,
+                    "y": 5
+                },
+                "panelIndex": "53377d5a-7df3-4634-9300-293ce2fbbd64",
+                "title": "Apps Completed",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Container Pending Ratio",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.ContainerPendingRatio.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "layerType": "data",
+                                "metricAccessor": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "19d0e843-0006-4b64-b917-42e38c5f7e75",
+                    "w": 6,
+                    "x": 0,
+                    "y": 10
+                },
+                "panelIndex": "19d0e843-0006-4b64-b917-42e38c5f7e75",
+                "title": "Container Pending Ratio",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Apps Killed",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.AppsKilled.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "layerType": "data",
+                                "metricAccessor": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "b9e76ae0-d057-4ff7-900d-aee86b4b32ec",
+                    "w": 6,
+                    "x": 6,
+                    "y": 10
+                },
+                "panelIndex": "b9e76ae0-d057-4ff7-900d-aee86b4b32ec",
+                "title": "Apps Killed",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.elasticmapreduce.metrics.S3BytesWritten.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.S3BytesWritten.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "fc0a7c7e-c30a-4777-b344-39bf15c70c45",
+                    "w": 24,
+                    "x": 0,
+                    "y": 15
+                },
+                "panelIndex": "fc0a7c7e-c30a-4777-b344-39bf15c70c45",
+                "title": "S3 Bytes Written",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.elasticmapreduce.metrics.HDFSBytesWritten.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.HDFSBytesWritten.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "dc9d2105-5101-498d-9b75-44e95382c477",
+                    "w": 24,
+                    "x": 24,
+                    "y": 15
+                },
+                "panelIndex": "dc9d2105-5101-498d-9b75-44e95382c477",
+                "title": "HDFS Bytes Written",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.elasticmapreduce.metrics.HDFSBytesRead.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.HDFSBytesRead.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "c16dc181-d15d-4301-9bf3-95dddd75a64b",
+                    "w": 24,
+                    "x": 0,
+                    "y": 30
+                },
+                "panelIndex": "c16dc181-d15d-4301-9bf3-95dddd75a64b",
+                "title": "HDFS Bytes Read",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.elasticmapreduce.metrics.MemoryTotalMB.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.MemoryTotalMB.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "032f8c5d-1580-4b7f-b3f2-fc075533a51b",
+                    "w": 24,
+                    "x": 24,
+                    "y": 30
+                },
+                "panelIndex": "032f8c5d-1580-4b7f-b3f2-fc075533a51b",
+                "title": "Memory Total MB",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.elasticmapreduce.metrics.CoreNodesRunning.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.CoreNodesRunning.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "3832f35d-690e-4ec8-bcd8-6c808b1fc277",
+                    "w": 24,
+                    "x": 0,
+                    "y": 45
+                },
+                "panelIndex": "3832f35d-690e-4ec8-bcd8-6c808b1fc277",
+                "title": "Core Nodes Running",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.elasticmapreduce.metrics.TotalNodesRunning.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.TotalNodesRunning.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "fbe53db9-c526-4b2c-a2d5-0a76a301d466",
+                    "w": 24,
+                    "x": 24,
+                    "y": 45
+                },
+                "panelIndex": "fbe53db9-c526-4b2c-a2d5-0a76a301d466",
+                "title": "Total Nodes Running",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.elasticmapreduce.metrics.TaskNodesRunning.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.TaskNodesRunning.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "d2541523-f58c-485a-9bea-0899d9eb95b4",
+                    "w": 24,
+                    "x": 0,
+                    "y": 60
+                },
+                "panelIndex": "d2541523-f58c-485a-9bea-0899d9eb95b4",
+                "title": "Task Nodes Running",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.elasticmapreduce.metrics.MemoryAvailableMB.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.MemoryAvailableMB.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "1f421921-3327-443f-8bfc-01645f331bdc",
+                    "w": 24,
+                    "x": 24,
+                    "y": 60
+                },
+                "panelIndex": "1f421921-3327-443f-8bfc-01645f331bdc",
+                "title": "Memory Available MB",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.elasticmapreduce.metrics.MemoryReservedMB.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.MemoryReservedMB.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "curveType": "LINEAR",
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "a1f95551-a9a4-44c6-afa2-3b43e23df9e4",
+                    "w": 24,
+                    "x": 0,
+                    "y": 75
+                },
+                "panelIndex": "a1f95551-a9a4-44c6-afa2-3b43e23df9e4",
+                "title": "Memory Reserved MB",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "775c326f-9e29-49ea-a6f9-aab9fb4ee280": {
+                                            "columnOrder": [
+                                                "2aaf65a9-0922-4200-9704-740e9132668e",
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109",
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                            ],
+                                            "columns": {
+                                                "2aaf65a9-0922-4200-9704-740e9132668e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.JobFlowId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.JobFlowId"
+                                                },
+                                                "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.elasticmapreduce.metrics.MemoryAllocatedMB.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.elasticmapreduce.metrics.MemoryAllocatedMB.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f1c1b021-d02d-4e4a-bd4d-7b8a5a10adb6"
+                                        ],
+                                        "layerId": "775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2aaf65a9-0922-4200-9704-740e9132668e",
+                                        "xAccessor": "83ef5d76-6b8c-49e6-b6c6-e0e3604d6109"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "1785d7d7-8a43-4a93-a550-1590b005b31c",
+                    "w": 24,
+                    "x": 24,
+                    "y": 75
+                },
+                "panelIndex": "1785d7d7-8a43-4a93-a550-1590b005b31c",
+                "title": "Memory Allocated MB",
+                "type": "lens",
+                "version": "8.7.1"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Metrics AWS] EMR Overview",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-06-19T14:28:24.447Z",
+    "id": "aws-98f85120-0ea4-11ee-9c37-e55025c0278a",
+    "migrationVersion": {
+        "dashboard": "8.7.0"
+    },
+    "references": [
+        {
+            "id": "metrics-*",
+            "name": "927fa50c-bf7d-4f7b-8679-518aa7f51262:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "ef158595-61d2-4e7e-a55a-b6fd0fa8214d:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "c3ce6c26-e55a-44e2-907c-1d2aab3529b7:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "9e85d781-6cf2-4e95-ac2f-385711c74765:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "53377d5a-7df3-4634-9300-293ce2fbbd64:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "19d0e843-0006-4b64-b917-42e38c5f7e75:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "b9e76ae0-d057-4ff7-900d-aee86b4b32ec:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "fc0a7c7e-c30a-4777-b344-39bf15c70c45:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "dc9d2105-5101-498d-9b75-44e95382c477:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "c16dc181-d15d-4301-9bf3-95dddd75a64b:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "032f8c5d-1580-4b7f-b3f2-fc075533a51b:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "3832f35d-690e-4ec8-bcd8-6c808b1fc277:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "fbe53db9-c526-4b2c-a2d5-0a76a301d466:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "d2541523-f58c-485a-9bea-0899d9eb95b4:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "1f421921-3327-443f-8bfc-01645f331bdc:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a1f95551-a9a4-44c6-afa2-3b43e23df9e4:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "1785d7d7-8a43-4a93-a550-1590b005b31c:indexpattern-datasource-layer-775c326f-9e29-49ea-a6f9-aab9fb4ee280",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_939bbdd4-5843-4f44-bd0a-cc15f4f4efe8:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_a5ba1a06-889c-4758-b15b-b22263411798:optionsListDataView",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "dashboard"
+}

--- a/packages/aws/kibana/dashboard/aws-a4482820-03aa-11ee-84d4-7f15bab18041.json
+++ b/packages/aws/kibana/dashboard/aws-a4482820-03aa-11ee-84d4-7f15bab18041.json
@@ -1,0 +1,2904 @@
+{
+    "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"9edfaf7a-7867-4413-84df-4648537b365a\":{\"order\":0,\"width\":\"medium\",\"grow\":false,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"cloud.region\",\"title\":\"AWS Region\",\"id\":\"9edfaf7a-7867-4413-84df-4648537b365a\",\"enhancements\":{}}}}"
+        },
+        "description": "Overview of AWS API Gateway Metrics",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ff2c6fd1-df0b-409d-a7e7-033a129edba3": {
+                                            "columnOrder": [
+                                                "f87d2d15-ecd3-4cf3-85e5-911976418f35",
+                                                "21bcc448-3bbc-4949-8471-40e126445935",
+                                                "11242c77-c1e8-482f-a8ab-d14342367450"
+                                            ],
+                                            "columns": {
+                                                "11242c77-c1e8-482f-a8ab-d14342367450": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of aws.apigateway.metrics.Count.sum",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.Count.sum"
+                                                },
+                                                "21bcc448-3bbc-4949-8471-40e126445935": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f87d2d15-ecd3-4cf3-85e5-911976418f35": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "11242c77-c1e8-482f-a8ab-d14342367450",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiName"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "11242c77-c1e8-482f-a8ab-d14342367450"
+                                        ],
+                                        "layerId": "ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "f87d2d15-ecd3-4cf3-85e5-911976418f35",
+                                        "xAccessor": "21bcc448-3bbc-4949-8471-40e126445935"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "36a3594d-c18b-4d09-ae87-7561750822ae",
+                    "w": 16,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "36a3594d-c18b-4d09-ae87-7561750822ae",
+                "title": "[REST] Count",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-f9ae930c-999d-4b82-a9ce-01d6237fa03c",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "f9ae930c-999d-4b82-a9ce-01d6237fa03c": {
+                                            "columnOrder": [
+                                                "e4c799b1-e347-44b0-808c-65f88416a451",
+                                                "be99357c-3cd9-43b9-a2d8-5b5d7756b2ba",
+                                                "ac152c6a-33c5-41c3-9b8c-44521c17fa56"
+                                            ],
+                                            "columns": {
+                                                "ac152c6a-33c5-41c3-9b8c-44521c17fa56": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.apigateway.metrics.4XXError.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.4XXError.sum"
+                                                },
+                                                "be99357c-3cd9-43b9-a2d8-5b5d7756b2ba": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "e4c799b1-e347-44b0-808c-65f88416a451": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "ac152c6a-33c5-41c3-9b8c-44521c17fa56",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiName"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "ac152c6a-33c5-41c3-9b8c-44521c17fa56"
+                                        ],
+                                        "layerId": "f9ae930c-999d-4b82-a9ce-01d6237fa03c",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "e4c799b1-e347-44b0-808c-65f88416a451",
+                                        "xAccessor": "be99357c-3cd9-43b9-a2d8-5b5d7756b2ba"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "b2ece1d0-652f-481e-9dec-ae411c897a44",
+                    "w": 16,
+                    "x": 16,
+                    "y": 0
+                },
+                "panelIndex": "b2ece1d0-652f-481e-9dec-ae411c897a44",
+                "title": "[REST] 4XX Error",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-48d7bfc9-ad80-47ac-974e-a265b9c3af45",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "48d7bfc9-ad80-47ac-974e-a265b9c3af45": {
+                                            "columnOrder": [
+                                                "b20f70ed-a07d-4597-bde9-43ff24a2732f",
+                                                "224712a8-acca-4be7-b9bb-6ee35d71ce2f",
+                                                "90c328ce-f5c8-48a0-8545-57ea1ec6d7fe"
+                                            ],
+                                            "columns": {
+                                                "224712a8-acca-4be7-b9bb-6ee35d71ce2f": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "90c328ce-f5c8-48a0-8545-57ea1ec6d7fe": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Median of aws.apigateway.metrics.5XXError.sum",
+                                                    "operationType": "median",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.5XXError.sum"
+                                                },
+                                                "b20f70ed-a07d-4597-bde9-43ff24a2732f": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "90c328ce-f5c8-48a0-8545-57ea1ec6d7fe",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiName"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "90c328ce-f5c8-48a0-8545-57ea1ec6d7fe"
+                                        ],
+                                        "layerId": "48d7bfc9-ad80-47ac-974e-a265b9c3af45",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "b20f70ed-a07d-4597-bde9-43ff24a2732f",
+                                        "xAccessor": "224712a8-acca-4be7-b9bb-6ee35d71ce2f"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "e970e1a1-b243-46e0-b200-2cf787f26561",
+                    "w": 16,
+                    "x": 32,
+                    "y": 0
+                },
+                "panelIndex": "e970e1a1-b243-46e0-b200-2cf787f26561",
+                "title": "[REST] 5XX Error",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiName"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.apigateway.metrics.Latency.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "ms"
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.Latency.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "8b56a477-3e09-4bb0-94c3-9add2e443772",
+                    "w": 24,
+                    "x": 0,
+                    "y": 13
+                },
+                "panelIndex": "8b56a477-3e09-4bb0-94c3-9add2e443772",
+                "title": "[REST] Latency",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiName"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.apigateway.metrics.IntegrationLatency.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "ms"
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.IntegrationLatency.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "51e609da-7bb4-4579-843f-88e9748e0982",
+                    "w": 24,
+                    "x": 24,
+                    "y": 13
+                },
+                "panelIndex": "51e609da-7bb4-4579-843f-88e9748e0982",
+                "title": "[REST] Integration Latency",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiName"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.apigateway.metrics.CacheHitCount.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.CacheHitCount.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "eb48842e-d380-4291-aa03-47960594babd",
+                    "w": 24,
+                    "x": 0,
+                    "y": 26
+                },
+                "panelIndex": "eb48842e-d380-4291-aa03-47960594babd",
+                "title": "[REST] Cache Hit Count",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiName"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.apigateway.metrics.CacheMissCount.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.CacheMissCount.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "a1ef019a-60b1-41d9-845c-cecc5f0450c5",
+                    "w": 24,
+                    "x": 24,
+                    "y": 26
+                },
+                "panelIndex": "a1ef019a-60b1-41d9-845c-cecc5f0450c5",
+                "title": "[REST] Cache Miss Count",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ff2c6fd1-df0b-409d-a7e7-033a129edba3": {
+                                            "columnOrder": [
+                                                "f87d2d15-ecd3-4cf3-85e5-911976418f35",
+                                                "21bcc448-3bbc-4949-8471-40e126445935",
+                                                "11242c77-c1e8-482f-a8ab-d14342367450"
+                                            ],
+                                            "columns": {
+                                                "11242c77-c1e8-482f-a8ab-d14342367450": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of aws.apigateway.metrics.Count.sum",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.Count.sum"
+                                                },
+                                                "21bcc448-3bbc-4949-8471-40e126445935": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f87d2d15-ecd3-4cf3-85e5-911976418f35": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "11242c77-c1e8-482f-a8ab-d14342367450",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "11242c77-c1e8-482f-a8ab-d14342367450"
+                                        ],
+                                        "layerId": "ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "f87d2d15-ecd3-4cf3-85e5-911976418f35",
+                                        "xAccessor": "21bcc448-3bbc-4949-8471-40e126445935"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "070fab3f-bc1d-4ac3-830a-97a86f9a277f",
+                    "w": 24,
+                    "x": 0,
+                    "y": 39
+                },
+                "panelIndex": "070fab3f-bc1d-4ac3-830a-97a86f9a277f",
+                "title": "[HTTP] Count",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-da960427-d6bb-4f17-a5ac-9be25356186a",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "da960427-d6bb-4f17-a5ac-9be25356186a": {
+                                            "columnOrder": [
+                                                "c6eaba88-8446-4a94-b32b-e0f6cc784fc2",
+                                                "7af933af-8c3e-47b8-9e15-9cd504966672",
+                                                "53bb15bf-1d19-4aaa-be68-5015b194e60b"
+                                            ],
+                                            "columns": {
+                                                "53bb15bf-1d19-4aaa-be68-5015b194e60b": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.apigateway.metrics.DataProcessed.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.DataProcessed.avg"
+                                                },
+                                                "7af933af-8c3e-47b8-9e15-9cd504966672": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "c6eaba88-8446-4a94-b32b-e0f6cc784fc2": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "53bb15bf-1d19-4aaa-be68-5015b194e60b",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "53bb15bf-1d19-4aaa-be68-5015b194e60b"
+                                        ],
+                                        "layerId": "da960427-d6bb-4f17-a5ac-9be25356186a",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c6eaba88-8446-4a94-b32b-e0f6cc784fc2",
+                                        "xAccessor": "7af933af-8c3e-47b8-9e15-9cd504966672"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "de3fd32b-c351-4b26-8c9d-84ce99ed24b5",
+                    "w": 24,
+                    "x": 24,
+                    "y": 39
+                },
+                "panelIndex": "de3fd32b-c351-4b26-8c9d-84ce99ed24b5",
+                "title": "[HTTP] Data Processed",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ff2c6fd1-df0b-409d-a7e7-033a129edba3": {
+                                            "columnOrder": [
+                                                "f87d2d15-ecd3-4cf3-85e5-911976418f35",
+                                                "21bcc448-3bbc-4949-8471-40e126445935",
+                                                "11242c77-c1e8-482f-a8ab-d14342367450"
+                                            ],
+                                            "columns": {
+                                                "11242c77-c1e8-482f-a8ab-d14342367450": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.apigateway.metrics.Latency.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "ms"
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.Latency.avg"
+                                                },
+                                                "21bcc448-3bbc-4949-8471-40e126445935": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f87d2d15-ecd3-4cf3-85e5-911976418f35": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "11242c77-c1e8-482f-a8ab-d14342367450",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "11242c77-c1e8-482f-a8ab-d14342367450"
+                                        ],
+                                        "layerId": "ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "f87d2d15-ecd3-4cf3-85e5-911976418f35",
+                                        "xAccessor": "21bcc448-3bbc-4949-8471-40e126445935"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "4979b1bc-45c5-4164-9887-498b4f893513",
+                    "w": 24,
+                    "x": 0,
+                    "y": 51
+                },
+                "panelIndex": "4979b1bc-45c5-4164-9887-498b4f893513",
+                "title": "[HTTP] Latency",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ff2c6fd1-df0b-409d-a7e7-033a129edba3": {
+                                            "columnOrder": [
+                                                "f87d2d15-ecd3-4cf3-85e5-911976418f35",
+                                                "21bcc448-3bbc-4949-8471-40e126445935",
+                                                "11242c77-c1e8-482f-a8ab-d14342367450"
+                                            ],
+                                            "columns": {
+                                                "11242c77-c1e8-482f-a8ab-d14342367450": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.apigateway.metrics.IntegrationLatency.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "ms"
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.IntegrationLatency.avg"
+                                                },
+                                                "21bcc448-3bbc-4949-8471-40e126445935": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f87d2d15-ecd3-4cf3-85e5-911976418f35": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "11242c77-c1e8-482f-a8ab-d14342367450",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "11242c77-c1e8-482f-a8ab-d14342367450"
+                                        ],
+                                        "layerId": "ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "f87d2d15-ecd3-4cf3-85e5-911976418f35",
+                                        "xAccessor": "21bcc448-3bbc-4949-8471-40e126445935"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "3aa94e06-0dfe-4ae2-93e8-be0627ab841e",
+                    "w": 24,
+                    "x": 24,
+                    "y": 51
+                },
+                "panelIndex": "3aa94e06-0dfe-4ae2-93e8-be0627ab841e",
+                "title": "[HTTP] Integration Latency",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-5e9706cb-90ee-4f08-af6a-f2a8048628af",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "5e9706cb-90ee-4f08-af6a-f2a8048628af": {
+                                            "columnOrder": [
+                                                "c0d552ba-af46-4959-a9f9-be4bfcb553ec",
+                                                "688be07c-0c70-400a-a931-6abee54ce8e6",
+                                                "cd10361b-ce2e-454c-8612-6be186ffefac"
+                                            ],
+                                            "columns": {
+                                                "688be07c-0c70-400a-a931-6abee54ce8e6": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "c0d552ba-af46-4959-a9f9-be4bfcb553ec": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "cd10361b-ce2e-454c-8612-6be186ffefac",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                },
+                                                "cd10361b-ce2e-454c-8612-6be186ffefac": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Median of aws.apigateway.metrics.4xx.sum",
+                                                    "operationType": "median",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.4xx.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "cd10361b-ce2e-454c-8612-6be186ffefac"
+                                        ],
+                                        "layerId": "5e9706cb-90ee-4f08-af6a-f2a8048628af",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c0d552ba-af46-4959-a9f9-be4bfcb553ec",
+                                        "xAccessor": "688be07c-0c70-400a-a931-6abee54ce8e6"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "dc9f0691-ccda-4403-8158-c6191d5090eb",
+                    "w": 24,
+                    "x": 0,
+                    "y": 64
+                },
+                "panelIndex": "dc9f0691-ccda-4403-8158-c6191d5090eb",
+                "title": "[HTTP] 4XX Error",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-da960427-d6bb-4f17-a5ac-9be25356186a",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "da960427-d6bb-4f17-a5ac-9be25356186a": {
+                                            "columnOrder": [
+                                                "c6eaba88-8446-4a94-b32b-e0f6cc784fc2",
+                                                "7af933af-8c3e-47b8-9e15-9cd504966672",
+                                                "53bb15bf-1d19-4aaa-be68-5015b194e60b"
+                                            ],
+                                            "columns": {
+                                                "53bb15bf-1d19-4aaa-be68-5015b194e60b": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Median of aws.apigateway.metrics.5xx.sum",
+                                                    "operationType": "median",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.5xx.sum"
+                                                },
+                                                "7af933af-8c3e-47b8-9e15-9cd504966672": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "c6eaba88-8446-4a94-b32b-e0f6cc784fc2": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "53bb15bf-1d19-4aaa-be68-5015b194e60b",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "53bb15bf-1d19-4aaa-be68-5015b194e60b"
+                                        ],
+                                        "layerId": "da960427-d6bb-4f17-a5ac-9be25356186a",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c6eaba88-8446-4a94-b32b-e0f6cc784fc2",
+                                        "xAccessor": "7af933af-8c3e-47b8-9e15-9cd504966672"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "98f24465-f278-4e2c-93db-9112014a449e",
+                    "w": 24,
+                    "x": 24,
+                    "y": 64
+                },
+                "panelIndex": "98f24465-f278-4e2c-93db-9112014a449e",
+                "title": "[HTTP] 5XX Error",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.apigateway.metrics.ConnectCount.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.ConnectCount.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "bfa3b44b-89ba-43e4-99b7-02ab03bd0a72",
+                    "w": 24,
+                    "x": 0,
+                    "y": 77
+                },
+                "panelIndex": "bfa3b44b-89ba-43e4-99b7-02ab03bd0a72",
+                "title": "[WebSocket] Connect Count",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.apigateway.metrics.MessageCount.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.MessageCount.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "bf18dbe6-4dcb-4145-a699-bdd859a7ba99",
+                    "w": 24,
+                    "x": 24,
+                    "y": 77
+                },
+                "panelIndex": "bf18dbe6-4dcb-4145-a699-bdd859a7ba99",
+                "title": "[WebSocket] Message Count",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-56b0bb53-472a-48f9-bc07-b3c340f5a74e",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "56b0bb53-472a-48f9-bc07-b3c340f5a74e": {
+                                            "columnOrder": [
+                                                "dc78b53d-e3d1-442e-a751-07556c6f9656",
+                                                "57b02865-fe07-4419-b48a-2f1d42a80e75",
+                                                "10f58695-52de-4d25-ba4b-71441b986e85"
+                                            ],
+                                            "columns": {
+                                                "10f58695-52de-4d25-ba4b-71441b986e85": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.apigateway.metrics.Latency.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "ms"
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.Latency.avg"
+                                                },
+                                                "57b02865-fe07-4419-b48a-2f1d42a80e75": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "dc78b53d-e3d1-442e-a751-07556c6f9656": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "10f58695-52de-4d25-ba4b-71441b986e85",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "10f58695-52de-4d25-ba4b-71441b986e85"
+                                        ],
+                                        "layerId": "56b0bb53-472a-48f9-bc07-b3c340f5a74e",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "dc78b53d-e3d1-442e-a751-07556c6f9656",
+                                        "xAccessor": "57b02865-fe07-4419-b48a-2f1d42a80e75"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "8aa530e9-cf48-4966-b829-6e856d749ef9",
+                    "w": 24,
+                    "x": 0,
+                    "y": 89
+                },
+                "panelIndex": "8aa530e9-cf48-4966-b829-6e856d749ef9",
+                "title": "[WebSocket] Latency",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of aws.apigateway.metrics.IntegrationLatency.avg",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "ms"
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.IntegrationLatency.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "8773ffcd-1b64-4784-8271-ba54e73eb63d",
+                    "w": 24,
+                    "x": 24,
+                    "y": 89
+                },
+                "panelIndex": "8773ffcd-1b64-4784-8271-ba54e73eb63d",
+                "title": "[WebSocket] Integration Latency",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-8e802b8a-241a-42a9-b6fe-64d720488b94",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "8e802b8a-241a-42a9-b6fe-64d720488b94": {
+                                            "columnOrder": [
+                                                "f55efbe7-a4ff-4374-ae5d-f1c4599797ca",
+                                                "91aeb449-6f44-43a2-9e2d-56e2682d4d6e",
+                                                "22b71b00-c6df-43e4-af1d-785e060bf345"
+                                            ],
+                                            "columns": {
+                                                "22b71b00-c6df-43e4-af1d-785e060bf345": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.apigateway.metrics.ClientError.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.ClientError.sum"
+                                                },
+                                                "91aeb449-6f44-43a2-9e2d-56e2682d4d6e": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f55efbe7-a4ff-4374-ae5d-f1c4599797ca": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "22b71b00-c6df-43e4-af1d-785e060bf345",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "22b71b00-c6df-43e4-af1d-785e060bf345"
+                                        ],
+                                        "layerId": "8e802b8a-241a-42a9-b6fe-64d720488b94",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "f55efbe7-a4ff-4374-ae5d-f1c4599797ca",
+                                        "xAccessor": "91aeb449-6f44-43a2-9e2d-56e2682d4d6e"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "1f4e10e2-b08d-4ad1-9991-9e76c0485cc1",
+                    "w": 16,
+                    "x": 0,
+                    "y": 102
+                },
+                "panelIndex": "1f4e10e2-b08d-4ad1-9991-9e76c0485cc1",
+                "title": "[WebSocket] Client Error",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.apigateway.metrics.ExecutionError.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.ExecutionError.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "c2039848-87fc-4336-8f9c-c1f3195029d1",
+                    "w": 16,
+                    "x": 16,
+                    "y": 102
+                },
+                "panelIndex": "c2039848-87fc-4336-8f9c-c1f3195029d1",
+                "title": "[WebSocket] Execution Error",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2cfef95f-fa80-4a29-b211-9874dba1c2bb": {
+                                            "columnOrder": [
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254",
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                            ],
+                                            "columns": {
+                                                "23c27e1f-f9a4-4abb-9732-aeca6f42070d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.ApiId",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "88f0a2a6-8f91-47a7-8b7d-ae008db08c21",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.ApiId"
+                                                },
+                                                "3d7acb77-f3cc-4fea-bf5a-f1975f3be254": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "60s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "88f0a2a6-8f91-47a7-8b7d-ae008db08c21": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sum of aws.apigateway.metrics.IntegrationError.sum",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.apigateway.metrics.IntegrationError.sum"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "88f0a2a6-8f91-47a7-8b7d-ae008db08c21"
+                                        ],
+                                        "layerId": "2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "23c27e1f-f9a4-4abb-9732-aeca6f42070d",
+                                        "xAccessor": "3d7acb77-f3cc-4fea-bf5a-f1975f3be254"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "55f916cb-6995-4565-98d0-d88b442fe88e",
+                    "w": 16,
+                    "x": 32,
+                    "y": 102
+                },
+                "panelIndex": "55f916cb-6995-4565-98d0-d88b442fe88e",
+                "title": "[WebSocket] Integration Error",
+                "type": "lens",
+                "version": "8.7.1"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Metrics AWS] API Gateway Overview",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-06-19T12:09:04.326Z",
+    "id": "aws-a4482820-03aa-11ee-84d4-7f15bab18041",
+    "migrationVersion": {
+        "dashboard": "8.7.0"
+    },
+    "references": [
+        {
+            "id": "metrics-*",
+            "name": "36a3594d-c18b-4d09-ae87-7561750822ae:indexpattern-datasource-layer-ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "b2ece1d0-652f-481e-9dec-ae411c897a44:indexpattern-datasource-layer-f9ae930c-999d-4b82-a9ce-01d6237fa03c",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "e970e1a1-b243-46e0-b200-2cf787f26561:indexpattern-datasource-layer-48d7bfc9-ad80-47ac-974e-a265b9c3af45",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "8b56a477-3e09-4bb0-94c3-9add2e443772:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "51e609da-7bb4-4579-843f-88e9748e0982:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "eb48842e-d380-4291-aa03-47960594babd:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a1ef019a-60b1-41d9-845c-cecc5f0450c5:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "070fab3f-bc1d-4ac3-830a-97a86f9a277f:indexpattern-datasource-layer-ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "de3fd32b-c351-4b26-8c9d-84ce99ed24b5:indexpattern-datasource-layer-da960427-d6bb-4f17-a5ac-9be25356186a",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "4979b1bc-45c5-4164-9887-498b4f893513:indexpattern-datasource-layer-ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "3aa94e06-0dfe-4ae2-93e8-be0627ab841e:indexpattern-datasource-layer-ff2c6fd1-df0b-409d-a7e7-033a129edba3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "dc9f0691-ccda-4403-8158-c6191d5090eb:indexpattern-datasource-layer-5e9706cb-90ee-4f08-af6a-f2a8048628af",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "98f24465-f278-4e2c-93db-9112014a449e:indexpattern-datasource-layer-da960427-d6bb-4f17-a5ac-9be25356186a",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "bfa3b44b-89ba-43e4-99b7-02ab03bd0a72:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "bf18dbe6-4dcb-4145-a699-bdd859a7ba99:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "8aa530e9-cf48-4966-b829-6e856d749ef9:indexpattern-datasource-layer-56b0bb53-472a-48f9-bc07-b3c340f5a74e",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "8773ffcd-1b64-4784-8271-ba54e73eb63d:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "1f4e10e2-b08d-4ad1-9991-9e76c0485cc1:indexpattern-datasource-layer-8e802b8a-241a-42a9-b6fe-64d720488b94",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "c2039848-87fc-4336-8f9c-c1f3195029d1:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "55f916cb-6995-4565-98d0-d88b442fe88e:indexpattern-datasource-layer-2cfef95f-fa80-4a29-b211-9874dba1c2bb",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_9edfaf7a-7867-4413-84df-4648537b365a:optionsListDataView",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "dashboard"
+}

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.45.1
+version: 1.45.2
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.45.0
+version: 1.45.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration

--- a/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/default.yml
@@ -50,5 +50,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/capture_loss/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/default.yml
@@ -335,5 +335,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/default.yml
@@ -165,5 +165,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dce_rpc/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/default.yml
@@ -183,5 +183,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dhcp/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/default.yml
@@ -184,5 +184,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dnp3/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -300,5 +300,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dns/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/default.yml
@@ -158,5 +158,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/dpd/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/default.yml
@@ -133,5 +133,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/files/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/default.yml
@@ -229,5 +229,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - set:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ftp/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/default.yml
@@ -247,5 +247,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/http/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/default.yml
@@ -296,5 +296,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/intel/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/default.yml
@@ -186,5 +186,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/irc/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/default.yml
@@ -360,5 +360,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/kerberos/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/known_certs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/known_certs/elasticsearch/ingest_pipeline/default.yml
@@ -125,5 +125,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/known_hosts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/known_hosts/elasticsearch/ingest_pipeline/default.yml
@@ -67,5 +67,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/known_services/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/known_services/elasticsearch/ingest_pipeline/default.yml
@@ -98,5 +98,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/default.yml
@@ -176,5 +176,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/modbus/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/default.yml
@@ -199,5 +199,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/mysql/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/default.yml
@@ -268,5 +268,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/notice/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/default.yml
@@ -202,5 +202,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ntlm/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/ntp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ntp/elasticsearch/ingest_pipeline/default.yml
@@ -189,5 +189,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/ntp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ntp/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/default.yml
@@ -115,5 +115,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ocsp/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/default.yml
@@ -58,5 +58,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/pe/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/default.yml
@@ -176,5 +176,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/radius/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/default.yml
@@ -209,5 +209,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/rdp/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/default.yml
@@ -184,5 +184,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/rfb/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/signature/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/signature/elasticsearch/ingest_pipeline/default.yml
@@ -145,5 +145,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/signature/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/signature/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/default.yml
@@ -236,5 +236,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/sip/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/default.yml
@@ -286,5 +286,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_cmd/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/default.yml
@@ -252,5 +252,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_files/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/default.yml
@@ -160,5 +160,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smb_mapping/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/default.yml
@@ -188,5 +188,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/smtp/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/default.yml
@@ -183,5 +183,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/snmp/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/default.yml
@@ -200,5 +200,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/socks/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/software/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/software/elasticsearch/ingest_pipeline/default.yml
@@ -98,5 +98,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/default.yml
@@ -196,5 +196,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - set:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ssh/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/default.yml
@@ -531,5 +531,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - set:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/ssl/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/default.yml
@@ -140,5 +140,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - set:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/stats/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/default.yml
@@ -164,5 +164,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/syslog/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/default.yml
@@ -122,5 +122,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/traceroute/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/default.yml
@@ -159,5 +159,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/tunnel/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/default.yml
@@ -157,5 +157,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/weird/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/default.yml
@@ -417,5 +417,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{_ingest.on_failure_message}}"
+      value: '{{{_ingest.on_failure_message}}}'

--- a/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/third-party.yml
+++ b/packages/zeek/data_stream/x509/elasticsearch/ingest_pipeline/third-party.yml
@@ -30,6 +30,9 @@ processors:
       field: event.original
       target_field: _temp_
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-


### PR DESCRIPTION
## What does this PR do?

Modify zeek integration to correctly set `event.kind` for pipeline errors and ensure `error.message` is an array.

## Checklist

- [X] I have reviewed tips for building integrations and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's changelog.yml file.
- [ ] I have verified that Kibana version constraints are current according to guidelines.
 
## Author's Checklist

- [ ]  

## How to test this PR locally

## Related issues

* For #6582

## Screenshots