### PR TITLE
[Cloud security] Add a BC comment to config files

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -17,7 +17,7 @@
       link: https://github.com/elastic/integrations/pull/6622
     - description: Add a backward compatibility comment for the fetchers section
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6622
+      link: https://github.com/elastic/integrations/pull/6665
 - version: "1.3.0"
   changes:
     - description: New vulnerability management integration

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -15,9 +15,6 @@
     - description: Fix CIS 1.1.19 rule
       type: bugfix
       link: https://github.com/elastic/integrations/pull/6622
-    - description: Add a backward compatibility comment for the fetchers section
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/6665
 - version: "1.3.0"
   changes:
     - description: New vulnerability management integration

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -15,6 +15,9 @@
     - description: Fix CIS 1.1.19 rule
       type: bugfix
       link: https://github.com/elastic/integrations/pull/6622
+    - description: Add a backward compatibility comment for the fetchers section
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6622
 - version: "1.3.0"
   changes:
     - description: New vulnerability management integration

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -1,4 +1,5 @@
 period: 24h
+{{!-- BACKWARD COMPATIBILITY (fetchers) cloudbeat verision < 8.10 --}}
 fetchers:
   - name: aws-iam
   - name: aws-ec2-network

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/eks.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/eks.yml.hbs
@@ -25,7 +25,7 @@ config:
         {{/if}}
         type: {{aws.credentials.type}}
 
-
+{{!-- BACKWARD COMPATIBILITY (fetchers) cloudbeat verision < 8.10 --}}
 fetchers:
   - name: kube-api
   - name: process

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/vanilla.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/vanilla.yml.hbs
@@ -4,6 +4,7 @@ config:
     deployment: self_managed
     benchmark: cis_k8s
 
+{{!-- BACKWARD COMPATIBILITY (fetchers) cloudbeat verision < 8.10 --}}
 fetchers:
   - name: kube-api
   - name: process


### PR DESCRIPTION
## What does this PR do?
Adds a comment to the cloud security config file that the fetchers section is kept for BC, once we do not support a cloudbeat version < 8.10, this section can be removed.
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues
- https://github.com/elastic/cloudbeat/pull/1033