### PR TITLE
Kafka package: revert back change to dynamic_dataset/namespace

### DIFF
--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Revert changes to permissions to reroute events to logs-*-* for log datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6803
 - version: "1.8.0"
   changes:
     - description: Enable time series data streams for the metrics datasets. This dramatically reduces storage for metrics and is expected to progressively improve query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Revert changes to permissions to reroute events to logs-*-* for log datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.8.0"
   changes:
     - description: Enable time series data streams for the metrics datasets. This dramatically reduces storage for metrics and is expected to progressively improve query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.

--- a/packages/kafka/data_stream/log/manifest.yml
+++ b/packages/kafka/data_stream/log/manifest.yml
@@ -48,3 +48,6 @@ streams:
     template_path: log.yml.hbs
     title: Kafka log logs (log)
     description: Collect Kafka log logs using log input
+    
+# Ensures agents have permissions to write data to `logs-kafka.log-*`
+elasticsearch.dynamic_namespace: true

--- a/packages/kafka/data_stream/log/manifest.yml
+++ b/packages/kafka/data_stream/log/manifest.yml
@@ -48,6 +48,3 @@ streams:
     template_path: log.yml.hbs
     title: Kafka log logs (log)
     description: Collect Kafka log logs using log input
-# Ensures agents have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kafka
 title: Kafka
-version: "1.8.0"
+version: "1.9.0"
 license: basic
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Revert back changes from issue https://github.com/elastic/kibana/pull/157897. 

Removing the following configs from the system package manifest

```
elasticsearch.dynamic_dataset: true
elasticsearch.dynamic_namespace: true
```

This change is reverted as for monitoring Kafka is not needed. The logs that are collected by the datastream kafka.log are written by the Kafka service and must go to a specific dataset for the integration to work.

There is a kafka_log package that reads topics from Kafka. This is the scenario where routing is needed to sort the data into different data streams.

The change of adding the permissions was made with the assumption this is the kafka_log package, but it isn't so it must be reverted.

The change only affects users using Fleet and will change back the API permissions for the Elastic Agents after an upgrade.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/kibana/pull/157897

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
