### PR TITLE
Add env. vars to manage docker output in CI jobs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,8 +22,6 @@ pipeline {
     JOB_GCS_EXT_CREDENTIALS = 'fleet-ci-gcs-plugin-file-credentials'
     STACK_VERSION = "${params.stackVersion}"
     BENCHMARK_THRESHOLD = '15'
-    // Elastic package links definitions
-    ELASTIC_PACKAGE_LINKS_FILE_PATH = "${env.HOME}/${env.BASE_DIR}/links_table.yml"
 
     // Signing
     JOB_SIGNING_CREDENTIALS = 'sign-artifacts-with-gpg-job'
@@ -41,6 +39,13 @@ pipeline {
     INTEGRATIONS_TESTED = "0"
     FORCE_CHECK_ALL = "${params.force_check_all}"
     SKIP_PUBLISHING = "${params.skip_publishing}"
+
+    // Elastic package settings
+    // Manage docker output/logs
+    ELASTIC_PACKAGE_COMPOSE_DISABLE_ANSI = 'true'
+    ELASTIC_PACKAGE_COMPOSE_DISABLE_PULL_PROGRESS_INFORMATION = 'true'
+    // links definitions
+    ELASTIC_PACKAGE_LINKS_FILE_PATH = "${env.HOME}/${env.BASE_DIR}/links_table.yml"
   }
   options {
     timeout(time: 4, unit: 'HOURS')


### PR DESCRIPTION
## What does this PR do?

This PR adds the needed environment variables to remove docker-compose logs (pull and up subcommands), so they are available for the next elastic-package version.
- Tested with the changes from https://github.com/elastic/elastic-package/pull/1330 in this CI job with just a few packages: https://fleet-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/PR-6742/2/pipeline

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Merged elastic-package PR https://github.com/elastic/elastic-package/pull/1330

## How to test this PR locally


Run in one of the packages in this repository with the variables defined. For instance

```bash
export ELASTIC_PACKAGE_COMPOSE_DISABLE_ANSI=true
export ELASTIC_PACKAGE_COMPOSE_DISABLE_PULL_PROGRESS_INFORMATION=true

elastic-package stack up -v -d
elastic-package stack test -v
elastic-package stack down
```
## Related issues

- Relates https://github.com/elastic/elastic-package/pull/1330 , https://github.com/elastic/integrations/pull/6742

