### PR TITLE
[azure] Ensure url.path cannot be duplicated

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.5.25"
+  changes:
+    - description: Handle duplicate url.path field in application gateway logs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6866
 - version: "1.5.24"
   changes:
     - description: Handle firewall events for DNAT'ed requests with attributes

--- a/packages/azure/data_stream/application_gateway/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/application_gateway/elasticsearch/ingest_pipeline/default.yml
@@ -76,6 +76,13 @@ processors:
       field: json.properties.requestUri
       target_field: url.path
       ignore_missing: true
+      if: 'ctx.url?.path == null'
+      description: 'Renames the original `json.properties.requestUri` field to `url.path` to match the ECS field name. The `url.path` field is not touched if the document already has one.'
+  - remove:
+      field: json.properties.httpMethod
+      ignore_missing: true
+      if: 'ctx.url?.path != null'
+      description: 'The `json.properties.httpMethod` field is no longer required if the document has a `url.path` field.'
   - set:
       field: url.path
       copy_from: url.original

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 1.5.24
+version: 1.5.25
 release: ga
 description: This Elastic integration collects logs from Azure
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This is the same fix as in #5361, but for the `url.path` field.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Open the dev tools and run the following query to simulate a request:

```
POST _ingest/pipeline/logs-azure.application_gateway-1.5.25/_simulate
{
  "docs": [
    {
      "_source": {
        "json": {
          "properties": {
            "requestUri": "https://example.com"
          }
        },
        "url": {
          "path": "https://elastic.co"
        }
      }
    }
  ]
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
