### PR TITLE
[Airflow] Enable TSDB

### DIFF
--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Enable time series data streams for the metrics datasets. This dramatically reduces storage for metrics and is expected to progressively improve query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: tbd
 - version: "0.1.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/airflow/data_stream/statsd/manifest.yml
+++ b/packages/airflow/data_stream/statsd/manifest.yml
@@ -6,3 +6,5 @@ streams:
     enabled: true
     title: Airflow metrics
     description: Collect Airflow metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -1,6 +1,6 @@
 name: airflow
 title: Airflow
-version: "0.1.0"
+version: "0.2.0"
 description: Airflow Integration.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
- Enhancement

## What does this PR do?

This PR enables TSDB on airflow package. It enables index_mode: "time_series" for all the airflow metrics data streams.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues


- Relates #6152 
