### PR TITLE
sophos: fix log config indentation

### DIFF
--- a/packages/sophos/changelog.yml
+++ b/packages/sophos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.1"
+  changes:
+    - description: Fix indentation in log agent config.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6773
 - version: "2.11.0"
   changes:
     - description: Allow user configuration of timezone offset in XG data stream.

--- a/packages/sophos/data_stream/xg/agent/stream/log.yml.hbs
+++ b/packages/sophos/data_stream/xg/agent/stream/log.yml.hbs
@@ -21,7 +21,7 @@ processors:
 - add_fields:
     target: '_conf'
     fields:
-	    tz_offset: '{{tz_offset}}'
+        tz_offset: '{{tz_offset}}'
         default: {{default_host_name}}
         mappings:
 {{#if known_devices}}

--- a/packages/sophos/manifest.yml
+++ b/packages/sophos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: sophos
 title: Sophos
-version: "2.11.0"
+version: "2.11.1"
 description: Collect logs from Sophos with Elastic Agent.
 categories: ["security", "network", "firewall_security"]
 release: ga


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Fixes indentation in the log config yml/hbs.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #6690

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
