### PR TITLE
[Cassandra] Add dimension fields for metrics datastream for TSDB enab…

### DIFF
--- a/packages/cassandra/changelog.yml
+++ b/packages/cassandra/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Add dimension fields for metrics datastream for TSDB enablement.
+      type: enhancement
+      link: tbc
 - version: "1.7.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/cassandra/changelog.yml
+++ b/packages/cassandra/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add dimension fields for metrics datastream for TSDB enablement.
       type: enhancement
-      link: tbc
+      link: https://github.com/elastic/integrations/pull/6822
 - version: "1.7.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/cassandra/data_stream/metrics/fields/ecs.yml
+++ b/packages/cassandra/data_stream/metrics/fields/ecs.yml
@@ -16,5 +16,32 @@
   name: event.type
 - external: ecs
   name: service.address
+  dimension: true
 - external: ecs
   name: service.type
+- external: ecs
+  name: host.name
+  dimension: true
+- external: ecs
+  name: agent.id
+  dimension: true
+- external: ecs
+  name: cloud.project.id
+- external: ecs
+  name: cloud.instance.id
+  dimension: true
+- external: ecs
+  name: cloud.provider
+  dimension: true
+- external: ecs
+  name: container.id
+  dimension: true
+- external: ecs
+  name: cloud.account.id
+  dimension: true
+- external: ecs
+  name: cloud.region
+  dimension: true
+- external: ecs
+  name: cloud.availability_zone
+  dimension: true

--- a/packages/cassandra/data_stream/metrics/fields/fields.yml
+++ b/packages/cassandra/data_stream/metrics/fields/fields.yml
@@ -184,10 +184,8 @@
       fields:
         - name: cluster
           type: keyword
-          dimension: true
         - name: data_center
           type: keyword
-          dimension: true
         - name: joining_nodes
           type: keyword
         - name: leaving_nodes
@@ -198,7 +196,6 @@
           type: keyword
         - name: rack
           type: keyword
-          dimension: true
         - name: unreachable_nodes
           type: keyword
         - name: version

--- a/packages/cassandra/data_stream/metrics/fields/fields.yml
+++ b/packages/cassandra/data_stream/metrics/fields/fields.yml
@@ -184,8 +184,10 @@
       fields:
         - name: cluster
           type: keyword
+          dimension: true
         - name: data_center
           type: keyword
+          dimension: true
         - name: joining_nodes
           type: keyword
         - name: leaving_nodes
@@ -196,6 +198,7 @@
           type: keyword
         - name: rack
           type: keyword
+          dimension: true
         - name: unreachable_nodes
           type: keyword
         - name: version

--- a/packages/cassandra/docs/README.md
+++ b/packages/cassandra/docs/README.md
@@ -336,6 +336,7 @@ An example event for `metrics` looks as following:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
 | cassandra.metrics.cache.key_cache.capacity |  | long |
 | cassandra.metrics.cache.key_cache.one_minute_hit_rate |  | long |
 | cassandra.metrics.cache.key_cache.requests.one_minute_rate |  | long |
@@ -417,6 +418,13 @@ An example event for `metrics` looks as following:
 | cassandra.metrics.thread_pools.read_stage.request.pending |  | long |
 | cassandra.metrics.thread_pools.request_response_stage.request.active |  | long |
 | cassandra.metrics.thread_pools.request_response_stage.request.pending |  | long |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
+| cloud.instance.id | Instance ID of the host machine. | keyword |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |
+| container.id | Unique container id. | keyword |
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
@@ -428,6 +436,7 @@ An example event for `metrics` looks as following:
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
 

--- a/packages/cassandra/manifest.yml
+++ b/packages/cassandra/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cassandra
 title: Cassandra
-version: "1.7.0"
+version: "1.8.0"
 license: basic
 description: This Elastic integration collects logs and metrics from cassandra.
 type: integration


### PR DESCRIPTION

- Enhancement


## What does this PR do?

This PR adds dimensions fields for metrics datastream of Cassandra to support TSDB enablement.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).





- Relates #6708 
