### PR TITLE
[Kubenretes Integration] Adding deployment condition status in kube state deployment dataset

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.44.0"
+  changes:
+    - description: Adding kube-state-metrics kubernetes.deployment.status
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6603
 - version: "1.43.0"
   changes:
     - description: Expand index pattern for adHocDataviews for CCS use case

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.44.0"
   changes:
-    - description: Adding kube-state-metrics kubernetes.deployment.status
+    - description: Introducing kubernetes.deployment.status.* metrics
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6603
+      link: https://github.com/elastic/integrations/pull/6821
 - version: "1.43.0"
   changes:
     - description: Expand index pattern for adHocDataviews for CCS use case

--- a/packages/kubernetes/data_stream/state_deployment/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_deployment/fields/fields.yml
@@ -5,6 +5,16 @@
       type: boolean
       description: |
         Kubernetes deployment paused status
+    - name: status
+      type: group
+      fields:
+        - name: available
+          type: keyword
+          description: |
+            Deployment Available Condition status (true, false or unknown)
+        - name: progressing
+          type: keyword
+          description: Deployment Progresing Condition status (true, false or unknown) (true, false or unknown)
     - name: replicas
       type: group
       fields:

--- a/packages/kubernetes/data_stream/state_deployment/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_deployment/fields/fields.yml
@@ -14,7 +14,7 @@
             Deployment Available Condition status (true, false or unknown)
         - name: progressing
           type: keyword
-          description: Deployment Progresing Condition status (true, false or unknown) (true, false or unknown)
+          description: Deployment Progresing Condition status (true, false or unknown)
     - name: replicas
       type: group
       fields:

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -800,6 +800,8 @@ An example event for `state_deployment` looks as following:
 | kubernetes.deployment.replicas.desired | Deployment number of desired replicas (spec) | integer | gauge |
 | kubernetes.deployment.replicas.unavailable | Deployment unavailable replicas | integer | gauge |
 | kubernetes.deployment.replicas.updated | Deployment updated replicas | integer | gauge |
+| kubernetes.deployment.status.available | Deployment Available Condition status (true, false or unknown) | keyword |  |
+| kubernetes.deployment.status.progressing | Deployment Progresing Condition status (true, false or unknown) (true, false or unknown) | keyword |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: kubernetes
 title: Kubernetes
-version: 1.43.0
+version: 1.44.0
 license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -11,7 +11,7 @@ categories:
   - kubernetes
 release: ga
 conditions:
-  kibana.version: "^8.8.2"
+  kibana.version: "^8.8.0"
 screenshots:
   - src: /img/metricbeat_kubernetes_overview.png
     title: Metricbeat Kubernetes Overview

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -11,7 +11,7 @@ categories:
   - kubernetes
 release: ga
 conditions:
-  kibana.version: "^8.8.0"
+  kibana.version: "^8.8.2"
 screenshots:
   - src: /img/metricbeat_kubernetes_overview.png
     title: Metricbeat Kubernetes Overview


### PR DESCRIPTION
**** DONT MERGE UNTIL 8.10 is released****

- Enhancement

## What does this PR do?

Introduces in Kubernetes Integration the new deployment condition status field

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

See inforamtion here: https://github.com/elastic/elastic-agent/issues/2995

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/2995
- Relates https://github.com/elastic/beats/pull/35999

