### PR TITLE
ti_misp: retain email subjects in misp.attribute

### DIFF
--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Retain email subjects in misp.attributes.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6794
 - version: "1.17.0"
   changes:
     - description: Document valid duration units.

--- a/packages/ti_misp/data_stream/threat_attributes/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/elasticsearch/ingest_pipeline/default.yml
@@ -418,7 +418,9 @@ processors:
       field:
         - misp.attribute.value
       ignore_missing: true
-      if: ctx.threat?.indicator?.type != null
+      # Special-case email subject as it is potentially useful, but cannot yet be
+      # put in threat.indicator.email.subject as it is not an ECS field.
+      if: ctx.threat?.indicator?.type != null && ctx.misp?.attribute?.type != "email-subject"
   - remove:
       field:
         - temp_tags

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.17.0"
+version: "1.18.0"
 release: ga
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Retains the `misp.attribute.value` when the `misp.attribute.type` is "email-subject".

This cannot be tested because the current pipeline sets `threat.indicator.type` to "email-message" for emails and this is not a valid value for this field according to the ECS definition.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] IMO I think a better solution to this issue would be to remove the `remove` processor that this PR changes.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #6598

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
