### PR TITLE
[HAProxy] Remove uncessary Timezone default in manifest

### DIFF
--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove unecessary default from Timezone Offset
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6767
+      link: https://github.com/elastic/integrations/pull/6769
 - version: "1.7.0"
   changes:
     - description: Add possibility for overriding timezones in UI

--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Remove unecessary default from Timezone Offset
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6767
 - version: "1.7.0"
   changes:
     - description: Add possibility for overriding timezones in UI

--- a/packages/haproxy/data_stream/log/manifest.yml
+++ b/packages/haproxy/data_stream/log/manifest.yml
@@ -33,7 +33,6 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: UTC
         description: IANA time zone or time offset (e.g. `+0200`) to use when interpreting syslog timestamps without a time zone. Can also be set to `local` to use the agent's local time zone which is the default.
       - name: processors
         type: yaml

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -1,6 +1,6 @@
 name: haproxy
 title: HAProxy
-version: "1.7.0"
+version: "1.7.1"
 description: Collect logs and metrics from HAProxy servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Followup on the older PR https://github.com/elastic/integrations/pull/6767, the UTC default is unecessary and should have been removed.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


