### PR TITLE
[ti_misp] fix the fingerprint processor for the attributes pipeline.

### DIFF
--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix the fingerprint processor in the Attributes Pipeline.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/ADD_LATER
+      link: https://github.com/elastic/integrations/pull/6719
 - version: "1.16.1"
   changes:
     - description: Keep the same timestamp for later pages in a pagination sequence.

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.2"
+  changes:
+    - description: Fix the fingerprint processor in the Attributes Pipeline.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/ADD_LATER
 - version: "1.16.1"
   changes:
     - description: Keep the same timestamp for later pages in a pagination sequence.

--- a/packages/ti_misp/data_stream/threat_attributes/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/elasticsearch/ingest_pipeline/default.yml
@@ -29,8 +29,8 @@ processors:
       target_field: misp.attribute
   - fingerprint:
       fields:
-        - misp.attribute.Attribute.uuid
-        - misp.attribute.Attribute.Event.uuid
+        - misp.attribute.uuid
+        - misp.attribute.Event.uuid
       target_field: "_id"
       ignore_missing: true
   - set:

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.16.1"
+version: "1.16.2"
 release: ga
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR fix the fingerprint processor on the MISP Attributes Ingest Pipeline, it was making a reference to a field that does not exist in the document.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #6686 
