### PR TITLE
[qrs]*: ensure event.kind is correctly set for pipeline errors

### DIFF
--- a/packages/qnap_nas/changelog.yml
+++ b/packages/qnap_nas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "1.10.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/qnap_nas/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qnap_nas/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -290,5 +290,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/qnap_nas/manifest.yml
+++ b/packages/qnap_nas/manifest.yml
@@ -1,6 +1,6 @@
 name: qnap_nas
 title: QNAP NAS
-version: "1.10.0"
+version: "1.11.0"
 description: Collect logs from QNAP NAS devices with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/radware/changelog.yml
+++ b/packages/radware/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.15.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "0.14.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/radware/data_stream/defensepro/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/radware/data_stream/defensepro/elasticsearch/ingest_pipeline/default.yml
@@ -63,6 +63,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/radware/manifest.yml
+++ b/packages/radware/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: radware
 title: Radware DefensePro Logs
-version: "0.14.0"
+version: "0.15.0"
 description: Collect defensePro logs from Radware devices with Elastic Agent.
 categories: ["security"]
 type: integration

--- a/packages/santa/changelog.yml
+++ b/packages/santa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.8.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "3.7.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/santa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/santa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -111,5 +111,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/santa/manifest.yml
+++ b/packages/santa/manifest.yml
@@ -1,6 +1,6 @@
 name: santa
 title: Google Santa
-version: "3.7.0"
+version: "3.8.0"
 release: ga
 description: Collect logs from Google Santa with Elastic Agent.
 type: integration

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml
@@ -530,6 +530,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sentinel_one/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
@@ -809,6 +809,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sentinel_one/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -696,6 +696,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sentinel_one/data_stream/group/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/group/elasticsearch/ingest_pipeline/default.yml
@@ -163,6 +163,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -1162,6 +1162,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: sentinel_one
 title: SentinelOne
-version: "1.9.0"
+version: "1.10.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Ensure error.message is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/slack/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/slack/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -417,7 +417,7 @@ processors:
       }
       handleMap(ctx);
 on_failure:
-  - set:
+  - append:
       field: error.message
       value: >-
         Processor '{{ _ingest.on_failure_processor_type }}'

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: slack
 title: "Slack Logs"
-version: "1.5.0"
+version: "1.6.0"
 license: basic
 release: ga
 description: "Slack Logs Integration"

--- a/packages/snort/changelog.yml
+++ b/packages/snort/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -198,5 +198,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/json.yml
+++ b/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/json.yml
@@ -176,5 +176,8 @@ processors:
 
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/plaintext.yml
+++ b/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/plaintext.yml
@@ -49,5 +49,8 @@ processors:
         }
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: '{{ _ingest.on_failure_message }}'
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/snort/manifest.yml
+++ b/packages/snort/manifest.yml
@@ -1,6 +1,6 @@
 name: snort
 title: Snort
-version: "1.7.0"
+version: "1.8.0"
 description: Collect logs from Snort with Elastic Agent.
 type: integration
 icons:

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/snyk/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/snyk/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -83,5 +83,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/snyk/data_stream/vulnerabilities/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/snyk/data_stream/vulnerabilities/elasticsearch/ingest_pipeline/default.yml
@@ -196,5 +196,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/snyk/manifest.yml
+++ b/packages/snyk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: snyk
 title: "Snyk"
-version: "1.9.0"
+version: "1.10.0"
 license: basic
 description: Collect logs from Snyk with Elastic Agent.
 type: integration

--- a/packages/sonicwall_firewall/changelog.yml
+++ b/packages/sonicwall_firewall/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "1.5.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/sonicwall_firewall/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sonicwall_firewall/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1299,5 +1299,8 @@ processors:
 
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sonicwall_firewall/manifest.yml
+++ b/packages/sonicwall_firewall/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sonicwall_firewall
 title: "SonicWall Firewall"
-version: "1.5.0"
+version: "1.6.0"
 license: basic
 release: ga
 description: "Integration for SonicWall firewall logs"

--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "2.9.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/utm/elasticsearch/ingest_pipeline/default.yml
@@ -79,6 +79,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antispam.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antispam.yml
@@ -131,5 +131,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antivirus.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antivirus.yml
@@ -218,5 +218,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/atp.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/atp.yml
@@ -116,5 +116,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/cfilter.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/cfilter.yml
@@ -164,5 +164,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
@@ -563,6 +563,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: |-
-      Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" failed with message "{{ _ingest.on_failure_message }}"
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/event.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/event.yml
@@ -124,6 +124,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
-
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/firewall.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/firewall.yml
@@ -228,5 +228,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/idp.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/idp.yml
@@ -111,5 +111,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/sandstorm.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/sandstorm.yml
@@ -129,5 +129,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/systemhealth.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/systemhealth.yml
@@ -178,5 +178,8 @@ processors:
 
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/waf.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/waf.yml
@@ -170,5 +170,8 @@ processors:
     ignore_missing: true
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/wifi.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/wifi.yml
@@ -23,5 +23,8 @@ processors:
 #############
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+    value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sophos
 title: Sophos
-version: "2.9.0"
+version: "2.10.0"
 description: Collect logs from Sophos with Elastic Agent.
 categories: ["security", "network", "firewall_security"]
 release: ga

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "1.4.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/sophos_central/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos_central/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -652,7 +652,6 @@ on_failure:
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'
-  - append:
+  - set:
       field: event.kind
       value: pipeline_error
-      allow_duplicates: false

--- a/packages/sophos_central/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos_central/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -444,7 +444,6 @@ on_failure:
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'
-  - append:
+  - set:
       field: event.kind
       value: pipeline_error
-      allow_duplicates: false

--- a/packages/sophos_central/manifest.yml
+++ b/packages/sophos_central/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: sophos_central
 title: Sophos Central
-version: "1.4.0"
+version: "1.5.0"
 description: This Elastic integration collects logs from Sophos Central with Elastic Agent.
 type: integration
 categories:

--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.16.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "0.15.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/squid/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/squid/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -63,6 +63,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/squid/manifest.yml
+++ b/packages/squid/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: squid
 title: Squid Logs
-version: "0.15.0"
+version: "0.16.0"
 description: Collect and parse logs from Squid devices with Elastic Agent.
 categories: ["security", "network", "proxy_security"]
 type: integration

--- a/packages/symantec_endpoint/changelog.yml
+++ b/packages/symantec_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "2.7.0"
   changes:
     - description: Use `ip_address` field to populate `related.ip`.

--- a/packages/symantec_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/symantec_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1114,9 +1114,11 @@ processors:
 
 on_failure:
 - set:
+    field: event.kind
+    value: pipeline_error
+- append:
     field: error.message
     value: 'processor {{ _ingest.on_failure_processor_type }}: {{ _ingest.on_failure_message }}'
-
 - remove:
     if: ctx.tags == null || !ctx.tags.contains('debug')
     ignore_missing: true

--- a/packages/symantec_endpoint/manifest.yml
+++ b/packages/symantec_endpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: symantec_endpoint
 title: Symantec Endpoint Protection
-version: "2.7.0"
+version: "2.8.0"
 description: Collect logs from Symantec Endpoint Protection with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/sysmon_linux/changelog.yml
+++ b/packages/sysmon_linux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Ensure event.kind is correctly set for pipeline errors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6663
 - version: "0.4.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/sysmon_linux/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sysmon_linux/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1346,6 +1346,9 @@ processors:
 
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: "error.message"
       value: |-
         Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/sysmon_linux/manifest.yml
+++ b/packages/sysmon_linux/manifest.yml
@@ -1,6 +1,6 @@
 name: sysmon_linux
 title: Sysmon for Linux
-version: "0.4.0"
+version: "0.5.0"
 description: Collect Sysmon Linux logs with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Modify qnap_nas, radware, santa, sentinel_one, slack, snort, snyk, sonicwall_firewall, sophos, sophos_central, squid, symantec_endpoint and sysmon_linux to correctly set `event.kind` for pipeline errors and ensure `error.message` is an array.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6582

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
