### PR TITLE
netskope: remove netskope.events.region and netskope.events.region.id

### DIFF
--- a/packages/netskope/changelog.yml
+++ b/packages/netskope/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Remove `netskope.events.region` and `netskope.events.region.id` fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6833
 - version: "1.9.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/netskope/data_stream/events/fields/fields.yml
+++ b/packages/netskope/data_stream/events/fields/fields.yml
@@ -851,17 +851,6 @@
           type: keyword
         - name: username
           type: keyword
-    - name: region
-      type: keyword
-      description: |
-        N/A
-    - name: region
-      type: group
-      fields:
-        - name: id
-          type: keyword
-          description: |
-            Region ID (as provided by the cloud provider).
     - name: repo
       type: keyword
       description: |

--- a/packages/netskope/docs/README.md
+++ b/packages/netskope/docs/README.md
@@ -1029,8 +1029,6 @@ An example event for `alerts` looks as following:
 | netskope.events.referer.query |  | keyword |
 | netskope.events.referer.scheme |  | keyword |
 | netskope.events.referer.username |  | keyword |
-| netskope.events.region | N/A | keyword |
-| netskope.events.region.id | Region ID (as provided by the cloud provider). | keyword |
 | netskope.events.repo | N/A | keyword |
 | netskope.events.request.count | Total number of HTTP requests (equal to number of transaction events for this page event) sent from client to server over one underlying TCP connection. | long |
 | netskope.events.request.id | Unique request ID for the event. | keyword |

--- a/packages/netskope/manifest.yml
+++ b/packages/netskope/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: netskope
 title: "Netskope"
-version: "1.9.0"
+version: "1.9.1"
 license: basic
 description: Collect logs from Netskope with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Removes `netskope.events.region` and `netskope.events.region.id`. These fields are not used and cause a mapping conflict.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #6705

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
