### PR TITLE
sql_input: Add `merge_results` feature to SQL Input package

### DIFF
--- a/packages/sql_input/agent/input/input.yml.hbs
+++ b/packages/sql_input/agent/input/input.yml.hbs
@@ -7,5 +7,6 @@ driver: {{driver}}
 sql_queries: {{sql_queries}}
 raw_data.enabled: true
 period: {{period}}
+merge_results: {{merge_results}}
 data_stream:
-  dataset: {{data_stream.dataset}}
+  dataset: {{data_stream.dataset}}  

--- a/packages/sql_input/agent/input/input.yml.hbs
+++ b/packages/sql_input/agent/input/input.yml.hbs
@@ -9,4 +9,4 @@ raw_data.enabled: true
 period: {{period}}
 merge_results: {{merge_results}}
 data_stream:
-  dataset: {{data_stream.dataset}}  
+  dataset: {{data_stream.dataset}}

--- a/packages/sql_input/changelog.yml
+++ b/packages/sql_input/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add merge_results feature
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/6922
 - version: "0.2.1"
   changes:
     - description: Add system test cases.

--- a/packages/sql_input/changelog.yml
+++ b/packages/sql_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Add merge_results feature
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "0.2.1"
   changes:
     - description: Add system test cases.

--- a/packages/sql_input/docs/README.md
+++ b/packages/sql_input/docs/README.md
@@ -83,24 +83,23 @@ For more examples of response format pelase refer [here](https://www.elastic.co/
 
 
 ### Merge Results
-Merge multiple queries to single event.
+Merge multiple queries into a single event.
 
-Multiple queries will create multiple events, one for each query.  It may be preferrable to create a single event by combining the metrics together in a single event.
+Multiple queries will create multiple events, one for each query.  It may be preferable to create a single event by combining the metrics together in a single event.
 
 This feature can be enabled using the `merge_results` config.
 
-Merge Results can merge queries having response format as variable. 
-However, for queries with response format as table, a merge is possible only if each table query produces a single row.
+`merge_results` can merge queries having response format as "variable". 
+However, for queries with a response format as "table", a merge is possible only if each table query produces a single row.
 
-For example, if we have 2 queries as below for postgresql. 
+For example, if we have 2 queries as below for PostgreSQL:
 
 sql_queries:
-  - query: "SELECT blks_hit,blks_read FROM pg_stat_database limit 1;"
-
-    response_format: table
-  - query: "select checkpoints_timed,checkpoints_req from pg_stat_bgwriter;"
-
+  - query: "SELECT blks_hit,blks_read FROM pg_stat_database LIMIT 1;"
     response_format: table
 
-Merge results feature will create a combined event, where `blks_hit`, `blks_read`, `checkpoints_timed` and `checkpoints_req` are part of same event.
+  - query: "SELECT checkpoints_timed,checkpoints_req FROM pg_stat_bgwriter;"
+    response_format: table
+
+The `merge_results` feature will create a combined event, where `blks_hit`, `blks_read`, `checkpoints_timed` and `checkpoints_req` are part of the same event.
 

--- a/packages/sql_input/docs/README.md
+++ b/packages/sql_input/docs/README.md
@@ -81,3 +81,26 @@ Expects any number of columns. This mode generates a single event for each row.
 
 For more examples of response format pelase refer [here](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-sql.html)
 
+
+### Merge Results
+Merge multiple queries to single event.
+
+Multiple queries will create multiple events, one for each query.  It may be preferrable to create a single event by combining the metrics together in a single event.
+
+This feature can be enabled using the `merge_results` config.
+
+Merge Results can merge queries having response format as variable. 
+However, for queries with response format as table, a merge is possible only if each table query produces a single row.
+
+For example, if we have 2 queries as below for postgresql. 
+
+sql_queries:
+  - query: "SELECT blks_hit,blks_read FROM pg_stat_database limit 1;"
+
+    response_format: table
+  - query: "select checkpoints_timed,checkpoints_req from pg_stat_bgwriter;"
+
+    response_format: table
+
+Merge results feature will create a combined event, where `blks_hit`, `blks_read`, `checkpoints_timed` and `checkpoints_req` are part of same event.
+

--- a/packages/sql_input/manifest.yml
+++ b/packages/sql_input/manifest.yml
@@ -50,11 +50,11 @@ policy_templates:
         default: "- query: SHOW GLOBAL STATUS LIKE 'Innodb_system%'\n  response_format: variables\n        \n"
       - name: merge_results
         type: bool
-        title: Merge results
+        title: Merge Results
         multi: false
         required: false
-        show_user: true
+        show_user: false
         default: false
-        description: Merge results from multiple queries to a single event
+        description: Merge results from multiple queries to a single event(restrictions apply)
 owner:
   github: elastic/obs-infraobs-integrations

--- a/packages/sql_input/manifest.yml
+++ b/packages/sql_input/manifest.yml
@@ -55,6 +55,6 @@ policy_templates:
         required: false
         show_user: false
         default: false
-        description: Merge results from multiple queries to a single event(restrictions apply)
+        description: Merge results from multiple queries to a single event (restrictions apply)
 owner:
   github: elastic/obs-infraobs-integrations

--- a/packages/sql_input/manifest.yml
+++ b/packages/sql_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: sql
 title: "SQL Input"
-version: "0.2.1"
+version: "0.3.0"
 description: "Collects Metrics by Quering on SQL Databases"
 type: input
 categories:
@@ -48,5 +48,13 @@ policy_templates:
         required: true
         show_user: true
         default: "- query: SHOW GLOBAL STATUS LIKE 'Innodb_system%'\n  response_format: variables\n        \n"
+      - name: merge_results
+        type: bool
+        title: Merge_Results
+        multi: false
+        required: false
+        show_user: true
+        default: false
+        description: Merge metrics from multiple queries to a single event
 owner:
   github: elastic/obs-infraobs-integrations

--- a/packages/sql_input/manifest.yml
+++ b/packages/sql_input/manifest.yml
@@ -50,7 +50,7 @@ policy_templates:
         default: "- query: SHOW GLOBAL STATUS LIKE 'Innodb_system%'\n  response_format: variables\n        \n"
       - name: merge_results
         type: bool
-        title: Merge_Results
+        title: Merge results
         multi: false
         required: false
         show_user: true

--- a/packages/sql_input/manifest.yml
+++ b/packages/sql_input/manifest.yml
@@ -55,6 +55,6 @@ policy_templates:
         required: false
         show_user: true
         default: false
-        description: Merge metrics from multiple queries to a single event
+        description: Merge results from multiple queries to a single event
 owner:
   github: elastic/obs-infraobs-integrations


### PR DESCRIPTION

- Enhancement

## What does this PR do?

This PR adds the merge_results feature to SQL Input Package. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes https://github.com/elastic/integrations/issues/6896

## Screenshots
Two queries for MYSQL 
<img width="651" alt="Screenshot 2023-07-11 at 7 24 19 PM" src="https://github.com/elastic/integrations/assets/102962586/0cc2409c-2a62-40a0-ac96-4c603df092bc">

Metrics of both queries merged in single event
<img width="703" alt="Screenshot 2023-07-11 at 7 12 51 PM" src="https://github.com/elastic/integrations/assets/102962586/f914a5f0-59b1-40ea-80fe-a80a3fa38b80">

