### PR TITLE
[Google Workspace] Convert visualisations to Lens

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Convert dashboards to Lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6914
 - version: "2.10.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/google_workspace/kibana/dashboard/google_workspace-3be0b490-3430-11ed-9f31-c9178ccae8cd.json
+++ b/packages/google_workspace/kibana/dashboard/google_workspace-3be0b490-3430-11ed-9f31-c9178ccae8cd.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Overview of Google Workspace Rules.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,7 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
             "syncTooltips": false,
             "useMargins": true
         },
@@ -52,7 +52,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "49d52ffc-77d4-4564-b467-21113069fd3f": {
                                             "columnOrder": [
@@ -90,7 +90,7 @@
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -105,7 +105,7 @@
                 "panelIndex": "123197a0-8c1a-4b5f-9328-f42cff317429",
                 "title": "Total Severity [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -119,7 +119,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "91b13cbe-d02c-49f3-bdc7-60e804a3576a": {
                                             "columnOrder": [
@@ -176,15 +176,17 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "c792ccd0-e339-4a57-9b77-8ec01540876c"
-                                        ],
                                         "layerId": "91b13cbe-d02c-49f3-bdc7-60e804a3576a",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "fb52ca0a-d8cc-4d5f-83c0-c28cefb0f8ce",
+                                        "metrics": [
+                                            "fb52ca0a-d8cc-4d5f-83c0-c28cefb0f8ce"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "c792ccd0-e339-4a57-9b77-8ec01540876c"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -207,7 +209,7 @@
                 "panelIndex": "a995f12f-5ce4-4fbf-9d8c-411ee0fe691f",
                 "title": "Distribution of Rules by Severity [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -221,7 +223,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "788b8016-043d-4d6d-945c-3f2e1dc365d3": {
                                             "columnOrder": [
@@ -295,7 +297,7 @@
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetricNew"
+                        "visualizationType": "lnsMetric"
                     },
                     "enhancements": {}
                 },
@@ -308,7 +310,7 @@
                 },
                 "panelIndex": "c82a2b25-eb5e-40b2-b3b2-650d74c936f9",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -322,7 +324,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "568a0980-a917-48ad-bde5-ebb17d8e623a": {
                                             "columnOrder": [
@@ -379,15 +381,17 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "959dbeaa-f55c-45e8-9b38-b98952a1612b"
-                                        ],
                                         "layerId": "568a0980-a917-48ad-bde5-ebb17d8e623a",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "414f2299-b09f-409a-8855-ff346d86f770",
+                                        "metrics": [
+                                            "414f2299-b09f-409a-8855-ff346d86f770"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "959dbeaa-f55c-45e8-9b38-b98952a1612b"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -410,7 +414,7 @@
                 "panelIndex": "3c4011fa-9c5c-48e6-abae-693bf685851e",
                 "title": "Distribution of Rules by Device Type [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -424,7 +428,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "e0b93956-6fd4-4842-a441-e185bd29c77c": {
                                             "columnOrder": [
@@ -481,15 +485,17 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "37b9483a-d496-4993-99e3-a2487dfcc9de"
-                                        ],
                                         "layerId": "e0b93956-6fd4-4842-a441-e185bd29c77c",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "5be194b7-6d94-4677-b820-ebe7fdc33582",
+                                        "metrics": [
+                                            "5be194b7-6d94-4677-b820-ebe7fdc33582"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "37b9483a-d496-4993-99e3-a2487dfcc9de"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -512,7 +518,7 @@
                 "panelIndex": "6cb8bd6f-be16-43ef-85dc-1f5007ca46ef",
                 "title": "Distribution of Rules by Event Action [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -526,7 +532,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "b04c4c24-d9f1-4a60-9b0f-8bd4fb9f80a4": {
                                             "columnOrder": [
@@ -583,15 +589,17 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "087501c1-0b44-4947-824d-23d688acd8b0"
-                                        ],
                                         "layerId": "b04c4c24-d9f1-4a60-9b0f-8bd4fb9f80a4",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "c9367b78-19e4-4f77-aeb3-bc453bc5a289",
+                                        "metrics": [
+                                            "c9367b78-19e4-4f77-aeb3-bc453bc5a289"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "087501c1-0b44-4947-824d-23d688acd8b0"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -614,7 +622,7 @@
                 "panelIndex": "a2806b00-58d7-4fb8-97c4-59c3da0220a0",
                 "title": "Distribution of Rules by Rule Type [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -628,7 +636,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f2ade8d5-c408-4496-afd1-cecb15659a59": {
                                             "columnOrder": [
@@ -739,7 +747,7 @@
                 "panelIndex": "4e8cd032-411a-4a42-92b4-ee98a8f803af",
                 "title": "Distribution of Rules by Data Source [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -753,7 +761,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "58c070e1-e2d0-4496-8b94-249b85491fb2": {
                                             "columnOrder": [
@@ -810,15 +818,17 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "a87c4d55-df7d-4f2c-9921-aa3749be256e"
-                                        ],
                                         "layerId": "58c070e1-e2d0-4496-8b94-249b85491fb2",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "e5c683c3-dba5-44ca-a638-fe7a80eccee6",
+                                        "metrics": [
+                                            "e5c683c3-dba5-44ca-a638-fe7a80eccee6"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "a87c4d55-df7d-4f2c-9921-aa3749be256e"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -841,7 +851,7 @@
                 "panelIndex": "554995d9-c1b1-4a58-9bea-a82cefc57583",
                 "title": "Distribution of Rules by Resource Type [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -855,7 +865,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "47571350-d5fe-468c-b53e-aab0f4883775": {
                                             "columnOrder": [
@@ -940,7 +950,7 @@
                 "panelIndex": "1759911d-52c6-4cae-895c-d6bc9c90d8ed",
                 "title": "Top 10 Organization Domain [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -954,7 +964,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c032fb76-0265-4e61-9008-5ae30772f62f": {
                                             "columnOrder": [
@@ -1039,7 +1049,7 @@
                 "panelIndex": "bede3b5c-48c7-48b9-94fd-0d60bcd6761f",
                 "title": "Top 10 User IP [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1053,7 +1063,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "2b72303a-7466-4238-acdc-376df532b930": {
                                             "columnOrder": [
@@ -1136,130 +1146,217 @@
                 "panelIndex": "918fbb38-c024-4a02-9451-e24d2f821105",
                 "title": "Top 10 Trigger of the Rule Evaluation [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-b54a111e-6e78-4a5f-85f0-25ca75d8a8c0",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "1385e8ae-8493-4b2a-8e9d-0622e3415752",
+                                "type": "index-pattern"
                             }
-                        },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "annotations": [],
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color_rules": [
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "b54a111e-6e78-4a5f-85f0-25ca75d8a8c0": {
+                                            "columnOrder": [
+                                                "6ebec1fd-805f-4a2d-b0a7-d5a4e23aa4d5",
+                                                "c4085abf-16cd-4fb5-8149-33f5d9b4f2f0",
+                                                "067cca01-9d38-48df-a5d2-130190e2b166",
+                                                "7368f97b-373a-4fa9-b67c-76128f9aba27"
+                                            ],
+                                            "columns": {
+                                                "067cca01-9d38-48df-a5d2-130190e2b166": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "google_workspace.rules.severity: \"MEDIUM\""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Medium severity",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "6ebec1fd-805f-4a2d-b0a7-d5a4e23aa4d5": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "7368f97b-373a-4fa9-b67c-76128f9aba27": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "High severity",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "c4085abf-16cd-4fb5-8149-33f5d9b4f2f0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "google_workspace.rules.severity: \"LOW\""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Low severity",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
                                 {
-                                    "id": "767fa210-34e3-11ed-99ee-6d37de6553b1"
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "1385e8ae-8493-4b2a-8e9d-0622e3415752",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "google_workspace.rules"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "google_workspace.rules"
+                                        }
+                                    }
                                 }
                             ],
-                            "bar_color_rules": [
-                                {
-                                    "id": "7412e7d0-34e3-11ed-99ee-6d37de6553b1"
-                                }
-                            ],
-                            "drop_last_bucket": 0,
-                            "filter": {
+                            "internalReferences": [],
+                            "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
-                            "gauge_color_rules": [
-                                {
-                                    "id": "789059a0-34e3-11ed-99ee-6d37de6553b1"
-                                }
-                            ],
-                            "gauge_inner_width": 10,
-                            "gauge_style": "half",
-                            "gauge_width": 10,
-                            "id": "27f31679-7606-4f1e-b1d3-acc503edc784",
-                            "index_pattern_ref_name": "metrics_a770d1b0-ce49-4e7c-9b2f-d61438af1415_0_index_pattern",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "formatter": "default",
-                                    "id": "e8e519c9-71f7-4662-8cbc-7b22c4b7965d",
-                                    "label": "Triggered Rules by Severity",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "agg_with": "noop",
-                                            "field": "google_workspace.rules.matched.trigger",
-                                            "id": "86d42c61-1989-446d-b39c-638c17283ab1",
-                                            "order": "desc",
-                                            "type": "cardinality"
-                                        }
-                                    ],
-                                    "override_index_pattern": 0,
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "series_drop_last_bucket": 0,
-                                    "series_index_pattern": {
-                                        "id": "logs-*"
-                                    },
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "google_workspace.rules.severity",
-                                    "terms_size": "10",
-                                    "time_range_mode": "entire_time_range"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": true
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "c4085abf-16cd-4fb5-8149-33f5d9b4f2f0",
+                                            "067cca01-9d38-48df-a5d2-130190e2b166",
+                                            "7368f97b-373a-4fa9-b67c-76128f9aba27"
+                                        ],
+                                        "layerId": "b54a111e-6e78-4a5f-85f0-25ca75d8a8c0",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area",
+                                        "showGridlines": false,
+                                        "xAccessor": "6ebec1fd-805f-4a2d-b0a7-d5a4e23aa4d5",
+                                        "yConfig": [
+                                            {
+                                                "color": "#da8b45",
+                                                "forAccessor": "067cca01-9d38-48df-a5d2-130190e2b166"
+                                            },
+                                            {
+                                                "color": "#e7664c",
+                                                "forAccessor": "7368f97b-373a-4fa9-b67c-76128f9aba27"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yTitle": "Count"
+                            }
                         },
                         "title": "",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 18,
-                    "i": "a770d1b0-ce49-4e7c-9b2f-d61438af1415",
+                    "i": "0feb30f3-8ffe-471a-a25d-79b8d1f54d58",
                     "w": 48,
                     "x": 0,
                     "y": 75
                 },
-                "panelIndex": "a770d1b0-ce49-4e7c-9b2f-d61438af1415",
+                "panelIndex": "0feb30f3-8ffe-471a-a25d-79b8d1f54d58",
                 "title": "Triggered Rules by Severity Over Time [Logs Google Workspace]",
-                "type": "visualization",
-                "version": "8.4.0"
+                "type": "lens",
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Google Workspace] Rules",
         "version": 1
     },
-    "coreMigrationVersion": "8.4.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-11T10:27:23.321Z",
     "id": "google_workspace-3be0b490-3430-11ed-9f31-c9178ccae8cd",
     "migrationVersion": {
-        "dashboard": "8.4.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -1324,7 +1421,12 @@
         },
         {
             "id": "logs-*",
-            "name": "a770d1b0-ce49-4e7c-9b2f-d61438af1415:metrics_a770d1b0-ce49-4e7c-9b2f-d61438af1415_0_index_pattern",
+            "name": "0feb30f3-8ffe-471a-a25d-79b8d1f54d58:indexpattern-datasource-layer-b54a111e-6e78-4a5f-85f0-25ca75d8a8c0",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "0feb30f3-8ffe-471a-a25d-79b8d1f54d58:1385e8ae-8493-4b2a-8e9d-0622e3415752",
             "type": "index-pattern"
         }
     ],

--- a/packages/google_workspace/kibana/dashboard/google_workspace-f8210e80-3b28-11ed-8bdd-f5c5df6c1370.json
+++ b/packages/google_workspace/kibana/dashboard/google_workspace-f8210e80-3b28-11ed-8bdd-f5c5df6c1370.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Overview of Google Workspace Drive.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,7 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
             "syncTooltips": false,
             "useMargins": true
         },
@@ -78,7 +78,7 @@
                 "panelIndex": "88d9b7a3-a631-4079-a36f-0ce9401f59d8",
                 "title": "Drive Activity by Location [Logs Google Workspace]",
                 "type": "map",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -97,7 +97,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "23370ea2-03f9-4302-8b0c-4c4ee6a81318": {
                                             "columnOrder": [
@@ -176,15 +176,17 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "d6471b8e-6e22-459d-a682-9b0a04757f64"
-                                        ],
                                         "layerId": "23370ea2-03f9-4302-8b0c-4c4ee6a81318",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "bd04ef7a-ea8e-4f46-b6e7-f824cacc5885",
+                                        "metrics": [
+                                            "bd04ef7a-ea8e-4f46-b6e7-f824cacc5885"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "d6471b8e-6e22-459d-a682-9b0a04757f64"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -207,7 +209,7 @@
                 "panelIndex": "13fdbdfd-2204-42e6-a0df-5ec6abd24eb2",
                 "title": "Distribution of Document Downloads by Title [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -221,7 +223,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "18651fd1-ac7a-4ab0-8610-1e890b4b9846": {
                                             "columnOrder": [
@@ -278,15 +280,17 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "1871eda3-319f-46ab-949b-2e2bf749c54d"
-                                        ],
                                         "layerId": "18651fd1-ac7a-4ab0-8610-1e890b4b9846",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "0aab9f3f-951e-4d6f-8597-64dc7f874ef9",
+                                        "metrics": [
+                                            "0aab9f3f-951e-4d6f-8597-64dc7f874ef9"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "1871eda3-319f-46ab-949b-2e2bf749c54d"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -309,77 +313,175 @@
                 "panelIndex": "d59d4f9e-73e8-48ab-9f31-3f36a9b49d0e",
                 "title": "Distribution of Drive Events by Event Action [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-4721a8fd-d8f8-46c7-bb67-0f58ddcbbf46",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "4721a8fd-d8f8-46c7-bb67-0f58ddcbbf46": {
+                                            "columnOrder": [
+                                                "04a94f43-284c-439c-9334-920d730b9b1e",
+                                                "04b9d728-f91c-4086-b0da-97738067fae9",
+                                                "b6120c8b-d77d-474e-a750-0c296ba72880"
+                                            ],
+                                            "columns": {
+                                                "04a94f43-284c-439c-9334-920d730b9b1e": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "04b9d728-f91c-4086-b0da-97738067fae9": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of source.geo.country_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "source.geo.country_name"
+                                                },
+                                                "b6120c8b-d77d-474e-a750-0c296ba72880": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Country Name",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
                                 }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "b6120c8b-d77d-474e-a750-0c296ba72880"
+                                        ],
+                                        "layerId": "4721a8fd-d8f8-46c7-bb67-0f58ddcbbf46",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "splitAccessor": "04b9d728-f91c-4086-b0da-97738067fae9",
+                                        "xAccessor": "04a94f43-284c-439c-9334-920d730b9b1e",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "b6120c8b-d77d-474e-a750-0c296ba72880"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
                             }
                         },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 0,
-                            "id": "8b7f0824-9e4a-41c8-b2b9-b0a7d9a00273",
-                            "index_pattern_ref_name": "metrics_f334e21c-1d4d-426c-953e-dbb45d99219e_0_index_pattern",
-                            "interval": "",
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "formatter": "default",
-                                    "id": "65ff96dc-8f2a-4a60-92a3-ad0f249b245d",
-                                    "label": "Country Name",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "id": "e68be7b0-708a-400b-badb-0175c3224d21",
-                                            "type": "count"
-                                        }
-                                    ],
-                                    "override_index_pattern": 0,
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "series_drop_last_bucket": 0,
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "source.geo.country_name",
-                                    "time_range_mode": "entire_time_range"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": true
-                        },
-                        "title": "",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
+                        "title": "Drive Activity by Country Over Time [Logs Google Workspace] (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 15,
@@ -390,8 +492,8 @@
                 },
                 "panelIndex": "f334e21c-1d4d-426c-953e-dbb45d99219e",
                 "title": "Drive Activity by Country Over Time [Logs Google Workspace]",
-                "type": "visualization",
-                "version": "8.4.0"
+                "type": "lens",
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -410,7 +512,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "aacc9a6c-42f7-426a-b5c2-030c3d002d6e": {
                                             "columnOrder": [
@@ -517,7 +619,7 @@
                 "panelIndex": "5abea4dd-c858-4dfd-bc80-d949ef49a10b",
                 "title": "Top 10 Uploads by Title [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -531,7 +633,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "065ef144-3d40-40fa-ba4a-df4b27642fff": {
                                             "columnOrder": [
@@ -644,7 +746,7 @@
                 "panelIndex": "4bc634ec-bd01-47a4-9f99-5e43edc2de2a",
                 "title": "Distribution of Drive Events by Document Type [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -663,7 +765,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "944c8671-ceff-4edc-b04e-850f6442d26a": {
                                             "columnOrder": [
@@ -770,7 +872,7 @@
                 "panelIndex": "2606ea99-ab2d-4a46-9528-f254bd341971",
                 "title": "Top 10 Viewed Documents [Logs Google Workspace]",
                 "type": "lens",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -786,7 +888,7 @@
                 "panelIndex": "c0550726-6ce7-4d12-a078-3903beb1b4f8",
                 "panelRefName": "panel_c0550726-6ce7-4d12-a078-3903beb1b4f8",
                 "type": "search",
-                "version": "8.4.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -802,17 +904,18 @@
                 "panelIndex": "cb11b1b1-3767-4eeb-92b3-b05d38a01d78",
                 "panelRefName": "panel_cb11b1b1-3767-4eeb-92b3-b05d38a01d78",
                 "type": "search",
-                "version": "8.4.0"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Google Workspace] Drive",
         "version": 1
     },
-    "coreMigrationVersion": "8.4.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-11T11:00:26.137Z",
     "id": "google_workspace-f8210e80-3b28-11ed-8bdd-f5c5df6c1370",
     "migrationVersion": {
-        "dashboard": "8.4.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -842,7 +945,7 @@
         },
         {
             "id": "logs-*",
-            "name": "f334e21c-1d4d-426c-953e-dbb45d99219e:metrics_f334e21c-1d4d-426c-953e-dbb45d99219e_0_index_pattern",
+            "name": "f334e21c-1d4d-426c-953e-dbb45d99219e:indexpattern-datasource-layer-4721a8fd-d8f8-46c7-bb67-0f58ddcbbf46",
             "type": "index-pattern"
         },
         {

--- a/packages/google_workspace/kibana/dashboard/google_workspace-f8210e80-3b28-11ed-8bdd-f5c5df6c1370.json
+++ b/packages/google_workspace/kibana/dashboard/google_workspace-f8210e80-3b28-11ed-8bdd-f5c5df6c1370.json
@@ -414,7 +414,7 @@
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
                                     "x": true,
-                                    "yLeft": true,
+                                    "yLeft": false,
                                     "yRight": true
                                 },
                                 "fillOpacity": 0.5,
@@ -912,7 +912,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-11T11:00:26.137Z",
+    "created_at": "2023-07-12T11:52:52.520Z",
     "id": "google_workspace-f8210e80-3b28-11ed-8bdd-f5c5df6c1370",
     "migrationVersion": {
         "dashboard": "8.7.0"

--- a/packages/google_workspace/kibana/search/google_workspace-1cac9ed0-3b2f-11ed-8bdd-f5c5df6c1370.json
+++ b/packages/google_workspace/kibana/search/google_workspace-1cac9ed0-3b2f-11ed-8bdd-f5c5df6c1370.json
@@ -79,7 +79,7 @@
         "title": "Documents Shared Outside of the Organization [Logs Google Workspace]"
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-11T10:57:00.342Z",
+    "created_at": "2023-07-12T11:50:53.983Z",
     "id": "google_workspace-1cac9ed0-3b2f-11ed-8bdd-f5c5df6c1370",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/google_workspace/kibana/search/google_workspace-1cac9ed0-3b2f-11ed-8bdd-f5c5df6c1370.json
+++ b/packages/google_workspace/kibana/search/google_workspace-1cac9ed0-3b2f-11ed-8bdd-f5c5df6c1370.json
@@ -78,7 +78,8 @@
         ],
         "title": "Documents Shared Outside of the Organization [Logs Google Workspace]"
     },
-    "coreMigrationVersion": "8.4.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-11T10:57:00.342Z",
     "id": "google_workspace-1cac9ed0-3b2f-11ed-8bdd-f5c5df6c1370",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/google_workspace/kibana/search/google_workspace-2c40f770-3b24-11ed-8bdd-f5c5df6c1370.json
+++ b/packages/google_workspace/kibana/search/google_workspace-2c40f770-3b24-11ed-8bdd-f5c5df6c1370.json
@@ -79,7 +79,7 @@
         "title": "ACL Changes [Logs Google Workspace]"
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-11T10:57:00.342Z",
+    "created_at": "2023-07-12T11:50:53.983Z",
     "id": "google_workspace-2c40f770-3b24-11ed-8bdd-f5c5df6c1370",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/google_workspace/kibana/search/google_workspace-2c40f770-3b24-11ed-8bdd-f5c5df6c1370.json
+++ b/packages/google_workspace/kibana/search/google_workspace-2c40f770-3b24-11ed-8bdd-f5c5df6c1370.json
@@ -78,7 +78,8 @@
         ],
         "title": "ACL Changes [Logs Google Workspace]"
     },
-    "coreMigrationVersion": "8.4.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-11T10:57:00.342Z",
     "id": "google_workspace-2c40f770-3b24-11ed-8bdd-f5c5df6c1370",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.10.0"
+version: "2.11.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

- Updated the visualizations of Google Workspace dashboards to Lens
- The screenshots were not updated since the integration already contains 7 screenshots and converted visualisations don't appear in them

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Part of #6787

## Screenshots

**Before**
![old-rules](https://github.com/elastic/integrations/assets/29475387/f8d0ed13-7920-40e2-9957-6c3085e2ed4e)
![Screenshot 2023-07-11 at 12 57 49](https://github.com/elastic/integrations/assets/29475387/3aacfb47-8ef3-4e37-ba36-10bb06dfec5f)

**After**
![new-rules](https://github.com/elastic/integrations/assets/29475387/83db8231-9c79-4e05-95ea-e8cbcdcc9626)
<img width="947" alt="Screenshot 2023-07-12 at 13 54 55" src="https://github.com/elastic/integrations/assets/29475387/27df3598-551e-4cb9-a4cf-57f6abde9379">



