### PR TITLE
windows: set event.action to the event's sysmon name

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.0"
+  changes:
+    - description: Set `event.action` to sysmon name in sysmon_operational.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6882
 - version: "1.25.0"
   changes:
     - description: Add support for sysmon 15.0/event 29.

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
@@ -31,6 +31,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -126,6 +127,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -196,6 +198,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileDelete (File Delete archived)",
                 "category": [
                     "file"
                 ],
@@ -301,6 +304,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -400,6 +404,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -470,6 +475,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -536,6 +542,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileDelete (File Delete archived)",
                 "category": [
                     "file"
                 ],
@@ -636,6 +643,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -738,6 +746,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -827,6 +836,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -926,6 +936,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1013,6 +1024,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1114,6 +1126,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1251,6 +1264,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1349,6 +1363,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1443,6 +1458,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1543,6 +1559,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1630,6 +1647,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1729,6 +1747,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1798,6 +1817,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -1889,6 +1909,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -1984,6 +2005,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -2054,6 +2076,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -2120,6 +2143,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -2238,6 +2262,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -2338,6 +2363,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -2483,6 +2509,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -2621,6 +2648,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -2769,6 +2797,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -2883,6 +2912,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3032,6 +3062,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3186,6 +3217,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3280,6 +3312,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3415,6 +3448,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3512,6 +3546,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3648,6 +3683,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3740,6 +3776,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3830,6 +3867,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -3959,6 +3997,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -4078,6 +4117,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -4152,6 +4192,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "ServiceConfigurationChange",
                 "category": [
                     "configuration"
                 ],
@@ -4220,6 +4261,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -4345,6 +4387,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -4485,6 +4528,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -4629,6 +4673,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -4729,6 +4774,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -4869,6 +4915,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -5013,6 +5060,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -5091,6 +5139,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Sysmon service state changed",
                 "category": [
                     "process"
                 ],
@@ -5161,6 +5210,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -5247,6 +5297,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -5315,6 +5366,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process creation",
                 "category": [
                     "process"
                 ],
@@ -5452,6 +5504,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -5584,6 +5637,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -5661,6 +5715,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process creation",
                 "category": [
                     "process"
                 ],
@@ -5828,6 +5883,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -5935,6 +5991,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6078,6 +6135,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6184,6 +6242,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6304,6 +6363,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6404,6 +6464,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6495,6 +6556,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6572,6 +6634,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6645,6 +6708,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6710,6 +6774,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process terminated",
                 "category": [
                     "process"
                 ],
@@ -6826,6 +6891,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -6934,6 +7000,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -7025,6 +7092,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -7094,6 +7162,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process terminated",
                 "category": [
                     "process"
                 ],
@@ -7210,6 +7279,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -7288,6 +7358,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process creation",
                 "category": [
                     "process"
                 ],
@@ -7391,6 +7462,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -7468,6 +7540,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -7547,6 +7620,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -7626,6 +7700,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -7731,6 +7806,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -7867,6 +7943,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -7949,6 +8026,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8044,6 +8122,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -8125,6 +8204,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8234,6 +8314,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -8307,6 +8388,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8386,6 +8468,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8463,6 +8546,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8539,6 +8623,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8615,6 +8700,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8693,6 +8779,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8770,6 +8857,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8851,6 +8939,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -8932,6 +9021,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -9042,6 +9132,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -9133,6 +9224,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -9267,6 +9359,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -9416,6 +9509,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -9565,6 +9659,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -9709,6 +9804,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -9817,6 +9913,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -9923,6 +10020,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -10013,6 +10111,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -10148,6 +10247,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -10299,6 +10399,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -10440,6 +10541,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -10515,6 +10617,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Network connection",
                 "category": [
                     "network"
                 ],
@@ -10589,6 +10692,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process terminated",
                 "category": [
                     "process"
                 ],
@@ -10639,6 +10743,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process terminated",
                 "category": [
                     "process"
                 ],
@@ -10689,6 +10794,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "A process changed a file creation time",
                 "category": [
                     "file"
                 ],
@@ -10749,6 +10855,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "A process changed a file creation time",
                 "category": [
                     "file"
                 ],
@@ -10809,6 +10916,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "A process changed a file creation time",
                 "category": [
                     "file"
                 ],
@@ -10869,6 +10977,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "A process changed a file creation time",
                 "category": [
                     "file"
                 ],
@@ -10936,6 +11045,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process terminated",
                 "category": [
                     "process"
                 ],
@@ -10986,6 +11096,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "A process changed a file creation time",
                 "category": [
                     "file"
                 ],
@@ -11071,6 +11182,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -11212,6 +11324,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -11313,6 +11426,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -11454,6 +11568,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -11592,6 +11707,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -11714,6 +11830,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -11857,6 +11974,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -11982,6 +12100,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -12068,6 +12187,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -12202,6 +12322,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -12316,6 +12437,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -12401,6 +12523,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -12535,6 +12658,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -12680,6 +12804,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -12804,6 +12929,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -12939,6 +13065,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -13065,6 +13192,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -13193,6 +13321,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -13344,6 +13473,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -13484,6 +13614,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -13622,6 +13753,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -13765,6 +13897,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -13909,6 +14042,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14012,6 +14146,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14153,6 +14288,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14249,6 +14385,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14355,6 +14492,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14450,6 +14588,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14545,6 +14684,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14639,6 +14779,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14735,6 +14876,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14825,6 +14967,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -14924,6 +15067,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15019,6 +15163,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15125,6 +15270,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15221,6 +15367,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15316,6 +15463,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15411,6 +15559,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15553,6 +15702,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15668,6 +15818,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15772,6 +15923,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -15907,6 +16059,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16002,6 +16155,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16095,6 +16249,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16236,6 +16391,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16333,6 +16489,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16427,6 +16584,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16566,6 +16724,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16713,6 +16872,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16811,6 +16971,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -16952,6 +17113,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -17096,6 +17258,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -17242,6 +17405,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -17381,6 +17545,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -17521,6 +17686,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -17875,6 +18041,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18052,6 +18219,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18151,6 +18319,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18249,6 +18418,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18328,6 +18498,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18418,6 +18589,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18560,6 +18732,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18707,6 +18880,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18808,6 +18982,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -18944,6 +19119,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -19095,6 +19271,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -19238,6 +19415,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -19363,6 +19541,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -19471,6 +19650,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -19573,6 +19753,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -19709,6 +19890,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -19824,6 +20006,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -19969,6 +20152,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20066,6 +20250,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20160,6 +20345,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20251,6 +20437,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20328,6 +20515,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20398,6 +20586,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20468,6 +20657,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20562,6 +20752,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20654,6 +20845,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -20723,6 +20915,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process creation",
                 "category": [
                     "process"
                 ],
@@ -20820,6 +21013,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "ProcessTampering (Process image change)",
                 "category": [
                     "process"
                 ],
@@ -20874,6 +21068,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileDelete (File Delete archived)",
                 "category": [
                     "file"
                 ],
@@ -20948,6 +21143,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Image loaded",
                 "category": [
                     "process"
                 ],
@@ -21039,6 +21235,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -21105,6 +21302,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "ClipboardChange (New content in the clipboard)",
                 "code": "24",
                 "created": "2021-02-25T15:04:48.607Z",
                 "kind": "event",
@@ -21172,6 +21370,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "A process changed a file creation time",
                 "category": [
                     "file"
                 ],
@@ -21287,6 +21486,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -21363,6 +21563,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileDeleteDetected (File Delete logged)",
                 "category": [
                     "file"
                 ],
@@ -21437,6 +21638,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileDeleteDetected (File Delete logged)",
                 "category": [
                     "file"
                 ],
@@ -21511,7 +21713,7 @@
                 "version": "8.0.0"
             },
             "event": {
-                "action": "Registry value set (rule: RegistryEvent)",
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -21594,7 +21796,7 @@
                 "version": "8.0.0"
             },
             "event": {
-                "action": "Registry value set (rule: RegistryEvent)",
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -21677,7 +21879,7 @@
                 "version": "8.0.0"
             },
             "event": {
-                "action": "Registry value set (rule: RegistryEvent)",
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -21760,7 +21962,7 @@
                 "version": "8.0.0"
             },
             "event": {
-                "action": "Registry value set (rule: RegistryEvent)",
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -21843,7 +22045,7 @@
                 "version": "8.0.0"
             },
             "event": {
-                "action": "Registry value set (rule: RegistryEvent)",
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -21926,7 +22128,7 @@
                 "version": "8.0.0"
             },
             "event": {
-                "action": "Registry value set (rule: RegistryEvent)",
+                "action": "RegistryEvent (Value Set)",
                 "category": [
                     "configuration",
                     "registry"
@@ -22009,6 +22211,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "Process creation",
                 "category": [
                     "process"
                 ],
@@ -22110,7 +22313,7 @@
                 "version": "8.0.0"
             },
             "event": {
-                "action": "Process Create (rule: ProcessCreate)",
+                "action": "Process creation",
                 "agent_id_status": "verified",
                 "category": [
                     "process"
@@ -22180,7 +22383,7 @@
                 "version": "8.0.0"
             },
             "event": {
-                "action": "Process accessed (rule: ProcessAccess)",
+                "action": "ProcessAccess",
                 "agent_id_status": "verified",
                 "category": [
                     "process"
@@ -22239,6 +22442,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "CreateRemoteThread",
                 "category": [
                     "process"
                 ],
@@ -22301,6 +22505,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "RawAccessRead",
                 "category": [
                     "process"
                 ],
@@ -22358,6 +22563,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "WmiEvent (WmiEventFilter activity detected)",
                 "category": [
                     "process"
                 ],
@@ -22419,6 +22625,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "WmiEvent (WmiEventConsumer activity detected)",
                 "category": [
                     "process"
                 ],
@@ -22486,6 +22693,7 @@
                 "code": "DriverCommunication"
             },
             "event": {
+                "action": "Error",
                 "category": [
                     "process"
                 ],
@@ -22541,6 +22749,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileBlockExecutable",
                 "category": [
                     "file"
                 ],
@@ -22614,6 +22823,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileBlockExecutable",
                 "category": [
                     "file"
                 ],
@@ -22687,6 +22897,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileBlockShredding",
                 "category": [
                     "file"
                 ],
@@ -22792,6 +23003,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "DNSEvent (DNS query)",
                 "category": [
                     "network"
                 ],
@@ -22867,6 +23079,7 @@
                 "version": "8.0.0"
             },
             "event": {
+                "action": "FileExecutableDetected",
                 "category": [
                     "file"
                 ],

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -48,7 +48,7 @@ processors:
       value: '{{winlog.event_id}}'
 
   - script:
-      description: Set event category and type for all event types.
+      description: Set event action, category and type for all event types.
       lang: painless
       params:
         "1":
@@ -56,11 +56,13 @@ processors:
             - process
           type:
             - start
+          action: 'Process creation'
         "2":
           category:
             - file
           type:
             - change
+          action: 'A process changed a file creation time'
         "3":
           category:
             - network
@@ -68,99 +70,118 @@ processors:
             - start
             - connection
             - protocol
+          action: 'Network connection'
         "4":
           category:
             - process
           type:
             - change
+          action: 'Sysmon service state changed'
         "5":
           category:
             - process
           type:
             - end
+          action: 'Process terminated'
         "6":
           category:
             - driver
           type:
             - start
+          action: 'Driver loaded'
         "7":
           category:
             - process
           type:
             - change
+          action: 'Image loaded'
         "8":
           category:
             - process
           type:
             - change
+          action: 'CreateRemoteThread'
         "9":
           category:
             - process
           type:
             - access
+          action: 'RawAccessRead'
         "10":
           category:
             - process
           type:
             - access
+          action: 'ProcessAccess'
         "11":
           category:
             - file
           type:
             - creation
+          action: 'FileCreate'
         "12":
           category:
             - configuration
             - registry
           type:
             - change
+          action: 'RegistryEvent (Object create and delete)'
         "13":
           category:
             - configuration
             - registry
           type:
             - change
+          action: 'RegistryEvent (Value Set)'
         "14":
           category:
             - configuration
             - registry
           type:
             - change
+          action: 'RegistryEvent (Key and Value Rename)'
         "15":
           category:
             - file
           type:
             - access
+          action: 'FileCreateStreamHash'
         "16":
           category:
             - configuration
           type:
             - change
+          action: 'ServiceConfigurationChange'
         "17":
           category:
             - file
           type:
             - creation
+          action: 'PipeEvent (Pipe Created)'
         "18":
           category:
             - file
           type:
             - access
+          action: 'PipeEvent (Pipe Connected)'
         "19":
           category:
             - process
           type:
             - creation
+          action: 'WmiEvent (WmiEventFilter activity detected)'
         "20":
           category:
             - process
           type:
             - creation
+          action: 'WmiEvent (WmiEventConsumer activity detected)'
         "21":
           category:
             - process
           type:
             - access
+          action: 'WmiEvent (WmiEventConsumerToFilter activity detected)'
         "22":
           category:
             - network
@@ -168,49 +189,58 @@ processors:
             - connection
             - protocol
             - info
+          action: 'DNSEvent (DNS query)'
         "23":
           category:
             - file
           type:
             - deletion
+          action: 'FileDelete (File Delete archived)'
         "24":
           type:
             - change
+          action: 'ClipboardChange (New content in the clipboard)'
         "25":
           category:
             - process
           type:
             - change
+          action: 'ProcessTampering (Process image change)'
         "26":
           category:
             - file
           type:
             - deletion
+          action: 'FileDeleteDetected (File Delete logged)'
         "27":
           category:
             - file
           type:
             - creation
             - denied
+          action: 'FileBlockExecutable'
         "28":
           category:
             - file
           type:
             - deletion
             - denied
+          action: 'FileBlockShredding'
         "29":
           category:
             - file
           type:
             - creation
+          action: 'FileExecutableDetected'
         "255":
           category:
             - process
           type:
             - error
+          action: 'Error'
       tag: Add ECS categorization fields
       source: |-
-        if (ctx?.event?.code == null || params.get(ctx.event.code) == null) {
+        if (ctx.event?.code == null || params.get(ctx.event.code) == null) {
           return;
         }
         def hm = new HashMap(params[ctx.event.code]);

--- a/packages/windows/data_stream/sysmon_operational/sample_event.json
+++ b/packages/windows/data_stream/sysmon_operational/sample_event.json
@@ -46,6 +46,7 @@
         "version": "8.6.2"
     },
     "event": {
+        "action": "DNSEvent (DNS query)",
         "agent_id_status": "verified",
         "category": [
             "network"

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -825,6 +825,7 @@ An example event for `sysmon_operational` looks as following:
         "version": "8.6.2"
     },
     "event": {
+        "action": "DNSEvent (DNS query)",
         "agent_id_status": "verified",
         "category": [
             "network"

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.25.0
+version: 1.26.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Sets `event.action` to the event's sysmon name.

Event details from https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For https://github.com/elastic/integrations/pull/6761#discussion_r1256488180

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
