### PR TITLE
Add metric_type mapping for compute data stream

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.23.0"
+  changes:
+    - description: Add `metric_type` field mapping for `compute`` datastream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.22.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `metric_type` field mapping for `compute`` datastream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6798
 - version: "2.22.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/gcp/data_stream/compute/fields/fields.yml
+++ b/packages/gcp/data_stream/compute/fields/fields.yml
@@ -4,58 +4,77 @@
   fields:
     - name: firewall.dropped.bytes
       type: long
+      metric_type: counter
       description: Incoming bytes dropped by the firewall
     - name: firewall.dropped_packets_count.value
       type: long
+      metric_type: counter
       description: Incoming packets dropped by the firewall
     - name: instance.cpu.reserved_cores.value
       type: double
+      metric_type: gauge
       description: Number of cores reserved on the host of the instance
     - name: instance.cpu.usage_time.sec
       type: double
+      metric_type: counter
       description: Usage for all cores in seconds
     - name: instance.cpu.usage.pct
       type: double
+      metric_type: gauge
       description: The fraction of the allocated CPU that is currently in use on the instance
     - name: instance.disk.read.bytes
       type: long
+      metric_type: counter
       description: Count of bytes read from disk
     - name: instance.disk.read_ops_count.value
       type: long
+      metric_type: counter
       description: Count of disk read IO operations
     - name: instance.disk.write.bytes
       type: long
+      metric_type: counter
       description: Count of bytes written to disk
     - name: instance.disk.write_ops_count.value
       type: long
+      metric_type: counter
       description: Count of disk write IO operations
     - name: instance.memory.balloon.ram_size.value
       type: long
+      metric_type: gauge
       description: The total amount of memory in the VM. This metric is only available for VMs that belong to the e2 family.
     - name: instance.memory.balloon.ram_used.value
       type: long
+      metric_type: gauge
       description: Memory currently used in the VM. This metric is only available for VMs that belong to the e2 family.
     - name: instance.memory.balloon.swap_in.bytes
       type: long
+      metric_type: counter
       description: The amount of memory read into the guest from its own swap space. This metric is only available for VMs that belong to the e2 family.
     - name: instance.memory.balloon.swap_out.bytes
       type: long
+      metric_type: counter
       description: The amount of memory written from the guest to its own swap space. This metric is only available for VMs that belong to the e2 family.
     - name: instance.network.ingress.bytes
       type: long
       description: Count of bytes received from the network
+      metric_type: counter
     - name: instance.network.ingress.packets.count
       type: long
+      metric_type: counter
       description: Count of packets received from the network
     - name: instance.network.egress.bytes
       type: long
+      metric_type: counter
       description: Count of bytes sent over the network
     - name: instance.network.egress.packets.count
       type: long
+      metric_type: counter
       description: Count of packets sent over the network
     - name: instance.uptime.sec
       type: long
+      metric_type: gauge
       description: Number of seconds the VM has been running.
     - name: instance.uptime_total.sec
       type: long
+      metric_type: gauge
       description: Elapsed time since the VM was started, in seconds. Sampled every 60 seconds. After sampling, data is not visible for up to 120 seconds.

--- a/packages/gcp/docs/README.md
+++ b/packages/gcp/docs/README.md
@@ -1523,75 +1523,75 @@ The `compute` dataset is designed to fetch metrics for [Compute Engine](https://
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host, resource, or service is located. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |
-| error.message | Error message. | match_only_text |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| gcp.compute.firewall.dropped.bytes | Incoming bytes dropped by the firewall | long |
-| gcp.compute.firewall.dropped_packets_count.value | Incoming packets dropped by the firewall | long |
-| gcp.compute.instance.cpu.reserved_cores.value | Number of cores reserved on the host of the instance | double |
-| gcp.compute.instance.cpu.usage.pct | The fraction of the allocated CPU that is currently in use on the instance | double |
-| gcp.compute.instance.cpu.usage_time.sec | Usage for all cores in seconds | double |
-| gcp.compute.instance.disk.read.bytes | Count of bytes read from disk | long |
-| gcp.compute.instance.disk.read_ops_count.value | Count of disk read IO operations | long |
-| gcp.compute.instance.disk.write.bytes | Count of bytes written to disk | long |
-| gcp.compute.instance.disk.write_ops_count.value | Count of disk write IO operations | long |
-| gcp.compute.instance.memory.balloon.ram_size.value | The total amount of memory in the VM. This metric is only available for VMs that belong to the e2 family. | long |
-| gcp.compute.instance.memory.balloon.ram_used.value | Memory currently used in the VM. This metric is only available for VMs that belong to the e2 family. | long |
-| gcp.compute.instance.memory.balloon.swap_in.bytes | The amount of memory read into the guest from its own swap space. This metric is only available for VMs that belong to the e2 family. | long |
-| gcp.compute.instance.memory.balloon.swap_out.bytes | The amount of memory written from the guest to its own swap space. This metric is only available for VMs that belong to the e2 family. | long |
-| gcp.compute.instance.network.egress.bytes | Count of bytes sent over the network | long |
-| gcp.compute.instance.network.egress.packets.count | Count of packets sent over the network | long |
-| gcp.compute.instance.network.ingress.bytes | Count of bytes received from the network | long |
-| gcp.compute.instance.network.ingress.packets.count | Count of packets received from the network | long |
-| gcp.compute.instance.uptime.sec | Number of seconds the VM has been running. | long |
-| gcp.compute.instance.uptime_total.sec | Elapsed time since the VM was started, in seconds. Sampled every 60 seconds. After sampling, data is not visible for up to 120 seconds. | long |
-| gcp.labels.metadata.\* |  | object |
-| gcp.labels.metrics.\* |  | object |
-| gcp.labels.resource.\* |  | object |
-| gcp.labels.system.\* |  | object |
-| gcp.labels.user.\* |  | object |
-| gcp.metrics.\*.\*.\*.\* | Metrics that returned from Google Cloud API query. | object |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |  |
+| error.message | Error message. | match_only_text |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| gcp.compute.firewall.dropped.bytes | Incoming bytes dropped by the firewall | long | counter |
+| gcp.compute.firewall.dropped_packets_count.value | Incoming packets dropped by the firewall | long | counter |
+| gcp.compute.instance.cpu.reserved_cores.value | Number of cores reserved on the host of the instance | double | gauge |
+| gcp.compute.instance.cpu.usage.pct | The fraction of the allocated CPU that is currently in use on the instance | double | gauge |
+| gcp.compute.instance.cpu.usage_time.sec | Usage for all cores in seconds | double | counter |
+| gcp.compute.instance.disk.read.bytes | Count of bytes read from disk | long | counter |
+| gcp.compute.instance.disk.read_ops_count.value | Count of disk read IO operations | long | counter |
+| gcp.compute.instance.disk.write.bytes | Count of bytes written to disk | long | counter |
+| gcp.compute.instance.disk.write_ops_count.value | Count of disk write IO operations | long | counter |
+| gcp.compute.instance.memory.balloon.ram_size.value | The total amount of memory in the VM. This metric is only available for VMs that belong to the e2 family. | long | gauge |
+| gcp.compute.instance.memory.balloon.ram_used.value | Memory currently used in the VM. This metric is only available for VMs that belong to the e2 family. | long | gauge |
+| gcp.compute.instance.memory.balloon.swap_in.bytes | The amount of memory read into the guest from its own swap space. This metric is only available for VMs that belong to the e2 family. | long | counter |
+| gcp.compute.instance.memory.balloon.swap_out.bytes | The amount of memory written from the guest to its own swap space. This metric is only available for VMs that belong to the e2 family. | long | counter |
+| gcp.compute.instance.network.egress.bytes | Count of bytes sent over the network | long | counter |
+| gcp.compute.instance.network.egress.packets.count | Count of packets sent over the network | long | counter |
+| gcp.compute.instance.network.ingress.bytes | Count of bytes received from the network | long | counter |
+| gcp.compute.instance.network.ingress.packets.count | Count of packets received from the network | long | counter |
+| gcp.compute.instance.uptime.sec | Number of seconds the VM has been running. | long | gauge |
+| gcp.compute.instance.uptime_total.sec | Elapsed time since the VM was started, in seconds. Sampled every 60 seconds. After sampling, data is not visible for up to 120 seconds. | long | gauge |
+| gcp.labels.metadata.\* |  | object |  |
+| gcp.labels.metrics.\* |  | object |  |
+| gcp.labels.resource.\* |  | object |  |
+| gcp.labels.system.\* |  | object |  |
+| gcp.labels.user.\* |  | object |  |
+| gcp.metrics.\*.\*.\*.\* | Metrics that returned from Google Cloud API query. | object |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.name.text | Multi-field of `host.os.name`. | text |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 
 
 An example event for `compute` looks as following:

--- a/packages/gcp/docs/compute.md
+++ b/packages/gcp/docs/compute.md
@@ -101,72 +101,72 @@ An example event for `compute` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host, resource, or service is located. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |
-| error.message | Error message. | match_only_text |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| gcp.compute.firewall.dropped.bytes | Incoming bytes dropped by the firewall | long |
-| gcp.compute.firewall.dropped_packets_count.value | Incoming packets dropped by the firewall | long |
-| gcp.compute.instance.cpu.reserved_cores.value | Number of cores reserved on the host of the instance | double |
-| gcp.compute.instance.cpu.usage.pct | The fraction of the allocated CPU that is currently in use on the instance | double |
-| gcp.compute.instance.cpu.usage_time.sec | Usage for all cores in seconds | double |
-| gcp.compute.instance.disk.read.bytes | Count of bytes read from disk | long |
-| gcp.compute.instance.disk.read_ops_count.value | Count of disk read IO operations | long |
-| gcp.compute.instance.disk.write.bytes | Count of bytes written to disk | long |
-| gcp.compute.instance.disk.write_ops_count.value | Count of disk write IO operations | long |
-| gcp.compute.instance.memory.balloon.ram_size.value | The total amount of memory in the VM. This metric is only available for VMs that belong to the e2 family. | long |
-| gcp.compute.instance.memory.balloon.ram_used.value | Memory currently used in the VM. This metric is only available for VMs that belong to the e2 family. | long |
-| gcp.compute.instance.memory.balloon.swap_in.bytes | The amount of memory read into the guest from its own swap space. This metric is only available for VMs that belong to the e2 family. | long |
-| gcp.compute.instance.memory.balloon.swap_out.bytes | The amount of memory written from the guest to its own swap space. This metric is only available for VMs that belong to the e2 family. | long |
-| gcp.compute.instance.network.egress.bytes | Count of bytes sent over the network | long |
-| gcp.compute.instance.network.egress.packets.count | Count of packets sent over the network | long |
-| gcp.compute.instance.network.ingress.bytes | Count of bytes received from the network | long |
-| gcp.compute.instance.network.ingress.packets.count | Count of packets received from the network | long |
-| gcp.compute.instance.uptime.sec | Number of seconds the VM has been running. | long |
-| gcp.compute.instance.uptime_total.sec | Elapsed time since the VM was started, in seconds. Sampled every 60 seconds. After sampling, data is not visible for up to 120 seconds. | long |
-| gcp.labels.metadata.\* |  | object |
-| gcp.labels.metrics.\* |  | object |
-| gcp.labels.resource.\* |  | object |
-| gcp.labels.system.\* |  | object |
-| gcp.labels.user.\* |  | object |
-| gcp.metrics.\*.\*.\*.\* | Metrics that returned from Google Cloud API query. | object |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |  |
+| error.message | Error message. | match_only_text |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| gcp.compute.firewall.dropped.bytes | Incoming bytes dropped by the firewall | long | counter |
+| gcp.compute.firewall.dropped_packets_count.value | Incoming packets dropped by the firewall | long | counter |
+| gcp.compute.instance.cpu.reserved_cores.value | Number of cores reserved on the host of the instance | double | gauge |
+| gcp.compute.instance.cpu.usage.pct | The fraction of the allocated CPU that is currently in use on the instance | double | gauge |
+| gcp.compute.instance.cpu.usage_time.sec | Usage for all cores in seconds | double | counter |
+| gcp.compute.instance.disk.read.bytes | Count of bytes read from disk | long | counter |
+| gcp.compute.instance.disk.read_ops_count.value | Count of disk read IO operations | long | counter |
+| gcp.compute.instance.disk.write.bytes | Count of bytes written to disk | long | counter |
+| gcp.compute.instance.disk.write_ops_count.value | Count of disk write IO operations | long | counter |
+| gcp.compute.instance.memory.balloon.ram_size.value | The total amount of memory in the VM. This metric is only available for VMs that belong to the e2 family. | long | gauge |
+| gcp.compute.instance.memory.balloon.ram_used.value | Memory currently used in the VM. This metric is only available for VMs that belong to the e2 family. | long | gauge |
+| gcp.compute.instance.memory.balloon.swap_in.bytes | The amount of memory read into the guest from its own swap space. This metric is only available for VMs that belong to the e2 family. | long | counter |
+| gcp.compute.instance.memory.balloon.swap_out.bytes | The amount of memory written from the guest to its own swap space. This metric is only available for VMs that belong to the e2 family. | long | counter |
+| gcp.compute.instance.network.egress.bytes | Count of bytes sent over the network | long | counter |
+| gcp.compute.instance.network.egress.packets.count | Count of packets sent over the network | long | counter |
+| gcp.compute.instance.network.ingress.bytes | Count of bytes received from the network | long | counter |
+| gcp.compute.instance.network.ingress.packets.count | Count of packets received from the network | long | counter |
+| gcp.compute.instance.uptime.sec | Number of seconds the VM has been running. | long | gauge |
+| gcp.compute.instance.uptime_total.sec | Elapsed time since the VM was started, in seconds. Sampled every 60 seconds. After sampling, data is not visible for up to 120 seconds. | long | gauge |
+| gcp.labels.metadata.\* |  | object |  |
+| gcp.labels.metrics.\* |  | object |  |
+| gcp.labels.resource.\* |  | object |  |
+| gcp.labels.system.\* |  | object |  |
+| gcp.labels.user.\* |  | object |  |
+| gcp.metrics.\*.\*.\*.\* | Metrics that returned from Google Cloud API query. | object |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.name.text | Multi-field of `host.os.name`. | text |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.22.0"
+version: "2.23.0"
 release: ga
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Add metric_type mapping for GCP compute datastream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

 https://github.com/elastic/integrations/issues/6711

## Screenshots


