### PR TITLE
sophos: fix handling of date parsing

### DIFF
--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Allow user configuration of timezone offset in XG data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6676
+    - description: Fix handling of sophos.xg.eventtime when it contains an invalid timezone.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6676
 - version: "2.10.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-anti-spam.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-anti-spam.log-expected.json
@@ -89,6 +89,7 @@
                     "quarantine_reason": "Spam",
                     "spamaction": "DROP",
                     "src_country_code": "R1",
+                    "timezone": "IST",
                     "user_name": "gaurav"
                 }
             },
@@ -194,7 +195,8 @@
                     "priority": "Warning",
                     "quarantine_reason": "Spam",
                     "spamaction": "WARN",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -297,6 +299,7 @@
                     "quarantine_reason": "Other",
                     "spamaction": "Accept",
                     "src_country_code": "R1",
+                    "timezone": "IST",
                     "user_name": "gaurav"
                 }
             },
@@ -402,7 +405,8 @@
                     "priority": "Warning",
                     "quarantine_reason": "RBL",
                     "spamaction": "DROP",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -507,6 +511,7 @@
                     "quarantine_reason": "Spam",
                     "spamaction": "Accept",
                     "src_country_code": "R1",
+                    "timezone": "IST",
                     "user_name": "gaurav"
                 }
             },
@@ -612,7 +617,8 @@
                     "priority": "Warning",
                     "quarantine_reason": "Spam",
                     "spamaction": "Drop",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -717,7 +723,8 @@
                     "priority": "Information",
                     "quarantine_reason": "DLP",
                     "spamaction": "DROP",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -820,7 +827,8 @@
                     "priority": "Information",
                     "quarantine_reason": "Other",
                     "spamaction": "Accept",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -919,7 +927,8 @@
                     "priority": "Information",
                     "quarantine_reason": "Other",
                     "spamaction": "REJECT",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1005,7 +1014,8 @@
                     "priority": "Warning",
                     "quarantine_reason": "Other",
                     "spamaction": "TMPREJECT",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1105,6 +1115,7 @@
                     "quarantine_reason": "Other",
                     "spamaction": "SANDSTORM ALLOW",
                     "src_country_code": "R1",
+                    "timezone": "IST",
                     "user_name": "gaurav"
                 }
             },
@@ -1209,7 +1220,8 @@
                     "mailsize": "419835",
                     "priority": "Warning",
                     "spamaction": "DROP",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1315,6 +1327,7 @@
                     "quarantine_reason": "Other",
                     "spamaction": "Accept",
                     "src_country_code": "R1",
+                    "timezone": "IST",
                     "user_name": "gaurav"
                 }
             },
@@ -1418,7 +1431,8 @@
                     "mailsize": "0",
                     "priority": "Warning",
                     "quarantine_reason": "Other",
-                    "spamaction": "Change Subject"
+                    "spamaction": "Change Subject",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1519,7 +1533,8 @@
                     "mailsize": "0",
                     "priority": "Information",
                     "quarantine_reason": "Other",
-                    "spamaction": "Accept"
+                    "spamaction": "Accept",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1622,7 +1637,8 @@
                     "mailsize": "0",
                     "priority": "Warning",
                     "quarantine_reason": "Other",
-                    "spamaction": "Accept"
+                    "spamaction": "Accept",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1725,7 +1741,8 @@
                     "mailsize": "0",
                     "priority": "Warning",
                     "quarantine_reason": "Other",
-                    "spamaction": "Accept"
+                    "spamaction": "Accept",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1826,7 +1843,8 @@
                     "mailsize": "0",
                     "priority": "Information",
                     "quarantine_reason": "Other",
-                    "spamaction": "Accept"
+                    "spamaction": "Accept",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1929,7 +1947,8 @@
                     "priority": "Information",
                     "quarantine_reason": "Other",
                     "spamaction": "DELIVERED",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-anti-virus-ftp.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-anti-virus-ftp.log-expected.json
@@ -76,6 +76,7 @@
                     "log_type": "Anti-Virus",
                     "priority": "Critical",
                     "src_country_code": "R1",
+                    "timezone": "CEST",
                     "virus": "EICAR-AV-Test"
                 }
             },
@@ -161,7 +162,8 @@
                     "log_id": "031001609002",
                     "log_subtype": "Allowed",
                     "log_type": "Anti-Virus",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "CEST"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-anti-virus-smtp.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-anti-virus-smtp.log-expected.json
@@ -90,6 +90,7 @@
                     "quarantine_reason": " Infected",
                     "src_country_code": "R1",
                     "subject": "virus infected message",
+                    "timezone": "IST",
                     "virus": "EICAR-AV-Test"
                 }
             },
@@ -196,6 +197,7 @@
                     "quarantine_reason": "Other",
                     "src_country_code": "R1",
                     "subject": "EICAR",
+                    "timezone": "IST",
                     "virus": "EICAR-AV-Test"
                 }
             },
@@ -302,6 +304,7 @@
                     "quarantine_reason": "Other",
                     "src_country_code": "R1",
                     "subject": "EICAR test email",
+                    "timezone": "IST",
                     "virus": "EICAR-AV- Test"
                 }
             },

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-anti-virus-web.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-anti-virus-web.log-expected.json
@@ -36,6 +36,7 @@
                 "original": "device=\"SFW\" date=2016-12-02 time=18:48:18 timezone=\"GMT\" device_name=\"SFVUNL\" device_id=C01001K234RXPA1 log_id=034806208001 log_type=\"Anti-Virus\" log_component=\"HTTPS\" log_subtype=\"Virus\" priority=Critical fw_rule_id=2 user_name=\"rich\" iap=13 virus=\"EICAR-AV-Test\" url=\"https://secure.eicar.org/eicar.com\" domainname=\"secure.eicar.org\" src_ip=192.168.73.220 src_country_code=R1 dst_ip=216.160.83.61 dst_country_code=DEU protocol=\"TCP\" src_port=51499 dst_port=443 sent_bytes=0 recv_bytes=353",
                 "outcome": "success",
                 "severity": 2,
+                "timezone": "GMT",
                 "type": [
                     "info",
                     "denied",
@@ -88,6 +89,7 @@
                     "log_type": "Anti-Virus",
                     "priority": "Critical",
                     "src_country_code": "R1",
+                    "timezone": "GMT",
                     "virus": "EICAR-AV-Test"
                 }
             },
@@ -132,6 +134,7 @@
                 "original": "device=\"SFW\" date=2016-12-02 time=18:57:57 timezone=\"GMT\" device_name=\"SFVUNL\" device_id=C01001K234RXPA1 log_id=030906208001 log_type=\"Anti-Virus\" log_component=\"HTTP\" log_subtype=\"Virus\" priority=Critical fw_rule_id=0 user_name=\"rich\" iap=13 virus=\"Sandstorm\" url=\"http://floater.baldrys.ca/badb.exe\" domainname=\"floater.baldrys.ca\" src_ip=192.168.73.220 src_country_code=R1 dst_ip=192.168.73.220 dst_country_code=R1 protocol=\"TCP\" src_port=54110 dst_port=80 sent_bytes=0 recv_bytes=1594715",
                 "outcome": "success",
                 "severity": 2,
+                "timezone": "GMT",
                 "type": [
                     "info",
                     "denied",
@@ -183,6 +186,7 @@
                     "log_type": "Anti-Virus",
                     "priority": "Critical",
                     "src_country_code": "R1",
+                    "timezone": "GMT",
                     "virus": "Sandstorm"
                 }
             },

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-atp-firewall.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-atp-firewall.log-expected.json
@@ -72,7 +72,8 @@
                     "log_subtype": "Alert",
                     "log_type": "ATP",
                     "priority": "Notice",
-                    "threatname": "C2/Generic-A"
+                    "threatname": "C2/Generic-A",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -162,7 +163,8 @@
                     "log_subtype": "Drop",
                     "log_type": "ATP",
                     "priority": "Warning",
-                    "threatname": "C2 /Generic-A"
+                    "threatname": "C2 /Generic-A",
+                    "timezone": "IST"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-authentication.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-authentication.log-expected.json
@@ -54,7 +54,8 @@
                     "log_subtype": "Authentication",
                     "log_type": "Event",
                     "priority": "Information",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -126,7 +127,8 @@
                     "log_subtype": "Authentication",
                     "log_type": "Event",
                     "priority": "Information",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -195,7 +197,8 @@
                     "log_subtype": "Authentication",
                     "log_type": "Event",
                     "priority": "Information",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "IST"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-content-filtering-http.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-content-filtering-http.log-expected.json
@@ -33,6 +33,7 @@
                 "outcome": "success",
                 "reason": "cached clean",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "connection"
@@ -81,7 +82,8 @@
                     "log_id": "050901616001",
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -128,6 +130,7 @@
                 "outcome": "success",
                 "reason": " cloud clean",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "connection"
@@ -175,7 +178,8 @@
                     "log_id": "050901616001",
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -231,6 +235,7 @@
                 "outcome": "success",
                 "reason": "eligible",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "connection"
@@ -280,7 +285,8 @@
                     "log_id": "050901616001",
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -339,6 +345,7 @@
                 "outcome": "success",
                 "reason": "not eligible",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "connection"
@@ -388,7 +395,8 @@
                     "log_id": "050901616001",
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -448,6 +456,7 @@
                 "outcome": "success",
                 "reason": "pending",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "info",
                     "denied",
@@ -497,7 +506,8 @@
                     "log_id": "050902616002",
                     "log_subtype": "Denied",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -556,6 +566,7 @@
                 "original": "device=\"SFW\" date=2016-12-02 time=19:30:33 timezone=\"GMT\" device_name=\"SFVUNL\" device_id=C01001K234RXPA1 log_id=050902616002 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Denied\" priority=Information fw_rule_id=2 user_name=\"rich\" user_gp=\"Clientless Open Group\" iap=14 category=\"Financial Services\" category_type=\"Unproductive\" url=\"https://www.vancity.com/\" contenttype=\"\" override_token=\"\" src_ip=192.168.73.220 dst_ip=67.43.156.15 protocol=\"TCP\" src_port=60444 dst_port=443 sent_bytes=0 recv_bytes=0 domain=www.vancity.com exceptions= activityname=\" Finance \u0026 Investing\" reason=\"\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "info",
                     "denied",
@@ -606,7 +617,8 @@
                     "log_id": "050902616002",
                     "log_subtype": "Denied",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -663,6 +675,7 @@
                 "original": "device=\"SFW\" date=2016-12-02 time=18:50:20 timezone=\"GMT\" device_name=\"SFVUNL\" device_id=C01001K234RXPA1 log_id=050927616005 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Warned\" priority=Information fw_rule_id=2 user_name=\"rich\" user_gp=\"Clientless Open Group\" iap=13 category=\"Search Engines\" category_type=\"Acceptable\" url=\"http://www.google.com/\" contenttype=\"\" override_token=\"\" src_ip=192.168.73.220 dst_ip=67.43.156.15 protocol=\"TCP\" src_port=37832 dst_port=80 sent_bytes=0 recv_bytes=0 domain=www.google.com exceptions= activityname=\"Search\" reason=\"\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "connection"
@@ -712,7 +725,8 @@
                     "log_id": "050927616005",
                     "log_subtype": "Warned",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -770,6 +784,7 @@
                 "outcome": "success",
                 "reason": "not eligible",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "connection"
@@ -820,7 +835,8 @@
                     "log_id": "050901616006",
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-content-filtering-web-content-policy.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-content-filtering-web-content-policy.log-expected.json
@@ -13,7 +13,8 @@
                 "kind": "event",
                 "original": "device_name=\"SF01V\" device_id=SFDemo-c45b327 log_id=058420116010 log_type=\"Content Filtering\" log_component=\"Web Content Policy\" log_subtype=\"Alert\" user=\"gi123456\" src_ip=10.108.108.49 transaction_id=\"e4a127f7-a850-477c-920e-a471b38727c1\" dictionary_name=\"complicated_Custom\" site_category=Information Technology website=\"ta-web-static-testing.qa.astaro.de\" direction=\"in\" action=\"Deny\" file_name=\"cgi_echo.pl\" context_match=\"Not\" context_prefix=\"blah blah hello \" context_suffix=\" hello blah \"",
                 "outcome": "success",
-                "severity": 1
+                "severity": 1,
+                "timezone": "UTC"
             },
             "host": {
                 "name": "defaulttest.local"

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-firewall.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-firewall.log-expected.json
@@ -116,7 +116,8 @@
                     "priority": "Information",
                     "src_country_code": "R1",
                     "src_zone_type": "LAN",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -247,7 +248,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -361,7 +363,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -463,7 +466,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Notice",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -581,7 +585,8 @@
                     "log_subtype": "Allowed",
                     "log_type": "Firewall",
                     "priority": "Notice",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -682,7 +687,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -782,7 +788,8 @@
                     "log_type": "Firewall",
                     "message": "Invalid UDP destination.",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -874,7 +881,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -973,7 +981,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1074,7 +1083,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Warning",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1170,7 +1180,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1270,7 +1281,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1369,7 +1381,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1485,7 +1498,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1572,7 +1586,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1682,7 +1697,8 @@
                     "log_type": "Firewall",
                     "priority": "Information",
                     "src_zone_type": " LAN",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "CEST"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-idp.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-idp.log-expected.json
@@ -71,7 +71,8 @@
                     "priority": "Warning",
                     "rule_priority": "1",
                     "src_country_code": "R1",
-                    "target": "Server"
+                    "target": "Server",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -153,7 +154,8 @@
                     "priority": "Warning",
                     "rule_priority": "1",
                     "src_country_code": "R1",
-                    "target": "Server"
+                    "target": "Server",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -235,7 +237,8 @@
                     "priority": "Warning",
                     "rule_priority": "5",
                     "src_country_code": "R1",
-                    "target": "Server"
+                    "target": "Server",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -317,7 +320,8 @@
                     "priority": "Warning",
                     "rule_priority": "3",
                     "src_country_code": "HKG",
-                    "target": "Client"
+                    "target": "Client",
+                    "timezone": "IST"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-sandstorm.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-sandstorm.log-expected.json
@@ -16,6 +16,7 @@
                 "outcome": "success",
                 "reason": "eligible",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "end",
@@ -50,7 +51,8 @@
                     "log_id": "136501618041",
                     "log_subtype": "Allowed",
                     "log_type": "Sandbox",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "tags": [
@@ -76,6 +78,7 @@
                 "outcome": "success",
                 "reason": "cloud clean",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed"
                 ]
@@ -123,7 +126,8 @@
                     "log_id": "136501618041",
                     "log_subtype": "Allowed",
                     "log_type": "Sandbox",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -207,7 +211,8 @@
                     "log_id": "136502218042",
                     "log_subtype": "Denied",
                     "log_type": "Sandbox",
-                    "priority": "Critical"
+                    "priority": "Critical",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -242,6 +247,7 @@
                 "outcome": "success",
                 "reason": "pending",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "start",
                     "connection"
@@ -290,7 +296,8 @@
                     "log_id": "136528618043",
                     "log_subtype": "Pending",
                     "log_type": "Sandbox",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -325,6 +332,7 @@
                 "outcome": "success",
                 "reason": "pending",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "start",
                     "connection"
@@ -373,7 +381,8 @@
                     "log_id": "136528618043",
                     "log_subtype": "Pending",
                     "log_type": "Sandbox",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-systemhealth.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-systemhealth.log-expected.json
@@ -39,6 +39,7 @@
                     "log_type": "System Health",
                     "priority": "Information",
                     "system_cpu": 1.29,
+                    "timezone": "CEST",
                     "user_cpu": 7.6
                 }
             },
@@ -84,6 +85,7 @@
                     "log_subtype": "Usage",
                     "log_type": "System Health",
                     "priority": "Information",
+                    "timezone": "CEST",
                     "total_memory": 2100191232,
                     "unit": "byte",
                     "used": 1521541120
@@ -135,6 +137,7 @@
                     "receiveddrops": 0.0,
                     "receivederrors": "0.00",
                     "receivedkbits": 4.55,
+                    "timezone": "CEST",
                     "transmitteddrops": 0.0,
                     "transmittederrors": "0.00",
                     "transmittedkbits": 2.03
@@ -184,7 +187,8 @@
                     "priority": "Information",
                     "reports": 11.0,
                     "signature": 11.0,
-                    "temp": 4.0
+                    "temp": 4.0,
+                    "timezone": "CEST"
                 }
             },
             "tags": [
@@ -228,6 +232,7 @@
                     "log_subtype": "Usage",
                     "log_type": "System Health",
                     "priority": "Information",
+                    "timezone": "CEST",
                     "users": 0
                 }
             },

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-wireless.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-18-5-wireless.log-expected.json
@@ -40,7 +40,8 @@
                     "log_subtype": "Information",
                     "log_type": "Wireless Protection",
                     "priority": "Information",
-                    "ssid": "SPIDIGO2015"
+                    "ssid": "SPIDIGO2015",
+                    "timezone": "IST"
                 }
             },
             "tags": [
@@ -87,7 +88,8 @@
                     "log_subtype": "Information",
                     "log_type": "Wireless Protection",
                     "priority": "Information",
-                    "ssid": "SPIDIGO2015"
+                    "ssid": "SPIDIGO2015",
+                    "timezone": "IST"
                 }
             },
             "tags": [

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-xg.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-sophos-xg.log-expected.json
@@ -79,7 +79,8 @@
                     "mailsize": "19728",
                     "priority": "Information",
                     "quarantine_reason": "Other",
-                    "spamaction": "QUEUED"
+                    "spamaction": "QUEUED",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -192,7 +193,8 @@
                     "priority": "Information",
                     "quarantine_reason": "Other",
                     "spamaction": "Accept",
-                    "src_country_code": "USA"
+                    "src_country_code": "USA",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -320,7 +322,8 @@
                     "priority": "Warning",
                     "quarantine_reason": "Spam",
                     "spamaction": "Reject",
-                    "src_country_code": "BRA"
+                    "src_country_code": "BRA",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -448,7 +451,8 @@
                     "priority": "Warning",
                     "quarantine_reason": "RBL",
                     "spamaction": "Prefix Subject",
-                    "src_country_code": "GBR"
+                    "src_country_code": "GBR",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -565,6 +569,7 @@
                     "quarantine_reason": "Spam",
                     "spamaction": "Accept",
                     "src_country_code": "R1",
+                    "timezone": "IST",
                     "user_name": "gaurav"
                 }
             },
@@ -670,7 +675,8 @@
                     "priority": "Warning",
                     "quarantine_reason": "Spam",
                     "spamaction": "Drop",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -775,7 +781,8 @@
                     "priority": "Information",
                     "quarantine_reason": "DLP",
                     "spamaction": "DROP",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -878,7 +885,8 @@
                     "priority": "Information",
                     "quarantine_reason": "Other",
                     "spamaction": "Accept",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -964,7 +972,8 @@
                     "priority": "Warning",
                     "quarantine_reason": "Other",
                     "spamaction": "TMPREJECT",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1064,7 +1073,8 @@
                     "mailsize": "419835",
                     "priority": "Warning",
                     "spamaction": "DROP",
-                    "src_country_code": "R1"
+                    "src_country_code": "R1",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -1170,6 +1180,7 @@
                     "quarantine_reason": "Other",
                     "spamaction": "Accept",
                     "src_country_code": "R1",
+                    "timezone": "IST",
                     "user_name": "gaurav"
                 }
             },
@@ -1272,6 +1283,7 @@
                     "log_type": "Anti-Virus",
                     "priority": "Critical",
                     "src_country_code": "R1",
+                    "timezone": "CEST",
                     "virus": "Sandstorm"
                 }
             },
@@ -1393,6 +1405,7 @@
                     "log_type": "Anti-Virus",
                     "priority": "Critical",
                     "src_country_code": "R1",
+                    "timezone": "CEST",
                     "virus": "EICAR-AV-Test"
                 }
             },
@@ -1529,6 +1542,7 @@
                     "quarantine_reason": "Infected",
                     "src_country_code": "DEU",
                     "subject": "ZAHLUNG (PROFORMA INVOICE)",
+                    "timezone": "CEST",
                     "virus": "TR/AD.AgentTesla.eaz"
                 }
             },
@@ -1658,6 +1672,7 @@
                     "quarantine_reason": "Infected",
                     "src_country_code": "USA",
                     "subject": "Re: NEW PRO-FORMA INVOICE",
+                    "timezone": "CEST",
                     "virus": "Mal/BredoZp-B"
                 }
             },
@@ -1776,6 +1791,7 @@
                     "quarantine_reason": "Other",
                     "src_country_code": "R1",
                     "subject": "EICAR",
+                    "timezone": "IST",
                     "virus": "EICAR-AV-Test"
                 }
             },
@@ -1882,6 +1898,7 @@
                     "quarantine_reason": "Other",
                     "src_country_code": "R1",
                     "subject": "EICAR test email",
+                    "timezone": "IST",
                     "virus": "EICAR-AV-Test"
                 }
             },
@@ -1974,6 +1991,7 @@
                     "log_type": "Anti-Virus",
                     "priority": "Critical",
                     "src_country_code": "R1",
+                    "timezone": "CEST",
                     "virus": "EICAR-AV-Test"
                 }
             },
@@ -2057,7 +2075,8 @@
                     "log_id": "031001609002",
                     "log_subtype": "Allowed",
                     "log_type": "Anti-Virus",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -2145,7 +2164,8 @@
                     "log_subtype": "Drop",
                     "log_type": "ATP",
                     "priority": "Warning",
-                    "threatname": "C2/Generic-A"
+                    "threatname": "C2/Generic-A",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -2235,7 +2255,8 @@
                     "log_subtype": "Drop",
                     "log_type": "ATP",
                     "priority": "Warning",
-                    "threatname": "C2/Generic-A"
+                    "threatname": "C2/Generic-A",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -2339,7 +2360,8 @@
                     "log_subtype": "Drop",
                     "log_type": "ATP",
                     "priority": "Warning",
-                    "threatname": "C2/Generic-A"
+                    "threatname": "C2/Generic-A",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -2443,7 +2465,8 @@
                     "log_subtype": "Alert",
                     "log_type": "ATP",
                     "priority": "Notice",
-                    "threatname": "C2/Generic-A"
+                    "threatname": "C2/Generic-A",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -2537,7 +2560,8 @@
                     "log_id": "050901616001",
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -2640,7 +2664,8 @@
                     "log_id": "050902616002",
                     "log_subtype": "Denied",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -2753,7 +2778,8 @@
                     "log_type": "Content Filtering",
                     "priority": "Information",
                     "src_country_code": "DEU",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -2861,7 +2887,8 @@
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
                     "priority": "Information",
-                    "status_code": "400"
+                    "status_code": "400",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -2978,7 +3005,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Content Filtering",
                     "priority": "Information",
-                    "status_code": "200"
+                    "status_code": "200",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -3094,7 +3122,8 @@
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
                     "priority": "Information",
-                    "status_code": "304"
+                    "status_code": "304",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -3150,7 +3179,8 @@
                 "kind": "event",
                 "original": "\u003c30\u003edevice=\"SFW\" date=2016-12-02 time=18:50:20 timezone=\"GMT\" device_name=\"SF01V\" device_id=1234567890123456 log_id=058420116010 log_type=\"Content Filtering\" log_component=\"Web Content Policy\" log_subtype=\"Alert\" user=\"gi123456\" src_ip=10.108.108.49 transaction_id=\"e4a127f7-a850-477c-920e-a471b38727c1\" dictionary_name=\"complicated_Custom\" site_category=Information Technology website=\"ta-web-static-testing.qa. astaro.de\" direction=\"in\" action=\"Deny\" file_name=\"cgi_echo.pl\" context_match=\"Not\" context_prefix=\"blah blah hello \" context_suffix=\" hello blah \"",
                 "outcome": "success",
-                "severity": 1
+                "severity": 1,
+                "timezone": "GMT"
             },
             "host": {
                 "name": "testhost.local"
@@ -3188,6 +3218,7 @@
                     "log_subtype": "Alert",
                     "log_type": "Content Filtering",
                     "site_category": "Information Technology",
+                    "timezone": "GMT",
                     "transaction_id": "e4a127f7-a850-477c-920e-a471b38727c1",
                     "user": "gi123456",
                     "website": "ta-web-static-testing.qa. astaro.de"
@@ -3232,6 +3263,7 @@
                 "original": "\u003c30\u003edevice=\"SFW\" date=2016-12-02 time=18:50:20 timezone=\"GMT\" device_name=\"SFVUNL\" device_id=C01001K234RXPA1 log_id=050927616005 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Warned\" status=\"\" priority=Information fw_rule_id=2 user_name=\"rich\" user_gp=\"Clientless Open Group\" iap=13 category=\"Search Engines\" category_type=\"Acceptable\" url=\"http://www.google.com/\" contenttype=\"\" override_token=\"\" httpresponsecode=\"\" src_ip=192.168.73.220 dst_ip=175.16.199.1 protocol=\"TCP\" src_port=37832 dst_port=80 sent_bytes=0 recv_bytes=0 domain=www.google.com exceptions= activityname=\" Search\" reason=\"\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "connection"
@@ -3281,7 +3313,8 @@
                     "log_id": "050927616005",
                     "log_subtype": "Warned",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -3339,6 +3372,7 @@
                 "outcome": "success",
                 "reason": "not eligible",
                 "severity": 6,
+                "timezone": "GMT",
                 "type": [
                     "allowed",
                     "connection"
@@ -3389,7 +3423,8 @@
                     "log_id": "050901616006",
                     "log_subtype": "Allowed",
                     "log_type": "Content Filtering",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "GMT"
                 }
             },
             "source": {
@@ -3469,7 +3504,8 @@
                     "log_subtype": "Authentication",
                     "log_type": "Event",
                     "priority": "Information",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -3563,7 +3599,8 @@
                     "log_type": "Event",
                     "priority": "Warning",
                     "remotenetwork": "10.84.234.5/32",
-                    "status": "Failed"
+                    "status": "Failed",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -3627,7 +3664,8 @@
                     "log_subtype": "System",
                     "log_type": "Event",
                     "priority": "Error",
-                    "status": "Expire"
+                    "status": "Expire",
+                    "timezone": "CEST"
                 }
             },
             "tags": [
@@ -3687,7 +3725,8 @@
                     "log_subtype": "Authentication",
                     "log_type": "Event",
                     "priority": "Information",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -3762,7 +3801,8 @@
                     "newversion": "1.0.407795 ",
                     "oldversion": "1.0.407794",
                     "priority": "Notice",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "CEST"
                 }
             },
             "tags": [
@@ -3809,7 +3849,8 @@
                     "log_type": "Event",
                     "priority": "Information",
                     "raw_data": "192.168.110.10",
-                    "status": "Expire"
+                    "status": "Expire",
+                    "timezone": "CEST"
                 }
             },
             "tags": [
@@ -3869,7 +3910,8 @@
                     "log_subtype": "Authentication",
                     "log_type": "Event",
                     "priority": "Information",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -3945,7 +3987,8 @@
                     "priority": "Information",
                     "remote_ip": "10.82.234.12",
                     "starttime": "0",
-                    "status": "Established"
+                    "status": "Established",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -4008,7 +4051,8 @@
                     "log_subtype": "Authentication",
                     "log_type": "Event",
                     "priority": "Notice",
-                    "status": "Failed"
+                    "status": "Failed",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -4076,7 +4120,8 @@
                     "newversion": "1.0.0298 ",
                     "oldversion": "1.0.0297",
                     "priority": "Notice",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "CEST"
                 }
             },
             "tags": [
@@ -4128,7 +4173,8 @@
                     "log_type": "Event",
                     "priority": "Information",
                     "status": "Successful",
-                    "syslog_server_name": "'Logstash'"
+                    "syslog_server_name": "'Logstash'",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -4186,7 +4232,8 @@
                     "log_subtype": "Admin",
                     "log_type": "Event",
                     "priority": "Notice",
-                    "status": "Failed"
+                    "status": "Failed",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -4251,7 +4298,8 @@
                     "newversion": "9.17.10 ",
                     "oldversion": "9.17.09",
                     "priority": "Notice",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "CEST"
                 }
             },
             "tags": [
@@ -4296,7 +4344,8 @@
                     "log_id": "063311617923",
                     "log_subtype": "System",
                     "log_type": "Event",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "CEST"
                 }
             },
             "tags": [
@@ -4362,7 +4411,8 @@
                     "log_type": "Event",
                     "priority": "Information",
                     "start_time": "1591086575",
-                    "status": "Successful"
+                    "status": "Successful",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -4422,14 +4472,15 @@
                     "branch_name": "Gaurav Patel",
                     "device": "SFW",
                     "device_name": "XG125w",
-                    "eventtime": "2017-03-16 12:56:01 IST",
+                    "eventtime": "2017-03-16T10:56:01.000Z",
                     "log_component": "RED",
                     "log_id": "066811618014",
                     "log_subtype": "System",
                     "log_type": "Event",
                     "priority": "Information",
                     "red_id": "A350196C47072B0",
-                    "status": "Connected"
+                    "status": "Connected",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -4479,14 +4530,15 @@
                     "branch_name": "Gaurav Patel",
                     "device": "SFW",
                     "device_name": "XG125w",
-                    "eventtime": "2017-03-16 12:53:27 IST",
+                    "eventtime": "2017-03-16T10:53:27.000Z",
                     "log_component": "RED",
                     "log_id": "066811618015",
                     "log_subtype": "System",
                     "log_type": "Event",
                     "priority": "Information",
                     "red_id": "A350196C47072B0",
-                    "status": "Disconnected"
+                    "status": "Disconnected",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -4536,14 +4588,15 @@
                     "branch_name": "NY",
                     "device": "SFW",
                     "device_name": "XG125w",
-                    "eventtime": "2017-03-16 12:46:26 IST",
+                    "eventtime": "2017-03-16T10:46:26.000Z",
                     "log_component": "RED",
                     "log_id": "066811618016",
                     "log_subtype": "System",
                     "log_type": "Event",
                     "priority": "Information",
                     "red_id": "A350196C47072B0",
-                    "status": "Interim"
+                    "status": "Interim",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -4593,6 +4646,7 @@
                     "log_type": "Event",
                     "priority": "Notice",
                     "status": "Success",
+                    "timezone": "IST",
                     "updatedip": "10.198.232.86"
                 }
             },
@@ -4713,7 +4767,8 @@
                     "priority": "Information",
                     "src_country_code": "R1",
                     "src_zone_type": "LAN",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -4856,7 +4911,8 @@
                     "priority": "Information",
                     "src_country_code": "R1",
                     "src_zone_type": "DMZ",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -4986,7 +5042,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -5107,7 +5164,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -5224,7 +5282,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -5345,7 +5404,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -5465,7 +5525,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Warning",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -5578,7 +5639,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -5708,7 +5770,8 @@
                     "priority": "Information",
                     "src_country_code": "R1",
                     "src_zone_type": "VPN",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -5831,7 +5894,8 @@
                     "log_subtype": "Allowed",
                     "log_type": "Firewall",
                     "priority": "Notice",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -5953,7 +6017,8 @@
                     "log_type": "Firewall",
                     "priority": "Information",
                     "src_country_code": "R1",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -6072,7 +6137,8 @@
                     "log_type": "Firewall",
                     "message": "Invalid UDP destination.",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -6164,7 +6230,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -6263,7 +6330,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -6364,7 +6432,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Warning",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -6460,7 +6529,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -6566,7 +6636,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -6665,7 +6736,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -6767,7 +6839,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -6881,7 +6954,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Firewall",
                     "priority": "Information",
-                    "status": "Deny"
+                    "status": "Deny",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -6979,7 +7053,8 @@
                     "priority": "Warning",
                     "rule_priority": "2",
                     "src_country_code": "ROU",
-                    "target": "Server"
+                    "target": "Server",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -7084,7 +7159,8 @@
                     "priority": "Warning",
                     "rule_priority": "1",
                     "src_country_code": "CHN",
-                    "target": "Server"
+                    "target": "Server",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -7189,7 +7265,8 @@
                     "priority": "Warning",
                     "rule_priority": "2",
                     "src_country_code": "NLD",
-                    "target": "Server"
+                    "target": "Server",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -7283,7 +7360,8 @@
                     "priority": "Warning",
                     "rule_priority": "1",
                     "src_country_code": "R1",
-                    "target": "Server"
+                    "target": "Server",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -7365,7 +7443,8 @@
                     "priority": "Warning",
                     "rule_priority": "1",
                     "src_country_code": "R1",
-                    "target": "Server"
+                    "target": "Server",
+                    "timezone": "BST"
                 }
             },
             "source": {
@@ -7426,7 +7505,8 @@
                     "log_id": "138301618041",
                     "log_subtype": "Allowed",
                     "log_type": "Sandbox",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "IST"
                 }
             },
             "tags": [
@@ -7498,7 +7578,8 @@
                     "log_subtype": "Denied",
                     "log_type": "Sandbox",
                     "priority": "Critical",
-                    "source": "jsmith@iview.com"
+                    "source": "jsmith@iview.com",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -7561,7 +7642,8 @@
                     "log_id": "136501618041",
                     "log_subtype": "Allowed",
                     "log_type": "Sandbox",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "IST"
                 }
             },
             "tags": [
@@ -7636,7 +7718,8 @@
                     "log_id": "136528618043",
                     "log_subtype": "Pending",
                     "log_type": "Sandbox",
-                    "priority": "Information"
+                    "priority": "Information",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -7721,7 +7804,8 @@
                     "log_id": "136502218042",
                     "log_subtype": "Denied",
                     "log_type": "Sandbox",
-                    "priority": "Critical"
+                    "priority": "Critical",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -7802,7 +7886,8 @@
                     "log_id": "136502218042",
                     "log_subtype": "Denied",
                     "log_type": "Sandbox",
-                    "priority": "Critical"
+                    "priority": "Critical",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -7902,7 +7987,8 @@
                     "log_type": "WAF",
                     "priority": "Information",
                     "querystring": "?MailboxId=642ea57c-90ab-4571-8e05-c6997b2256f8@elastic.user.com",
-                    "server": "webmail.elasticuser.com"
+                    "server": "webmail.elasticuser.com",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -8007,7 +8093,8 @@
                     "log_type": "WAF",
                     "priority": "Information",
                     "querystring": "?MailboxId=642ea57c-90ab-4571-8e05-c6997b2256f8@elastic.user.com",
-                    "server": "webmail.elasticuser.com"
+                    "server": "webmail.elasticuser.com",
+                    "timezone": "CEST"
                 }
             },
             "source": {
@@ -8105,7 +8192,8 @@
                     "log_id": "075000617071",
                     "log_type": "WAF",
                     "priority": "Information",
-                    "server": "www.iviewtest.com:8989"
+                    "server": "www.iviewtest.com:8989",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -8197,7 +8285,8 @@
                     "log_type": "WAF",
                     "phpsessid": "jetkd9iadd969hsr77jpj4q974; _pk_id.1.fc3a=3a6250e215194a92.1485866024.1.1485866069.1485866024.; _pk_ses.1.fc3a=*",
                     "priority": "Information",
-                    "server": "www.iviewtest.com:8990"
+                    "server": "www.iviewtest.com:8990",
+                    "timezone": "IST"
                 }
             },
             "source": {
@@ -8295,6 +8384,7 @@
                     "log_type": "WAF",
                     "priority": "Information",
                     "sqli": ",",
+                    "timezone": "IST",
                     "xss": "): Last Matched Message: Request Missing a User Agent Header"
                 }
             },
@@ -8361,7 +8451,8 @@
                     "log_subtype": "Information",
                     "log_type": "Wireless Protection",
                     "priority": "Information",
-                    "ssid": "SPIDIGO2015"
+                    "ssid": "SPIDIGO2015",
+                    "timezone": "IST"
                 }
             },
             "tags": [
@@ -8408,7 +8499,8 @@
                     "log_subtype": "Information",
                     "log_type": "Wireless Protection",
                     "priority": "Information",
-                    "ssid": "SPIDIGO2015"
+                    "ssid": "SPIDIGO2015",
+                    "timezone": "IST"
                 }
             },
             "tags": [
@@ -8416,7 +8508,7 @@
             ]
         },
         {
-            "@timestamp": "2021-02-11T13:12:45.000Z",
+            "@timestamp": "2021-02-11T13:12:45.000+01:00",
             "destination": {
                 "as": {
                     "number": 209
@@ -8453,12 +8545,13 @@
                 ],
                 "code": "00001",
                 "duration": 0,
-                "end": "2021-02-11T13:12:45.000Z",
+                "end": "2021-02-11T13:12:45.000+01:00",
                 "kind": "event",
                 "original": "\u003c01\u003eFeb 11 13:12:45 _gateway device=\"SFW\" date=2021-02-11 time=13:12:45 timezone=\"CET\" device_name=\"XG210\" device_id=dem-dev log_id=010101600001 log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" status=\"Allow\" priority=Information duration=0 fw_rule_id=9 nat_rule_id=16 policy_type=1 user_name=\"\" user_gp=\"\" iap=0 ips_policy_id=0 appfilter_policy_id=0 application=\"\" application_risk=0 application_technology=\"\" application_category=\"\" vlan_id=\"\" ether_type=Unknown (0x0000) bridge_name=\"\" bridge_display_name=\"\" in_interface=\"Port2.109\" in_display_interface=\"CD21-IPs_WAN\" out_interface=\"Port5.200\" out_display_interface=\"Port5\" src_mac=11:22:33:44:55:66 dst_mac=66:55:44:33:22:11 src_ip=89.160.20.156 src_country_code=ESP dst_ip=175.16.199.1 dst_country_code=GB protocol=\"TCP\" src_port=33370 dst_port=443 sent_pkts=0  recv_pkts=0 sent_bytes=0 recv_bytes=0 tran_src_ip=216.160.83.57 tran_src_port=0 tran_dst_ip=216.160.83.61 tran_dst_port=0 srczonetype=\"WAN\" srczone=\"WAN\" dstzonetype=\"DMZ\" dstzone=\"Zone 9\" dir_disp=\"\" connevent=\"Start\" connid=\"3933925696\" vconnid=\"\" hb_health=\"No Heartbeat\" message=\"\" appresolvedby=\"Signature\" app_is_cloud=0",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-02-11T13:12:45.000Z",
+                "start": "2021-02-11T13:12:45.000+01:00",
+                "timezone": "CET",
                 "type": [
                     "start",
                     "allowed",
@@ -8533,7 +8626,8 @@
                     "priority": "Information",
                     "src_country_code": "ESP",
                     "src_zone_type": "WAN",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "CET"
                 }
             },
             "source": {
@@ -8669,7 +8763,8 @@
                     "log_type": "Firewall",
                     "priority": "Information",
                     "src_zone_type": "LAN",
-                    "status": "Allow"
+                    "status": "Allow",
+                    "timezone": "CEST"
                 }
             },
             "source": {

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-xg-cfilter-new.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-xg-cfilter-new.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2021-11-16T00:28:48.000Z",
+            "@timestamp": "2021-11-15T18:28:48.000-06:00",
             "destination": {
                 "ip": "192.168.1.15",
                 "port": 22083
@@ -20,6 +20,7 @@
                 "original": "Nov 16 00:28:48 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:28:48-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=054402617051 log_type=\"Content Filtering\" log_component=\"Application\" log_subtype=\"Denied\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" app_filter_policy_id=6 app_name=\"Torrent Clients P2P\" app_risk=5 app_technology=\"P2P\" app_category=\"P2P\" src_ip=\"192.168.2.32\" src_country=\"R1\" dst_ip=\"192.168.1.15\" dst_country=\"R1\" protocol=\"UDP\" src_port=44740 dst_port=22083 app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "info",
                     "denied",
@@ -81,7 +82,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:28:51.000Z",
+            "@timestamp": "2021-11-15T18:28:51.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -118,6 +119,7 @@
                 "original": "Nov 16 00:28:51 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:28:51-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50931 dst_port=443 bytes_sent=19591 bytes_received=2856085 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=173026752 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -195,7 +197,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:28:57.000Z",
+            "@timestamp": "2021-11-15T18:28:57.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -232,6 +234,7 @@
                 "original": "Nov 16 00:28:57 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:28:57-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50932 dst_port=443 bytes_sent=12138 bytes_received=1708430 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=2694936768 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -309,7 +312,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:03.000Z",
+            "@timestamp": "2021-11-15T18:29:03.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -346,6 +349,7 @@
                 "original": "Nov 16 00:29:03 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:03-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50933 dst_port=443 bytes_sent=15419 bytes_received=2608205 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=2564230592 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -423,7 +427,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:06.000Z",
+            "@timestamp": "2021-11-15T18:29:06.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -460,6 +464,7 @@
                 "original": "Nov 16 00:29:06 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:06-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"General Business\" http_category_type=\"Acceptable\" url=\"http://info.cspserver.net/api/v1/connect-test\" content_type=\"application/octet-stream\" src_ip=\"192.168.2.112\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=54640 dst_port=80 bytes_sent=77 bytes_received=249 domain=\"info.cspserver.net\" http_status=\"200\" con_id=2617088192 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"JPN\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -543,7 +548,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:07.000Z",
+            "@timestamp": "2021-11-15T18:29:07.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -580,6 +585,7 @@
                 "original": "Nov 16 00:29:07 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:07-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://array611.prod.do.dsp.mp.microsoft.com\" src_ip=\"192.168.2.110\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=53392 dst_port=443 bytes_sent=2128 bytes_received=3511 domain=\"array611.prod.do.dsp.mp.microsoft.com\" exceptions=\"av,https,validation,policy,zero-day protection\" http_status=\"0\" con_id=2916030976 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"IRL\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -658,7 +664,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:11.000Z",
+            "@timestamp": "2021-11-15T18:29:11.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -695,6 +701,7 @@
                 "original": "Nov 16 00:29:11 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:11-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50934 dst_port=443 bytes_sent=16674 bytes_received=2569044 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=2564227072 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -772,7 +779,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:16.000Z",
+            "@timestamp": "2021-11-15T18:29:16.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -809,6 +816,7 @@
                 "original": "Nov 16 00:29:16 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:16-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"IPAddress\" http_category_type=\"Acceptable\" url=\"http://89.160.20.156:8089/mind/mind42?type=myWanIpAddressGet\u0026bodyId=tsn%3A846001190AE52F2\" content_type=\"application/json\" src_ip=\"192.168.2.131\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=40230 dst_port=8089 bytes_sent=260 bytes_received=307 domain=\"89.160.20.156\" http_user_agent=\"TvHttpClient\" http_status=\"200\" con_id=3159010752 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -894,7 +902,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:20.000Z",
+            "@timestamp": "2021-11-15T18:29:20.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -931,6 +939,7 @@
                 "original": "Nov 16 00:29:20 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:20-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Online Chat\" http_category_type=\"Unproductive\" url=\"https://mtalk.google.com\" src_ip=\"192.168.2.162\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=53421 dst_port=443 bytes_sent=13804 bytes_received=33728 domain=\"mtalk.google.com\" http_status=\"0\" con_id=172826048 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1008,7 +1017,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:21.000Z",
+            "@timestamp": "2021-11-15T18:29:21.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1045,6 +1054,7 @@
                 "original": "Nov 16 00:29:21 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:21-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"IPAddress\" http_category_type=\"Acceptable\" url=\"http://89.160.20.156/tivo-service/mercury.cgi\" content_type=\"text/plain\" src_ip=\"192.168.2.131\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=33541 dst_port=80 bytes_sent=240 bytes_received=136 domain=\"89.160.20.156\" http_status=\"200\" con_id=175812032 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1129,7 +1139,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:22.000Z",
+            "@timestamp": "2021-11-15T18:29:22.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1166,6 +1176,7 @@
                 "original": "Nov 16 00:29:22 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:22-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"IPAddress\" http_category_type=\"Acceptable\" url=\"http://89.160.20.156/tivo-service/mlog.cgi?gzip\" content_type=\"text/plain\" src_ip=\"192.168.2.131\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=46564 dst_port=80 bytes_sent=253 bytes_received=123 domain=\"89.160.20.156\" http_status=\"200\" con_id=175808832 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1251,7 +1262,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:22.000Z",
+            "@timestamp": "2021-11-15T18:29:22.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1288,6 +1299,7 @@
                 "original": "Nov 16 00:29:22 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:22-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50935 dst_port=443 bytes_sent=10131 bytes_received=1834077 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=2719000448 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1365,7 +1377,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:23.000Z",
+            "@timestamp": "2021-11-15T18:29:23.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1402,6 +1414,7 @@
                 "original": "Nov 16 00:29:23 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:23-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" web_policy_id=1 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://alive.github.com\" src_ip=\"192.168.2.41\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=20492 dst_port=443 bytes_sent=18152 bytes_received=11890 domain=\"alive.github.com\" http_status=\"0\" con_id=2721561088 app_name=\"GitHub\" app_is_cloud=\"TRUE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\" app_risk=1 app_category=\"Storage and Backup\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1482,7 +1495,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:26.000Z",
+            "@timestamp": "2021-11-15T18:29:26.000-06:00",
             "destination": {
                 "bytes": 3059,
                 "ip": "192.168.2.90",
@@ -1501,6 +1514,7 @@
                 "original": "Nov 16 00:29:26 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:26-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"16\" web_policy_id=4 http_category=\"IPAddress\" http_category_type=\"Acceptable\" url=\"https://192.168.2.90\" src_ip=\"192.168.3.36\" dst_ip=\"192.168.2.90\" protocol=\"TCP\" src_port=37906 dst_port=8089 bytes_sent=1361 bytes_received=3059 domain=\"192.168.2.90\" http_status=\"0\" con_id=175809792 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"DMZ\" src_zone=\"DMZ\" dst_zone_type=\"LAN\" dst_zone=\"LAN\" src_country=\"R1\" dst_country=\"R1\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1578,7 +1592,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:28.000Z",
+            "@timestamp": "2021-11-15T18:29:28.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1615,6 +1629,7 @@
                 "original": "Nov 16 00:29:28 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:28-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" web_policy_id=1 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://tpcf.feedify.net\" src_ip=\"192.168.2.41\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=22569 dst_port=443 bytes_sent=1752 bytes_received=1556 domain=\"tpcf.feedify.net\" http_status=\"0\" con_id=2685143552 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1692,7 +1707,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:28.000Z",
+            "@timestamp": "2021-11-15T18:29:28.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1729,6 +1744,7 @@
                 "original": "Nov 16 00:29:28 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:28-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50936 dst_port=443 bytes_sent=12938 bytes_received=2516804 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=173140160 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1806,7 +1822,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:32.000Z",
+            "@timestamp": "2021-11-15T18:29:32.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1843,6 +1859,7 @@
                 "original": "Nov 16 00:29:32 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:32-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"General Business\" http_category_type=\"Acceptable\" url=\"https://logsink.devices.nest.com\" src_ip=\"192.168.2.109\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=49505 dst_port=443 bytes_sent=8057 bytes_received=1259 domain=\"logsink.devices.nest.com\" http_status=\"0\" con_id=3159009472 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -1920,7 +1937,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:33.000Z",
+            "@timestamp": "2021-11-15T18:29:33.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1957,6 +1974,7 @@
                 "original": "Nov 16 00:29:33 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:33-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=054402617051 log_type=\"Content Filtering\" log_component=\"Application\" log_subtype=\"Denied\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" app_filter_policy_id=6 app_name=\"Torrent Clients P2P\" app_risk=5 app_technology=\"P2P\" app_category=\"P2P\" src_ip=\"192.168.2.32\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=44740 dst_port=4000 app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "info",
                     "denied",
@@ -2018,7 +2036,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:29:36.000Z",
+            "@timestamp": "2021-11-15T18:29:36.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2055,6 +2073,7 @@
                 "original": "Nov 16 00:29:36 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:36-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"General Business\" http_category_type=\"Acceptable\" url=\"http://info.cspserver.net/api/v1/connect-test\" content_type=\"application/octet-stream\" src_ip=\"192.168.2.112\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=39118 dst_port=80 bytes_sent=77 bytes_received=249 domain=\"info.cspserver.net\" http_status=\"200\" con_id=3729897664 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"JPN\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -2138,7 +2157,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:39.000Z",
+            "@timestamp": "2021-11-15T18:29:39.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2175,6 +2194,7 @@
                 "original": "Nov 16 00:29:39 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:39-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://api.smartthings.com\" src_ip=\"192.168.2.102\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=49030 dst_port=443 bytes_sent=1157 bytes_received=4092 domain=\"api.smartthings.com\" http_status=\"0\" con_id=3729897984 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -2252,7 +2272,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:40.000Z",
+            "@timestamp": "2021-11-15T18:29:40.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2289,6 +2309,7 @@
                 "original": "Nov 16 00:29:40 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:40-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"http://connectivitycheck.gstatic.com/generate_204\" src_ip=\"192.168.2.105\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=52457 dst_port=80 bytes_sent=474 bytes_received=83 domain=\"connectivitycheck.gstatic.com\" http_user_agent=\"Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.81 Safari/537.36 CrKey/1.42.172094\" http_status=\"204\" con_id=407760320 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -2371,7 +2392,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:40.000Z",
+            "@timestamp": "2021-11-15T18:29:40.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2408,6 +2429,7 @@
                 "original": "Nov 16 00:29:40 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:40-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"http://connectivitycheck.gstatic.com/generate_204\" src_ip=\"192.168.2.123\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=35596 dst_port=80 bytes_sent=310 bytes_received=83 domain=\"connectivitycheck.gstatic.com\" http_user_agent=\"Mozilla/5.0 (Linux; Android 10.0; Build/QTS1.210311.008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000\" http_status=\"204\" con_id=3019156928 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -2490,7 +2512,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:40.000Z",
+            "@timestamp": "2021-11-15T18:29:40.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2527,6 +2549,7 @@
                 "original": "Nov 16 00:29:40 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:40-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" web_policy_id=1 http_category=\"Business Networking\" http_category_type=\"Acceptable\" url=\"https://realtime.www.linkedin.com\" src_ip=\"192.168.2.41\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=22465 dst_port=443 bytes_sent=2182 bytes_received=6231 domain=\"realtime.www.linkedin.com\" http_status=\"0\" con_id=172822528 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -2604,7 +2627,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:42.000Z",
+            "@timestamp": "2021-11-15T18:29:42.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2641,6 +2664,7 @@
                 "original": "Nov 16 00:29:42 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:42-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"8\" web_policy_id=4 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"http://checkip.dyndns.org/\" content_type=\"text/html\" src_ip=\"192.168.3.36\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=56126 dst_port=80 bytes_sent=91 bytes_received=270 domain=\"checkip.dyndns.org\" http_user_agent=\"ddclient/3.9.1\" http_status=\"200\" con_id=154693632 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"DMZ\" src_zone=\"DMZ\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"BRA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -2724,7 +2748,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:43.000Z",
+            "@timestamp": "2021-11-15T18:29:43.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2761,6 +2785,7 @@
                 "original": "Nov 16 00:29:43 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:43-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50937 dst_port=443 bytes_sent=17223 bytes_received=2569893 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=407384704 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -2838,7 +2863,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:43.000Z",
+            "@timestamp": "2021-11-15T18:29:43.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2875,6 +2900,7 @@
                 "original": "Nov 16 00:29:43 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:43-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Online Shopping\" http_category_type=\"Unproductive\" url=\"https://device-metrics-us-2.amazon.com\" src_ip=\"192.168.2.106\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=63937 dst_port=443 bytes_sent=3319 bytes_received=5643 domain=\"device-metrics-us-2.amazon.com\" http_status=\"0\" con_id=3019356672 app_name=\"Amazon Shopping\" app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\" app_risk=2 app_category=\"General Internet\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -2955,7 +2981,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:44.000Z",
+            "@timestamp": "2021-11-15T18:29:44.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2992,6 +3018,7 @@
                 "original": "Nov 16 00:29:44 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:44-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://settings-win.data.microsoft.com\" src_ip=\"192.168.2.32\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=59357 dst_port=443 bytes_sent=2144 bytes_received=4386 domain=\"settings-win.data.microsoft.com\" exceptions=\"av,https,validation,policy,zero-day protection\" http_status=\"0\" con_id=3159007232 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3070,7 +3097,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:47.000Z",
+            "@timestamp": "2021-11-15T18:29:47.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3107,6 +3134,7 @@
                 "original": "Nov 16 00:29:47 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:47-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://clientservices.googleapis.com\" src_ip=\"192.168.2.156\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=62996 dst_port=443 bytes_sent=1839 bytes_received=2046 domain=\"clientservices.googleapis.com\" http_status=\"0\" con_id=2432150656 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3184,7 +3212,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:47.000Z",
+            "@timestamp": "2021-11-15T18:29:47.000-06:00",
             "destination": {
                 "bytes": 2376,
                 "ip": "192.168.2.90",
@@ -3203,6 +3231,7 @@
                 "original": "Nov 16 00:29:47 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:47-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"16\" web_policy_id=4 http_category=\"IPAddress\" http_category_type=\"Acceptable\" url=\"https://192.168.2.90\" src_ip=\"192.168.3.36\" dst_ip=\"192.168.2.90\" protocol=\"TCP\" src_port=37912 dst_port=8089 bytes_sent=542 bytes_received=2376 domain=\"192.168.2.90\" http_status=\"0\" con_id=2721559808 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"DMZ\" src_zone=\"DMZ\" dst_zone_type=\"LAN\" dst_zone=\"LAN\" src_country=\"R1\" dst_country=\"R1\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3280,7 +3309,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:56.000Z",
+            "@timestamp": "2021-11-15T18:29:56.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3317,6 +3346,7 @@
                 "original": "Nov 16 00:29:56 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:56-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Entertainment\" http_category_type=\"Unproductive\" url=\"https://api.thetake.com\" src_ip=\"192.168.2.143\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=49274 dst_port=443 bytes_sent=2680 bytes_received=6023 domain=\"api.thetake.com\" http_status=\"0\" con_id=2685144512 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3394,7 +3424,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:29:57.000Z",
+            "@timestamp": "2021-11-15T18:29:57.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3431,6 +3461,7 @@
                 "original": "Nov 16 00:29:57 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:29:57-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://tools.google.com\" src_ip=\"192.168.2.105\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=35672 dst_port=443 bytes_sent=1719 bytes_received=8533 domain=\"tools.google.com\" http_status=\"0\" con_id=151870592 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3508,7 +3539,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:00.000Z",
+            "@timestamp": "2021-11-15T18:30:00.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3545,6 +3576,7 @@
                 "original": "Nov 16 00:30:00 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:00-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50938 dst_port=443 bytes_sent=25597 bytes_received=4923601 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=3019355392 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3622,7 +3654,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:01.000Z",
+            "@timestamp": "2021-11-15T18:30:01.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3659,6 +3691,7 @@
                 "original": "Nov 16 00:30:01 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:01-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://edge.microsoft.com\" src_ip=\"192.168.2.107\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=53571 dst_port=443 bytes_sent=10198 bytes_received=7256 domain=\"edge.microsoft.com\" exceptions=\"av,https,validation,policy,zero-day protection\" http_status=\"0\" con_id=2689611008 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3737,7 +3770,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:02.000Z",
+            "@timestamp": "2021-11-15T18:30:02.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3774,6 +3807,7 @@
                 "original": "Nov 16 00:30:02 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:02-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Search Engines\" http_category_type=\"Acceptable\" url=\"https://clients4.google.com\" src_ip=\"192.168.2.139\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=49726 dst_port=443 bytes_sent=4395 bytes_received=2128 domain=\"clients4.google.com\" http_status=\"0\" con_id=2432148096 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3851,7 +3885,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:03.000Z",
+            "@timestamp": "2021-11-15T18:30:03.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3888,6 +3922,7 @@
                 "original": "Nov 16 00:30:03 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:03-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://settings-win.data.microsoft.com\" src_ip=\"192.168.2.107\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=53600 dst_port=443 bytes_sent=1697 bytes_received=4408 domain=\"settings-win.data.microsoft.com\" exceptions=\"av,https,validation,policy,zero-day protection\" http_status=\"0\" con_id=173138560 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -3966,7 +4001,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:06.000Z",
+            "@timestamp": "2021-11-15T18:30:06.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4003,6 +4038,7 @@
                 "original": "Nov 16 00:30:06 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:06-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"General Business\" http_category_type=\"Acceptable\" url=\"http://info.cspserver.net/api/v1/connect-test\" content_type=\"application/octet-stream\" src_ip=\"192.168.2.112\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=39119 dst_port=80 bytes_sent=77 bytes_received=249 domain=\"info.cspserver.net\" http_status=\"200\" con_id=2841967104 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"JPN\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -4086,7 +4122,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:11.000Z",
+            "@timestamp": "2021-11-15T18:30:11.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4123,6 +4159,7 @@
                 "original": "Nov 16 00:30:11 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:11-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Games\" http_category_type=\"Unproductive\" url=\"https://catalog.gamepass.com\" src_ip=\"192.168.2.110\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=53588 dst_port=443 bytes_sent=1030 bytes_received=6770 domain=\"catalog.gamepass.com\" http_status=\"0\" con_id=2685088704 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -4200,7 +4237,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:16.000Z",
+            "@timestamp": "2021-11-15T18:30:16.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4237,6 +4274,7 @@
                 "original": "Nov 16 00:30:16 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:16-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Search Engines\" http_category_type=\"Acceptable\" url=\"https://clients4.google.com\" src_ip=\"192.168.2.105\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=52580 dst_port=443 bytes_sent=7011 bytes_received=2848 domain=\"clients4.google.com\" http_status=\"0\" con_id=3017219520 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -4314,7 +4352,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:25.000Z",
+            "@timestamp": "2021-11-15T18:30:25.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4351,6 +4389,7 @@
                 "original": "Nov 16 00:30:25 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:25-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://www.googleapis.com\" src_ip=\"192.168.2.126\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=53942 dst_port=443 bytes_sent=3093 bytes_received=63488 domain=\"www.googleapis.com\" http_status=\"0\" con_id=154695872 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -4428,7 +4467,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:25.000Z",
+            "@timestamp": "2021-11-15T18:30:25.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4465,6 +4504,7 @@
                 "original": "Nov 16 00:30:25 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:25-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://play.googleapis.com\" src_ip=\"192.168.2.126\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=48938 dst_port=443 bytes_sent=22415 bytes_received=7520 domain=\"play.googleapis.com\" http_status=\"0\" con_id=2169324160 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -4542,7 +4582,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:25.000Z",
+            "@timestamp": "2021-11-15T18:30:25.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4579,6 +4619,7 @@
                 "original": "Nov 16 00:30:25 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:25-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://android.googleapis.com\" src_ip=\"192.168.2.126\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=53450 dst_port=443 bytes_sent=9159 bytes_received=9567 domain=\"android.googleapis.com\" http_status=\"0\" con_id=173141120 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -4656,7 +4697,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:27.000Z",
+            "@timestamp": "2021-11-15T18:30:27.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4693,6 +4734,7 @@
                 "original": "Nov 16 00:30:27 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:27-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Online Chat\" http_category_type=\"Unproductive\" url=\"https://discord.com\" src_ip=\"192.168.2.156\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=62998 dst_port=443 bytes_sent=925 bytes_received=6253 domain=\"discord.com\" http_status=\"0\" con_id=3732575808 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -4770,7 +4812,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:28.000Z",
+            "@timestamp": "2021-11-15T18:30:28.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4807,6 +4849,7 @@
                 "original": "Nov 16 00:30:28 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:28-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"IPAddress\" http_category_type=\"Acceptable\" url=\"http://89.160.20.156:8089/mind/mind42?type=myWanIpAddressGet\u0026bodyId=tsn%3A846001190AE52F2\" content_type=\"application/json\" src_ip=\"192.168.2.131\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=40233 dst_port=8089 bytes_sent=260 bytes_received=307 domain=\"89.160.20.156\" http_user_agent=\"TvHttpClient\" http_status=\"200\" con_id=999028608 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -4892,7 +4935,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:28.000Z",
+            "@timestamp": "2021-11-15T18:30:28.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4929,6 +4972,7 @@
                 "original": "Nov 16 00:30:28 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:28-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" web_policy_id=1 http_category=\"General Business\" http_category_type=\"Acceptable\" url=\"https://backend-ssp.adstudio.cloud\" src_ip=\"192.168.2.41\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=22567 dst_port=443 bytes_sent=1004 bytes_received=584 domain=\"backend-ssp.adstudio.cloud\" http_status=\"0\" con_id=175214016 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -5006,7 +5050,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:30.000Z",
+            "@timestamp": "2021-11-15T18:30:30.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5043,6 +5087,7 @@
                 "original": "Nov 16 00:30:30 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:30-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://android.googleapis.com\" src_ip=\"192.168.2.126\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=53458 dst_port=443 bytes_sent=2417 bytes_received=2607 domain=\"android.googleapis.com\" http_status=\"0\" con_id=3732577728 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -5120,7 +5165,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:30.000Z",
+            "@timestamp": "2021-11-15T18:30:30.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5157,6 +5202,7 @@
                 "original": "Nov 16 00:30:30 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:30-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Content Delivery\" http_category_type=\"Acceptable\" url=\"https://hls14.asiancdn.net\" src_ip=\"192.168.2.111\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50939 dst_port=443 bytes_sent=36759 bytes_received=5080099 domain=\"hls14.asiancdn.net\" http_status=\"0\" con_id=173138880 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -5234,7 +5280,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:33.000Z",
+            "@timestamp": "2021-11-15T18:30:33.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5271,6 +5317,7 @@
                 "original": "Nov 16 00:30:33 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:33-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://vortex.data.microsoft.com\" src_ip=\"192.168.2.119\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=59478 dst_port=443 bytes_sent=37822 bytes_received=10552 domain=\"vortex.data.microsoft.com\" exceptions=\"av,https,validation,policy,zero-day protection\" http_status=\"0\" con_id=2564229952 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -5349,7 +5396,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:36.000Z",
+            "@timestamp": "2021-11-15T18:30:36.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5386,6 +5433,7 @@
                 "original": "Nov 16 00:30:36 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:36-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"General Business\" http_category_type=\"Acceptable\" url=\"http://info.cspserver.net/api/v1/connect-test\" content_type=\"application/octet-stream\" src_ip=\"192.168.2.112\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=55510 dst_port=80 bytes_sent=77 bytes_received=249 domain=\"info.cspserver.net\" http_status=\"200\" con_id=3159008512 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"JPN\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -5469,7 +5517,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:36.000Z",
+            "@timestamp": "2021-11-15T18:30:36.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5506,6 +5554,7 @@
                 "original": "Nov 16 00:30:36 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:36-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" web_policy_id=1 http_category=\"Advertisements\" http_category_type=\"Unproductive\" url=\"https://us-trc-events.taboola.com\" src_ip=\"192.168.2.41\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=22570 dst_port=443 bytes_sent=7587 bytes_received=1633 domain=\"us-trc-events.taboola.com\" http_status=\"0\" con_id=999027328 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"
@@ -5583,7 +5632,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-16T00:30:38.000Z",
+            "@timestamp": "2021-11-15T18:30:38.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5620,6 +5669,7 @@
                 "original": "Nov 16 00:30:38 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:30:38-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=050901616001 log_type=\"Content Filtering\" log_component=\"HTTP\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" web_policy_id=12 http_category=\"Information Technology\" http_category_type=\"Acceptable\" url=\"https://deviceintegritytokens-pa.googleapis.com\" src_ip=\"192.168.2.126\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=50210 dst_port=443 bytes_sent=45093 bytes_received=2901 domain=\"deviceintegritytokens-pa.googleapis.com\" http_status=\"0\" con_id=408293376 app_is_cloud=\"FALSE\" used_quota=\"0\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" src_country=\"R1\" dst_country=\"USA\"",
                 "outcome": "success",
                 "severity": 6,
+                "timezone": "-06:00",
                 "type": [
                     "allowed",
                     "connection"

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-xg-event-new.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-xg-event-new.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2021-11-16T02:52:23.000Z",
+            "@timestamp": "2021-11-15T20:52:23.000-06:00",
             "ecs": {
                 "version": "8.8.0"
             },
@@ -9,7 +9,8 @@
                 "code": "60020",
                 "kind": "event",
                 "original": "Nov 16 02:52:23 sophos device_name=\"SFW\" timestamp=\"2021-11-15T20:52:23-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=063411660020 log_type=\"Event\" log_component=\"DHCP Server\" log_subtype=\"System\" log_version=1 status=\"Renew\" severity=\"Information\" reported_ip=\"192.168.2.131\" src_mac=\"00:11:d9:a0:19:11\" reported_host=\"TIVO-846001190AE52F2\" message=\"Lease IP 192.168.2.250 renewed for MAC 00:11:d9:a0:19:11\" lease_time=\"345600\"",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -53,7 +54,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T02:57:56.000Z",
+            "@timestamp": "2021-11-15T20:57:56.000-06:00",
             "ecs": {
                 "version": "8.8.0"
             },
@@ -61,7 +62,8 @@
                 "code": "60020",
                 "kind": "event",
                 "original": "Nov 16 02:57:56 sophos device_name=\"SFW\" timestamp=\"2021-11-15T20:57:56-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=063411660020 log_type=\"Event\" log_component=\"DHCP Server\" log_subtype=\"System\" log_version=1 status=\"Renew\" severity=\"Information\" reported_ip=\"192.168.2.112\" src_mac=\"88:57:1d:2d:FF:db\" reported_host=\"TIZEN-ODg6NTc6MUQ6MkQ6MTk6REIKK\" message=\"Lease IP 192.168.2.250 renewed for MAC 88:57:1d:2d:19:db\" lease_time=\"345600\"",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -105,7 +107,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T03:04:08.000Z",
+            "@timestamp": "2021-11-15T21:04:08.000-06:00",
             "ecs": {
                 "version": "8.8.0"
             },
@@ -113,7 +115,8 @@
                 "code": "60020",
                 "kind": "event",
                 "original": "Nov 16 03:04:08 sophos device_name=\"SFW\" timestamp=\"2021-11-15T21:04:08-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=063411660020 log_type=\"Event\" log_component=\"DHCP Server\" log_subtype=\"System\" log_version=1 status=\"Renew\" severity=\"Information\" reported_ip=\"192.168.2.112\" src_mac=\"88:57:1d:2d:FF:db\" reported_host=\"TIZEN-ODg6NTc6MUQ6MkQ6MTk6REIKK\" message=\"Lease IP 192.168.2.250 renewed for MAC 88:57:1d:2d:19:db\" lease_time=\"345600\"",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"

--- a/packages/sophos/data_stream/xg/_dev/test/pipeline/test-xg-firewall-new.log-expected.json
+++ b/packages/sophos/data_stream/xg/_dev/test/pipeline/test-xg-firewall-new.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2021-11-16T00:25:00.000Z",
+            "@timestamp": "2021-11-15T18:25:00.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -37,7 +37,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:00 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:00-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"00:26:37:EE:47:20\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.111\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"TCP\" src_port=50875 dst_port=443 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"3153941760\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -119,7 +120,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:01.000Z",
+            "@timestamp": "2021-11-15T18:25:01.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -155,7 +156,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:01 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:01-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"A4:FC:77:2E:BD:6F\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.162\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"TCP\" src_port=56257 dst_port=443 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"151869632\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -237,7 +239,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:01.000Z",
+            "@timestamp": "2021-11-15T18:25:01.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -273,7 +275,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:01 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:01-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"00:26:37:EE:47:20\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.111\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"TCP\" src_port=50876 dst_port=443 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2719000128\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -355,7 +358,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:01.000Z",
+            "@timestamp": "2021-11-15T18:25:01.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -390,12 +393,13 @@
                 ],
                 "code": "00001",
                 "duration": 31000000000,
-                "end": "2021-11-16T00:25:32.000Z",
+                "end": "2021-11-15T18:25:32.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:01 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:01-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=31 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"2718999808\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:01.000Z"
+                "start": "2021-11-15T18:25:01.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -481,7 +485,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:01.000Z",
+            "@timestamp": "2021-11-15T18:25:01.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -516,7 +520,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:01 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:01-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010102600002\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Denied\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"0\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"IPv4 (0x0800)\" in_interface=\"Port1\" src_mac=\"00:26:37:ee:47:20\" src_ip=\"192.168.2.111\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=61709 dst_port=443 hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -582,7 +587,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:01.000Z",
+            "@timestamp": "2021-11-15T18:25:01.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -617,7 +622,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:01 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:01-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010102600002\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Denied\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"0\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"IPv4 (0x0800)\" in_interface=\"Port1\" src_mac=\"00:26:37:ee:47:20\" src_ip=\"192.168.2.111\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=61709 dst_port=443 hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -683,7 +689,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:01.000Z",
+            "@timestamp": "2021-11-15T18:25:01.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -718,7 +724,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:01 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:01-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2916030336\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -800,7 +807,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:02.000Z",
+            "@timestamp": "2021-11-15T18:25:02.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -835,12 +842,13 @@
                 ],
                 "code": "00001",
                 "duration": 39000000000,
-                "end": "2021-11-16T00:25:41.000Z",
+                "end": "2021-11-15T18:25:41.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:02 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:02-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=39 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"3153944000\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:02.000Z"
+                "start": "2021-11-15T18:25:02.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -926,7 +934,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:02.000Z",
+            "@timestamp": "2021-11-15T18:25:02.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -961,7 +969,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:02 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:02-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010102600002\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Denied\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"0\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"IPv4 (0x0800)\" in_interface=\"Port1\" src_mac=\"00:26:37:ee:47:20\" src_ip=\"192.168.2.111\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=61709 dst_port=443 hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1027,7 +1036,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:02.000Z",
+            "@timestamp": "2021-11-15T18:25:02.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1062,7 +1071,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:02 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:02-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2916028416\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1144,7 +1154,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:03.000Z",
+            "@timestamp": "2021-11-15T18:25:03.000-06:00",
             "destination": {
                 "ip": "192.168.1.15",
                 "mac": "00-50-56-9F-39-33",
@@ -1162,7 +1172,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:03 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:03-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"00:50:56:9F:CD:68\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.32\" src_country=\"R1\" dst_ip=\"192.168.1.15\" dst_country=\"R1\" protocol=\"TCP\" src_port=59346 dst_port=22083 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2916031936\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1244,7 +1255,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:03.000Z",
+            "@timestamp": "2021-11-15T18:25:03.000-06:00",
             "destination": {
                 "ip": "192.168.1.15",
                 "mac": "00-50-56-9F-39-33",
@@ -1262,7 +1273,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:03 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:03-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"00:50:56:9F:CD:68\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.32\" src_country=\"R1\" dst_ip=\"192.168.1.15\" dst_country=\"R1\" protocol=\"TCP\" src_port=59347 dst_port=22083 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"172022272\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1344,7 +1356,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:03.000Z",
+            "@timestamp": "2021-11-15T18:25:03.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1379,7 +1391,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:03 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:03-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010102600002\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Denied\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"0\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"IPv4 (0x0800)\" in_interface=\"Port1\" src_mac=\"00:26:37:ee:47:20\" src_ip=\"192.168.2.111\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=61709 dst_port=443 hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1445,7 +1458,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:03.000Z",
+            "@timestamp": "2021-11-15T18:25:03.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1480,12 +1493,13 @@
                 ],
                 "code": "00001",
                 "duration": 36000000000,
-                "end": "2021-11-16T00:25:39.000Z",
+                "end": "2021-11-15T18:25:39.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:03 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:03-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=36 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"408294336\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:03.000Z"
+                "start": "2021-11-15T18:25:03.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1571,7 +1585,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:03.000Z",
+            "@timestamp": "2021-11-15T18:25:03.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1606,7 +1620,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:03 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:03-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2916030976\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1688,7 +1703,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:04.000Z",
+            "@timestamp": "2021-11-15T18:25:04.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1723,12 +1738,13 @@
                 ],
                 "code": "00001",
                 "duration": 35000000000,
-                "end": "2021-11-16T00:25:39.000Z",
+                "end": "2021-11-15T18:25:39.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:04 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:04-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=35 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"1000195968\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:04.000Z"
+                "start": "2021-11-15T18:25:04.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1814,7 +1830,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:04.000Z",
+            "@timestamp": "2021-11-15T18:25:04.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1849,7 +1865,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:04 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:04-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2916029696\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -1931,7 +1948,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:05.000Z",
+            "@timestamp": "2021-11-15T18:25:05.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -1967,12 +1984,13 @@
                 ],
                 "code": "00001",
                 "duration": 18000000000,
-                "end": "2021-11-16T00:25:23.000Z",
+                "end": "2021-11-15T18:25:23.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:05 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:05-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=18 fw_rule_id=\"19\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=5 app_filter_policy_id=8 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"2C:AA:8E:2A:5C:23\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.122\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"TCP\" src_port=41242 dst_port=80 packets_sent=4  packets_received=2 bytes_sent=216 bytes_received=112 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"154390528\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:05.000Z"
+                "start": "2021-11-15T18:25:05.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2058,7 +2076,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:05.000Z",
+            "@timestamp": "2021-11-15T18:25:05.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2093,7 +2111,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:05 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:05-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010102600002\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Denied\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"0\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"IPv4 (0x0800)\" in_interface=\"Port1\" src_mac=\"00:26:37:ee:47:20\" src_ip=\"192.168.2.111\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=61709 dst_port=443 hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2159,7 +2178,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:05.000Z",
+            "@timestamp": "2021-11-15T18:25:05.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2194,12 +2213,13 @@
                 ],
                 "code": "00001",
                 "duration": 37000000000,
-                "end": "2021-11-16T00:25:42.000Z",
+                "end": "2021-11-15T18:25:42.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:05 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:05-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=37 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"999027328\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:05.000Z"
+                "start": "2021-11-15T18:25:05.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2285,7 +2305,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:05.000Z",
+            "@timestamp": "2021-11-15T18:25:05.000-06:00",
             "destination": {
                 "ip": "192.168.10.1",
                 "mac": "00-50-56-9F-39-33",
@@ -2303,7 +2323,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:05 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:05-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 app_name=\"DNS\" app_risk=1 app_technology=\"Network Protocol\" app_category=\"Infrastructure\" ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"88:57:1D:2D:19:DB\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.112\" src_country=\"R1\" dst_ip=\"192.168.10.1\" dst_country=\"R1\" protocol=\"UDP\" src_port=47944 dst_port=53 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2685088064\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2389,7 +2410,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:05.000Z",
+            "@timestamp": "2021-11-15T18:25:05.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2425,7 +2446,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:05 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:05-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"88:57:1D:2D:19:DB\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.112\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"JPN\" protocol=\"TCP\" src_port=55499 dst_port=80 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"151867392\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2507,7 +2529,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:05.000Z",
+            "@timestamp": "2021-11-15T18:25:05.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2542,7 +2564,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:06 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:05-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"151870592\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2624,7 +2647,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:06.000Z",
+            "@timestamp": "2021-11-15T18:25:06.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2660,12 +2683,13 @@
                 ],
                 "code": "00001",
                 "duration": 16000000000,
-                "end": "2021-11-16T00:25:22.000Z",
+                "end": "2021-11-15T18:25:22.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:06 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:06-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=16 fw_rule_id=\"19\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=5 app_filter_policy_id=8 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"2C:AA:8E:1D:B6:D9\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.118\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"TCP\" src_port=44720 dst_port=80 packets_sent=4  packets_received=2 bytes_sent=216 bytes_received=112 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"172108928\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:06.000Z"
+                "start": "2021-11-15T18:25:06.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2751,7 +2775,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:06.000Z",
+            "@timestamp": "2021-11-15T18:25:06.000-06:00",
             "destination": {
                 "ip": "192.168.2.90",
                 "mac": "00-50-56-9F-EF-8A",
@@ -2769,7 +2793,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:06 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:06-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"16\" nat_rule_id=\"0\" fw_rule_type=\"USER\" web_policy_id=4 ips_policy_id=6 app_filter_policy_id=7 ether_type=\"Unknown (0x0000)\" in_interface=\"Port3\" out_interface=\"Port1\" src_mac=\"00:50:56:9F:49:13\" dst_mac=\"00:50:56:9F:EF:8A\" src_ip=\"192.168.3.36\" src_country=\"R1\" dst_ip=\"192.168.2.90\" dst_country=\"R1\" protocol=\"TCP\" src_port=48524 dst_port=9988 src_zone_type=\"DMZ\" src_zone=\"DMZ\" dst_zone_type=\"LAN\" dst_zone=\"LAN\" con_event=\"Start\" con_id=\"2685088384\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port3\" out_display_interface=\"Port1\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2847,7 +2872,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:07.000Z",
+            "@timestamp": "2021-11-15T18:25:07.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2882,7 +2907,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:07 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:07-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"172105728\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -2964,7 +2990,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:08.000Z",
+            "@timestamp": "2021-11-15T18:25:08.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -2999,7 +3025,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:08 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:08-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"407386944\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -3081,7 +3108,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:08.000Z",
+            "@timestamp": "2021-11-15T18:25:08.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3116,12 +3143,13 @@
                 ],
                 "code": "00001",
                 "duration": 33000000000,
-                "end": "2021-11-16T00:25:41.000Z",
+                "end": "2021-11-15T18:25:41.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:08 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:08-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=33 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"407384064\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:08.000Z"
+                "start": "2021-11-15T18:25:08.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -3207,7 +3235,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:08.000Z",
+            "@timestamp": "2021-11-15T18:25:08.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3243,12 +3271,13 @@
                 ],
                 "code": "00001",
                 "duration": 19000000000,
-                "end": "2021-11-16T00:25:27.000Z",
+                "end": "2021-11-15T18:25:27.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:08 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:08-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=19 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 app_name=\"Youtube Website\" app_risk=3 app_technology=\"Browser Based\" app_category=\"Streaming Media\" ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"00:26:37:EE:47:20\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.111\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"TCP\" src_port=50872 dst_port=443 packets_sent=31  packets_received=31 bytes_sent=9718 bytes_received=4992 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"154391168\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:08.000Z"
+                "start": "2021-11-15T18:25:08.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -3338,7 +3367,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:08.000Z",
+            "@timestamp": "2021-11-15T18:25:08.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3373,12 +3402,13 @@
                 ],
                 "code": "00001",
                 "duration": 35000000000,
-                "end": "2021-11-16T00:25:43.000Z",
+                "end": "2021-11-15T18:25:43.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:08 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:08-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=35 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"2719001728\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:08.000Z"
+                "start": "2021-11-15T18:25:08.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -3464,7 +3494,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:09.000Z",
+            "@timestamp": "2021-11-15T18:25:09.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3499,7 +3529,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:09 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:09-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"1000196608\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -3581,7 +3612,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:09.000Z",
+            "@timestamp": "2021-11-15T18:25:09.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3616,12 +3647,13 @@
                 ],
                 "code": "00001",
                 "duration": 38000000000,
-                "end": "2021-11-16T00:25:47.000Z",
+                "end": "2021-11-15T18:25:47.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:09 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:09-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=38 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"2719001088\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:09.000Z"
+                "start": "2021-11-15T18:25:09.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -3707,7 +3739,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:09.000Z",
+            "@timestamp": "2021-11-15T18:25:09.000-06:00",
             "destination": {
                 "ip": "192.168.1.167",
                 "mac": "00-50-56-9F-39-33",
@@ -3725,7 +3757,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:09 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:09-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"00:50:56:9F:B1:FE\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.16\" src_country=\"R1\" dst_ip=\"192.168.1.167\" dst_country=\"R1\" protocol=\"TCP\" src_port=63043 dst_port=8089 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2685089984\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -3807,7 +3840,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:09.000Z",
+            "@timestamp": "2021-11-15T18:25:09.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3843,12 +3876,13 @@
                 ],
                 "code": "00001",
                 "duration": 411000000000,
-                "end": "2021-11-16T00:32:00.000Z",
+                "end": "2021-11-15T18:32:00.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:09 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:09-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=411 fw_rule_id=\"11\" nat_rule_id=\"9\" fw_rule_type=\"USER\" web_policy_id=1 ips_policy_id=8 app_filter_policy_id=6 app_name=\"Secure Socket Layer Protocol\" app_risk=1 app_technology=\"Network Protocol\" app_category=\"Infrastructure\" ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"24:4B:FE:DD:C6:CE\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.41\" src_country=\"R1\" dst_ip=\"89.160.20.156\" protocol=\"TCP\" src_port=21957 dst_port=443 packets_sent=20  packets_received=22 bytes_sent=2297 bytes_received=2229 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"407759360\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:09.000Z"
+                "start": "2021-11-15T18:25:09.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -3938,7 +3972,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:10.000Z",
+            "@timestamp": "2021-11-15T18:25:10.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -3973,7 +4007,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:10 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:10-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"1000197248\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -4055,7 +4090,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:10.000Z",
+            "@timestamp": "2021-11-15T18:25:10.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4090,12 +4125,13 @@
                 ],
                 "code": "00001",
                 "duration": 32000000000,
-                "end": "2021-11-16T00:25:42.000Z",
+                "end": "2021-11-15T18:25:42.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:10 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:10-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=32 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"407385024\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:10.000Z"
+                "start": "2021-11-15T18:25:10.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -4181,7 +4217,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:10.000Z",
+            "@timestamp": "2021-11-15T18:25:10.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4216,12 +4252,13 @@
                 ],
                 "code": "00001",
                 "duration": 30000000000,
-                "end": "2021-11-16T00:25:40.000Z",
+                "end": "2021-11-15T18:25:40.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:10 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:10-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=30 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"154696512\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:10.000Z"
+                "start": "2021-11-15T18:25:10.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -4307,7 +4344,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:11.000Z",
+            "@timestamp": "2021-11-15T18:25:11.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4342,7 +4379,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:11 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:11-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"154391168\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -4424,7 +4462,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:11.000Z",
+            "@timestamp": "2021-11-15T18:25:11.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4459,12 +4497,13 @@
                 ],
                 "code": "00001",
                 "duration": 32000000000,
-                "end": "2021-11-16T00:25:43.000Z",
+                "end": "2021-11-15T18:25:43.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:11 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:11-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=32 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"407385984\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:11.000Z"
+                "start": "2021-11-15T18:25:11.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -4550,7 +4589,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:11.000Z",
+            "@timestamp": "2021-11-15T18:25:11.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4586,7 +4625,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:11 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:11-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" nat_rule_id=\"9\" fw_rule_type=\"USER\" web_policy_id=1 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"24:4B:FE:DD:C6:CE\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.41\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=59335 dst_port=443 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2685088704\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -4668,7 +4708,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:12.000Z",
+            "@timestamp": "2021-11-15T18:25:12.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4703,12 +4743,13 @@
                 ],
                 "code": "00001",
                 "duration": 38000000000,
-                "end": "2021-11-16T00:25:50.000Z",
+                "end": "2021-11-15T18:25:50.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:12 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:12-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=38 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"1000194368\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:12.000Z"
+                "start": "2021-11-15T18:25:12.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -4794,7 +4835,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:12.000Z",
+            "@timestamp": "2021-11-15T18:25:12.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4829,7 +4870,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:12 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:12-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2694935808\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -4911,7 +4953,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:12.000Z",
+            "@timestamp": "2021-11-15T18:25:12.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -4946,7 +4988,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:12 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:12-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"54:60:09:FD:33:EC\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.105\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"1000194368\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -5028,7 +5071,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:12.000Z",
+            "@timestamp": "2021-11-15T18:25:12.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5064,7 +5107,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:12 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:12-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" nat_rule_id=\"9\" fw_rule_type=\"USER\" web_policy_id=1 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"24:4B:FE:DD:C6:CE\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.41\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=62171 dst_port=443 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"151868992\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -5146,7 +5190,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:12.000Z",
+            "@timestamp": "2021-11-15T18:25:12.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5182,12 +5226,13 @@
                 ],
                 "code": "00001",
                 "duration": 17000000000,
-                "end": "2021-11-16T00:25:29.000Z",
+                "end": "2021-11-15T18:25:29.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:12 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:12-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=17 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 app_name=\"Secure Socket Layer Protocol\" app_risk=1 app_technology=\"Network Protocol\" app_category=\"Infrastructure\" ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"34:C9:3D:23:51:C2\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.110\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"TCP\" src_port=53271 dst_port=443 packets_sent=11  packets_received=13 bytes_sent=1030 bytes_received=6770 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"172106048\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:12.000Z"
+                "start": "2021-11-15T18:25:12.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -5277,7 +5322,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:12.000Z",
+            "@timestamp": "2021-11-15T18:25:12.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5313,7 +5358,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:12 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:12-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" nat_rule_id=\"9\" fw_rule_type=\"USER\" web_policy_id=1 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"24:4B:FE:DD:C6:CE\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.41\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=52915 dst_port=443 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"407385024\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -5395,7 +5441,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:13.000Z",
+            "@timestamp": "2021-11-15T18:25:13.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5430,7 +5476,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:13 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:13-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"407386624\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -5512,7 +5559,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:13.000Z",
+            "@timestamp": "2021-11-15T18:25:13.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5547,12 +5594,13 @@
                 ],
                 "code": "00001",
                 "duration": 37000000000,
-                "end": "2021-11-16T00:25:50.000Z",
+                "end": "2021-11-15T18:25:50.000-06:00",
                 "kind": "event",
                 "original": "Nov 16 00:25:13 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:13-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" duration=37 fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"10:BF:48:7D:ED:22\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.121\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"AUS\" protocol=\"ICMP\" icmp_type=8 packets_sent=2  packets_received=2 bytes_sent=168 bytes_received=168 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Stop\" con_id=\"407385344\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
                 "severity": 6,
-                "start": "2021-11-16T00:25:13.000Z"
+                "start": "2021-11-15T18:25:13.000-06:00",
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -5638,7 +5686,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:13.000Z",
+            "@timestamp": "2021-11-15T18:25:13.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5674,7 +5722,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:13 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:13-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"12\" nat_rule_id=\"12\" fw_rule_type=\"USER\" web_policy_id=12 ips_policy_id=8 app_filter_policy_id=6 app_name=\"DNS\" app_risk=1 app_technology=\"Network Protocol\" app_category=\"Infrastructure\" ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"54:60:09:FD:33:EC\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.105\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=34141 dst_port=53 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"407385344\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"
@@ -5760,7 +5809,7 @@
             ]
         },
         {
-            "@timestamp": "2021-11-16T00:25:13.000Z",
+            "@timestamp": "2021-11-15T18:25:13.000-06:00",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -5796,7 +5845,8 @@
                 "kind": "event",
                 "original": "Nov 16 00:25:13 sophos device_name=\"SFW\" timestamp=\"2021-11-15T18:25:13-0600\" device_model=\"SFVH\" device_serial_id=\"C01001BQC8TFFFF\" log_id=\"010101600001\" log_type=\"Firewall\" log_component=\"Firewall Rule\" log_subtype=\"Allowed\" log_version=1 severity=\"Information\" fw_rule_id=\"11\" nat_rule_id=\"9\" fw_rule_type=\"USER\" web_policy_id=1 ips_policy_id=8 app_filter_policy_id=6 ether_type=\"Unknown (0x0000)\" in_interface=\"Port1\" out_interface=\"Port2\" src_mac=\"24:4B:FE:DD:C6:CE\" dst_mac=\"00:50:56:9F:39:33\" src_ip=\"192.168.2.41\" src_country=\"R1\" dst_ip=\"89.160.20.156\" dst_country=\"USA\" protocol=\"UDP\" src_port=51751 dst_port=443 src_trans_ip=\"192.168.1.2\" src_zone_type=\"LAN\" src_zone=\"LAN\" dst_zone_type=\"WAN\" dst_zone=\"WAN\" con_event=\"Start\" con_id=\"2719001088\" hb_status=\"No Heartbeat\" app_resolved_by=\"Signature\" app_is_cloud=\"FALSE\" qualifier=\"New\" in_display_interface=\"Port1\" out_display_interface=\"Port2\"",
                 "outcome": "success",
-                "severity": 6
+                "severity": 6,
+                "timezone": "-06:00"
             },
             "host": {
                 "name": "defaulttest.local"

--- a/packages/sophos/data_stream/xg/agent/stream/log.yml.hbs
+++ b/packages/sophos/data_stream/xg/agent/stream/log.yml.hbs
@@ -21,6 +21,7 @@ processors:
 - add_fields:
     target: '_conf'
     fields:
+	    tz_offset: '{{tz_offset}}'
         default: {{default_host_name}}
         mappings:
 {{#if known_devices}}

--- a/packages/sophos/data_stream/xg/agent/stream/tcp.yml.hbs
+++ b/packages/sophos/data_stream/xg/agent/stream/tcp.yml.hbs
@@ -21,6 +21,7 @@ processors:
 - add_fields:
     target: '_conf'
     fields:
+        tz_offset: '{{tz_offset}}'
         default: {{default_host_name}}
         mappings:
 {{#if known_devices}}

--- a/packages/sophos/data_stream/xg/agent/stream/udp.yml.hbs
+++ b/packages/sophos/data_stream/xg/agent/stream/udp.yml.hbs
@@ -21,6 +21,7 @@ processors:
 - add_fields:
     target: '_conf'
     fields:
+        tz_offset: '{{tz_offset}}'
         default: {{default_host_name}}
         mappings:
 {{#if known_devices}}

--- a/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,51 @@ processors:
       ctx.sophos.xg = lowercaseMap;
 
 # Parse the date
+# Time zone can come from four sources, choose in order: log timestamp, log timezone,
+# config, locale, default to UTC.
+- grok:
+    field: sophos.xg.timestamp
+    tag: "grok_timestamp_timezone"
+    patterns:
+      - '%{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE:_temp_.tz}?'
+    ignore_failure: true
+    if: ctx.sophos?.xg?.timestamp != null
+- set:
+    field: _temp_.tz
+    copy_from: sophos.xg.timezone
+    override: false
+    if: ctx.sophos?.xg?.timezone != null
+- set:
+    field: _temp_.tz
+    value: UTC
+    if: ctx._temp_?.tz == 'Z'
+- set:
+    field: _temp_.tz
+    copy_from: _conf.tz_offset
+    override: false
+    if: ctx._conf?.tz_offset != null && ctx._conf?.tz_offset != 'local'
+- set:
+    field: _temp_.tz
+    copy_from: event.timezone
+    override: false
+    if: ctx.event?.timezone != null
+- set:
+    field: _temp_.tz
+    value: UTC
+    override: false
+- set:
+    field: event.timezone
+    copy_from: _temp_.tz
+- gsub:
+    field: event.timezone
+    pattern: '([+-][0-9]{2})([0-9]{2})'
+    replacement: '$1:$2'
+    ignore_missing: true
+- gsub:
+    field: event.timezone
+    pattern: '([+-])([0-9]):?([0-9]{2})'
+    replacement: '$10$2:$3'
+    ignore_missing: true
 - set:
     field: _temp_.time
     value: "{{sophos.xg.date}} {{sophos.xg.time}}"
@@ -49,24 +94,34 @@ processors:
     ignore_empty_value: true
     if: ctx._temp_?.time == null
 - date:
-    if: ctx._temp_?.time != null && ctx.event?.timezone == null
     field: _temp_.time
-    target_field: "@timestamp"
+    timezone: "{{{ event.timezone }}}"
     formats:
-    - yyyy-MM-dd HH:mm:ss
-    - yyyy-MM-dd HH:mm:ss Z
-    - yyyy-MM-dd HH:mm:ss z
-    - ISO8601
-- date:
-    if: ctx._temp_?.time != null && ctx.event?.timezone != null
-    timezone: "{{ event.timezone }}"
-    field: _temp_.time
-    target_field: "@timestamp"
-    formats:
-    - yyyy-MM-dd HH:mm:ss
-    - yyyy-MM-dd HH:mm:ss Z
-    - yyyy-MM-dd HH:mm:ss z
-    - ISO8601
+      - yyyy-MM-dd HH:mm:ss
+      - yyyy-MM-dd HH:mm:ss Z
+      - yyyy-MM-dd HH:mm:ss z
+      - ISO8601
+    if: ctx._temp_?.time != null
+    on_failure:
+      - remove:
+          field: event.timezone
+          ignore_missing: true
+      # Try to re-parse as UTC to catch when TZ is invalid or unknown.
+      - date:
+          tag: "date_utc_fallback"
+          timezone: UTC
+          field: _temp_.time
+          formats:
+            - yyyy-MM-dd HH:mm:ss
+            - yyyy-MM-dd HH:mm:ss Z
+            - yyyy-MM-dd HH:mm:ss z
+            - ISO8601
+          on_failure:
+            - append:
+                field: error.message
+                value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
+            - fail:
+                message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
 # Sets starts, end and duration when start and duration is known
 - script:
@@ -250,7 +305,6 @@ processors:
     - sophos.xg.time
     - sophos.xg.timestamp
     - sophos.xg.duration
-    - sophos.xg.timezone
     - sophos.xg.dir_disp
     - sophos.xg.log_occurrence
     - sophos.xg.nat_rule_id
@@ -363,6 +417,33 @@ processors:
 - pipeline:
     name: '{{ IngestPipeline "wifi" }}'
     if: "ctx.sophos?.xg?.log_type == 'Wireless Protection'"
+
+- date:
+    if: ctx.sophos?.xg?.eventtime != null && ctx.event?.timezone == null
+    field: sophos.xg.eventtime
+    timezone: UTC
+    target_field: sophos.xg.eventtime
+    formats:
+    - yyyy-MM-dd HH:mm:ss
+    - yyyy-MM-dd HH:mm:ss Z
+    - yyyy-MM-dd HH:mm:ss z
+    - ISO8601
+    on_failure:
+      - remove:
+          field: sophos.xg.eventtime
+- date:
+    if: ctx.sophos?.xg?.eventtime != null && ctx.event?.timezone != null
+    timezone: "{{ event.timezone }}"
+    field: sophos.xg.eventtime
+    target_field: sophos.xg.eventtime
+    formats:
+    - yyyy-MM-dd HH:mm:ss
+    - yyyy-MM-dd HH:mm:ss Z
+    - yyyy-MM-dd HH:mm:ss z
+    - ISO8601
+    on_failure:
+      - remove:
+          field: sophos.xg.eventtime
 
 ##################
 # GeoIP Enrichment

--- a/packages/sophos/data_stream/xg/fields/fields.yml
+++ b/packages/sophos/data_stream/xg/fields/fields.yml
@@ -707,7 +707,7 @@
         - name: timezone
           type: keyword
           description: |
-            Time (hh:mm:ss) when the event occurred
+            Original reported timezone for the event timestamp.
         - name: to_email_address
           type: keyword
           description: |

--- a/packages/sophos/data_stream/xg/manifest.yml
+++ b/packages/sophos/data_stream/xg/manifest.yml
@@ -58,6 +58,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: true
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: processors
         type: yaml
         title: Processors
@@ -148,6 +156,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: true
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: udp_options
         type: yaml
         title: Custom UDP Options
@@ -218,6 +234,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: true
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/sophos/docs/README.md
+++ b/packages/sophos/docs/README.md
@@ -1242,7 +1242,7 @@ An example event for `xg` looks as following:
 | sophos.xg.temp | Temp | float |
 | sophos.xg.threatname | ATP threatname | keyword |
 | sophos.xg.timestamp | timestamp | date |
-| sophos.xg.timezone | Time (hh:mm:ss) when the event occurred | keyword |
+| sophos.xg.timezone | Original reported timezone for the event timestamp. | keyword |
 | sophos.xg.to_email_address | Receipeint email address | keyword |
 | sophos.xg.total_memory | Total Memory | integer |
 | sophos.xg.trans_dst_ip | Translated destination IP address for outgoing traffic | ip |

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sophos
 title: Sophos
-version: "2.10.0"
+version: "2.11.0"
 description: Collect logs from Sophos with Elastic Agent.
 categories: ["security", "network", "firewall_security"]
 release: ga


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Ensure fields that have been defined as date are parseable as date. Also add timezone configuration and progressively determine timezone from logs, config, locale.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #6546

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
