### PR TITLE
[Cloud Security] [AWS Orgs] Add config option

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -5,11 +5,14 @@
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
 
-- version: "1.5.0-preview1"
+- version: "1.5.0-preview20"
   changes:
     - description: Modify CIS GCP config
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6687
+    - description: Support AWS Organization onboarding option
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6682
 - version: "1.4.0-preview22"
   changes:
     - description: Populate new CloudFormation param ElasticArtifactServer

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/aws.yml.hbs
@@ -13,6 +13,9 @@ config:
     deployment: aws
     benchmark: cis_aws
     aws:
+      {{#if aws.account_type}}
+      account_type: {{aws.account_type}}
+      {{/if}}
       credentials:
         {{#if access_key_id}}
         access_key_id: {{access_key_id}}

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -111,6 +111,12 @@ streams:
         multi: false
         required: false
         show_user: false
+      - name: aws.account_type
+        type: text
+        title: Fetch resources from AWS organization instead of single account
+        multi: false
+        required: false
+        show_user: false
   - input: cloudbeat/cis_gcp
     title: CIS GCP Benchmark
     description: CIS Benchmark for Google Cloud Platform Foundation

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.5.0-preview1"
+version: "1.5.0-preview20"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
Adds the `aws.account_type` enum option which can take the `single_account` and `organization_account` values.


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues


- Relates https://github.com/elastic/cloudbeat/issues/1037
- Relates https://github.com/elastic/cloudbeat/pull/1072