### PR TITLE
[hid_bravura_monitor.winlog] Add ECS error.code mapping

### DIFF
--- a/packages/hid_bravura_monitor/changelog.yml
+++ b/packages/hid_bravura_monitor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Add ECS error.code mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/6766
 - version: "1.8.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/hid_bravura_monitor/data_stream/winlog/fields/ecs.yml
+++ b/packages/hid_bravura_monitor/data_stream/winlog/fields/ecs.yml
@@ -1,6 +1,8 @@
 - external: ecs
   name: ecs.version
 - external: ecs
+  name: error.code
+- external: ecs
   name: event.action
 - external: ecs
   name: event.category

--- a/packages/hid_bravura_monitor/docs/README.md
+++ b/packages/hid_bravura_monitor/docs/README.md
@@ -550,6 +550,7 @@ An example event for `winlog` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| error.code | Error code describing the error. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
 | event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |

--- a/packages/hid_bravura_monitor/manifest.yml
+++ b/packages/hid_bravura_monitor/manifest.yml
@@ -1,6 +1,6 @@
 name: hid_bravura_monitor
 title: Bravura Monitor
-version: "1.8.0"
+version: "1.8.1"
 categories: ["security", "iam"]
 release: ga
 description: Collect logs from Bravura Security Fabric with Elastic Agent.


### PR DESCRIPTION
## What does this PR do?

The `winlog` input can produce error.code under some conditions so make sure their is a mapping present for the field that is aligned to ECS.

Relates #6766

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
