### PR TITLE
iptables: ensure event.kind is correctly set for pipeline errors

### DIFF
--- a/packages/iptables/_dev/deploy/docker/Dockerfile
+++ b/packages/iptables/_dev/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM ubuntu:20.04
 
 RUN apt-get update \
       && apt install -y systemd-journal-remote \

--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6616
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/iptables/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/iptables/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -373,6 +373,9 @@ on_failure:
       field:
         - _tmp
       ignore_failure: true
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/iptables/manifest.yml
+++ b/packages/iptables/manifest.yml
@@ -1,6 +1,6 @@
 name: iptables
 title: Iptables
-version: "1.8.0"
+version: "1.9.0"
 description: Collect logs from Iptables with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Modify iptables to correctly set `event.kind` for pipeline errors and ensure `error.message` is an array.

Change testing docker image to provide a journald that is compatible with beats.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6582
- Fixes #6547

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
