### PR TITLE
Auditd package: revert back change to dynamic_dataset/namespace

### DIFF
--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Revert changes to permissions to reroute events to logs-*-* for log datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6808
 - version: "3.10.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.11.0"
+  changes:
+    - description: Revert changes to permissions to reroute events to logs-*-* for log datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.10.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/auditd/data_stream/log/manifest.yml
+++ b/packages/auditd/data_stream/log/manifest.yml
@@ -39,6 +39,3 @@ streams:
     template_path: log.yml.hbs
     title: Auditd logs
     description: Collect Auditd logs using log input
-# Ensures agents have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd Logs
-version: "3.10.0"
+version: "3.11.0"
 description: Collect logs from Linux audit daemon with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Revert back changes from issue https://github.com/elastic/kibana/pull/157897. 

Removing the following configs from the system package manifest

```
elasticsearch.dynamic_dataset: true
elasticsearch.dynamic_namespace: true
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/kibana/pull/157897

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
