### PR TITLE
TI Util package fix incorrect index in dashboard

### DIFF
--- a/packages/ti_util/changelog.yml
+++ b/packages/ti_util/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Update to use security-solution-default.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.2.0"
   changes:
     - description: Update package-spec version to 2.7.0.

--- a/packages/ti_util/changelog.yml
+++ b/packages/ti_util/changelog.yml
@@ -1,8 +1,8 @@
 # newer versions go on top
-- version: "1.3.0"
+- version: "1.2.1"
   changes:
     - description: Update to use security-solution-default.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/1234
 - version: "1.2.0"
   changes:

--- a/packages/ti_util/changelog.yml
+++ b/packages/ti_util/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update to use security-solution-default.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/6793
 - version: "1.2.0"
   changes:
     - description: Update package-spec version to 2.7.0.

--- a/packages/ti_util/kibana/dashboard/ti_util-9eff2529-fff5-4064-b825-fa089f260bfa.json
+++ b/packages/ti_util/kibana/dashboard/ti_util-9eff2529-fff5-4064-b825-fa089f260bfa.json
@@ -39,7 +39,7 @@
                 "panelIndex": "52b6e098-78e7-4482-a7a6-82b2872ce2ff",
                 "panelRefName": "panel_52b6e098-78e7-4482-a7a6-82b2872ce2ff",
                 "type": "visualization",
-                "version": "8.3.3"
+                "version": "8.4.0"
             },
             {
                 "embeddableConfig": {
@@ -149,8 +149,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -169,13 +168,13 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "094d3230-9faf-11ec-97aa-f96c187b40e1",
+                                "id": "security-solution-default",
                                 "name": "indexpattern-datasource-layer-7f967027-a827-4d0a-84c3-0de7d2be82fe",
                                 "type": "index-pattern"
                             },
                             {
-                                "id": "094d3230-9faf-11ec-97aa-f96c187b40e1",
-                                "name": "cb98b703-c883-4cfb-94f4-0d4ef75fc047",
+                                "id": "security-solution-default",
+                                "name": "c4f72a3f-d887-4210-8a8c-a7580687c5d3",
                                 "type": "index-pattern"
                             }
                         ],
@@ -214,8 +213,8 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "cb98b703-c883-4cfb-94f4-0d4ef75fc047",
-                                        "key": "signal.rule.name",
+                                        "index": "c4f72a3f-d887-4210-8a8c-a7580687c5d3",
+                                        "key": "kibana.alert.rule.name",
                                         "negate": false,
                                         "params": {
                                             "query": "Threat Intel Indicator Match"
@@ -224,7 +223,7 @@
                                     },
                                     "query": {
                                         "match_phrase": {
-                                            "signal.rule.name": "Threat Intel Indicator Match"
+                                            "kibana.alert.rule.name": "Threat Intel Indicator Match"
                                         }
                                     }
                                 }
@@ -274,8 +273,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -437,8 +435,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -590,8 +587,7 @@
                         "visualizationType": "lnsChoropleth"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 19,
@@ -712,8 +708,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 10,
@@ -732,13 +727,13 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "094d3230-9faf-11ec-97aa-f96c187b40e1",
+                                "id": "security-solution-default",
                                 "name": "indexpattern-datasource-layer-69f5ebb7-aa0a-43cf-a9c9-c7c92b8b6c4d",
                                 "type": "index-pattern"
                             },
                             {
-                                "id": "094d3230-9faf-11ec-97aa-f96c187b40e1",
-                                "name": "e6fcffca-8eee-4825-832d-f4974a54b1d8",
+                                "id": "security-solution-default",
+                                "name": "69de1ad2-e63e-4d3f-bd3a-0531efbf7b2f",
                                 "type": "index-pattern"
                             }
                         ],
@@ -748,25 +743,10 @@
                                     "layers": {
                                         "69f5ebb7-aa0a-43cf-a9c9-c7c92b8b6c4d": {
                                             "columnOrder": [
-                                                "207ff036-44d5-4684-8c3c-1e6879438750",
                                                 "42bbf52a-63f5-4197-adeb-69d0684d8f5a",
                                                 "ff5c9e07-b62c-45d8-946c-1bcdba04bf00"
                                             ],
                                             "columns": {
-                                                "207ff036-44d5-4684-8c3c-1e6879438750": {
-                                                    "customLabel": true,
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "Alerts",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "signal.original_time"
-                                                },
                                                 "42bbf52a-63f5-4197-adeb-69d0684d8f5a": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
@@ -814,8 +794,8 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "e6fcffca-8eee-4825-832d-f4974a54b1d8",
-                                        "key": "signal.rule.name",
+                                        "index": "69de1ad2-e63e-4d3f-bd3a-0531efbf7b2f",
+                                        "key": "kibana.alert.rule.name",
                                         "negate": false,
                                         "params": {
                                             "query": "Threat Intel Indicator Match"
@@ -824,7 +804,7 @@
                                     },
                                     "query": {
                                         "match_phrase": {
-                                            "signal.rule.name": "Threat Intel Indicator Match"
+                                            "kibana.alert.rule.name": "Threat Intel Indicator Match"
                                         }
                                     }
                                 }
@@ -859,8 +839,7 @@
                                         "layerId": "69f5ebb7-aa0a-43cf-a9c9-c7c92b8b6c4d",
                                         "layerType": "data",
                                         "seriesType": "line",
-                                        "splitAccessor": "42bbf52a-63f5-4197-adeb-69d0684d8f5a",
-                                        "xAccessor": "207ff036-44d5-4684-8c3c-1e6879438750"
+                                        "splitAccessor": "42bbf52a-63f5-4197-adeb-69d0684d8f5a"
                                     }
                                 ],
                                 "legend": {
@@ -881,8 +860,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 10,
@@ -1079,8 +1057,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 18,
@@ -1234,8 +1211,7 @@
                         "visualizationType": "lnsPie"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 18,
@@ -1388,8 +1364,7 @@
                         "visualizationType": "lnsPie"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 18,
@@ -1435,13 +1410,13 @@
             "type": "index-pattern"
         },
         {
-            "id": ".siem-signals*",
+            "id": "security-solution-default",
             "name": "fe7a0d65-b4b0-4fa4-8ca0-6f64cca21d9b:indexpattern-datasource-layer-7f967027-a827-4d0a-84c3-0de7d2be82fe",
             "type": "index-pattern"
         },
         {
-            "id": ".siem-signals*",
-            "name": "fe7a0d65-b4b0-4fa4-8ca0-6f64cca21d9b:cb98b703-c883-4cfb-94f4-0d4ef75fc047",
+            "id": "security-solution-default",
+            "name": "fe7a0d65-b4b0-4fa4-8ca0-6f64cca21d9b:c4f72a3f-d887-4210-8a8c-a7580687c5d3",
             "type": "index-pattern"
         },
         {
@@ -1490,13 +1465,13 @@
             "type": "index-pattern"
         },
         {
-            "id": ".siem-signals*",
+            "id": "security-solution-default",
             "name": "9df96344-a3ae-46ef-8ba6-e0e0fa70b64e:indexpattern-datasource-layer-69f5ebb7-aa0a-43cf-a9c9-c7c92b8b6c4d",
             "type": "index-pattern"
         },
         {
-            "id": ".siem-signals*",
-            "name": "9df96344-a3ae-46ef-8ba6-e0e0fa70b64e:e6fcffca-8eee-4825-832d-f4974a54b1d8",
+            "id": "security-solution-default",
+            "name": "9df96344-a3ae-46ef-8ba6-e0e0fa70b64e:69de1ad2-e63e-4d3f-bd3a-0531efbf7b2f",
             "type": "index-pattern"
         },
         {
@@ -1561,12 +1536,12 @@
         },
         {
             "id": "ti_util-854dd9b5-b286-4329-84a7-1435fe04e3b7",
-            "name": "tag-ti_anomali-ti_abusech-320c5c80-3b0c-11ec-ae50-2fdf1e96c6a6",
+            "name": "tag-ti_util-854dd9b5-b286-4329-84a7-1435fe04e3b7",
             "type": "tag"
         },
         {
             "id": "ti_util-3e4bef62-18b5-4f4a-96fa-45b0ec39bd73",
-            "name": "tag-0b18ad10-1363-11ed-8a97-0bde330acd6d",
+            "name": "tag-ti_util-3e4bef62-18b5-4f4a-96fa-45b0ec39bd73",
             "type": "tag"
         }
     ],

--- a/packages/ti_util/manifest.yml
+++ b/packages/ti_util/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_util
 title: "Threat Intelligence Utilities"
-version: 1.3.0
+version: 1.2.1
 description: Prebuilt Threat Intelligence dashboard for Elastic Security
 categories:
   - security

--- a/packages/ti_util/manifest.yml
+++ b/packages/ti_util/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_util
 title: "Threat Intelligence Utilities"
-version: 1.2.0
+version: 1.3.0
 description: Prebuilt Threat Intelligence dashboard for Elastic Security
 categories:
   - security


### PR DESCRIPTION
## What does this PR do?

This PR updates two panels in the ti_util dashboard per updates in 8.x described [here](https://www.elastic.co/guide/en/security/8.0/whats-new.html#index-updates-8.0).

1.  Switch index from `.siem-signals-<space-id>` to `.alerts-security.alerts-<space-id>` 
2. Switch filter field from `signal.rule.name` to `kibana.alert.rule.name`

## Checklist

- [ ] ~I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them~.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).