### PR TITLE
fortigate_fortimanager,sentinel_one_cloud_funnel: relax date tests

### DIFF
--- a/packages/fortinet_fortimanager/changelog.yml
+++ b/packages/fortinet_fortimanager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1-next"
+  changes:
+    - description: Relax constraints on date values for testing.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6857
 - version: "2.3.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/fortinet_fortimanager/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -2,3 +2,6 @@ fields:
   tags:
     - preserve_original_event
     - preserve_duplicate_custom_fields
+# Temporarily relax constraints on data fields. Remove after 8.9 is lowest kibana.version.
+dynamic_fields:
+  fortimanager.log.itime: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1-next"
+  changes:
+    - description: Relax constraints on date values for testing.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6857
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -2,3 +2,24 @@ fields:
   tags:
     - preserve_original_event
     - preserve_duplicate_custom_fields
+# Temporarily relax constraints on data fields. Remove after 8.9 is lowest kibana.version.
+dynamic_fields:
+  "@timestamp": "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  file.created: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  file.mtime: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  process.parent.start: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  process.start: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.os_src_process.start_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.sca.atlantis_ingest_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.sca.ingest_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.src.process.parent.start_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.src.process.start_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.tgt.file.creation_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.tgt.file.modification_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.tgt.process.parent.start_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.tgt.process.start_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.ti_indicator.modification_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.ti_indicator.original_event.time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.ti_indicator.upload_time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.ti_indicator.valid_until: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"
+  sentinel_one_cloud_funnel.event.time: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Elasticsearch 8.9 includes a fix to correctly handle epoch_millis formatted timestamps in the date ingest pipeline processor. This causes pipeline checks to fails in integrations where the timestamp now parsed accurately. So temporarily relax the test constraints on date fields while version skew exists.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #6850

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
