### PR TITLE
[Airflow] Add metrictype mapping for the fields of statsd datastream.

### DIFF
--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.1.1"
+- version: "0.2.0"
   changes:
     - description: Add metrictype mapping for the fields of statsd datastream.
       type: enhancement

--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Add metrictype mapping for the fields of statsd datastream.
+      type: enhancement
+      link: tbd
 - version: "0.1.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add metrictype mapping for the fields of statsd datastream.
       type: enhancement
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/6775
 - version: "0.1.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/airflow/data_stream/statsd/fields/fields.yml
+++ b/packages/airflow/data_stream/statsd/fields/fields.yml
@@ -2,9 +2,8 @@
   type: group
   fields:
     - name: '*.count'
-      type: object
-      object_type: double
-      object_type_mapping_type: "*"
+      type: double
+      metric_type: counter
       description: Airflow counters
     - name: '*.max'
       type: object
@@ -37,9 +36,8 @@
       object_type_mapping_type: "*"
       description: Airflow standard deviation timers metric
     - name: '*.value'
-      type: object
-      object_type: double
-      object_type_mapping_type: "*"
+      type: double
+      metric_type: gauge
       description: Airflow gauges
     - name: 'dag_file'
       type: keyword

--- a/packages/airflow/docs/README.md
+++ b/packages/airflow/docs/README.md
@@ -25,64 +25,64 @@ statsd_prefix =
 ```
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| agent.id |  | keyword |
-| airflow.\*.count | Airflow counters | object |
-| airflow.\*.max | Airflow max timers metric | object |
-| airflow.\*.mean | Airflow mean timers metric | object |
-| airflow.\*.mean_rate | Airflow mean rate timers metric | object |
-| airflow.\*.median | Airflow median timers metric | object |
-| airflow.\*.min | Airflow min timers metric | object |
-| airflow.\*.stddev | Airflow standard deviation timers metric | object |
-| airflow.\*.value | Airflow gauges | object |
-| airflow.dag_file | Airflow dag file metadata | keyword |
-| airflow.dag_id | Airflow dag id metadata | keyword |
-| airflow.job_name | Airflow job name metadata | keyword |
-| airflow.operator_name | Airflow operator name metadata | keyword |
-| airflow.pool_name | Airflow pool name metadata | keyword |
-| airflow.status | Airflow status metadata | keyword |
-| airflow.task_id | Airflow task id metadata | keyword |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| container.runtime | Runtime managing this container. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| service.address | Service address | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| agent.id |  | keyword |  |
+| airflow.\*.count | Airflow counters | double | counter |
+| airflow.\*.max | Airflow max timers metric | object |  |
+| airflow.\*.mean | Airflow mean timers metric | object |  |
+| airflow.\*.mean_rate | Airflow mean rate timers metric | object |  |
+| airflow.\*.median | Airflow median timers metric | object |  |
+| airflow.\*.min | Airflow min timers metric | object |  |
+| airflow.\*.stddev | Airflow standard deviation timers metric | object |  |
+| airflow.\*.value | Airflow gauges | double | gauge |
+| airflow.dag_file | Airflow dag file metadata | keyword |  |
+| airflow.dag_id | Airflow dag id metadata | keyword |  |
+| airflow.job_name | Airflow job name metadata | keyword |  |
+| airflow.operator_name | Airflow operator name metadata | keyword |  |
+| airflow.pool_name | Airflow pool name metadata | keyword |  |
+| airflow.status | Airflow status metadata | keyword |  |
+| airflow.task_id | Airflow task id metadata | keyword |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| container.runtime | Runtime managing this container. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.name.text | Multi-field of `host.os.name`. | text |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 
 

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -8,7 +8,7 @@ license: basic
 categories:
   - observability
 conditions:
-  kibana.version: "^8.9.0"
+  kibana.version: "^8.5.0"
 icons:
   - src: /img/airflow.svg
     title: Airflow logo

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -1,6 +1,6 @@
 name: airflow
 title: Airflow
-version: "0.1.0"
+version: "0.1.1"
 description: Airflow Integration.
 type: integration
 format_version: 1.0.0
@@ -8,7 +8,7 @@ license: basic
 categories:
   - observability
 conditions:
-  kibana.version: "^8.5.0"
+  kibana.version: "^8.9.0"
 icons:
   - src: /img/airflow.svg
     title: Airflow logo

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -1,6 +1,6 @@
 name: airflow
 title: Airflow
-version: "0.1.1"
+version: "0.2.0"
 description: Airflow Integration.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
- Enhancement


## What does this PR do?

This PR adds metric_type mapping for the fields of statsD datastream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes #6729 


## Screenshots

<img width="1635" alt="Screenshot 2023-07-03 at 12 35 59 PM" src="https://github.com/elastic/integrations/assets/102972658/b6dc0c9b-7567-4bcd-a4a7-af36ef47f262">
<img width="1694" alt="Screenshot 2023-07-03 at 12 36 17 PM" src="https://github.com/elastic/integrations/assets/102972658/acee2ba2-e401-4777-be50-2b5a8abc75e9">
<img width="823" alt="Screenshot 2023-07-03 at 12 36 35 PM" src="https://github.com/elastic/integrations/assets/102972658/7705c983-db1b-4398-a491-f64600b22558">
<img width="765" alt="Screenshot 2023-07-03 at 12 36 50 PM" src="https://github.com/elastic/integrations/assets/102972658/a0a4c3f8-a4de-49ea-a7ac-8f3b09207d3b">



