### PR TITLE
Activemq package: revert back change to dynamic_dataset/namespace

### DIFF
--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.13.0"
+  changes:
+    - description: Revert changes to permissions to reroute events to logs-*-* for log datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.12.0"
   changes:
     - description: Enable time series data streams for the metrics datasets. This dramatically reduces storage for metrics and is expected to progressively improve query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.

--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Revert changes to permissions to reroute events to logs-*-* for log datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6805
 - version: "0.12.0"
   changes:
     - description: Enable time series data streams for the metrics datasets. This dramatically reduces storage for metrics and is expected to progressively improve query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.

--- a/packages/activemq/data_stream/log/manifest.yml
+++ b/packages/activemq/data_stream/log/manifest.yml
@@ -39,6 +39,3 @@ streams:
     template_path: log.yml.hbs
     title: ActiveMQ log
     description: Collect ActiveMQ log logs using log input
-# Ensures agents have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,6 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: "0.12.0"
+version: "0.13.0"
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Revert back changes from issue https://github.com/elastic/kibana/pull/157897. 

Removing the following configs from the activemq package manifest

```
elasticsearch.dynamic_dataset: true
elasticsearch.dynamic_namespace: true
```

We would like to revert these permissions in favour of creating a separate input package to reroute traffic from Activemq. 

The idea is that we would like to have datastream-based integrations to monitor a specific application, while we should have input packages instead to reroute "mixed" traffic (from different sources) from that application.

The datastream `log` is actually looking at the activemq application logs, not at the traffic from activemq. This is why it doesn't make sense to allow rerouting for this package. Those logs should be in a fixed location (where they are right now).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/kibana/pull/157897

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
