### PR TITLE
aws_logs package: allow reroute to logs-*-*

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.5.0"
+  changes:
+    - description: Add permissions to reroute events to logs-*-* for generic datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.4.0"
   changes:
     - description: Add multiline support for using s3 input

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add permissions to reroute events to logs-*-* for generic datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6841
 - version: "0.4.0"
   changes:
     - description: Add multiline support for using s3 input

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -367,3 +367,7 @@ streams:
           The Ingest Node pipeline ID to be used by the integration.
         required: false
         show_user: true
+# Ensures agents have permissions to write data to `logs-*-*`
+elasticsearch:
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: 0.4.0
+version: 0.5.0
 release: beta
 license: basic
 categories:


### PR DESCRIPTION
## What does this PR do?

Add permissions to write to logs-*-*. Same changes as in this issue https://github.com/elastic/kibana/pull/157897. 


```
# Ensures agents have permissions to write data to `logs-*-*`
elasticsearch:
  dynamic_dataset: true
  dynamic_namespace: true
```

Similar change was applied to aws package and then reverted at https://github.com/elastic/integrations/pull/6806. That was the wrong package to modify.

This package aws_log is instead the right one, since it should reroute the traffic from AWS logs in cloudwatch


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/kibana/pull/157897

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
