### PR TITLE
Update ECS reference in build.yml to use tag instead of branch

### DIFF
--- a/packages/1password/_dev/build/build.yml
+++ b/packages/1password/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/akamai/_dev/build/build.yml
+++ b/packages/akamai/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/arista_ngfw/_dev/build/build.yml
+++ b/packages/arista_ngfw/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/atlassian_bitbucket/_dev/build/build.yml
+++ b/packages/atlassian_bitbucket/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/atlassian_confluence/_dev/build/build.yml
+++ b/packages/atlassian_confluence/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/atlassian_jira/_dev/build/build.yml
+++ b/packages/atlassian_jira/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/auditd/_dev/build/build.yml
+++ b/packages/auditd/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/auditd_manager/_dev/build/build.yml
+++ b/packages/auditd_manager/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/auth0/_dev/build/build.yml
+++ b/packages/auth0/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/azure_blob_storage/_dev/build/build.yml
+++ b/packages/azure_blob_storage/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/azure_frontdoor/_dev/build/build.yml
+++ b/packages/azure_frontdoor/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/barracuda/_dev/build/build.yml
+++ b/packages/barracuda/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/barracuda_cloudgen_firewall/_dev/build/build.yml
+++ b/packages/barracuda_cloudgen_firewall/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/bitdefender/_dev/build/build.yml
+++ b/packages/bitdefender/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/bitwarden/_dev/build/build.yml
+++ b/packages/bitwarden/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/bluecoat/_dev/build/build.yml
+++ b/packages/bluecoat/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/box_events/_dev/build/build.yml
+++ b/packages/box_events/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/carbon_black_cloud/_dev/build/build.yml
+++ b/packages/carbon_black_cloud/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/carbonblack_edr/_dev/build/build.yml
+++ b/packages/carbonblack_edr/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cef/_dev/build/build.yml
+++ b/packages/cef/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/cel/_dev/build/build.yml
+++ b/packages/cel/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/checkpoint/_dev/build/build.yml
+++ b/packages/checkpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_aironet/_dev/build/build.yml
+++ b/packages/cisco_aironet/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_asa/_dev/build/build.yml
+++ b/packages/cisco_asa/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_duo/_dev/build/build.yml
+++ b/packages/cisco_duo/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_ftd/_dev/build/build.yml
+++ b/packages/cisco_ftd/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_ios/_dev/build/build.yml
+++ b/packages/cisco_ios/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_ise/_dev/build/build.yml
+++ b/packages/cisco_ise/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_meraki/_dev/build/build.yml
+++ b/packages/cisco_meraki/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_nexus/_dev/build/build.yml
+++ b/packages/cisco_nexus/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/cisco_secure_email_gateway/_dev/build/build.yml
+++ b/packages/cisco_secure_email_gateway/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_secure_endpoint/_dev/build/build.yml
+++ b/packages/cisco_secure_endpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cisco_umbrella/_dev/build/build.yml
+++ b/packages/cisco_umbrella/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/citrix_waf/_dev/build/build.yml
+++ b/packages/citrix_waf/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cloudflare/_dev/build/build.yml
+++ b/packages/cloudflare/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cloudflare_logpush/_dev/build/build.yml
+++ b/packages/cloudflare_logpush/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/crowdstrike/_dev/build/build.yml
+++ b/packages/crowdstrike/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cyberark_pta/_dev/build/build.yml
+++ b/packages/cyberark_pta/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cyberarkpas/_dev/build/build.yml
+++ b/packages/cyberarkpas/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/cylance/_dev/build/build.yml
+++ b/packages/cylance/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/darktrace/_dev/build/build.yml
+++ b/packages/darktrace/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/f5/_dev/build/build.yml
+++ b/packages/f5/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/f5_bigip/_dev/build/build.yml
+++ b/packages/f5_bigip/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/fim/_dev/build/build.yml
+++ b/packages/fim/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/fireeye/_dev/build/build.yml
+++ b/packages/fireeye/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/forcepoint_web/_dev/build/build.yml
+++ b/packages/forcepoint_web/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/forgerock/_dev/build/build.yml
+++ b/packages/forgerock/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/fortinet_forticlient/_dev/build/build.yml
+++ b/packages/fortinet_forticlient/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/fortinet_fortiedr/_dev/build/build.yml
+++ b/packages/fortinet_fortiedr/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/fortinet_fortigate/_dev/build/build.yml
+++ b/packages/fortinet_fortigate/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/fortinet_fortimail/_dev/build/build.yml
+++ b/packages/fortinet_fortimail/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/fortinet_fortimanager/_dev/build/build.yml
+++ b/packages/fortinet_fortimanager/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/gcp/_dev/build/build.yml
+++ b/packages/gcp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/gcp_pubsub/_dev/build/build.yml
+++ b/packages/gcp_pubsub/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/github/_dev/build/build.yml
+++ b/packages/github/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/google_cloud_storage/_dev/build/build.yml
+++ b/packages/google_cloud_storage/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/google_workspace/_dev/build/build.yml
+++ b/packages/google_workspace/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/hashicorp_vault/_dev/build/build.yml
+++ b/packages/hashicorp_vault/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/hid_bravura_monitor/_dev/build/build.yml
+++ b/packages/hid_bravura_monitor/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/http_endpoint/_dev/build/build.yml
+++ b/packages/http_endpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/httpjson/_dev/build/build.yml
+++ b/packages/httpjson/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/imperva/_dev/build/build.yml
+++ b/packages/imperva/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/infoblox_bloxone_ddi/_dev/build/build.yml
+++ b/packages/infoblox_bloxone_ddi/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/infoblox_nios/_dev/build/build.yml
+++ b/packages/infoblox_nios/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/iptables/_dev/build/build.yml
+++ b/packages/iptables/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/jamf_compliance_reporter/_dev/build/build.yml
+++ b/packages/jamf_compliance_reporter/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/jumpcloud/_dev/build/build.yml
+++ b/packages/jumpcloud/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/juniper_junos/_dev/build/build.yml
+++ b/packages/juniper_junos/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/juniper_netscreen/_dev/build/build.yml
+++ b/packages/juniper_netscreen/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/juniper_srx/_dev/build/build.yml
+++ b/packages/juniper_srx/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/keycloak/_dev/build/build.yml
+++ b/packages/keycloak/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/lastpass/_dev/build/build.yml
+++ b/packages/lastpass/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/log/_dev/build/build.yml
+++ b/packages/log/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/lyve_cloud/_dev/build/build.yml
+++ b/packages/lyve_cloud/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/m365_defender/_dev/build/build.yml
+++ b/packages/m365_defender/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/mattermost/_dev/build/build.yml
+++ b/packages/mattermost/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/microsoft_defender_endpoint/_dev/build/build.yml
+++ b/packages/microsoft_defender_endpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/microsoft_dhcp/_dev/build/build.yml
+++ b/packages/microsoft_dhcp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/microsoft_exchange_online_message_trace/_dev/build/build.yml
+++ b/packages/microsoft_exchange_online_message_trace/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/mimecast/_dev/build/build.yml
+++ b/packages/mimecast/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/modsecurity/_dev/build/build.yml
+++ b/packages/modsecurity/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/mysql_enterprise/_dev/build/build.yml
+++ b/packages/mysql_enterprise/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/netflow/_dev/build/build.yml
+++ b/packages/netflow/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/netscout/_dev/build/build.yml
+++ b/packages/netscout/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/netskope/_dev/build/build.yml
+++ b/packages/netskope/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/network_traffic/_dev/build/build.yml
+++ b/packages/network_traffic/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/o365/_dev/build/build.yml
+++ b/packages/o365/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/okta/_dev/build/build.yml
+++ b/packages/okta/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/osquery/_dev/build/build.yml
+++ b/packages/osquery/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/panw/_dev/build/build.yml
+++ b/packages/panw/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/panw_cortex_xdr/_dev/build/build.yml
+++ b/packages/panw_cortex_xdr/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/pfsense/_dev/build/build.yml
+++ b/packages/pfsense/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ping_one/_dev/build/build.yml
+++ b/packages/ping_one/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/proofpoint_tap/_dev/build/build.yml
+++ b/packages/proofpoint_tap/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/pulse_connect_secure/_dev/build/build.yml
+++ b/packages/pulse_connect_secure/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/qnap_nas/_dev/build/build.yml
+++ b/packages/qnap_nas/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/radware/_dev/build/build.yml
+++ b/packages/radware/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/rapid7_insightvm/_dev/build/build.yml
+++ b/packages/rapid7_insightvm/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/santa/_dev/build/build.yml
+++ b/packages/santa/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/sentinel_one/_dev/build/build.yml
+++ b/packages/sentinel_one/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/slack/_dev/build/build.yml
+++ b/packages/slack/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/snort/_dev/build/build.yml
+++ b/packages/snort/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/snyk/_dev/build/build.yml
+++ b/packages/snyk/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/sonicwall_firewall/_dev/build/build.yml
+++ b/packages/sonicwall_firewall/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/sophos/_dev/build/build.yml
+++ b/packages/sophos/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/sophos_central/_dev/build/build.yml
+++ b/packages/sophos_central/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/squid/_dev/build/build.yml
+++ b/packages/squid/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/suricata/_dev/build/build.yml
+++ b/packages/suricata/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/symantec_endpoint/_dev/build/build.yml
+++ b/packages/symantec_endpoint/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/sysmon_linux/_dev/build/build.yml
+++ b/packages/sysmon_linux/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/system_audit/_dev/build/build.yml
+++ b/packages/system_audit/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/tanium/_dev/build/build.yml
+++ b/packages/tanium/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/tcp/_dev/build/build.yml
+++ b/packages/tcp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/tenable_io/_dev/build/build.yml
+++ b/packages/tenable_io/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/tenable_sc/_dev/build/build.yml
+++ b/packages/tenable_sc/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/thycotic_ss/_dev/build/build.yml
+++ b/packages/thycotic_ss/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_abusech/_dev/build/build.yml
+++ b/packages/ti_abusech/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_anomali/_dev/build/build.yml
+++ b/packages/ti_anomali/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_cif3/_dev/build/build.yml
+++ b/packages/ti_cif3/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_cybersixgill/_dev/build/build.yml
+++ b/packages/ti_cybersixgill/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_misp/_dev/build/build.yml
+++ b/packages/ti_misp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_otx/_dev/build/build.yml
+++ b/packages/ti_otx/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_rapid7_threat_command/_dev/build/build.yml
+++ b/packages/ti_rapid7_threat_command/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_recordedfuture/_dev/build/build.yml
+++ b/packages/ti_recordedfuture/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/ti_threatq/_dev/build/build.yml
+++ b/packages/ti_threatq/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/tines/_dev/build/build.yml
+++ b/packages/tines/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/trellix_epo_cloud/_dev/build/build.yml
+++ b/packages/trellix_epo_cloud/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/trend_micro_vision_one/_dev/build/build.yml
+++ b/packages/trend_micro_vision_one/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/trendmicro/_dev/build/build.yml
+++ b/packages/trendmicro/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/udp/_dev/build/build.yml
+++ b/packages/udp/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/vectra_detect/_dev/build/build.yml
+++ b/packages/vectra_detect/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/winlog/_dev/build/build.yml
+++ b/packages/winlog/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/zeek/_dev/build/build.yml
+++ b/packages/zeek/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/zerofox/_dev/build/build.yml
+++ b/packages/zerofox/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/zeronetworks/_dev/build/build.yml
+++ b/packages/zeronetworks/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/zoom/_dev/build/build.yml
+++ b/packages/zoom/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/zscaler_zia/_dev/build/build.yml
+++ b/packages/zscaler_zia/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true

--- a/packages/zscaler_zpa/_dev/build/build.yml
+++ b/packages/zscaler_zpa/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0
     import_mappings: true


### PR DESCRIPTION
Use of branches introduces uncontrolled changes that produces unexpected failures in unrelated PRs.

Changes introduced in 8.8 branch alter the content of packages, use the `v8.8.0` tag.

Follow up: https://github.com/elastic/elastic-package/issues/1336