### PR TITLE
cel: make debug log field redactions available

### DIFF
--- a/packages/cel/_dev/test/system/test-basic-auth-config.yml
+++ b/packages/cel/_dev/test/system/test-basic-auth-config.yml
@@ -1,6 +1,7 @@
 vars:
   username: test
   password: test
+  redact_fields: [foo]
   resource_url: http://{{Hostname}}:{{Port}}/testbasicauth/api
   program: |
     bytes(

--- a/packages/cel/_dev/test/system/test-get-config.yml
+++ b/packages/cel/_dev/test/system/test-get-config.yml
@@ -1,4 +1,5 @@
 vars:
+  redact_fields: [foo]
   resource_url: http://{{Hostname}}:{{Port}}/test/api
   enable_request_tracer: true
   program: |

--- a/packages/cel/_dev/test/system/test-oauth-config.yml
+++ b/packages/cel/_dev/test/system/test-oauth-config.yml
@@ -1,4 +1,5 @@
 vars:
+  redact_fields: [foo]
   oauth_id: test
   oauth_secret: test
   oauth_token_url: http://{{Hostname}}:{{Port}}/testoauth/token

--- a/packages/cel/_dev/test/system/test-oauth-scope-config.yml
+++ b/packages/cel/_dev/test/system/test-oauth-scope-config.yml
@@ -1,4 +1,5 @@
 vars:
+  redact_fields: [foo]
   oauth_id: test
   oauth_secret: test
   oauth_scopes: ["token_scope"]

--- a/packages/cel/agent/input/input.yml.hbs
+++ b/packages/cel/agent/input/input.yml.hbs
@@ -8,6 +8,13 @@ program: {{escape_string program}}
 state:
   {{state}}
 {{/if}}
+redact.delete: {{delete_redacted_fields}}
+{{#if redact_fields}}
+redact.fields:
+{{#each redact_fields as |field|}}
+  - {{field}}
+{{/each}}
+{{/if}}
 
 {{#if regexp}}
 regexp:

--- a/packages/cel/changelog.yml
+++ b/packages/cel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.1.0"
+  changes:
+    - description: Make debug log field redactions available.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6831
 - version: "1.0.0"
   changes:
     - description: Make package GA.

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -3,7 +3,7 @@ name: cel
 title: CEL Custom API
 description: Collect custom events from an API with Elastic agent
 type: input
-version: "1.0.0"
+version: "1.1.0"
 categories:
   - custom
 conditions:
@@ -118,6 +118,25 @@ policy_templates:
         description: The URL endpoint that will be used to generate the tokens during the oauth2 flow. It is required if no oauth_custom variable is set or provider is not specified in oauth_custom variable.
         show_user: true
         required: false
+      - name: redact_fields
+        type: text
+        title: Redacted fields
+        description: |
+          Fields to redact in debug logs. When logging at debug-level the input state and CEL evaluation state are included
+          in logs. This may leak secrets, so list sensitive state fields in this configuration.
+        show_user: true
+        multi: true
+        required: false
+      - name: delete_redacted_fields
+        type: bool
+        title: Delete redacted fields
+        description: |
+          The default behavior for field redaction is to replace characters with `*`s. If field value length or presence will
+          leak information, the fields can be deleted from logging by setting this configuration to true.
+        show_user: true
+        multi: false
+        default: false
+        required: true
       - name: resource_ssl
         type: yaml
         title: Resource SSL Configuration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This exposes the redact.fields and redact.delete options of the CEL input configuration. The redact.delete option is always sent to ensure that the CEL input will receive a redact config object as this is planned to be made a required configuration option there.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
