### PR TITLE
Fix bugs in Cisco IOS and FTD ingest pipelines

### DIFF
--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1463,20 +1463,20 @@ processors:
       value: "{{{event.duration}}}"
       ignore_empty_value: true
   #
-  # Ensure source.bytes is integer
+  # Ensure source.bytes is long
   #
   - convert:
       if: "ctx.source?.bytes != null"
       field: "source.bytes"
-      type: "integer"
+      type: "long"
 
   #
-  # Ensure destination.bytes is integer
+  # Ensure destination.bytes is long
   #
   - convert:
       if: "ctx.destination?.bytes != null"
       field: "destination.bytes"
-      type: "integer"
+      type: "long"
 
   #
   # Sum source.bytes and destination.bytes in network.bytes

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -120,7 +120,7 @@ processors:
       field: message
       tag: grok_message
       patterns:
-        - "%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}: %{GREEDYDATA:message}"
+        - "%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}: (\\w+\\d+(\\/\\d+)?\\: fman_fp_image\\: )?%{GREEDYDATA:message}"
   - convert:
       field: event.severity
       type: long


### PR DESCRIPTION
[Fix: Dissect cisco iOS logs with prefix fman_fp_image](https://github.com/elastic/integrations/commit/6f33845cc16741cca519741892e46f25a9532305)

[Fix: Change data type to long for source.bytes and destination.bytes](https://github.com/elastic/integrations/commit/56fd384c1743f200794174f7f854be669a14b818)