### PR TITLE
all: document valid initial interval units.

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "2.10.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/akamai/data_stream/siem/manifest.yml
+++ b/packages/akamai/data_stream/siem/manifest.yml
@@ -56,7 +56,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: initial_interval
         type: text
@@ -65,7 +65,7 @@ streams:
         required: true
         show_user: true
         default: 24h
-        description: Initial interval to poll for events.  Default is 24 hours.
+        description: Initial interval to poll for events. Default is 24 hours. Supported units for this parameter are h/m/s.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.10.0"
+version: "2.11.0"
 description: Collect logs from Akamai with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/atlassian_bitbucket/changelog.yml
+++ b/packages/atlassian_bitbucket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.11.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/atlassian_bitbucket/data_stream/audit/manifest.yml
+++ b/packages/atlassian_bitbucket/data_stream/audit/manifest.yml
@@ -100,7 +100,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: initial_interval
         type: text
@@ -108,7 +108,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call.  Defaults to 24 hours.
+        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
         default: 24h
       - name: ssl
         type: yaml

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: atlassian_bitbucket
 title: Atlassian Bitbucket
-version: "1.11.0"
+version: "1.12.0"
 description: Collect logs from Atlassian Bitbucket with Elastic Agent.
 type: integration
 categories:

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.12.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/atlassian_confluence/data_stream/audit/manifest.yml
+++ b/packages/atlassian_confluence/data_stream/audit/manifest.yml
@@ -108,7 +108,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: initial_interval
         type: text
@@ -116,7 +116,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call.  Defaults to 24 hours.
+        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
         default: 24h
       - name: ssl
         type: yaml

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.12.0"
+version: "1.13.0"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.12.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/atlassian_jira/data_stream/audit/manifest.yml
+++ b/packages/atlassian_jira/data_stream/audit/manifest.yml
@@ -108,7 +108,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: initial_interval
         type: text
@@ -116,7 +116,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval for the first API call.  Defaults to 24 hours.
+        description: Initial interval for the first API call. Defaults to 24 hours. Supported units for this parameter are h/m/s.
         default: 24h
       - name: ssl
         type: yaml

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.12.0"
+version: "1.13.0"
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration
 categories:

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.0.0"
   changes:
     - description: Release BitDefender as GA.

--- a/packages/bitdefender/data_stream/push_configuration/manifest.yml
+++ b/packages/bitdefender/data_stream/push_configuration/manifest.yml
@@ -38,7 +38,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/bitdefender/data_stream/push_statistics/manifest.yml
+++ b/packages/bitdefender/data_stream/push_statistics/manifest.yml
@@ -38,7 +38,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: bitdefender
 title: "BitDefender"
-version: "1.0.0"
+version: "1.1.0"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.5.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/box_events/data_stream/events/manifest.yml
+++ b/packages/box_events/data_stream/events/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: This sets the interval between requests to the Target Service, for example `300s` will send a request every 300 seconds. Events will be returned in batches of up to 100, with successive calls on expiry of the configured `interval` so you may wish to specify a lower interval when a substantial number of events are expected, however, we suggest to consider bandwidth when using lower settings
+        description: This sets the interval between requests to the Target Service, for example `300s` will send a request every 300 seconds. Events will be returned in batches of up to 100, with successive calls on expiry of the configured `interval` so you may wish to specify a lower interval when a substantial number of events are expected, however, we suggest to consider bandwidth when using lower settings. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: box_events
 title: Box Events
-version: "1.5.0"
+version: "1.6.0"
 release: ga
 license: basic
 description: "Collect logs from Box with Elastic Agent"

--- a/packages/cisco_secure_endpoint/changelog.yml
+++ b/packages/cisco_secure_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.16.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "2.15.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/cisco_secure_endpoint/data_stream/event/manifest.yml
+++ b/packages/cisco_secure_endpoint/data_stream/event/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: url
         type: text
@@ -49,7 +49,7 @@ streams:
         default: https://api.amp.cisco.com/v1/events?offset=0&limit=300
       - name: limit
         type: text
-        title: Initial Interval
+        title: Maximum logs per request
         multi: false
         required: true
         show_user: false
@@ -61,7 +61,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Initial Interval for first log pull
+        description: Initial Interval for first log pull. Supported units for this parameter are h/m/s.
         default: 24h
       - name: ssl
         type: yaml

--- a/packages/cisco_secure_endpoint/manifest.yml
+++ b/packages/cisco_secure_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: cisco_secure_endpoint
 title: Cisco Secure Endpoint
-version: "2.15.0"
+version: "2.16.0"
 description: Collect logs from Cisco Secure Endpoint (AMP) with Elastic Agent.
 type: integration
 categories:

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,14 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
+- version: "2.10.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "2.9.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/cloudflare/data_stream/audit/manifest.yml
+++ b/packages/cloudflare/data_stream/audit/manifest.yml
@@ -29,7 +29,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: initial_interval
         type: text
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval at which the logs will be pulled. Defaults to 30 days (720 hours). Max is 12960 hours (18 months).
+        description: Initial interval at which the logs will be pulled. Defaults to 30 days (720 hours). Max is 12960 hours (18 months). Supported units for this parameter are h/m/s.
         default: 720h
       - name: tags
         type: text

--- a/packages/cloudflare/data_stream/logpull/manifest.yml
+++ b/packages/cloudflare/data_stream/logpull/manifest.yml
@@ -36,7 +36,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 1s and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 1s and 1h. Supported units for this parameter are h/m/s.
         default: 5m
       - name: tags
         type: text

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: "2.9.0"
+version: "2.11.0"
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
 format_version: 2.7.0

--- a/packages/forgerock/changelog.yml
+++ b/packages/forgerock/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.3.1"
   changes:
     - description: Fix IDM Activity revision field type.

--- a/packages/forgerock/manifest.yml
+++ b/packages/forgerock/manifest.yml
@@ -1,6 +1,6 @@
 name: forgerock
 title: "ForgeRock"
-version: "1.3.1"
+version: "1.4.0"
 release: ga
 license: basic
 description: Collect audit logs from ForgeRock with Elastic Agent.
@@ -66,7 +66,7 @@ policy_templates:
           - name: initial_interval
             type: text
             title: Initial Interval
-            description: How far back to pull logs from ForgeRock. Can not be longer than 24 hours.
+            description: How far back to pull logs from ForgeRock. Can not be longer than 24 hours. Supported units for this parameter are h/m/s.
             multi: false
             required: true
             show_user: true
@@ -74,7 +74,7 @@ policy_templates:
           - name: interval
             type: text
             title: Interval
-            description: Duration between requests to the ForgeRock API.
+            description: Duration between requests to the ForgeRock API. Supported units for this parameter are h/m/s.
             default: 1h
             multi: false
             required: true

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,14 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
+- version: "1.14.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.13.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/github/data_stream/audit/manifest.yml
+++ b/packages/github/data_stream/audit/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: initial_interval
         type: text
@@ -39,7 +39,7 @@ streams:
         required: true
         show_user: true
         default: 730h # 30 days
-        description: Initial interval to poll for events.  Default is 730 hours (30 days).
+        description: Initial interval to poll for events. Default is 730 hours (30 days). Supported units for this parameter are h/m/s.
       - name: api_url
         type: text
         title: API URL.

--- a/packages/github/data_stream/code_scanning/manifest.yml
+++ b/packages/github/data_stream/code_scanning/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the alerts will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the alerts will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 10m
       - name: api_url
         type: text

--- a/packages/github/data_stream/dependabot/manifest.yml
+++ b/packages/github/data_stream/dependabot/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the alerts will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the alerts will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 10m
       - name: api_url
         type: text

--- a/packages/github/data_stream/issues/manifest.yml
+++ b/packages/github/data_stream/issues/manifest.yml
@@ -68,7 +68,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the alerts will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the alerts will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 10m
       - name: api_url
         type: text

--- a/packages/github/data_stream/secret_scanning/manifest.yml
+++ b/packages/github/data_stream/secret_scanning/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the alerts will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the alerts will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 10m
       - name: hide_secret
         required: true

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: "1.13.0"
+version: "1.15.0"
 release: ga
 description: Collect logs from GitHub with Elastic Agent.
 type: integration

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.0.0"
   changes:
     - description: Release JumpCloud as GA.

--- a/packages/jumpcloud/data_stream/events/manifest.yml
+++ b/packages/jumpcloud/data_stream/events/manifest.yml
@@ -78,7 +78,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/jumpcloud/manifest.yml
+++ b/packages/jumpcloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: jumpcloud
 title: "JumpCloud"
-version: "1.0.0"
+version: "1.1.0"
 description: "Collect logs from JumpCloud Directory as a Service"
 type: integration
 categories:

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.11.2"
   changes:
     - description: Added the mapping for user.name field into the incident data stream.

--- a/packages/m365_defender/data_stream/log/manifest.yml
+++ b/packages/m365_defender/data_stream/log/manifest.yml
@@ -13,7 +13,7 @@ streams:
         required: true
         show_user: true
         default: 5m
-        description: The interval between requests to the HTTP API.
+        description: The interval between requests to the HTTP API. Supported units for this parameter are h/m/s.
       - name: initial_interval
         type: text
         title: Initial Interval
@@ -21,7 +21,7 @@ streams:
         required: true
         show_user: true
         default: 168h
-        description: How far back in time to look for alerts the first time running. Default is 1 week.
+        description: How far back in time to look for alerts the first time running. Default is 1 week. Supported units for this parameter are h/m/s.
       - name: request_url
         type: text
         title: API URL Endpoint

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: m365_defender
 title: Microsoft M365 Defender
-version: "1.11.2"
+version: "1.12.0"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.14.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "2.13.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/manifest.yml
@@ -41,7 +41,7 @@ streams:
         required: true
         show_user: true
         default: 5m
-        description: The interval between requests to the HTTP API.
+        description: The interval between requests to the HTTP API. Supported units for this parameter are h/m/s.
       - name: scopes
         type: text
         title: Oauth2 Scopes

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.13.0"
+version: "2.14.0"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.5.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.5.0"
+version: "1.6.0"
 release: ga
 license: basic
 description: "Microsoft Exchange Online Message Trace Integration"
@@ -112,7 +112,7 @@ policy_templates:
           - name: interval
             type: text
             title: Interval
-            description: Duration between requests to Exchange Online
+            description: Duration between requests to Exchange Online. Supported units for this parameter are h/m/s.
             default: 1m
             multi: false
             required: true
@@ -120,7 +120,7 @@ policy_templates:
           - name: initial_interval
             type: text
             title: Initial Interval
-            description: How far back to pull the initial log from Exchange Online
+            description: How far back to pull the initial log from Exchange Online. Supported units for this parameter are h/m/s.
             default: 1h
             multi: false
             required: true

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.12.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.11.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/mimecast/data_stream/audit_events/manifest.yml
+++ b/packages/mimecast/data_stream/audit_events/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/data_stream/dlp_logs/manifest.yml
+++ b/packages/mimecast/data_stream/dlp_logs/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/data_stream/siem_logs/manifest.yml
+++ b/packages/mimecast/data_stream/siem_logs/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/data_stream/threat_intel_malware_customer/manifest.yml
+++ b/packages/mimecast/data_stream/threat_intel_malware_customer/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/data_stream/threat_intel_malware_grid/manifest.yml
+++ b/packages/mimecast/data_stream/threat_intel_malware_grid/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/data_stream/ttp_ap_logs/manifest.yml
+++ b/packages/mimecast/data_stream/ttp_ap_logs/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/data_stream/ttp_ip_logs/manifest.yml
+++ b/packages/mimecast/data_stream/ttp_ip_logs/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/data_stream/ttp_url_logs/manifest.yml
+++ b/packages/mimecast/data_stream/ttp_url_logs/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 1.0.0
 name: mimecast
 title: "Mimecast"
-version: "1.11.0"
+version: "1.12.0"
 license: basic
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.22.1"
   changes:
     - description: Fix a concurrent modification exception that occurred while modifying okta.target[].detailEntry.

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "1.22.1"
+version: "1.23.0"
 release: ga
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
@@ -52,6 +52,7 @@ policy_templates:
             required: true
             show_user: true
             default: 60s
+            description: Interval at which logs are pulled. Supported units for this parameter are h/m/s.
           - name: initial_interval
             type: text
             title: Initial Interval
@@ -59,6 +60,7 @@ policy_templates:
             required: true
             show_user: true
             default: 24h
+            description: Initial Interval for first log pull. Supported units for this parameter are h/m/s.
           - name: ssl
             type: yaml
             title: SSL

--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.12.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/panw_cortex_xdr/data_stream/alerts/manifest.yml
+++ b/packages/panw_cortex_xdr/data_stream/alerts/manifest.yml
@@ -55,7 +55,7 @@ streams:
         required: true
         show_user: true
         default: 5m
-        description: How often the API is polled for new alerts.
+        description: How often the API is polled for new alerts. Supported units for this parameter are h/m/s.
       - name: initial_interval
         type: text
         title: Initial Interval
@@ -63,7 +63,7 @@ streams:
         required: true
         show_user: true
         default: 24h
-        description: How far back in time to look for alerts the first time running.
+        description: How far back in time to look for alerts the first time running. Supported units for this parameter are h/m/s.
       - name: ssl
         type: yaml
         title: SSL

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,6 +1,6 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "1.12.0"
+version: "1.13.0"
 release: ga
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.6.0"
   changes:
     - description: Ensure error.message is correctly set for pipeline errors.

--- a/packages/slack/data_stream/audit/manifest.yml
+++ b/packages/slack/data_stream/audit/manifest.yml
@@ -16,7 +16,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 2m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: initial_interval
         type: text
@@ -24,7 +24,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval at which the logs will be pulled. Defaults to 30 days (720 hours).
+        description: Initial interval at which the logs will be pulled. Defaults to 30 days (720 hours). Supported units for this parameter are h/m/s.
         default: 720h
       - name: limit
         type: integer

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: slack
 title: "Slack Logs"
-version: "1.6.0"
+version: "1.7.0"
 license: basic
 release: ga
 description: "Slack Logs Integration"

--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.13.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/ti_abusech/data_stream/malware/manifest.yml
+++ b/packages/ti_abusech/data_stream/malware/manifest.yml
@@ -27,6 +27,7 @@ streams:
       - name: interval
         type: text
         title: Interval
+        description: Interval at which the logs will be pulled. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/ti_abusech/data_stream/malwarebazaar/manifest.yml
+++ b/packages/ti_abusech/data_stream/malwarebazaar/manifest.yml
@@ -27,6 +27,7 @@ streams:
       - name: interval
         type: text
         title: Interval
+        description: Interval at which the logs will be pulled. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/ti_abusech/data_stream/threatfox/manifest.yml
+++ b/packages/ti_abusech/data_stream/threatfox/manifest.yml
@@ -27,6 +27,7 @@ streams:
       - name: interval
         type: text
         title: Interval
+        description: Interval at which the logs will be pulled. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: AbuseCH
-version: "1.13.0"
+version: "1.14.0"
 release: ga
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration

--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.0.0"
   changes:
     - description: Release Collective Intelligence Framework as GA.

--- a/packages/ti_cif3/data_stream/feed/manifest.yml
+++ b/packages/ti_cif3/data_stream/feed/manifest.yml
@@ -58,7 +58,7 @@ streams:
         required: true
         show_user: true
         default: 60m
-        description: How frequently to pull the feed.
+        description: How frequently to pull the feed. Supported units for this parameter are h/m/s.
       # this doesn't currently work
       #- name: filters
       #  type: yaml

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: "1.0.0"
+version: "1.1.0"
 license: basic
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."
 type: integration

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -1,4 +1,14 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
+- version: "1.14.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.13.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/ti_cybersixgill/data_stream/threat/manifest.yml
+++ b/packages/ti_cybersixgill/data_stream/threat/manifest.yml
@@ -46,6 +46,7 @@ streams:
       - name: interval
         type: text
         title: Interval
+        description: Interval at which the logs will be pulled. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true
@@ -57,7 +58,7 @@ streams:
         required: true
         show_user: false
         default: 2160h
-        description: How far back to look for indicators the first time the agent is started.
+        description: How far back to look for indicators the first time the agent is started. Supported units for this parameter are h/m/s.
       - name: ssl
         type: yaml
         title: SSL

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.13.0"
+version: "1.15.0"
 release: ga
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.16.2"
   changes:
     - description: Fix the fingerprint processor in the Attributes Pipeline.

--- a/packages/ti_misp/data_stream/threat/manifest.yml
+++ b/packages/ti_misp/data_stream/threat/manifest.yml
@@ -20,12 +20,12 @@ streams:
         description: The API token used to access the MISP instance.
       - name: initial_interval
         type: text
-        title: Interval
+        title: Initial interval
         multi: false
         required: true
         show_user: true
         default: 120h
-        description: How far back to look for indicators the first time the agent is started.
+        description: How far back to look for indicators the first time the agent is started. Supported units for this parameter are h/m/s.
       - name: http_client_timeout
         type: text
         title: HTTP Client Timeout
@@ -58,6 +58,7 @@ streams:
       - name: interval
         type: text
         title: Interval
+        description: Interval at which the logs will be pulled. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/ti_misp/data_stream/threat_attributes/manifest.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/manifest.yml
@@ -20,12 +20,12 @@ streams:
         description: The API token used to access the MISP instance.
       - name: initial_interval
         type: text
-        title: Interval
+        title: Initial interval
         multi: false
         required: true
         show_user: true
         default: 120h
-        description: How far back to look for indicators the first time the agent is started.
+        description: How far back to look for indicators the first time the agent is started. Supported units for this parameter are h/m/s.
       - name: http_client_timeout
         type: text
         title: HTTP Client Timeout
@@ -58,6 +58,7 @@ streams:
       - name: interval
         type: text
         title: Interval
+        description: Interval at which the logs will be pulled. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.16.2"
+version: "1.17.0"
 release: ga
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.11.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/ti_otx/data_stream/threat/manifest.yml
+++ b/packages/ti_otx/data_stream/threat/manifest.yml
@@ -34,6 +34,7 @@ streams:
       - name: interval
         type: text
         title: Interval
+        description: Interval at which the logs will be pulled. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.11.0"
+version: "1.12.0"
 release: ga
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.12.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/ti_threatq/data_stream/threat/manifest.yml
+++ b/packages/ti_threatq/data_stream/threat/manifest.yml
@@ -64,6 +64,7 @@ streams:
       - name: interval
         type: text
         title: Interval
+        description: Interval at which the logs will be pulled. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: true

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.12.0"
+version: "1.13.0"
 release: ga
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration

--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.0.0"
   changes:
     - description: Release Tines as GA.

--- a/packages/tines/data_stream/audit_logs/manifest.yml
+++ b/packages/tines/data_stream/audit_logs/manifest.yml
@@ -38,7 +38,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false
@@ -60,7 +60,7 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: Period of historical audit logs to collect when first collection request occurs
+        description: Period of historical audit logs to collect when first collection request occurs. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/tines/data_stream/time_saved/manifest.yml
+++ b/packages/tines/data_stream/time_saved/manifest.yml
@@ -38,7 +38,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false
@@ -76,7 +76,7 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: Period of historical audit logs to collect when first collection request occurs
+        description: Period of historical audit logs to collect when first collection request occurs. Supported units for this parameter are h/m/s.
         multi: false
         required: true
         show_user: false

--- a/packages/tines/manifest.yml
+++ b/packages/tines/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: tines
 title: "Tines"
-version: "1.0.0"
+version: "1.1.0"
 description: "Tines Logs & Time Saved Reports"
 type: integration
 categories:

--- a/packages/zerofox/changelog.yml
+++ b/packages/zerofox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.12.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/zerofox/manifest.yml
+++ b/packages/zerofox/manifest.yml
@@ -1,6 +1,6 @@
 name: zerofox
 title: ZeroFox
-version: "1.12.0"
+version: "1.13.0"
 description: Collect logs from ZeroFox with Elastic Agent.
 type: integration
 format_version: 2.7.0
@@ -52,7 +52,7 @@ policy_templates:
           - name: initial_interval
             type: text
             title: Initial Interval
-            description: How far back to pull the initial alerts
+            description: How far back to pull the initial alerts. Supported units for this parameter are h/m/s.
             multi: false
             required: true
             show_user: true
@@ -60,7 +60,7 @@ policy_templates:
           - name: interval
             type: text
             title: Periodic Polling Interval
-            description: How often to poll the ZeroFox API for new alerts
+            description: How often to poll the ZeroFox API for new alerts. Supported units for this parameter are h/m/s.
             multi: false
             required: true
             show_user: true

--- a/packages/zeronetworks/changelog.yml
+++ b/packages/zeronetworks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Document valid duration units.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6706
 - version: "1.0.0"
   changes:
     - description: Release Zero Networks as GA.

--- a/packages/zeronetworks/data_stream/audit/manifest.yml
+++ b/packages/zeronetworks/data_stream/audit/manifest.yml
@@ -19,7 +19,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        description: Interval at which the logs will be pulled. The value must be between 5m and 1h.
+        description: Interval at which the logs will be pulled. The value must be between 5m and 1h. Supported units for this parameter are h/m/s.
         default: 5m
       - name: initial_interval
         type: text
@@ -27,7 +27,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        description: Initial interval at which the logs will be pulled. Defaults to 7 days (168 hours).
+        description: Initial interval at which the logs will be pulled. Defaults to 7 days (168 hours). Supported units for this parameter are h/m/s.
         default: 168h
       - name: limit
         type: integer

--- a/packages/zeronetworks/manifest.yml
+++ b/packages/zeronetworks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: zeronetworks
 title: "Zero Networks"
-version: "1.0.0"
+version: "1.1.0"
 source:
   license: "Elastic-2.0"
 description: "Zero Networks Logs integration"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Add note in manifests of akamai, atlassian_bitbucket, atlassian_confluence, atlassian_jira, cisco_secure_endpoint, cloudflare, forgerock, github, m365_defender, microsoft_exchange_online_message_trace, okta, panw_cortex_xdr, slack, ti_cybersixgill, ti_misp, tines, zerofox and zeronetworks to show valid initial interval units where not already specified.

Not all acceptable units are listed, but rather choose commonly used units that are already documented in other packages.



## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6684

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
