### PR TITLE
bluecoat,juniper_junos,juniper_netscreen: deprecate packages

### DIFF
--- a/packages/bluecoat/changelog.yml
+++ b/packages/bluecoat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.17.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6796
 - version: "0.16.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/bluecoat/manifest.yml
+++ b/packages/bluecoat/manifest.yml
@@ -1,12 +1,12 @@
 format_version: 2.7.0
 name: bluecoat
-title: Blue Coat Director Logs
-version: "0.16.0"
-description: Collect director logs from Blue Coat devices with Elastic Agent.
+title: Blue Coat Director Logs (Deprecated)
+version: "0.17.0"
+description: Deprecated. Director is no longer supported.
 categories: ["network", "security", "proxy_security"]
 type: integration
 conditions:
-  kibana.version: "^7.14.1 || ^8.0.0"
+  kibana.version: "^7.14.1 || ^8.8.0"
 policy_templates:
   - name: director
     title: Blue Coat Director

--- a/packages/juniper_junos/changelog.yml
+++ b/packages/juniper_junos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6796
 - version: "0.9.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/juniper_junos/manifest.yml
+++ b/packages/juniper_junos/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 1.0.0
 name: juniper_junos
-title: Juniper JunOS
-version: "0.9.0"
-description: Collect logs from Juniper JunOS with Elastic Agent.
+title: Juniper JunOS (Deprecated)
+version: "0.10.0"
+description: Deprecated. Use the Juniper SRX package instead.
 categories: ["network", "security"]
 release: experimental
 license: basic
 type: integration
 conditions:
-  kibana.version: "^8.0.0"
+  kibana.version: "^8.8.0"
 policy_templates:
   - name: juniper
     title: Juniper JunOS logs

--- a/packages/juniper_netscreen/changelog.yml
+++ b/packages/juniper_netscreen/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6796
 - version: "0.9.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/juniper_netscreen/manifest.yml
+++ b/packages/juniper_netscreen/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 1.0.0
 name: juniper_netscreen
-title: Juniper NetScreen
-version: "0.9.0"
-description: Collect logs from Juniper NetScreen with Elastic Agent.
+title: Juniper NetScreen (Deprecated)
+version: "0.10.0"
+description: Deprecated. Juniper NetScreen is no longer supported.
 categories: ["network", "security", "firewall_security"]
 release: experimental
 license: basic
 type: integration
 conditions:
-  kibana.version: "^8.0.0"
+  kibana.version: "^8.8.0"
 policy_templates:
   - name: juniper
     title: Juniper NetScreen logs


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Deprecates bluecoat, juniper_junos and juniper_netscreen.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #6789
- Closes #6790
- Closes #6791

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
