### PR TITLE
[MySql] Fix to correct the aggregate function used in dashboard

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix to correct the aggregate function used in dashboard for fields having `metric_type` value `counter`.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6828
 - version: "1.12.3"
   changes:
     - description: Add dimensions for TSDB enablement for performance datastream.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.4"
+  changes:
+    - description: Fix to correct the aggregate function used in dashboard for fields having `metric_type` value `counter`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.3"
   changes:
     - description: Add dimensions for TSDB enablement for performance datastream.

--- a/packages/mysql/kibana/visualization/mysql-493e8460-630d-11ea-a83e-25b8612d00cc.json
+++ b/packages/mysql/kibana/visualization/mysql-493e8460-630d-11ea-a83e-25b8612d00cc.json
@@ -90,7 +90,7 @@
                             {
                                 "field": "mysql.status.max_used_connections",
                                 "id": "e3d46bf1-630f-11ea-99e6-b5eed31db613",
-                                "type": "avg"
+                                "type": "max"
                             }
                         ],
                         "point_size": "0",

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: "1.12.3"
+version: "1.12.4"
 license: basic
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug

## What does this PR do?

The dashboard uses avg function on field having metric_type value `counter`. This is not a supported feature. The PR updates to use the max() function instead.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Dashboard testing

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
