### PR TITLE
m*: ensure event.kind is correctly set for pipeline errors

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6661
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -100,7 +100,6 @@ on_failure:
   - append:
       field: error.message
       value: '{{{_ingest.on_failure_message}}}'
-  - append:
+  - set:
       field: event.kind
       value: pipeline_error
-      allow_duplicates: false

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_alert.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_alert.yml
@@ -433,3 +433,10 @@ processors:
         - m365_defender.event.account.domain
         - m365_defender.event.title
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_app_and_identity.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_app_and_identity.yml
@@ -480,3 +480,10 @@ processors:
         - m365_defender.event.account.name
         - m365_defender.event.action.type
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_device.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_device.yml
@@ -1276,3 +1276,10 @@ processors:
         - m365_defender.event.device.category
         - m365_defender.event.action.type
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_email.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_email.yml
@@ -445,3 +445,10 @@ processors:
         - m365_defender.event.ip_address
         - m365_defender.event.action.type
       ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: m365_defender
 title: Microsoft M365 Defender
-version: "1.10.0"
+version: "1.11.0"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"

--- a/packages/mattermost/changelog.yml
+++ b/packages/mattermost/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6661
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/mattermost/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mattermost/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -443,6 +443,9 @@ processors:
       }
       handleMap(ctx);
 on_failure:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/mattermost/manifest.yml
+++ b/packages/mattermost/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: mattermost
 title: "Mattermost"
-version: "1.9.0"
+version: "1.10.0"
 description: Collect logs from Mattermost with Elastic Agent.
 type: integration
 categories:

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.13.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6661
 - version: "2.12.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -324,5 +324,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{_ingest.on_failure_message}}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.12.0"
+version: "2.13.0"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"

--- a/packages/microsoft_dhcp/changelog.yml
+++ b/packages/microsoft_dhcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6661
 - version: "1.13.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -54,6 +54,9 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
       value: |-
         Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/dhcp.yml
+++ b/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/dhcp.yml
@@ -355,6 +355,9 @@ processors:
       value: '{{{_tmp_.mac}}}'
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
       value: |-
         Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/dhcpv6.yml
+++ b/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/dhcpv6.yml
@@ -250,6 +250,9 @@ processors:
       if: ctx?.event?.outcome == null
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
       value: |-
         Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/microsoft_dhcp/manifest.yml
+++ b/packages/microsoft_dhcp/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_dhcp
 title: Microsoft DHCP
-version: "1.13.0"
+version: "1.14.0"
 license: basic
 description: Collect logs from Microsoft DHCP with Elastic Agent.
 type: integration

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6661
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -312,5 +312,8 @@ processors:
         dropEmptyFields(ctx);
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.4.0"
+version: "1.5.0"
 release: ga
 license: basic
 description: "Microsoft Exchange Online Message Trace Integration"

--- a/packages/mysql_enterprise/changelog.yml
+++ b/packages/mysql_enterprise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6661
 - version: "1.6.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/mysql_enterprise/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mysql_enterprise/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -243,5 +243,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/mysql_enterprise/manifest.yml
+++ b/packages/mysql_enterprise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql_enterprise
 title: "MySQL Enterprise"
-version: "1.6.0"
+version: "1.7.0"
 license: basic
 description: Collect audit logs from MySQL Enterprise with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Modify m365_defender, mattermost, microsoft_defender_endpoint, microsoft_dhcp, microsoft_exchange_online_message_trace and mysql_enterprise to correctly set `event.kind` for pipeline errors and ensure `error.message` is an array.

modsecurity is omitted as there is a pending PR to fix ingest in that package.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6582

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
