### PR TITLE
Docker package: revert back change to dynamic_dataset/namespace

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.0"
+  changes:
+    - description: Revert changes to permissions to reroute events to logs-*-* for container_logs datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.8.0"
   changes:
     - description: Enable time series data streams for the metrics datasets, except for event dataset. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Revert changes to permissions to reroute events to logs-*-* for container_logs datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6807
 - version: "2.8.0"
   changes:
     - description: Enable time series data streams for the metrics datasets, except for event dataset. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/docker/data_stream/container_logs/manifest.yml
+++ b/packages/docker/data_stream/container_logs/manifest.yml
@@ -47,6 +47,3 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-# Ensures agents have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.8.0
+version: 2.9.0
 release: ga
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Revert back changes from issue https://github.com/elastic/kibana/pull/157897. 

Removing the following configs from the system package manifest

```
elasticsearch.dynamic_dataset: true
elasticsearch.dynamic_namespace: true
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/kibana/pull/157897

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
