### PR TITLE
[np]*: ensure event.kind is correctly set for pipeline errors

### DIFF
--- a/packages/netscout/changelog.yml
+++ b/packages/netscout/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.16.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6662
 - version: "0.15.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/netscout/data_stream/sightline/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/netscout/data_stream/sightline/elasticsearch/ingest_pipeline/default.yml
@@ -63,6 +63,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/netscout/manifest.yml
+++ b/packages/netscout/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: netscout
 title: Arbor Peakflow SP Logs
-version: "0.15.0"
+version: "0.16.0"
 description: Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.
 categories: ["security", "network"]
 type: integration

--- a/packages/netskope/changelog.yml
+++ b/packages/netskope/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6662
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/netskope/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/netskope/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
@@ -1348,6 +1348,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
-- append:
-    field: error.message
-    value: '{{{ _ingest.on_failure_message }}}'
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/netskope/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/netskope/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -1088,6 +1088,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
-- append:
-    field: error.message
-    value: '{{{ _ingest.on_failure_message }}}'
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/netskope/manifest.yml
+++ b/packages/netskope/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netskope
 title: "Netskope"
-version: "1.8.0"
+version: "1.9.0"
 license: basic
 description: Collect logs from Netskope with Elastic Agent.
 type: integration

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.12.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6662
 - version: "3.11.0"
   changes:
     - description: Split panw.panos.url_category_list field in threat logs

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/authentication.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/authentication.yml
@@ -95,6 +95,9 @@ processors:
       copy_from: _temp_.user_agent
       ignore_failure: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/config.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/config.yml
@@ -92,6 +92,9 @@ processors:
       value: unknown
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/correlated_event.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/correlated_event.yml
@@ -51,6 +51,9 @@ processors:
       ignore_failure: true
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/decryption.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/decryption.yml
@@ -318,6 +318,9 @@ processors:
         ctx.tls.version_protocol = ctx._temp_?.tls.substring(0,3).toLowerCase();
         ctx.tls.version = ctx._temp_?.tls.substring(3,6);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -1662,6 +1662,9 @@ processors:
         dropEmptyFields(ctx);
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: 'error.message'
       value: '{{{ _ingest.on_failure_message }}} {{{ _ingest.on_failure_processor_type }}}'

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/globalprotect.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/globalprotect.yml
@@ -133,6 +133,9 @@ processors:
       ignore_failure: true
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/gtp.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/gtp.yml
@@ -175,6 +175,9 @@ processors:
       ignore_failure: true
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/hipmatch.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/hipmatch.yml
@@ -75,6 +75,9 @@ processors:
       ignore_failure: true
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/ip_tag.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/ip_tag.yml
@@ -50,6 +50,9 @@ processors:
       ignore_failure: true
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/sctp.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/sctp.yml
@@ -141,6 +141,9 @@ processors:
       ignore_failure: true
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/system.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/system.yml
@@ -50,6 +50,9 @@ processors:
       ignore_failure: true
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/threat.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/threat.yml
@@ -348,6 +348,9 @@ processors:
       separator: ","
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
@@ -321,6 +321,9 @@ processors:
       on_failure: [{'append': {'field': 'error.message', 'value': '{{{ _ingest.on_failure_message }}}'}}]
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/tunnel_inspection.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/tunnel_inspection.yml
@@ -218,6 +218,9 @@ processors:
       ignore_failure: true
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/userid.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/userid.yml
@@ -90,6 +90,9 @@ processors:
       on_failure: [{'append': {'field': 'error.message', 'value': '{{{ _ingest.on_failure_message }}}'}}]
 
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: >-

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "3.11.0"
+version: "3.12.0"
 release: ga
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration

--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6662
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/panw_cortex_xdr/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw_cortex_xdr/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
@@ -560,5 +560,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,6 +1,6 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "1.11.0"
+version: "1.12.0"
 release: ga
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6662
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -227,6 +227,9 @@ on_failure:
       field:
         - _tmp
       ignore_failure: true
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/dhcp.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/dhcp.yml
@@ -88,6 +88,9 @@ processors:
       allow_duplicates: false
       if: "ctx.pfsense?.log?.dhcp?.hostname != null"
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/firewall.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/firewall.yml
@@ -81,6 +81,9 @@ processors:
             - UNIX
             - UNIX_MS
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/haproxy.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/haproxy.yml
@@ -99,5 +99,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/ipsec.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/ipsec.yml
@@ -32,6 +32,9 @@ processors:
       field: network.protocol
       value: ipsec
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/openvpn.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/openvpn.yml
@@ -41,6 +41,9 @@ processors:
       field: network.protocol
       value: openvpn
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/php-fpm.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/php-fpm.yml
@@ -38,6 +38,9 @@ processors:
       target_field: host.name
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/squid.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/squid.yml
@@ -27,5 +27,8 @@ processors:
       if: "ctx.http?.response?.status_code != null && ctx.http.response.status_code >= 400"
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/unbound.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/unbound.yml
@@ -52,6 +52,9 @@ processors:
       copy_from: source
       ignore_empty_value: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,6 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.8.0"
+version: "1.9.0"
 release: ga
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration

--- a/packages/ping_one/changelog.yml
+++ b/packages/ping_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6662
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/ping_one/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ping_one/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -314,6 +314,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
-- append:
-    field: error.message
-    value: '{{{ _ingest.on_failure_message }}}'
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/ping_one/manifest.yml
+++ b/packages/ping_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: ping_one
 title: PingOne
-version: "1.3.0"
+version: "1.4.0"
 release: ga
 license: basic
 description: Collect logs from PingOne with Elastic-Agent.

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6662
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/proofpoint_tap/data_stream/clicks_blocked/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_tap/data_stream/clicks_blocked/elasticsearch/ingest_pipeline/default.yml
@@ -193,6 +193,9 @@ processors:
           }
           dropEmptyFields(ctx);
 on_failure:
-- append:
-    field: error.message
-    value: '{{{ _ingest.on_failure_message }}}'
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/proofpoint_tap/data_stream/clicks_permitted/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_tap/data_stream/clicks_permitted/elasticsearch/ingest_pipeline/default.yml
@@ -193,6 +193,9 @@ processors:
           }
           dropEmptyFields(ctx);
 on_failure:
-- append:
-    field: error.message
-    value: '{{{ _ingest.on_failure_message }}}'
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/proofpoint_tap/data_stream/message_blocked/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_tap/data_stream/message_blocked/elasticsearch/ingest_pipeline/default.yml
@@ -490,6 +490,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{{_ingest.on_failure_message}}}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/proofpoint_tap/data_stream/message_delivered/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_tap/data_stream/message_delivered/elasticsearch/ingest_pipeline/default.yml
@@ -483,5 +483,8 @@ processors:
         dropEmptyFields(ctx);
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{{_ingest.on_failure_message}}}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/proofpoint_tap/manifest.yml
+++ b/packages/proofpoint_tap/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: proofpoint_tap
 title: Proofpoint TAP
-version: "1.7.0"
+version: "1.8.0"
 license: basic
 description: Collect logs from Proofpoint TAP with Elastic Agent.
 type: integration

--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6662
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/pulse_connect_secure/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/pulse_connect_secure/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -130,5 +130,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/pulse_connect_secure/manifest.yml
+++ b/packages/pulse_connect_secure/manifest.yml
@@ -1,6 +1,6 @@
 name: pulse_connect_secure
 title: Pulse Connect Secure
-version: "1.9.0"
+version: "1.10.0"
 release: ga
 description: Collect logs from Pulse Connect Secure with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Modify netscout, panw, panw_cortex_xdr, pfsense, ping_one, proofpoint_tap and pulse_connect_secure  to correctly set `event.kind` for pipeline errors and ensure `error.message` is an array.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6582

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
