### PR TITLE
[Elasticsearch] Enable TSDB by default

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Enable time series data streams for the metrics datasets Index, Index Summary, Index Recovery, ML Job, Ingest Pipeline, Node and Node Stats. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6698
 - version: "1.8.1"
   changes:
     - description: Add metric_type mapping for the fields of metrics datasets to support TSDB.

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable time series data streams for the metrics datasets Index, Index Summary, Index Recovery, ML Job, Ingest Pipeline, Node and Node Stats. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6698
+      link: https://github.com/elastic/integrations/pull/6861
 - version: "1.8.1"
   changes:
     - description: Add metric_type mapping for the fields of metrics datasets to support TSDB.

--- a/packages/elasticsearch/data_stream/index/manifest.yml
+++ b/packages/elasticsearch/data_stream/index/manifest.yml
@@ -6,6 +6,7 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  index_mode: "time_series"
 streams:
   - input: elasticsearch/metrics
     title: Index metrics

--- a/packages/elasticsearch/data_stream/index_recovery/manifest.yml
+++ b/packages/elasticsearch/data_stream/index_recovery/manifest.yml
@@ -6,6 +6,7 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  index_mode: "time_series"
 streams:
   - input: elasticsearch/metrics
     title: Index recovery metrics

--- a/packages/elasticsearch/data_stream/index_summary/manifest.yml
+++ b/packages/elasticsearch/data_stream/index_summary/manifest.yml
@@ -6,6 +6,7 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  index_mode: "time_series"
 streams:
   - input: elasticsearch/metrics
     title: Index summary metrics

--- a/packages/elasticsearch/data_stream/ingest_pipeline/manifest.yml
+++ b/packages/elasticsearch/data_stream/ingest_pipeline/manifest.yml
@@ -7,6 +7,7 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  index_mode: "time_series"
 streams:
   - input: elasticsearch/metrics
     title: Ingest Pipeline metrics

--- a/packages/elasticsearch/data_stream/ml_job/manifest.yml
+++ b/packages/elasticsearch/data_stream/ml_job/manifest.yml
@@ -6,6 +6,7 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  index_mode: "time_series"
 streams:
   - input: elasticsearch/metrics
     title: Anomaly detection machine learning job metrics

--- a/packages/elasticsearch/data_stream/node/manifest.yml
+++ b/packages/elasticsearch/data_stream/node/manifest.yml
@@ -6,6 +6,7 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  index_mode: "time_series"
 streams:
   - input: elasticsearch/metrics
     title: Node metrics

--- a/packages/elasticsearch/data_stream/node_stats/manifest.yml
+++ b/packages/elasticsearch/data_stream/node_stats/manifest.yml
@@ -6,6 +6,7 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  index_mode: "time_series"
 streams:
   - input: elasticsearch/metrics
     title: Cluster nodes statistics

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.8.1
+version: 1.9.0
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Enable TSDB by default. Please refer to https://github.com/elastic/integrations/issues/6618 for more information.


## Related issues

Relates to https://github.com/elastic/integrations/issues/6618.