### PR TITLE
[sonicwall_firewall] - update package-spec to 2.9.0

### DIFF
--- a/packages/sonicwall_firewall/_dev/build/build.yml
+++ b/packages/sonicwall_firewall/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@8.8
+    reference: git@v8.8.0

--- a/packages/sonicwall_firewall/_dev/build/build.yml
+++ b/packages/sonicwall_firewall/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.8.0
+    reference: git@8.8

--- a/packages/sonicwall_firewall/changelog.yml
+++ b/packages/sonicwall_firewall/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update to package-spec 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6849
 - version: "1.6.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/sonicwall_firewall/changelog.yml
+++ b/packages/sonicwall_firewall/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Update to package-spec 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.6.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/sonicwall_firewall/data_stream/log/_dev/test/pipeline/test-drizzthacker.log-expected.json
+++ b/packages/sonicwall_firewall/data_stream/log/_dev/test/pipeline/test-drizzthacker.log-expected.json
@@ -58,7 +58,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -132,7 +134,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -216,7 +220,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -274,7 +280,9 @@
             },
             "message": "Invalid SNMP packet (Invalid engineID: 0)",
             "observer": {
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -339,7 +347,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -415,7 +425,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -493,7 +505,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -566,7 +580,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.1.1",
+                "ip": [
+                    "172.16.1.1"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -643,7 +659,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.1.1",
+                "ip": [
+                    "172.16.1.1"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -730,7 +748,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -801,7 +821,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -864,7 +886,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -928,7 +952,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.1.1",
+                "ip": [
+                    "172.16.1.1"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -989,7 +1015,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1032,7 +1060,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.1.1",
+                "ip": [
+                    "172.16.1.1"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1074,7 +1104,9 @@
                         "name": "X5"
                     }
                 },
-                "ip": "172.16.1.1",
+                "ip": [
+                    "172.16.1.1"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1123,7 +1155,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.1.1",
+                "ip": [
+                    "172.16.1.1"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1160,7 +1194,9 @@
             },
             "message": "Possible TCP Flood on IF X1 - src: 82.98.136.100:80 dst: 172.16.0.2:15912 - rate: 1869/sec continues",
             "observer": {
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1211,7 +1247,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1289,7 +1327,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1367,7 +1407,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1444,7 +1486,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1486,7 +1530,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1544,7 +1590,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1622,7 +1670,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1697,7 +1747,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1762,7 +1814,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1836,7 +1890,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1898,7 +1954,9 @@
                         "name": "X5"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -1944,7 +2002,9 @@
             },
             "message": "Response from NTP Server is either incomplete or invalid",
             "observer": {
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -2000,7 +2060,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",
@@ -2065,7 +2127,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "172.16.0.2",
+                "ip": [
+                    "172.16.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0000A0AAAA00",

--- a/packages/sonicwall_firewall/data_stream/log/_dev/test/pipeline/test-general.log-expected.json
+++ b/packages/sonicwall_firewall/data_stream/log/_dev/test/pipeline/test-general.log-expected.json
@@ -44,7 +44,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -118,7 +120,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -195,7 +199,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -275,7 +281,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -344,7 +352,9 @@
                         "name": "LAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -418,7 +428,9 @@
                         "name": "LAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -504,7 +516,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -570,7 +584,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -644,7 +660,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -721,7 +739,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -794,7 +814,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -877,7 +899,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -931,7 +955,9 @@
             },
             "message": "IKE Initiator: Start Quick Mode (Phase 2).",
             "observer": {
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1020,7 +1046,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1062,7 +1090,9 @@
             },
             "message": "Received notify: INVALID_ID_INFO",
             "observer": {
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1140,7 +1170,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1206,7 +1238,9 @@
                         "name": "LAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1274,7 +1308,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1357,7 +1393,9 @@
                         "name": "LAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1430,7 +1468,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1486,7 +1526,9 @@
                 "transport": "tcp"
             },
             "observer": {
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1553,7 +1595,9 @@
                         "name": "WAN"
                     }
                 },
-                "ip": "1.128.3.4",
+                "ip": [
+                    "1.128.3.4"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "000SERIAL",
@@ -1607,7 +1651,9 @@
                 "transport": "udp"
             },
             "observer": {
-                "ip": "10.0.0.1",
+                "ip": [
+                    "10.0.0.1"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "XXXXXXX",
@@ -1661,7 +1707,9 @@
             },
             "message": "IPSec VPN Decryption Failed (Replay check failure.)",
             "observer": {
-                "ip": "172.29.1.2",
+                "ip": [
+                    "172.29.1.2"
+                ],
                 "name": "YYYYYY",
                 "product": "SonicOS",
                 "serial_number": "XXXX",
@@ -1746,7 +1794,9 @@
                         "name": "X500"
                     }
                 },
-                "ip": "10.1.1.1",
+                "ip": [
+                    "10.1.1.1"
+                ],
                 "name": "YYYYYY",
                 "product": "SonicOS",
                 "serial_number": "XXXX",
@@ -1829,7 +1879,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "10.1.1.1",
+                "ip": [
+                    "10.1.1.1"
+                ],
                 "name": "YYYYYY",
                 "product": "SonicOS",
                 "serial_number": "XXXX",
@@ -1929,7 +1981,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "10.0.0.2",
+                "ip": [
+                    "10.0.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "123456789",
@@ -2027,7 +2081,9 @@
                     },
                     "zone": "Trusted"
                 },
-                "ip": "10.0.0.2",
+                "ip": [
+                    "10.0.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "123456789",
@@ -2138,7 +2194,9 @@
                     },
                     "zone": "Trusted"
                 },
-                "ip": "10.0.0.2",
+                "ip": [
+                    "10.0.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "12345678",
@@ -2241,7 +2299,9 @@
                     },
                     "zone": "Trusted"
                 },
-                "ip": "10.0.0.2",
+                "ip": [
+                    "10.0.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "12345678",
@@ -2349,7 +2409,9 @@
                     },
                     "zone": "Trusted"
                 },
-                "ip": "10.0.0.2",
+                "ip": [
+                    "10.0.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "12345678",
@@ -2461,7 +2523,9 @@
                         "name": "X0"
                     }
                 },
-                "ip": "10.0.0.2",
+                "ip": [
+                    "10.0.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "12345678",
@@ -2538,7 +2602,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.2",
+                "ip": [
+                    "10.0.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "12345678",
@@ -2634,7 +2700,9 @@
                     },
                     "zone": "Trusted"
                 },
-                "ip": "10.0.0.2",
+                "ip": [
+                    "10.0.0.2"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "12345678",
@@ -2740,7 +2808,9 @@
                         "name": "X20-V60"
                     }
                 },
-                "ip": "192.168.33.1",
+                "ip": [
+                    "192.168.33.1"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "ZZZZZZZZZ",
@@ -2835,7 +2905,9 @@
                         "name": "X4-V1032"
                     }
                 },
-                "ip": "192.168.255.6",
+                "ip": [
+                    "192.168.255.6"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "xxxxxxxxxxxxxxx",
@@ -2933,7 +3005,9 @@
                         "name": "X4-V1032"
                     }
                 },
-                "ip": "192.168.255.6",
+                "ip": [
+                    "192.168.255.6"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "xxxxxxxxxxxxxxx",
@@ -3027,7 +3101,9 @@
                     },
                     "zone": "TEST"
                 },
-                "ip": "192.168.255.6",
+                "ip": [
+                    "192.168.255.6"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "xxxxxxxxxxxxxxx",

--- a/packages/sonicwall_firewall/data_stream/log/_dev/test/pipeline/test-nat.log-expected.json
+++ b/packages/sonicwall_firewall/data_stream/log/_dev/test/pipeline/test-nat.log-expected.json
@@ -43,7 +43,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -119,7 +121,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -198,7 +202,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -274,7 +280,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",

--- a/packages/sonicwall_firewall/data_stream/log/_dev/test/pipeline/test-sonicos70-aws.log-expected.json
+++ b/packages/sonicwall_firewall/data_stream/log/_dev/test/pipeline/test-sonicos70-aws.log-expected.json
@@ -50,7 +50,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -152,7 +154,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -254,7 +258,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -352,7 +358,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -436,7 +444,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -547,7 +557,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -648,7 +660,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -723,7 +737,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -808,7 +824,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -910,7 +928,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1016,7 +1036,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1121,7 +1143,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1214,7 +1238,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1304,7 +1330,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1402,7 +1430,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1492,7 +1522,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1590,7 +1622,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1680,7 +1714,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1793,7 +1829,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1894,7 +1932,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -1995,7 +2035,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2096,7 +2138,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2197,7 +2241,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2298,7 +2344,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2384,7 +2432,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2474,7 +2524,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2578,7 +2630,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2684,7 +2738,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2799,7 +2855,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2900,7 +2958,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -2992,7 +3052,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3098,7 +3160,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3198,7 +3262,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3288,7 +3354,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3401,7 +3469,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3502,7 +3572,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3588,7 +3660,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3678,7 +3752,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3791,7 +3867,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3892,7 +3970,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -3984,7 +4064,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4090,7 +4172,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4195,7 +4279,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4288,7 +4374,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4378,7 +4466,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4476,7 +4566,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4566,7 +4658,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4679,7 +4773,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4780,7 +4876,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4881,7 +4979,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -4982,7 +5082,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5068,7 +5170,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5158,7 +5262,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5271,7 +5377,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5372,7 +5480,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5458,7 +5568,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5548,7 +5660,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5652,7 +5766,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5758,7 +5874,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5873,7 +5991,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -5974,7 +6094,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6066,7 +6188,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6172,7 +6296,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6272,7 +6398,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6362,7 +6490,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6475,7 +6605,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6576,7 +6708,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6662,7 +6796,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6752,7 +6888,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6850,7 +6988,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -6940,7 +7080,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7053,7 +7195,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7154,7 +7298,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7255,7 +7401,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7356,7 +7504,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7442,7 +7592,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7532,7 +7684,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7645,7 +7799,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7746,7 +7902,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7832,7 +7990,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -7922,7 +8082,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8026,7 +8188,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8132,7 +8296,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8238,7 +8404,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8353,7 +8521,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8454,7 +8624,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8546,7 +8718,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8646,7 +8820,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8729,7 +8905,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8826,7 +9004,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -8930,7 +9110,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9024,7 +9206,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9118,7 +9302,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9214,7 +9400,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9307,7 +9495,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9397,7 +9587,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9495,7 +9687,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9585,7 +9779,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9698,7 +9894,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9799,7 +9997,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -9900,7 +10100,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10001,7 +10203,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10087,7 +10291,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10177,7 +10383,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10290,7 +10498,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10391,7 +10601,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10477,7 +10689,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10567,7 +10781,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10671,7 +10887,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10777,7 +10995,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10892,7 +11112,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -10993,7 +11215,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11085,7 +11309,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11190,7 +11416,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11289,7 +11517,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11389,7 +11619,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11479,7 +11711,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11592,7 +11826,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11693,7 +11929,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11785,7 +12023,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11889,7 +12129,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -11967,7 +12209,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12051,7 +12295,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12129,7 +12375,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12214,7 +12462,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12307,7 +12557,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12397,7 +12649,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12495,7 +12749,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12585,7 +12841,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12698,7 +12956,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12799,7 +13059,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -12900,7 +13162,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13001,7 +13265,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13096,7 +13362,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13186,7 +13454,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13267,7 +13537,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13357,7 +13629,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13455,7 +13729,9 @@
                         "name": "X1"
                     }
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13545,7 +13821,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13658,7 +13936,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13759,7 +14039,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13851,7 +14133,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -13957,7 +14241,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -14072,7 +14358,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -14173,7 +14461,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",
@@ -14265,7 +14555,9 @@
                     },
                     "zone": "Untrusted"
                 },
-                "ip": "10.0.0.96",
+                "ip": [
+                    "10.0.0.96"
+                ],
                 "name": "firewall",
                 "product": "SonicOS",
                 "serial_number": "0040103CE114",

--- a/packages/sonicwall_firewall/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sonicwall_firewall/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -301,10 +301,15 @@ processors:
 #
   - convert:
       field: observer.hostname
-      target_field: observer.ip
+      target_field: _temp_.observer.ip
       type: ip
       ignore_missing: true
       ignore_failure: true
+  - append:
+      field: observer.ip
+      value: "{{{ _temp_.observer.ip }}}"
+      allow_duplicates: false
+      if: 'ctx._temp_?.observer?.ip != null'
 
   - remove:
       field: observer.hostname
@@ -1265,9 +1270,9 @@ processors:
       if: 'ctx.destination?.nat?.ip != null'
   - append:
       field: related.ip
-      value: "{{{ observer.ip }}}"
+      value: "{{{ _temp_.observer.ip }}}"
       allow_duplicates: false
-      if: 'ctx.observer?.ip != null'
+      if: 'ctx._temp_?.observer?.ip != null'
   - append:
       field: related.user
       value: "{{{ user.name }}}"

--- a/packages/sonicwall_firewall/data_stream/log/sample_event.json
+++ b/packages/sonicwall_firewall/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-05-16T08:18:39.000+02:00",
     "agent": {
-        "ephemeral_id": "6cc3228b-d89c-4104-b750-d9cb44ed5513",
-        "id": "08a5caf6-a717-4f5f-90e2-0f4eb7c59b00",
+        "ephemeral_id": "9c635b3a-cb8b-4d1a-891b-3f37008b59bb",
+        "id": "bb043b0c-36d1-4054-81ed-2d3f4546a433",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.0"
+        "version": "8.8.1"
     },
     "data_stream": {
         "dataset": "sonicwall_firewall.log",
@@ -33,9 +33,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "08a5caf6-a717-4f5f-90e2-0f4eb7c59b00",
+        "id": "bb043b0c-36d1-4054-81ed-2d3f4546a433",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.8.1"
     },
     "event": {
         "action": "connection-denied",
@@ -45,7 +45,7 @@
         ],
         "code": "713",
         "dataset": "sonicwall_firewall.log",
-        "ingested": "2022-05-23T13:47:58Z",
+        "ingested": "2023-07-06T18:14:01Z",
         "kind": "event",
         "outcome": "success",
         "sequence": "692",
@@ -62,7 +62,7 @@
     "log": {
         "level": "debug",
         "source": {
-            "address": "172.24.0.4:47831"
+            "address": "192.168.16.4:58483"
         }
     },
     "message": "� (TCP Flag(s): RST)",
@@ -84,7 +84,9 @@
             },
             "zone": "Untrusted"
         },
-        "ip": "10.0.0.96",
+        "ip": [
+            "10.0.0.96"
+        ],
         "name": "firewall",
         "product": "SonicOS",
         "serial_number": "0040103CE114",

--- a/packages/sonicwall_firewall/docs/README.md
+++ b/packages/sonicwall_firewall/docs/README.md
@@ -80,11 +80,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2022-05-16T08:18:39.000+02:00",
     "agent": {
-        "ephemeral_id": "6cc3228b-d89c-4104-b750-d9cb44ed5513",
-        "id": "08a5caf6-a717-4f5f-90e2-0f4eb7c59b00",
+        "ephemeral_id": "9c635b3a-cb8b-4d1a-891b-3f37008b59bb",
+        "id": "bb043b0c-36d1-4054-81ed-2d3f4546a433",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.0"
+        "version": "8.8.1"
     },
     "data_stream": {
         "dataset": "sonicwall_firewall.log",
@@ -112,9 +112,9 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "08a5caf6-a717-4f5f-90e2-0f4eb7c59b00",
+        "id": "bb043b0c-36d1-4054-81ed-2d3f4546a433",
         "snapshot": false,
-        "version": "8.2.0"
+        "version": "8.8.1"
     },
     "event": {
         "action": "connection-denied",
@@ -124,7 +124,7 @@ An example event for `log` looks as following:
         ],
         "code": "713",
         "dataset": "sonicwall_firewall.log",
-        "ingested": "2022-05-23T13:47:58Z",
+        "ingested": "2023-07-06T18:14:01Z",
         "kind": "event",
         "outcome": "success",
         "sequence": "692",
@@ -141,7 +141,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "debug",
         "source": {
-            "address": "172.24.0.4:47831"
+            "address": "192.168.16.4:58483"
         }
     },
     "message": "� (TCP Flag(s): RST)",
@@ -163,7 +163,9 @@ An example event for `log` looks as following:
             },
             "zone": "Untrusted"
         },
-        "ip": "10.0.0.96",
+        "ip": [
+            "10.0.0.96"
+        ],
         "name": "firewall",
         "product": "SonicOS",
         "serial_number": "0040103CE114",

--- a/packages/sonicwall_firewall/manifest.yml
+++ b/packages/sonicwall_firewall/manifest.yml
@@ -1,9 +1,7 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: sonicwall_firewall
 title: "SonicWall Firewall"
-version: "1.6.0"
-license: basic
-release: ga
+version: "1.7.0"
 description: "Integration for SonicWall firewall logs"
 type: integration
 categories:


### PR DESCRIPTION
# What does this PR do?

- Updates the package-spec version to `2.9.0`
- Ensure `observer.ip` is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=8.8 -format-version=2.9.0 packages/sonicwall_firewall
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870
