### PR TITLE
AWS package: revert back change to dynamic_dataset/namespace

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Revert changes to permissions to reroute events to logs-*-* for cloudwatch_logs and ec2_logs datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6806
 - version: "1.46.0"
   changes:
     - description: Enable time series data streams for the metrics datasets Billing, DynamoDB, EBS, ECS, ELB, Firewall, Kinesis, Lambda, NAT gateway, RDS, Redshift, S3 Storage Lens, SNS, SQS, Transit Gateway and VPN. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.47.0"
+  changes:
+    - description: Revert changes to permissions to reroute events to logs-*-* for cloudwatch_logs and ec2_logs datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.46.0"
   changes:
     - description: Enable time series data streams for the metrics datasets Billing, DynamoDB, EBS, ECS, ELB, Firewall, Kinesis, Lambda, NAT gateway, RDS, Redshift, S3 Storage Lens, SNS, SQS, Transit Gateway and VPN. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/aws/data_stream/cloudwatch_logs/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/manifest.yml
@@ -196,6 +196,3 @@ streams:
         title: Dataset name
         description: >
           Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-# Ensures agents have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true

--- a/packages/aws/data_stream/ec2_logs/manifest.yml
+++ b/packages/aws/data_stream/ec2_logs/manifest.yml
@@ -187,6 +187,3 @@ streams:
         type: bool
         multi: false
         default: false
-# Ensures agents have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.46.0
+version: 1.47.0
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Revert back changes from issue https://github.com/elastic/kibana/pull/157897. 

Removing the following configs from the system package manifest

```
elasticsearch.dynamic_dataset: true
elasticsearch.dynamic_namespace: true
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/kibana/pull/157897

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
