### PR TITLE
[AWS] Remove aws.dimensions.* fields and add specific dimension fields

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.45.3"
+  changes:
+    - description: Remove aws.dimensions.* from package-fields.yml
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6606
 - version: "1.45.2"
   changes:
     - description: Add AWS EMR metrics dashboard.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove aws.dimensions.* from package-fields.yml
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/6606
+      link: https://github.com/elastic/integrations/pull/6648
 - version: "1.45.2"
   changes:
     - description: Add AWS EMR metrics dashboard.

--- a/packages/aws/data_stream/apigateway_metrics/fields/package-fields.yml
+++ b/packages/aws/data_stream/apigateway_metrics/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/billing/fields/package-fields.yml
+++ b/packages/aws/data_stream/billing/fields/package-fields.yml
@@ -9,10 +9,6 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.
     - name: '*.metrics.*.*'
       type: object
       description: |
@@ -24,7 +20,6 @@
           type: keyword
           description: >
             ID used to identify linked account.
-
         - name: name
           type: keyword
           description: >

--- a/packages/aws/data_stream/cloudwatch_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/cloudwatch_metrics/fields/fields.yml
@@ -1,11 +1,6 @@
 - name: aws
   type: group
   fields:
-    - name: dimensions.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: Metric dimensions.
     - name: cloudwatch
       type: group
       fields:

--- a/packages/aws/data_stream/dynamodb/fields/package-fields.yml
+++ b/packages/aws/data_stream/dynamodb/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/ebs/fields/fields.yml
+++ b/packages/aws/data_stream/ebs/fields/fields.yml
@@ -64,3 +64,9 @@
         - name: namespace
           type: keyword
           description: The namespace specified when query cloudwatch api.
+    - name: dimensions
+      type: group
+      fields:
+        - name: VolumeId
+          type: keyword
+          description: Volume ID

--- a/packages/aws/data_stream/ebs/fields/fields.yml
+++ b/packages/aws/data_stream/ebs/fields/fields.yml
@@ -64,9 +64,3 @@
         - name: namespace
           type: keyword
           description: The namespace specified when query cloudwatch api.
-    - name: dimensions
-      type: group
-      fields:
-        - name: VolumeId
-          type: keyword
-          description: Volume ID

--- a/packages/aws/data_stream/ebs/fields/package-fields.yml
+++ b/packages/aws/data_stream/ebs/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/ec2_metrics/fields/package-fields.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/package-fields.yml
@@ -9,10 +9,6 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.
     - name: '*.metrics.*.*'
       type: object
       description: |

--- a/packages/aws/data_stream/ecs_metrics/fields/package-fields.yml
+++ b/packages/aws/data_stream/ecs_metrics/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/elb_metrics/fields/package-fields.yml
+++ b/packages/aws/data_stream/elb_metrics/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/emr_metrics/fields/package-fields.yml
+++ b/packages/aws/data_stream/emr_metrics/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/firewall_metrics/fields/package-fields.yml
+++ b/packages/aws/data_stream/firewall_metrics/fields/package-fields.yml
@@ -9,10 +9,6 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.
     - name: '*.metrics.*.*'
       type: object
       description: |

--- a/packages/aws/data_stream/kinesis/fields/package-fields.yml
+++ b/packages/aws/data_stream/kinesis/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/lambda/fields/package-fields.yml
+++ b/packages/aws/data_stream/lambda/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/natgateway/fields/package-fields.yml
+++ b/packages/aws/data_stream/natgateway/fields/package-fields.yml
@@ -9,10 +9,6 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.
     - name: '*.metrics.*.*'
       type: object
       description: |

--- a/packages/aws/data_stream/rds/fields/package-fields.yml
+++ b/packages/aws/data_stream/rds/fields/package-fields.yml
@@ -9,10 +9,6 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.
     - name: '*.metrics.*.*'
       type: object
       description: |

--- a/packages/aws/data_stream/redshift/fields/package-fields.yml
+++ b/packages/aws/data_stream/redshift/fields/package-fields.yml
@@ -5,10 +5,6 @@
       type: object
       description: |
         Tag key value pairs from aws resources.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.
     - name: '*.metrics.*.*'
       type: object
       description: |

--- a/packages/aws/data_stream/s3_daily_storage/fields/package-fields.yml
+++ b/packages/aws/data_stream/s3_daily_storage/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/s3_request/fields/package-fields.yml
+++ b/packages/aws/data_stream/s3_request/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/s3_storage_lens/fields/fields.yml
+++ b/packages/aws/data_stream/s3_storage_lens/fields/fields.yml
@@ -95,6 +95,33 @@
             - name: StorageBytes.avg
               type: long
               description: The total storage in bytes
+    - name: dimensions
+      type: group
+      fields:
+        - name: configuration_id
+          type: keyword
+          description: The dashboard name for the S3 Storage Lens configuration reported in the metrics.
+        - name: metrics_version
+          type: keyword
+          description: The version of the S3 Storage Lens metrics. The metrics version has a fixed value of 1.0.
+        - name: organization_id
+          type: keyword
+          description: The AWS Organizations ID for the metrics.
+        - name: aws_account_number
+          type: keyword
+          description: The AWS account that's associated with the metrics.
+        - name: aws_region
+          type: keyword
+          description: The AWS Region for the metrics.
+        - name: bucket_name
+          type: keyword
+          description: The name of the S3 bucket that's reported in the metrics.
+        - name: storage_class
+          type: keyword
+          description: The storage class for the bucket that's reported in the metrics.
+        - name: record_type
+          type: keyword
+          description: The granularity of the metrics such as ORGANIZATION, ACCOUNT, BUCKET.
 - name: aws.cloudwatch.namespace
   type: keyword
   description: The namespace specified when query cloudwatch api.

--- a/packages/aws/data_stream/s3_storage_lens/fields/package-fields.yml
+++ b/packages/aws/data_stream/s3_storage_lens/fields/package-fields.yml
@@ -9,10 +9,6 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.
     - name: '*.metrics.*.*'
       type: object
       description: |

--- a/packages/aws/data_stream/sns/fields/package-fields.yml
+++ b/packages/aws/data_stream/sns/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/sqs/fields/package-fields.yml
+++ b/packages/aws/data_stream/sqs/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/transitgateway/fields/package-fields.yml
+++ b/packages/aws/data_stream/transitgateway/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/usage/fields/package-fields.yml
+++ b/packages/aws/data_stream/usage/fields/package-fields.yml
@@ -9,7 +9,3 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.

--- a/packages/aws/data_stream/vpn/fields/package-fields.yml
+++ b/packages/aws/data_stream/vpn/fields/package-fields.yml
@@ -9,10 +9,6 @@
       type: keyword
       description: |
         Name of a S3 bucket.
-    - name: dimensions.*
-      type: object
-      description: |
-        Metric dimensions.
     - name: '*.metrics.*.*'
       type: object
       description: |

--- a/packages/aws/docs/apigateway.md
+++ b/packages/aws/docs/apigateway.md
@@ -156,7 +156,6 @@ An example event for `apigateway` looks as following:
 | aws.apigateway.metrics.Latency.avg | The time between when API Gateway receives a request from a client and when it returns a response to the client. | long | ms | gauge |
 | aws.apigateway.metrics.MessageCount.sum | The number of messages sent to the WebSocket API, either from or to the client. | long |  | counter |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |  |
 | aws.dimensions.ApiId | Each API created in API Gateway is assigned a unique ApiId, which is used to distinguish and reference that specific API within the system. | keyword |  |  |
 | aws.dimensions.ApiName | It represents a human-readable name that helps identify and differentiate the API within the API Gateway service. | keyword |  |  |
 | aws.dimensions.Method | It represents the HTTP method which defines the action that can be performed on a resource, such as retrieving, creating, updating, or deleting data. | keyword |  |  |

--- a/packages/aws/docs/billing.md
+++ b/packages/aws/docs/billing.md
@@ -135,7 +135,6 @@ An example event for `billing` looks as following:
 | aws.billing.group_definition.type | The string that represents the type of group. | keyword |  |
 | aws.billing.start_date | Start date for retrieving AWS costs. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.linked_account.id | ID used to identify linked account. | keyword |  |
 | aws.linked_account.name | Name or alias used to identify linked account. | keyword |  |
 | aws.s3.bucket.name | Name of a S3 bucket. | keyword |  |

--- a/packages/aws/docs/dynamodb.md
+++ b/packages/aws/docs/dynamodb.md
@@ -133,7 +133,6 @@ An example event for `dynamodb` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.DelegatedOperation | This dimension limits the data to operations DynamoDB performs on your behalf. | keyword |  |
 | aws.dimensions.GlobalSecondaryIndexName | This dimension limits the data to a global secondary index on a table. | keyword |  |
 | aws.dimensions.Operation | This dimension limits the data to one of the DynamoDB operations, such as PutItem, DeleteItem, UpdateItem, etc. | keyword |  |

--- a/packages/aws/docs/ebs.md
+++ b/packages/aws/docs/ebs.md
@@ -150,8 +150,7 @@ An example event for `ebs` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
-| aws.dimensions.VolumeId | Amazon EBS volume ID | keyword |  |
+| aws.dimensions.VolumeId | Volume ID | keyword |  |
 | aws.ebs.metrics.BurstBalance.avg | Used with General Purpose SSD (gp2), Throughput Optimized HDD (st1), and Cold HDD (sc1) volumes only. Provides information about the percentage of I/O credits (for gp2) or throughput credits (for st1 and sc1) remaining in the burst bucket. | double | gauge |
 | aws.ebs.metrics.VolumeConsumedReadWriteOps.avg | The total amount of read and write operations (normalized to 256K capacity units) consumed in a specified period of time. Used with Provisioned IOPS SSD volumes only. | double | gauge |
 | aws.ebs.metrics.VolumeIdleTime.sum | The total number of seconds in a specified period of time when no read or write operations were submitted. | double | gauge |

--- a/packages/aws/docs/ebs.md
+++ b/packages/aws/docs/ebs.md
@@ -150,7 +150,7 @@ An example event for `ebs` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.VolumeId | Volume ID | keyword |  |
+| aws.dimensions.VolumeId | Amazon EBS volume ID | keyword |  |
 | aws.ebs.metrics.BurstBalance.avg | Used with General Purpose SSD (gp2), Throughput Optimized HDD (st1), and Cold HDD (sc1) volumes only. Provides information about the percentage of I/O credits (for gp2) or throughput credits (for st1 and sc1) remaining in the burst bucket. | double | gauge |
 | aws.ebs.metrics.VolumeConsumedReadWriteOps.avg | The total amount of read and write operations (normalized to 256K capacity units) consumed in a specified period of time. Used with Provisioned IOPS SSD volumes only. | double | gauge |
 | aws.ebs.metrics.VolumeIdleTime.sum | The total number of seconds in a specified period of time when no read or write operations were submitted. | double | gauge |

--- a/packages/aws/docs/ec2.md
+++ b/packages/aws/docs/ec2.md
@@ -318,7 +318,6 @@ An example event for `ec2` looks as following:
 | @timestamp | Event timestamp. | date |
 | aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
-| aws.dimensions.\* | Metric dimensions. | object |
 | aws.dimensions.AutoScalingGroupName | An Auto Scaling group is a collection of instances you define if you're using Auto Scaling. | keyword |
 | aws.dimensions.ImageId | This dimension filters the data you request for all instances running this Amazon EC2 Amazon Machine Image (AMI) | keyword |
 | aws.dimensions.InstanceId | Amazon EC2 instance ID | keyword |

--- a/packages/aws/docs/ecs.md
+++ b/packages/aws/docs/ecs.md
@@ -136,7 +136,6 @@ An example event for `ecs` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.ClusterName | This dimension filters the data that you request for all resources in a specified cluster. All Amazon ECS metrics are filtered by ClusterName. | keyword |  |
 | aws.dimensions.ServiceName | This dimension filters the data that you request for all resources in a specified service within a specified cluster. | keyword |  |
 | aws.ecs.metrics.CPUReservation.avg | The percentage of CPU units that are reserved by running tasks in the cluster. | double | gauge |

--- a/packages/aws/docs/elb.md
+++ b/packages/aws/docs/elb.md
@@ -410,7 +410,6 @@ An example event for `elb` looks as following:
 | aws.applicationelb.metrics.RequestCount.sum | The number of requests processed over IPv4 and IPv6. | long | gauge |
 | aws.applicationelb.metrics.RuleEvaluations.sum | The number of rules processed by the load balancer given a request rate averaged over an hour. | long | gauge |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.AvailabilityZone | Filters the metric data by the specified Availability Zone. | keyword |  |
 | aws.dimensions.LoadBalancer | Filters the metric data by load balancer. | keyword |  |
 | aws.dimensions.LoadBalancerName | Filters the metric data by the specified load balancer. | keyword |  |

--- a/packages/aws/docs/emr.md
+++ b/packages/aws/docs/emr.md
@@ -110,7 +110,6 @@ An example event for `emr` looks as following:
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |  |
 | aws.dimensions.JobFlowId | Filters metrics by cluster ID. | keyword |  |  |
 | aws.elasticmapreduce.metrics.AppsCompleted.sum | The number of applications submitted to YARN that have completed. | long |  | counter |
 | aws.elasticmapreduce.metrics.AppsFailed.sum | The number of applications submitted to YARN that have failed to complete. | long |  | counter |

--- a/packages/aws/docs/firewall.md
+++ b/packages/aws/docs/firewall.md
@@ -416,7 +416,6 @@ An example event for `firewall` looks as following:
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.AvailabilityZone | Availability Zone in the Region where the Network Firewall firewall is active. | keyword |  |
 | aws.dimensions.CustomAction | Dimension for a publish metrics custom action that you defined. You can define this for a rule action in a stateless rule group or for a stateless default action in a firewall policy. | keyword |  |
 | aws.dimensions.Engine | Rules engine that processed the packet. The value for this is either Stateful or Stateless. | keyword |  |

--- a/packages/aws/docs/kinesis.md
+++ b/packages/aws/docs/kinesis.md
@@ -126,7 +126,6 @@ An example event for `kinesis` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.StreamName | The name of the Kinesis stream. All available statistics are filtered by StreamName. | keyword |  |
 | aws.kinesis.metrics.GetRecords_Bytes.avg | The average number of bytes retrieved from the Kinesis stream, measured over the specified time period. | double | gauge |
 | aws.kinesis.metrics.GetRecords_IteratorAgeMilliseconds.avg | The age of the last record in all GetRecords calls made against a Kinesis stream, measured over the specified time period. Age is the difference between the current time and when the last record of the GetRecords call was written to the stream. | double | gauge |

--- a/packages/aws/docs/lambda.md
+++ b/packages/aws/docs/lambda.md
@@ -123,7 +123,6 @@ An example event for `lambda` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.ExecutedVersion | Use the ExecutedVersion dimension to compare error rates for two versions of a function that are both targets of a weighted alias. | keyword |  |
 | aws.dimensions.FunctionName | Lambda function name. | keyword |  |
 | aws.dimensions.Resource | Resource name. | keyword |  |

--- a/packages/aws/docs/natgateway.md
+++ b/packages/aws/docs/natgateway.md
@@ -168,7 +168,6 @@ An example event for `natgateway` looks as following:
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.NatGatewayId | Filter the metric data by the NAT gateway ID. | keyword |  |
 | aws.natgateway.metrics.ActiveConnectionCount.max | The total number of concurrent active TCP connections through the NAT gateway. | long | gauge |
 | aws.natgateway.metrics.BytesInFromDestination.sum | The number of bytes received by the NAT gateway from the destination. | long | gauge |

--- a/packages/aws/docs/rds.md
+++ b/packages/aws/docs/rds.md
@@ -234,7 +234,6 @@ An example event for `rds` looks as following:
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.DBClusterIdentifier | This dimension filters the data that you request for a specific Amazon Aurora DB cluster. | keyword |  |
 | aws.dimensions.DBInstanceIdentifier | This dimension filters the data that you request for a specific DB instance. | keyword |  |
 | aws.dimensions.DatabaseClass | This dimension filters the data that you request for all instances in a database class. | keyword |  |

--- a/packages/aws/docs/redshift.md
+++ b/packages/aws/docs/redshift.md
@@ -184,7 +184,6 @@ An example event for `redshift` looks as following:
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.ClusterIdentifier | This dimension filters the data that you request for a specific Cluster identifier | keyword |  |
 | aws.dimensions.NodeID | This dimension filters the data that you request for a specific NodeID. | keyword |  |
 | aws.dimensions.QueryPriority | This dimension filters the data that you request for a specific query priority. | keyword |  |

--- a/packages/aws/docs/s3.md
+++ b/packages/aws/docs/s3.md
@@ -361,7 +361,6 @@ An example event for `s3_daily_storage` looks as following:
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
-| aws.dimensions.\* | Metric dimensions. | object |
 | aws.dimensions.BucketName | This dimension filters the data you request for the identified bucket only. | keyword |
 | aws.dimensions.FilterId | This dimension filters metrics configurations that you specify for request metrics on a bucket, for example, a prefix or a tag. | keyword |
 | aws.dimensions.StorageType | This dimension filters the data that you have stored in a bucket by types of storage. | keyword |
@@ -501,7 +500,6 @@ An example event for `s3_request` looks as following:
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
-| aws.dimensions.\* | Metric dimensions. | object |
 | aws.dimensions.BucketName | This dimension filters the data you request for the identified bucket only. | keyword |
 | aws.dimensions.FilterId | This dimension filters metrics configurations that you specify for request metrics on a bucket, for example, a prefix or a tag. | keyword |
 | aws.dimensions.StorageType | This dimension filters the data that you have stored in a bucket by types of storage. | keyword |

--- a/packages/aws/docs/s3_storage_lens.md
+++ b/packages/aws/docs/s3_storage_lens.md
@@ -188,7 +188,14 @@ An example event for `s3_storage_lens` looks as following:
 | @timestamp | Event timestamp. | date |
 | aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
-| aws.dimensions.\* | Metric dimensions. | object |
+| aws.dimensions.aws_account_number | The AWS account that's associated with the metrics. | keyword |
+| aws.dimensions.aws_region | The AWS Region for the metrics. | keyword |
+| aws.dimensions.bucket_name | The name of the S3 bucket that's reported in the metrics. | keyword |
+| aws.dimensions.configuration_id | The dashboard name for the S3 Storage Lens configuration reported in the metrics. | keyword |
+| aws.dimensions.metrics_version | The version of the S3 Storage Lens metrics. The metrics version has a fixed value of 1.0. | keyword |
+| aws.dimensions.organization_id | The AWS Organizations ID for the metrics. | keyword |
+| aws.dimensions.record_type | The granularity of the metrics such as ORGANIZATION, ACCOUNT, BUCKET. | keyword |
+| aws.dimensions.storage_class | The storage class for the bucket that's reported in the metrics. | keyword |
 | aws.s3.bucket.name | Name of a S3 bucket. | keyword |
 | aws.s3_storage_lens.metrics.4xxErrors.avg | The total 4xx errors in scope. | long |
 | aws.s3_storage_lens.metrics.5xxErrors.avg | The total 5xx errors in scope. | long |

--- a/packages/aws/docs/sns.md
+++ b/packages/aws/docs/sns.md
@@ -120,7 +120,6 @@ An example event for `sns` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.Application | Filters on application objects, which represent an app and device registered with one of the supported push notification services, such as APNs and FCM. | keyword |  |
 | aws.dimensions.Country | Filters on the destination country or region of an SMS message. | keyword |  |
 | aws.dimensions.Platform | Filters on platform objects for the push notification services, such as APNs and FCM. | keyword |  |

--- a/packages/aws/docs/sqs.md
+++ b/packages/aws/docs/sqs.md
@@ -127,7 +127,6 @@ An example event for `sqs` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.QueueName | SQS queue name | keyword |  |
 | aws.s3.bucket.name | Name of a S3 bucket. | keyword |  |
 | aws.sqs.empty_receives | The number of ReceiveMessage API calls that did not return a message. | long | gauge |

--- a/packages/aws/docs/transitgateway.md
+++ b/packages/aws/docs/transitgateway.md
@@ -153,7 +153,6 @@ An example event for `transitgateway` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.TransitGateway | Filters the metric data by transit gateway. | keyword |  |
 | aws.dimensions.TransitGatewayAttachment | Filters the metric data by transit gateway attachment. | keyword |  |
 | aws.s3.bucket.name | Name of a S3 bucket. | keyword |  |

--- a/packages/aws/docs/usage.md
+++ b/packages/aws/docs/usage.md
@@ -116,7 +116,6 @@ An example event for `usage` looks as following:
 | @timestamp | Event timestamp. | date |  |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.Class | The class of resource being tracked. | keyword |  |
 | aws.dimensions.Resource | The name of the API operation. | keyword |  |
 | aws.dimensions.Service | The name of the AWS service containing the resource. | keyword |  |

--- a/packages/aws/docs/vpn.md
+++ b/packages/aws/docs/vpn.md
@@ -103,7 +103,6 @@ An example event for `vpn` looks as following:
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.\*.metrics.\*.\* | Metrics that returned from Cloudwatch API query. | object |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.\* | Metric dimensions. | object |  |
 | aws.dimensions.TunnelIpAddress | Filters the metric data by the IP address of the tunnel for the virtual private gateway. | keyword |  |
 | aws.dimensions.VpnId | Filters the metric data by the Site-to-Site VPN connection ID. | keyword |  |
 | aws.s3.bucket.name | Name of a S3 bucket. | keyword |  |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.45.2
+version: 1.45.3
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

1. remove `aws.dimensions.*` fields from all aws metrics data streams
2. add specific dimensions for `elb` 
3. add specific dimensions for `s3_storage_lens`
4. remove duplicated `aws.dimensions.*` from `cloudwatch_metrics`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes  https://github.com/elastic/integrations/issues/6601