### PR TITLE
[IIS] update visualisation for counter fields

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.3"
+  changes:
+    - description: Update aggregator function for few counter fields.
+      type: bugfix
+      link: tbd
 - version: "1.12.2"
   changes:
     - description: Add dimension field mapping for website datastream to support tsdb.

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update aggregator function for few counter fields.
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/6780
 - version: "1.12.2"
   changes:
     - description: Add dimension field mapping for website datastream to support tsdb.

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.12.3"
   changes:
-    - description: Update aggregator function for few counter fields.
+    - description: Update aggregator function for a few fields having metric_type `counter`.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/6780
 - version: "1.12.2"

--- a/packages/iis/kibana/dashboard/iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7.json
@@ -1878,7 +1878,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total POST Requests ",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -2029,7 +2029,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total PUT Requests ",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -2211,7 +2211,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total DELETE Requests ",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -2393,7 +2393,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total GET Requests ",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {

--- a/packages/iis/kibana/dashboard/iis-ebc23240-8572-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-ebc23240-8572-11ea-91bc-ab084c7ec0e7.json
@@ -879,7 +879,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total Get Requests",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -906,7 +906,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total Delete Requests",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -946,7 +946,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total Post Requests",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -1596,7 +1596,7 @@
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Total Bytes Sent ",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -1649,7 +1649,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total Bytes Received",
-                                                    "operationType": "average",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: "1.12.2"
+version: "1.12.3"
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
- Bug


## What does this PR do?

This PR updates the aggregator function from average to max for few counter fields of IIS visualisations.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).




## Related issues


- Relates #6267


## Screenshots
![image](https://github.com/elastic/integrations/assets/102972658/f8514625-cecf-4160-bac5-9c47ab47745a)
![image](https://github.com/elastic/integrations/assets/102972658/cdff1fed-e0e6-48e8-b2b1-6bffb3643d76)
![image](https://github.com/elastic/integrations/assets/102972658/ce3b6733-7c5b-472c-8c49-6c42a8aecc15)
![image](https://github.com/elastic/integrations/assets/102972658/ac83ba9a-b14f-4bbd-8da3-d026fac05dcc)



