### PR TITLE
[HAProxy] Add timezone offset support

### DIFF
--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Add possibility for overriding timezones in UI
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6298
 - version: "1.6.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add possibility for overriding timezones in UI
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6298
+      link: https://github.com/elastic/integrations/pull/6767
 - version: "1.6.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/haproxy/data_stream/log/_dev/test/pipeline/test-default.log-config.yml
+++ b/packages/haproxy/data_stream/log/_dev/test/pipeline/test-default.log-config.yml
@@ -1,0 +1,5 @@
+fields:
+  tags:
+    - preserve_original_event
+  _conf:
+    tz_offset: "+0500"

--- a/packages/haproxy/data_stream/log/_dev/test/pipeline/test-default.log-expected.json
+++ b/packages/haproxy/data_stream/log/_dev/test/pipeline/test-default.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2023-09-20T15:42:59.000Z",
+            "@timestamp": "2023-09-20T15:42:59.000+05:00",
             "destination": {
                 "ip": "67.43.156.13",
                 "port": 5000
@@ -16,6 +16,7 @@
                 ],
                 "kind": "event",
                 "original": "Sep 20 15:42:59 67.43.156.13 haproxy[24551]: Connect from 67.43.156.13:40780 to 67.43.156.13:5000 (main/HTTP)",
+                "timezone": "+0500",
                 "type": [
                     "connection"
                 ]

--- a/packages/haproxy/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/haproxy/data_stream/log/agent/stream/log.yml.hbs
@@ -13,8 +13,15 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 exclude_files: [".gz$"]
+{{#if tz_offset}}
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: "{{tz_offset}}"
+{{/if}}
 processors:
+- add_locale: ~
 {{#if processors}}
 {{processors}}
 {{/if}}
-- add_locale: ~
+

--- a/packages/haproxy/data_stream/log/agent/stream/syslog.yml.hbs
+++ b/packages/haproxy/data_stream/log/agent/stream/syslog.yml.hbs
@@ -10,8 +10,14 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
+{{#if tz_offset}}
+fields_under_root: true
+fields:
+  _conf:
+    tz_offset: "{{tz_offset}}"
+{{/if}}
 processors:
+- add_locale: ~
 {{#if processors}}
 {{processors}}
 {{/if}}
-- add_locale: ~

--- a/packages/haproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/haproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -38,6 +38,10 @@ processors:
         HTTPS_DATA: >-
           %{NUMBER:haproxy.connections.fc_err:long}/%{NUMBER:haproxy.connections.ssl_fc_err:long}/%{NUMBER:haproxy.connections.ssl_c_err:long}/%{NUMBER:haproxy.connections.ssl_c_ca_err:long}/%{NUMBER:temp.ssl_fc_is_resumed:long}
           %{HOSTNAME:tls.client.server_name}/%{DATA:tls.version_protocol}v%{NUMBER:tls.version}/%{NOTSPACE:tls.cipher}
+  - set:
+      field: event.timezone
+      copy_from: _conf.tz_offset
+      if: ctx._conf?.tz_offset != null && ctx._conf.tz_offset != 'local'
   - date:
       if: ctx.event.timezone == null
       field: haproxy.request_date
@@ -173,6 +177,7 @@ processors:
   - remove:
       field: 
         - temp
+        - _conf
         - haproxy.request_date
       ignore_missing: true
   - script:

--- a/packages/haproxy/data_stream/log/manifest.yml
+++ b/packages/haproxy/data_stream/log/manifest.yml
@@ -34,7 +34,7 @@ streams:
         required: false
         show_user: false
         default: UTC
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Can also be set to `local` to use the agent's local time zone which is the default.
       - name: processors
         type: yaml
         title: Processors
@@ -86,7 +86,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Can also be set to `local` to use the agent's local time zone.
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Can also be set to `local` to use the agent's local time zone which is the default.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/haproxy/data_stream/log/manifest.yml
+++ b/packages/haproxy/data_stream/log/manifest.yml
@@ -27,6 +27,14 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: false
+        show_user: false
+        default: UTC
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone.
       - name: processors
         type: yaml
         title: Processors
@@ -72,6 +80,13 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: false
+        show_user: false
+        description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Can also be set to `local` to use the agent's local time zone.
       - name: processors
         type: yaml
         title: Processors

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -1,6 +1,6 @@
 name: haproxy
 title: HAProxy
-version: "1.6.0"
+version: "1.7.0"
 description: Collect logs and metrics from HAProxy servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

HAproxy mostly does not log with a timezone by default, and we hardcode add_local after any custom processors, so its not possible to override the local timezone.

The PR adds the common timezone offset which we use in other integration + changes the order of add_locale to be before custom processors.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


