### PR TITLE
[AWS] Enable TSDB for some metric datasets - Part 1

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable time series data streams for the metrics datasets Billing, DynamoDB, EBS, ECS, ELB, Firewall, Kinesis, Lambda, NAT gateway, RDS, Redshift, S3 Storage Lens, SNS, SQS, Transit Gateway and VPN. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6749
+      link: https://github.com/elastic/integrations/pull/6782
 - version: "1.45.9"
   changes:
     - description: Add new fingerprint dimension to AWS Billing.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.46.0"
+  changes:
+    - description: Enable time series data streams for the metrics datasets Billing, DynamoDB, EBS, ECS, ELB, Firewall, Kinesis, Lambda, NAT gateway, RDS, Redshift, S3 Storage Lens, SNS, SQS, Transit Gateway and VPN. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6749
 - version: "1.45.9"
   changes:
     - description: Add new fingerprint dimension to AWS Billing.

--- a/packages/aws/data_stream/billing/manifest.yml
+++ b/packages/aws/data_stream/billing/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS Billing Metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/dynamodb/manifest.yml
+++ b/packages/aws/data_stream/dynamodb/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS DynamoDB metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/ebs/manifest.yml
+++ b/packages/aws/data_stream/ebs/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS EBS metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/ecs_metrics/manifest.yml
+++ b/packages/aws/data_stream/ecs_metrics/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS ECS metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/elb_metrics/manifest.yml
+++ b/packages/aws/data_stream/elb_metrics/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS ELB metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/firewall_metrics/manifest.yml
+++ b/packages/aws/data_stream/firewall_metrics/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS Network Firewall metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/kinesis/manifest.yml
+++ b/packages/aws/data_stream/kinesis/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS Kinesis Data Stream metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/lambda/manifest.yml
+++ b/packages/aws/data_stream/lambda/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS Lambda metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/natgateway/manifest.yml
+++ b/packages/aws/data_stream/natgateway/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS NAT gateway metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/rds/manifest.yml
+++ b/packages/aws/data_stream/rds/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS RDS metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/redshift/manifest.yml
+++ b/packages/aws/data_stream/redshift/manifest.yml
@@ -1,5 +1,7 @@
 title: Amazon Redshift metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/s3_storage_lens/manifest.yml
+++ b/packages/aws/data_stream/s3_storage_lens/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS S3 Storage Lens metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/sns/manifest.yml
+++ b/packages/aws/data_stream/sns/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS SNS metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/sqs/manifest.yml
+++ b/packages/aws/data_stream/sqs/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS SQS metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/transitgateway/manifest.yml
+++ b/packages/aws/data_stream/transitgateway/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS Transit Gateway metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/vpn/manifest.yml
+++ b/packages/aws/data_stream/vpn/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS VPN metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.45.9
+version: 1.46.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Enable time series data streams for the metrics datasets:

- Billing
- DynamoDB
- EBS
- ECS
- ELB
- Firewall
- Kinesis
- Lambda
- NAT gateway
- RDS
- Redshift
- S3 Storage Lens
- SNS
- SQS
- Transit Gateway
- VPN.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6293.