### PR TITLE
[ci] Enable Slack notifications on daily job status

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -59,7 +59,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(prComment: false, slackHeader: "Integration job failed ${env.JENKINS_URL}search/?q=${env.INTEGRATION_JOB.replaceAll('/','+')}")
+      notifyBuildResult(prComment: false, slackComment: true, slackHeader: "Integration job failed ${env.JENKINS_URL}search/?q=${env.INTEGRATION_JOB.replaceAll('/','+')}")
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

As a minor improvement into the visibility of failures in the daily integration job, attempt to enable Slack notifications.

From digging into the [pipeline library](https://github.com/elastic/apm-pipeline-library/blob/main/vars/notifyBuildResult.groovy#L34), the current config is missing `slackComment: true` when notifying on the build status.

## Related issues

Relates to #6071. 
