### PR TITLE
[Docker] Enable TSDB by default

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,9 +1,14 @@
 # newer versions go on top
-- version: "2.7.0"
+- version: "2.7.1"
   changes:
-    - description: Add network.interface as dimension.
+    - description: Enable time series data streams for the metrics datasets, except for event dataset. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6340
+- version: "2.7.0"
+  changes:
+    - description: Add network.interface as dimension
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6646
 - version: "2.6.0"
   changes:
     - description: Add permissions to reroute events to logs-*-* for container_logs datastream

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable time series data streams for the metrics datasets, except for event dataset. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6340
+      link: https://github.com/elastic/integrations/pull/6647
 - version: "2.7.0"
   changes:
     - description: Add network.interface as dimension

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.7.1"
+- version: "2.8.0"
   changes:
     - description: Enable time series data streams for the metrics datasets, except for event dataset. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
       type: enhancement

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.0"
+  changes:
+    - description: Add network.interface as dimension.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6340
 - version: "2.6.0"
   changes:
     - description: Add permissions to reroute events to logs-*-* for container_logs datastream

--- a/packages/docker/data_stream/container/manifest.yml
+++ b/packages/docker/data_stream/container/manifest.yml
@@ -1,5 +1,7 @@
 type: metrics
 title: Docker container metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/cpu/manifest.yml
+++ b/packages/docker/data_stream/cpu/manifest.yml
@@ -1,5 +1,7 @@
 type: metrics
 title: Docker cpu metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/diskio/manifest.yml
+++ b/packages/docker/data_stream/diskio/manifest.yml
@@ -1,5 +1,7 @@
 type: metrics
 title: Docker diskio metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/healthcheck/manifest.yml
+++ b/packages/docker/data_stream/healthcheck/manifest.yml
@@ -1,5 +1,7 @@
 type: metrics
 title: Docker healthcheck metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/image/manifest.yml
+++ b/packages/docker/data_stream/image/manifest.yml
@@ -1,5 +1,7 @@
 type: metrics
 title: Docker image metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: docker/metrics
     enabled: false

--- a/packages/docker/data_stream/info/manifest.yml
+++ b/packages/docker/data_stream/info/manifest.yml
@@ -1,5 +1,7 @@
 type: metrics
 title: Docker info metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/memory/manifest.yml
+++ b/packages/docker/data_stream/memory/manifest.yml
@@ -1,5 +1,7 @@
 type: metrics
 title: Docker memory metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/data_stream/network/fields/fields.yml
+++ b/packages/docker/data_stream/network/fields/fields.yml
@@ -9,6 +9,7 @@
   fields:
     - name: interface
       type: keyword
+      dimension: true
       description: |
         Network interface name.
     - name: inbound

--- a/packages/docker/data_stream/network/manifest.yml
+++ b/packages/docker/data_stream/network/manifest.yml
@@ -1,5 +1,7 @@
 type: metrics
 title: Docker network metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: docker/metrics
     vars:

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.6.0
+version: 2.7.0
 release: ga
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.7.0
+version: 2.7.1
 release: ga
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -20,7 +20,7 @@ categories:
   - observability
   - containers
 conditions:
-  kibana.version: ^8.2.0
+  kibana.version: ^8.8.0
 policy_templates:
   - name: docker
     title: Docker logs and metrics

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.7.1
+version: 2.8.0
 release: ga
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Enable TSDB by default in all metrics data streams, except for events.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6393