### PR TITLE
Fix docker image to ubuntu 20.04 for journald system tests

### DIFF
--- a/packages/journald/_dev/deploy/docker/Dockerfile
+++ b/packages/journald/_dev/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM ubuntu:20.04
 
 RUN apt-get update \
       && apt install -y systemd-journal-remote \


### PR DESCRIPTION
Apply the same fix used for iptables in #6642.