### PR TITLE
cyberarkpas,darktrace,infoblox_bloxone_ddi,jamf_compliance_reporter,ti_abusech,ti_cybersixgill,zscaler_zpa: convert visualisations to len

### DIFF
--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.12.0"
   changes:
-    - description: Convert vizualisations to lens.
+    - description: Convert visualizations to lens.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6924
 - version: "2.11.0"

--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.12.0"
+  changes:
+    - description: Convert vizualisations to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6924
 - version: "2.11.0"
   changes:
     - description: Update package to ECS 8.8.0.

--- a/packages/cyberarkpas/kibana/dashboard/cyberarkpas-eb12ef60-96f6-11eb-bbf8-d77aef8ad7a6.json
+++ b/packages/cyberarkpas/kibana/dashboard/cyberarkpas-eb12ef60-96f6-11eb-bbf8-d77aef8ad7a6.json
@@ -112,103 +112,170 @@
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-458a62ba-2bce-4ab1-8d75-8f028536bb8e",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "458a62ba-2bce-4ab1-8d75-8f028536bb8e": {
+                                            "columnOrder": [
+                                                "a597ad44-9c41-4213-9423-79e2410b5c64",
+                                                "82fedc27-d244-492f-8757-8968d908e10b",
+                                                "d6d59597-fbb4-4f97-af03-0a586aaf7826"
+                                            ],
+                                            "columns": {
+                                                "82fedc27-d244-492f-8757-8968d908e10b": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of cyberarkpas.audit.desc",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "cyberarkpas.audit.desc"
+                                                },
+                                                "a597ad44-9c41-4213-9423-79e2410b5c64": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "d6d59597-fbb4-4f97-af03-0a586aaf7826": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
                                 }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "d6d59597-fbb4-4f97-af03-0a586aaf7826"
+                                        ],
+                                        "layerId": "458a62ba-2bce-4ab1-8d75-8f028536bb8e",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "bar_stacked",
+                                        "splitAccessor": "82fedc27-d244-492f-8757-8968d908e10b",
+                                        "xAccessor": "a597ad44-9c41-4213-9423-79e2410b5c64",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "d6d59597-fbb4-4f97-af03-0a586aaf7826"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
                             }
                         },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset:\"cyberarkpas.audit\" "
-                            },
-                            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                            "index_pattern": "",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "bar",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "formatter": "number",
-                                    "hide_in_legend": 0,
-                                    "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                                    "label": "",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                            "type": "count"
-                                        }
-                                    ],
-                                    "override_index_pattern": 0,
-                                    "palette": {
-                                        "name": "rainbow",
-                                        "params": {
-                                            "colors": [
-                                                "#68BC00",
-                                                "#009CE0",
-                                                "#B0BC00",
-                                                "#16A5A5",
-                                                "#D33115",
-                                                "#E27300",
-                                                "#FCC400",
-                                                "#7B64FF",
-                                                "#FA28FF",
-                                                "#333333",
-                                                "#808080",
-                                                "#194D33",
-                                                "#0062B1",
-                                                "#808900",
-                                                "#0C797D",
-                                                "#9F0500",
-                                                "#C45100",
-                                                "#FB9E00",
-                                                "#653294",
-                                                "#AB149E",
-                                                "#0F1419",
-                                                "#666666"
-                                            ],
-                                            "gradient": false
-                                        },
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "split_color_mode": null,
-                                    "split_mode": "terms",
-                                    "stacked": "stacked",
-                                    "terms_field": "cyberarkpas.audit.desc",
-                                    "type": "timeseries"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "title": "",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
+                        "title": "event types by time (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 13,
@@ -219,7 +286,7 @@
                 },
                 "panelIndex": "f2dc3750-9b7c-4b0e-a45d-3d3b08f74f3e",
                 "title": "event types by time",
-                "type": "visualization",
+                "type": "lens",
                 "version": "8.7.1"
             },
             {
@@ -1248,7 +1315,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-12T03:51:03.233Z",
+    "created_at": "2023-07-12T03:53:08.521Z",
     "id": "cyberarkpas-eb12ef60-96f6-11eb-bbf8-d77aef8ad7a6",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -1267,6 +1334,11 @@
         {
             "id": "logs-*",
             "name": "1007fa0d-a6a1-4682-a346-a90acc179da5:control_1007fa0d-a6a1-4682-a346-a90acc179da5_1_index_pattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "f2dc3750-9b7c-4b0e-a45d-3d3b08f74f3e:indexpattern-datasource-layer-458a62ba-2bce-4ab1-8d75-8f028536bb8e",
             "type": "index-pattern"
         },
         {

--- a/packages/cyberarkpas/kibana/dashboard/cyberarkpas-eb12ef60-96f6-11eb-bbf8-d77aef8ad7a6.json
+++ b/packages/cyberarkpas/kibana/dashboard/cyberarkpas-eb12ef60-96f6-11eb-bbf8-d77aef8ad7a6.json
@@ -270,7 +270,7 @@
                                 "yRightScale": "linear"
                             }
                         },
-                        "title": "event types by time (converted)",
+                        "title": "event types by time",
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },

--- a/packages/cyberarkpas/kibana/dashboard/cyberarkpas-eb12ef60-96f6-11eb-bbf8-d77aef8ad7a6.json
+++ b/packages/cyberarkpas/kibana/dashboard/cyberarkpas-eb12ef60-96f6-11eb-bbf8-d77aef8ad7a6.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Dashboard for CyberArk Privileged Access Security events.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -35,6 +34,9 @@
         },
         "optionsJSON": {
             "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -59,8 +61,7 @@
                                 {
                                     "fieldName": "observer.hostname",
                                     "id": "1617726994032",
-                                    "indexPattern": "logs-*",
-                                    "indexPatternRefName": "control_0_index_pattern",
+                                    "indexPatternRefName": "control_1007fa0d-a6a1-4682-a346-a90acc179da5_0_index_pattern",
                                     "label": " By Vault host",
                                     "options": {
                                         "dynamicOptions": true,
@@ -75,8 +76,7 @@
                                 {
                                     "fieldName": "event.code",
                                     "id": "1617811797137",
-                                    "indexPattern": "logs-*",
-                                    "indexPatternRefName": "control_1_index_pattern",
+                                    "indexPatternRefName": "control_1007fa0d-a6a1-4682-a346-a90acc179da5_1_index_pattern",
                                     "label": "By event code",
                                     "options": {
                                         "dynamicOptions": true,
@@ -108,7 +108,7 @@
                 "panelIndex": "1007fa0d-a6a1-4682-a346-a90acc179da5",
                 "title": "Filters",
                 "type": "visualization",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -130,8 +130,7 @@
                             "axis_formatter": "number",
                             "axis_position": "left",
                             "axis_scale": "normal",
-                            "default_index_pattern": "logs-*",
-                            "default_timefield": "@timestamp",
+                            "drop_last_bucket": 1,
                             "filter": {
                                 "language": "kuery",
                                 "query": "data_stream.dataset:\"cyberarkpas.audit\" "
@@ -204,7 +203,7 @@
                             "time_range_mode": "entire_time_range",
                             "tooltip_mode": "show_all",
                             "type": "timeseries",
-                            "use_kibana_indexes": true
+                            "use_kibana_indexes": false
                         },
                         "title": "",
                         "type": "metrics",
@@ -221,7 +220,7 @@
                 "panelIndex": "f2dc3750-9b7c-4b0e-a45d-3d3b08f74f3e",
                 "title": "event types by time",
                 "type": "visualization",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -240,7 +239,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "33bc0096-e418-4f81-9c7c-7fdd16cc5203": {
                                             "columnOrder": [
@@ -254,7 +253,7 @@
                                                     "label": " ",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -269,12 +268,16 @@
                             },
                             "visualization": {
                                 "accessor": "eedd5aa8-a7c4-466a-b10b-3a8cba3bac12",
-                                "layerId": "33bc0096-e418-4f81-9c7c-7fdd16cc5203"
+                                "layerId": "33bc0096-e418-4f81-9c7c-7fdd16cc5203",
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -289,7 +292,7 @@
                 "panelIndex": "af9e9f0b-a40c-411e-b441-2a779983ed24",
                 "title": "Count of events",
                 "type": "lens",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -308,7 +311,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "de047c06-a965-47aa-8a15-8b0266d5abc3": {
                                             "columnOrder": [
@@ -322,7 +325,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "b916e5f5-a64a-49f1-b37a-ee1825fc61a4": {
                                                     "dataType": "string",
@@ -357,14 +360,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "b916e5f5-a64a-49f1-b37a-ee1825fc61a4"
-                                        ],
                                         "layerId": "de047c06-a965-47aa-8a15-8b0266d5abc3",
+                                        "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "3effd03e-0ed9-4e2d-ba8e-d77ae505092e",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "3effd03e-0ed9-4e2d-ba8e-d77ae505092e"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "b916e5f5-a64a-49f1-b37a-ee1825fc61a4"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -387,7 +394,7 @@
                 "panelIndex": "7031905a-92ab-4e0e-aa58-72f1c07ff409",
                 "title": "Breakdown by outcome",
                 "type": "lens",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -416,7 +423,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "19858811-84d1-4f50-901c-dc1451972324": {
                                             "columnOrder": [
@@ -447,7 +454,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -463,7 +470,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -484,7 +491,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "event.code",
                                         "negate": false,
                                         "params": [
@@ -532,19 +539,23 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
+                                        "layerId": "19858811-84d1-4f50-901c-dc1451972324",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "e3526253-18e0-4122-b112-ee5b4b9e23d7"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
                                             "81dcff19-b14a-4e4b-999e-dbbcbdfdf816",
                                             "81dcff19-b14a-4e4b-999e-dbbcbdfdf816",
                                             "81dcff19-b14a-4e4b-999e-dbbcbdfdf816",
                                             "81dcff19-b14a-4e4b-999e-dbbcbdfdf816",
                                             "81dcff19-b14a-4e4b-999e-dbbcbdfdf816",
                                             "81dcff19-b14a-4e4b-999e-dbbcbdfdf816"
-                                        ],
-                                        "layerId": "19858811-84d1-4f50-901c-dc1451972324",
-                                        "legendDisplay": "default",
-                                        "metric": "e3526253-18e0-4122-b112-ee5b4b9e23d7",
-                                        "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -567,7 +578,7 @@
                 "panelIndex": "a24b9c0c-da95-4016-9fe5-2c0d34005832",
                 "title": "Top 10 user credentials accessed",
                 "type": "lens",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -596,7 +607,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "50325938-6a9e-4a26-946e-4468e68c6591": {
                                             "columnOrder": [
@@ -630,7 +641,7 @@
                                                     "label": "Credentials accessed",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "c05a39ad-2983-4f4a-900d-a939ecbda504": {
                                                     "dataType": "date",
@@ -638,6 +649,7 @@
                                                     "label": "@timestamp",
                                                     "operationType": "date_histogram",
                                                     "params": {
+                                                        "includeEmptyRows": true,
                                                         "interval": "auto"
                                                     },
                                                     "scale": "interval",
@@ -657,7 +669,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -678,7 +690,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "event.code",
                                         "negate": false,
                                         "params": [
@@ -746,6 +758,7 @@
                                             "a808a872-71b5-4a76-a939-354f68991881"
                                         ],
                                         "layerId": "50325938-6a9e-4a26-946e-4468e68c6591",
+                                        "layerType": "data",
                                         "position": "top",
                                         "seriesType": "area_stacked",
                                         "showGridlines": false,
@@ -755,6 +768,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "area_stacked",
@@ -783,7 +797,7 @@
                 "panelIndex": "1dc68cc6-e1b3-43ea-9b0e-f423d194b99a",
                 "title": "Credential access by time",
                 "type": "lens",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -807,7 +821,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "105faf70-8330-46b3-a82a-573a383068fa": {
                                             "columnOrder": [
@@ -823,7 +837,7 @@
                                                     "label": "Authentications",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "c51d6847-2fcc-4d13-a44f-49786cb979ed": {
                                                     "customLabel": true,
@@ -875,7 +889,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "event.category",
                                         "negate": false,
                                         "params": [
@@ -919,6 +933,7 @@
                                             "c0147524-accc-4dee-a4fc-44199e3459f1"
                                         ],
                                         "layerId": "105faf70-8330-46b3-a82a-573a383068fa",
+                                        "layerType": "data",
                                         "palette": {
                                             "name": "status",
                                             "type": "palette"
@@ -932,6 +947,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right",
                                     "showSingleSeries": false
                                 },
@@ -961,13 +977,13 @@
                 "panelIndex": "c56b3e4d-bfb6-4b06-a62b-282753b85f7a",
                 "title": "Vault Authentication attempts",
                 "type": "lens",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
                         "description": "",
-                        "layerListJSON": "[{\"sourceDescriptor\":{\"type\":\"EMS_TMS\",\"id\":null,\"isAutoSelect\":true},\"id\":\"a3734143-d6e1-4551-b0b1-8282a37e151b\",\"label\":null,\"minZoom\":0,\"maxZoom\":24,\"alpha\":1,\"visible\":true,\"style\":{\"type\":\"TILE\"},\"type\":\"VECTOR_TILE\"},{\"label\":\"logs-* | Source Point\",\"sourceDescriptor\":{\"indexPatternId\":\"logs-*\",\"geoField\":\"source.geo.location\",\"scalingType\":\"TOP_HITS\",\"topHitsSplitField\":\"source.ip\",\"tooltipProperties\":[\"host.name\",\"source.ip\",\"source.domain\",\"source.geo.country_iso_code\",\"source.as.organization.name\"],\"id\":\"5f2b25a1-01ea-45ca-a4a2-f1a670c3b149\",\"type\":\"ES_SEARCH\",\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"filterByMapBounds\":true,\"sortField\":\"\",\"sortOrder\":\"desc\",\"topHitsSize\":22},\"style\":{\"type\":\"VECTOR\",\"properties\":{\"icon\":{\"type\":\"STATIC\",\"options\":{\"value\":\"home\"}},\"fillColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#6092C0\"}},\"lineColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"lineWidth\":{\"type\":\"STATIC\",\"options\":{\"size\":2}},\"iconSize\":{\"type\":\"STATIC\",\"options\":{\"size\":8}},\"iconOrientation\":{\"type\":\"STATIC\",\"options\":{\"orientation\":0}},\"labelText\":{\"type\":\"STATIC\",\"options\":{\"value\":\"\"}},\"labelColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#000000\"}},\"labelSize\":{\"type\":\"STATIC\",\"options\":{\"size\":14}},\"labelBorderColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"symbolizeAs\":{\"options\":{\"value\":\"icon\"}},\"labelBorderSize\":{\"options\":{\"size\":\"SMALL\"}}},\"isTimeAware\":true},\"id\":\"2ad8e318-4ef4-4e89-94f2-f37e395c488c\",\"minZoom\":0,\"maxZoom\":24,\"alpha\":0.75,\"visible\":true,\"type\":\"VECTOR\",\"joins\":[]},{\"label\":\"logs-* | Destination point\",\"sourceDescriptor\":{\"indexPatternId\":\"logs-*\",\"geoField\":\"destination.geo.location\",\"scalingType\":\"TOP_HITS\",\"topHitsSplitField\":\"destination.ip\",\"tooltipProperties\":[\"host.name\",\"destination.ip\",\"destination.domain\",\"destination.geo.country_iso_code\",\"destination.as.organization.name\"],\"id\":\"bc95f479-964f-4498-be1e-376d34a01b0a\",\"type\":\"ES_SEARCH\",\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"filterByMapBounds\":true,\"sortField\":\"\",\"sortOrder\":\"desc\",\"topHitsSize\":35},\"style\":{\"type\":\"VECTOR\",\"properties\":{\"icon\":{\"type\":\"STATIC\",\"options\":{\"value\":\"marker\"}},\"fillColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#D36086\"}},\"lineColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"lineWidth\":{\"type\":\"STATIC\",\"options\":{\"size\":2}},\"iconSize\":{\"type\":\"STATIC\",\"options\":{\"size\":8}},\"iconOrientation\":{\"type\":\"STATIC\",\"options\":{\"orientation\":0}},\"labelText\":{\"type\":\"STATIC\",\"options\":{\"value\":\"\"}},\"labelColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#000000\"}},\"labelSize\":{\"type\":\"STATIC\",\"options\":{\"size\":14}},\"labelBorderColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"symbolizeAs\":{\"options\":{\"value\":\"icon\"}},\"labelBorderSize\":{\"options\":{\"size\":\"SMALL\"}}},\"isTimeAware\":true},\"id\":\"dbb878c8-4039-49f1-b2ff-ab7fb942ba55\",\"minZoom\":0,\"maxZoom\":24,\"alpha\":0.75,\"visible\":true,\"type\":\"VECTOR\",\"joins\":[]},{\"label\":\"logs-* | Line\",\"sourceDescriptor\":{\"indexPatternId\":\"logs-*\",\"sourceGeoField\":\"source.geo.location\",\"destGeoField\":\"destination.geo.location\",\"metrics\":[{\"type\":\"count\"},{\"type\":\"sum\",\"field\":\"destination.bytes\"}],\"id\":\"faf6884d-b7cb-41dd-ab86-95970d7c59d2\",\"type\":\"ES_PEW_PEW\",\"applyGlobalQuery\":true,\"applyGlobalTime\":true},\"style\":{\"type\":\"VECTOR\",\"properties\":{\"icon\":{\"type\":\"STATIC\",\"options\":{\"value\":\"marker\"}},\"fillColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#54B399\"}},\"lineColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#6092C0\"}},\"lineWidth\":{\"type\":\"DYNAMIC\",\"options\":{\"minSize\":1,\"maxSize\":8,\"field\":{\"name\":\"doc_count\",\"origin\":\"source\"},\"fieldMetaOptions\":{\"isEnabled\":true,\"sigma\":3}}},\"iconSize\":{\"type\":\"STATIC\",\"options\":{\"size\":6}},\"iconOrientation\":{\"type\":\"STATIC\",\"options\":{\"orientation\":0}},\"labelText\":{\"type\":\"STATIC\",\"options\":{\"value\":\"\"}},\"labelColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#000000\"}},\"labelSize\":{\"type\":\"STATIC\",\"options\":{\"size\":14}},\"labelBorderColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"symbolizeAs\":{\"options\":{\"value\":\"circle\"}},\"labelBorderSize\":{\"options\":{\"size\":\"SMALL\"}}},\"isTimeAware\":true},\"id\":\"9c450fbf-b009-4b53-9810-2f47ca8dcfa8\",\"minZoom\":0,\"maxZoom\":24,\"alpha\":0.75,\"visible\":true,\"type\":\"VECTOR\",\"joins\":[]}]",
+                        "layerListJSON": "[{\"sourceDescriptor\":{\"type\":\"EMS_TMS\",\"id\":null,\"isAutoSelect\":true,\"lightModeDefault\":\"road_map\"},\"id\":\"a3734143-d6e1-4551-b0b1-8282a37e151b\",\"label\":null,\"minZoom\":0,\"maxZoom\":24,\"alpha\":1,\"visible\":true,\"style\":{\"type\":\"TILE\"},\"type\":\"EMS_VECTOR_TILE\"},{\"label\":\"logs-* | Source Point\",\"sourceDescriptor\":{\"geoField\":\"source.geo.location\",\"scalingType\":\"TOP_HITS\",\"topHitsSplitField\":\"source.ip\",\"tooltipProperties\":[\"host.name\",\"source.ip\",\"source.domain\",\"source.geo.country_iso_code\",\"source.as.organization.name\"],\"id\":\"5f2b25a1-01ea-45ca-a4a2-f1a670c3b149\",\"type\":\"ES_SEARCH\",\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"filterByMapBounds\":true,\"sortField\":\"\",\"sortOrder\":\"desc\",\"topHitsSize\":22,\"indexPatternRefName\":\"layer_1_source_index_pattern\"},\"style\":{\"type\":\"VECTOR\",\"properties\":{\"icon\":{\"type\":\"STATIC\",\"options\":{\"value\":\"home\"}},\"fillColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#6092C0\"}},\"lineColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"lineWidth\":{\"type\":\"STATIC\",\"options\":{\"size\":2}},\"iconSize\":{\"type\":\"STATIC\",\"options\":{\"size\":8}},\"iconOrientation\":{\"type\":\"STATIC\",\"options\":{\"orientation\":0}},\"labelText\":{\"type\":\"STATIC\",\"options\":{\"value\":\"\"}},\"labelColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#000000\"}},\"labelSize\":{\"type\":\"STATIC\",\"options\":{\"size\":14}},\"labelBorderColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"symbolizeAs\":{\"options\":{\"value\":\"icon\"}},\"labelBorderSize\":{\"options\":{\"size\":\"SMALL\"}}},\"isTimeAware\":true},\"id\":\"2ad8e318-4ef4-4e89-94f2-f37e395c488c\",\"minZoom\":0,\"maxZoom\":24,\"alpha\":0.75,\"visible\":true,\"type\":\"GEOJSON_VECTOR\",\"joins\":[]},{\"label\":\"logs-* | Destination point\",\"sourceDescriptor\":{\"geoField\":\"destination.geo.location\",\"scalingType\":\"TOP_HITS\",\"topHitsSplitField\":\"destination.ip\",\"tooltipProperties\":[\"host.name\",\"destination.ip\",\"destination.domain\",\"destination.geo.country_iso_code\",\"destination.as.organization.name\"],\"id\":\"bc95f479-964f-4498-be1e-376d34a01b0a\",\"type\":\"ES_SEARCH\",\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"filterByMapBounds\":true,\"sortField\":\"\",\"sortOrder\":\"desc\",\"topHitsSize\":35,\"indexPatternRefName\":\"layer_2_source_index_pattern\"},\"style\":{\"type\":\"VECTOR\",\"properties\":{\"icon\":{\"type\":\"STATIC\",\"options\":{\"value\":\"marker\"}},\"fillColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#D36086\"}},\"lineColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"lineWidth\":{\"type\":\"STATIC\",\"options\":{\"size\":2}},\"iconSize\":{\"type\":\"STATIC\",\"options\":{\"size\":8}},\"iconOrientation\":{\"type\":\"STATIC\",\"options\":{\"orientation\":0}},\"labelText\":{\"type\":\"STATIC\",\"options\":{\"value\":\"\"}},\"labelColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#000000\"}},\"labelSize\":{\"type\":\"STATIC\",\"options\":{\"size\":14}},\"labelBorderColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"symbolizeAs\":{\"options\":{\"value\":\"icon\"}},\"labelBorderSize\":{\"options\":{\"size\":\"SMALL\"}}},\"isTimeAware\":true},\"id\":\"dbb878c8-4039-49f1-b2ff-ab7fb942ba55\",\"minZoom\":0,\"maxZoom\":24,\"alpha\":0.75,\"visible\":true,\"type\":\"GEOJSON_VECTOR\",\"joins\":[]},{\"label\":\"logs-* | Line\",\"sourceDescriptor\":{\"sourceGeoField\":\"source.geo.location\",\"destGeoField\":\"destination.geo.location\",\"metrics\":[{\"type\":\"count\"},{\"type\":\"sum\",\"field\":\"destination.bytes\"}],\"id\":\"faf6884d-b7cb-41dd-ab86-95970d7c59d2\",\"type\":\"ES_PEW_PEW\",\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"indexPatternRefName\":\"layer_3_source_index_pattern\"},\"style\":{\"type\":\"VECTOR\",\"properties\":{\"icon\":{\"type\":\"STATIC\",\"options\":{\"value\":\"marker\"}},\"fillColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#54B399\"}},\"lineColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#6092C0\"}},\"lineWidth\":{\"type\":\"DYNAMIC\",\"options\":{\"minSize\":1,\"maxSize\":8,\"field\":{\"name\":\"doc_count\",\"origin\":\"source\"},\"fieldMetaOptions\":{\"isEnabled\":true,\"sigma\":3}}},\"iconSize\":{\"type\":\"STATIC\",\"options\":{\"size\":6}},\"iconOrientation\":{\"type\":\"STATIC\",\"options\":{\"orientation\":0}},\"labelText\":{\"type\":\"STATIC\",\"options\":{\"value\":\"\"}},\"labelColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#000000\"}},\"labelSize\":{\"type\":\"STATIC\",\"options\":{\"size\":14}},\"labelBorderColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"symbolizeAs\":{\"options\":{\"value\":\"circle\"}},\"labelBorderSize\":{\"options\":{\"size\":\"SMALL\"}}},\"isTimeAware\":true},\"id\":\"9c450fbf-b009-4b53-9810-2f47ca8dcfa8\",\"minZoom\":0,\"maxZoom\":24,\"alpha\":0.75,\"visible\":true,\"type\":\"GEOJSON_VECTOR\",\"joins\":[]}]",
                         "mapStateJSON": "{\"zoom\":1.24,\"center\":{\"lon\":-49.38072,\"lat\":7.87497},\"timeFilters\":{\"from\":\"now-15w\",\"to\":\"now\"},\"refreshConfig\":{\"isPaused\":true,\"interval\":0},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"settings\":{\"autoFitToDataBounds\":false,\"backgroundColor\":\"#ffffff\",\"disableInteractive\":false,\"disableTooltipControl\":false,\"hideToolbarOverlay\":false,\"hideLayerControl\":false,\"hideViewControl\":false,\"initialLocation\":\"LAST_SAVED_LOCATION\",\"fixedLocation\":{\"lat\":0,\"lon\":0,\"zoom\":2},\"browserLocation\":{\"zoom\":2},\"maxZoom\":24,\"minZoom\":0,\"showScaleControl\":false,\"showSpatialFilters\":true,\"spatialFiltersAlpa\":0.3,\"spatialFiltersFillColor\":\"#DA8B45\",\"spatialFiltersLineColor\":\"#DA8B45\"}}",
                         "title": "",
                         "uiStateJSON": "{\"isLayerTOCOpen\":true,\"openTOCDetails\":[]}"
@@ -999,7 +1015,7 @@
                 "panelIndex": "cd1e20e7-706f-4d02-949c-d9f5908bad67",
                 "title": "Network sources and destinations",
                 "type": "map",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1028,7 +1044,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "028c5c1e-79f9-4999-8438-4889ac2b714c": {
                                             "columnOrder": [
@@ -1063,7 +1079,7 @@
                                                     "operationType": "count",
                                                     "params": {},
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -1079,7 +1095,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "event.category",
                                         "negate": false,
                                         "params": {
@@ -1100,7 +1116,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "event.outcome",
                                         "negate": false,
                                         "params": {
@@ -1137,6 +1153,7 @@
                                             "f2cd86e2-fb91-48b2-b8dd-e98395d28e00"
                                         ],
                                         "layerId": "028c5c1e-79f9-4999-8438-4889ac2b714c",
+                                        "layerType": "data",
                                         "position": "top",
                                         "seriesType": "bar_horizontal",
                                         "showGridlines": false,
@@ -1151,6 +1168,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_horizontal",
@@ -1179,7 +1197,7 @@
                 "panelIndex": "c6305b30-a7e2-4cc3-b49b-db99031f150e",
                 "title": "Top users by failed authentications to Vault",
                 "type": "lens",
-                "version": "7.12.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1194,9 +1212,10 @@
                     "y": 49
                 },
                 "panelIndex": "96a2c711-40a3-4dfc-87f5-4b193078e05a",
-                "panelRefName": "panel_9",
+                "panelRefName": "panel_96a2c711-40a3-4dfc-87f5-4b193078e05a",
                 "title": "Credential Access",
-                "version": "7.12.0"
+                "type": "search",
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1218,23 +1237,22 @@
                     "y": 64
                 },
                 "panelIndex": "6cd62115-65e7-416f-8da7-96b0d7a9d932",
-                "panelRefName": "panel_10",
+                "panelRefName": "panel_6cd62115-65e7-416f-8da7-96b0d7a9d932",
                 "title": "All logs",
-                "version": "7.12.0"
+                "type": "search",
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs CyberArk PAS] Overview",
         "version": 1
     },
-    "coreMigrationVersion": "7.12.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T03:51:03.233Z",
     "id": "cyberarkpas-eb12ef60-96f6-11eb-bbf8-d77aef8ad7a6",
     "migrationVersion": {
-        "dashboard": "7.11.0"
+        "dashboard": "8.7.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "logs-*",
@@ -1243,132 +1261,132 @@
         },
         {
             "id": "logs-*",
-            "name": "control_0_index_pattern",
+            "name": "1007fa0d-a6a1-4682-a346-a90acc179da5:control_1007fa0d-a6a1-4682-a346-a90acc179da5_0_index_pattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "control_1_index_pattern",
+            "name": "1007fa0d-a6a1-4682-a346-a90acc179da5:control_1007fa0d-a6a1-4682-a346-a90acc179da5_1_index_pattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-current-indexpattern",
+            "name": "af9e9f0b-a40c-411e-b441-2a779983ed24:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-layer-33bc0096-e418-4f81-9c7c-7fdd16cc5203",
+            "name": "af9e9f0b-a40c-411e-b441-2a779983ed24:indexpattern-datasource-layer-33bc0096-e418-4f81-9c7c-7fdd16cc5203",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-current-indexpattern",
+            "name": "7031905a-92ab-4e0e-aa58-72f1c07ff409:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-layer-de047c06-a965-47aa-8a15-8b0266d5abc3",
+            "name": "7031905a-92ab-4e0e-aa58-72f1c07ff409:indexpattern-datasource-layer-de047c06-a965-47aa-8a15-8b0266d5abc3",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-current-indexpattern",
+            "name": "a24b9c0c-da95-4016-9fe5-2c0d34005832:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-layer-19858811-84d1-4f50-901c-dc1451972324",
+            "name": "a24b9c0c-da95-4016-9fe5-2c0d34005832:indexpattern-datasource-layer-19858811-84d1-4f50-901c-dc1451972324",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "filter-index-pattern-0",
+            "name": "a24b9c0c-da95-4016-9fe5-2c0d34005832:filter-index-pattern-0",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "filter-index-pattern-1",
+            "name": "a24b9c0c-da95-4016-9fe5-2c0d34005832:filter-index-pattern-1",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-current-indexpattern",
+            "name": "1dc68cc6-e1b3-43ea-9b0e-f423d194b99a:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-layer-50325938-6a9e-4a26-946e-4468e68c6591",
+            "name": "1dc68cc6-e1b3-43ea-9b0e-f423d194b99a:indexpattern-datasource-layer-50325938-6a9e-4a26-946e-4468e68c6591",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "filter-index-pattern-0",
+            "name": "1dc68cc6-e1b3-43ea-9b0e-f423d194b99a:filter-index-pattern-0",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "filter-index-pattern-1",
+            "name": "1dc68cc6-e1b3-43ea-9b0e-f423d194b99a:filter-index-pattern-1",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-current-indexpattern",
+            "name": "c56b3e4d-bfb6-4b06-a62b-282753b85f7a:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-layer-105faf70-8330-46b3-a82a-573a383068fa",
+            "name": "c56b3e4d-bfb6-4b06-a62b-282753b85f7a:indexpattern-datasource-layer-105faf70-8330-46b3-a82a-573a383068fa",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "filter-index-pattern-0",
+            "name": "c56b3e4d-bfb6-4b06-a62b-282753b85f7a:filter-index-pattern-0",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "layer_1_source_index_pattern",
+            "name": "cd1e20e7-706f-4d02-949c-d9f5908bad67:layer_1_source_index_pattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "layer_2_source_index_pattern",
+            "name": "cd1e20e7-706f-4d02-949c-d9f5908bad67:layer_2_source_index_pattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "layer_3_source_index_pattern",
+            "name": "cd1e20e7-706f-4d02-949c-d9f5908bad67:layer_3_source_index_pattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-current-indexpattern",
+            "name": "c6305b30-a7e2-4cc3-b49b-db99031f150e:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "indexpattern-datasource-layer-028c5c1e-79f9-4999-8438-4889ac2b714c",
+            "name": "c6305b30-a7e2-4cc3-b49b-db99031f150e:indexpattern-datasource-layer-028c5c1e-79f9-4999-8438-4889ac2b714c",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "filter-index-pattern-0",
+            "name": "c6305b30-a7e2-4cc3-b49b-db99031f150e:filter-index-pattern-0",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "filter-index-pattern-1",
+            "name": "c6305b30-a7e2-4cc3-b49b-db99031f150e:filter-index-pattern-1",
             "type": "index-pattern"
         },
         {
             "id": "cyberarkpas-a9b82df0-97a5-11eb-bbf8-d77aef8ad7a6",
-            "name": "panel_9",
+            "name": "96a2c711-40a3-4dfc-87f5-4b193078e05a:panel_96a2c711-40a3-4dfc-87f5-4b193078e05a",
             "type": "search"
         },
         {
             "id": "cyberarkpas-fec0d170-96f7-11eb-bbf8-d77aef8ad7a6",
-            "name": "panel_10",
+            "name": "6cd62115-65e7-416f-8da7-96b0d7a9d932:panel_6cd62115-65e7-416f-8da7-96b0d7a9d932",
             "type": "search"
         }
     ],

--- a/packages/cyberarkpas/kibana/search/cyberarkpas-a9b82df0-97a5-11eb-bbf8-d77aef8ad7a6.json
+++ b/packages/cyberarkpas/kibana/search/cyberarkpas-a9b82df0-97a5-11eb-bbf8-d77aef8ad7a6.json
@@ -117,14 +117,12 @@
         "title": "Credential Access logs [Logs CyberArk PAS]",
         "version": 1
     },
-    "coreMigrationVersion": "7.12.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T03:50:17.631Z",
     "id": "cyberarkpas-a9b82df0-97a5-11eb-bbf8-d77aef8ad7a6",
     "migrationVersion": {
-        "search": "7.9.3"
+        "search": "8.0.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "logs-*",

--- a/packages/cyberarkpas/kibana/search/cyberarkpas-fec0d170-96f7-11eb-bbf8-d77aef8ad7a6.json
+++ b/packages/cyberarkpas/kibana/search/cyberarkpas-fec0d170-96f7-11eb-bbf8-d77aef8ad7a6.json
@@ -22,14 +22,12 @@
         "title": "All logs [Logs CyberArk PAS]",
         "version": 1
     },
-    "coreMigrationVersion": "7.12.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T03:50:17.631Z",
     "id": "cyberarkpas-fec0d170-96f7-11eb-bbf8-d77aef8ad7a6",
     "migrationVersion": {
-        "search": "7.9.3"
+        "search": "8.0.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "logs-*",

--- a/packages/cyberarkpas/manifest.yml
+++ b/packages/cyberarkpas/manifest.yml
@@ -1,6 +1,6 @@
 name: cyberarkpas
 title: CyberArk Privileged Access Security
-version: "2.11.0"
+version: "2.12.0"
 release: ga
 description: Collect logs from CyberArk Privileged Access Security with Elastic Agent.
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: ["security", "iam"]
 conditions:
-  kibana.version: ^7.16.0 || ^8.0.0
+  kibana.version: ^8.7.1
 screenshots:
   - src: /img/filebeat-cyberarkpas-overview.png
     title: filebeat cyberarkpas overview

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.6.0"
   changes:
-    - description: Convert vizualisation.
+    - description: Convert visualizations to lens.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6924
 - version: "1.5.0"

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Convert vizualisation.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6924
 - version: "1.5.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/darktrace/kibana/dashboard/darktrace-6bd3c320-13b2-11ed-bdc1-9f13147efcf8.json
+++ b/packages/darktrace/kibana/dashboard/darktrace-6bd3c320-13b2-11ed-bdc1-9f13147efcf8.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Darktrace System Status Alerts Overview.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [],
@@ -14,6 +13,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -39,7 +40,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1b85280d-b235-4523-b782-fd77e9046901": {
                                             "columnOrder": [
@@ -94,12 +95,15 @@
                             "visualization": {
                                 "accessor": "426426da-2361-40d0-a759-2591bdf082c9",
                                 "layerId": "1b85280d-b235-4523-b782-fd77e9046901",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -114,7 +118,7 @@
                 "panelIndex": "5f64c3c5-4d59-4abb-a6ab-234a1ee66151",
                 "title": "Number of Active Alerts [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -133,7 +137,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f27d6430-9a24-4f7b-86b0-43950b6f2393": {
                                             "columnOrder": [
@@ -190,15 +194,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "ecdeb1b2-48c5-4966-bca9-0f228a2916f3"
-                                        ],
                                         "layerId": "f27d6430-9a24-4f7b-86b0-43950b6f2393",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "11c181af-dff4-4a0a-ad2e-0846bd66affe",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "11c181af-dff4-4a0a-ad2e-0846bd66affe"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "ecdeb1b2-48c5-4966-bca9-0f228a2916f3"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -221,7 +228,7 @@
                 "panelIndex": "e7b10ecb-271a-4010-9947-9597225acd58",
                 "title": "Distribution of System Status Alerts by Priority Level [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -240,7 +247,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "b1042ac5-75bd-48e1-9c8c-4ab507402159": {
                                             "columnOrder": [
@@ -325,7 +332,7 @@
                 "panelIndex": "77e3df19-769a-414a-b96b-dbb37169629d",
                 "title": "Top 10 Hostname with Highest System Status Alerts [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -344,7 +351,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "607d2de2-df5d-4503-90e0-4ac42323c46e": {
                                             "columnOrder": [
@@ -429,7 +436,7 @@
                 "panelIndex": "7d794103-85bd-4669-b9bc-b9223d2eba5c",
                 "title": "Top 10 Alert Name with Highest System Status Alerts [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -445,17 +452,18 @@
                 "panelIndex": "00e77d89-2b5e-4f2d-bc08-f7d1ce5165dd",
                 "panelRefName": "panel_00e77d89-2b5e-4f2d-bc08-f7d1ce5165dd",
                 "type": "search",
-                "version": "8.2.1"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Darktrace] System Status Alerts Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.2.1",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:11:31.401Z",
     "id": "darktrace-6bd3c320-13b2-11ed-bdc1-9f13147efcf8",
     "migrationVersion": {
-        "dashboard": "8.2.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/darktrace/kibana/dashboard/darktrace-da768d80-1399-11ed-bdc1-9f13147efcf8.json
+++ b/packages/darktrace/kibana/dashboard/darktrace-da768d80-1399-11ed-bdc1-9f13147efcf8.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Darktrace Model Breach Alerts Overview.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [],
@@ -14,6 +13,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -34,7 +35,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "16c69f2e-ffe0-4393-9d91-dece311e3f0f": {
                                             "columnOrder": [
@@ -67,12 +68,15 @@
                             "visualization": {
                                 "accessor": "099298f5-fc58-4473-860e-84bc44f2e387",
                                 "layerId": "16c69f2e-ffe0-4393-9d91-dece311e3f0f",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -87,7 +91,7 @@
                 "panelIndex": "14e3bf5d-011f-48d2-83a9-fc62d707cdd1",
                 "title": "Number of Alerts [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -111,7 +115,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "8d4cd3ff-fd36-462e-ae82-826554dc847d": {
                                             "columnOrder": [
@@ -166,12 +170,15 @@
                             "visualization": {
                                 "accessor": "861dc1ff-427e-4512-bb2c-e28d3f7564b2",
                                 "layerId": "8d4cd3ff-fd36-462e-ae82-826554dc847d",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -186,7 +193,7 @@
                 "panelIndex": "07f13cdd-3a86-40e5-914f-8f50c695b6ee",
                 "title": "Number of Active Models [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -205,7 +212,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a4c3d027-4533-411a-b9f1-26f0a4fedb66": {
                                             "columnOrder": [
@@ -262,15 +269,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "1ea9479b-4db9-4215-97d9-1d7a275176ab"
-                                        ],
                                         "layerId": "a4c3d027-4533-411a-b9f1-26f0a4fedb66",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "36c1f412-cfb7-4ea0-b9c9-a323c72e800d",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "36c1f412-cfb7-4ea0-b9c9-a323c72e800d"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "1ea9479b-4db9-4215-97d9-1d7a275176ab"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -293,7 +303,7 @@
                 "panelIndex": "1fafffde-be8a-4e46-bc58-a52db1e94931",
                 "title": "Distribution of Model Breach Alerts by Model Category [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -312,7 +322,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "8a0016c8-0623-4e96-a007-240f0bfe88c2": {
                                             "columnOrder": [
@@ -395,6 +405,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -423,7 +434,7 @@
                 "panelIndex": "ddcd6a80-5ab0-4522-b984-022b7da2d4b0",
                 "title": "Distribution of Model Breach Alerts by Model Priority [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -442,7 +453,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "267ebe2d-c964-48cf-9c9a-1a1fb09f6e3c": {
                                             "columnOrder": [
@@ -499,15 +510,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "c2ee5623-973c-416f-80b0-bae47d66f83b"
-                                        ],
                                         "layerId": "267ebe2d-c964-48cf-9c9a-1a1fb09f6e3c",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "8630c019-3e7e-4734-b1c2-1a82f39fb7fc",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "8630c019-3e7e-4734-b1c2-1a82f39fb7fc"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "c2ee5623-973c-416f-80b0-bae47d66f83b"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -530,7 +544,7 @@
                 "panelIndex": "44710442-b7b8-413a-9e52-4d7ba519a296",
                 "title": "Distribution of Model Breach Alerts by Model Behaviour [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -549,7 +563,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "26e0acea-9274-411a-91a3-8537b1e00aff": {
                                             "columnOrder": [
@@ -637,7 +651,7 @@
                 "panelIndex": "747c1919-e215-4b97-9d8b-8ee528c1deaa",
                 "title": "Top 10 Model Breach Alerts by Highest Model Breach Score [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -656,7 +670,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "adde69bc-fda5-4560-8a54-202ca975652f": {
                                             "columnOrder": [
@@ -744,7 +758,7 @@
                 "panelIndex": "aca1678c-d3d8-478e-a09c-dfdd86a5b3f7",
                 "title": "Top 10 Model Name with Highest Model Breach [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -763,7 +777,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0c7a50df-8359-42ff-806d-a22eb35b597a": {
                                             "columnOrder": [
@@ -848,7 +862,7 @@
                 "panelIndex": "19b3fa09-6280-430a-9046-a613dfde3696",
                 "title": "Top 10 Device Type with Highest Model Breach [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -867,7 +881,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7bd679f9-8a5b-4906-beaa-750102e3a26f": {
                                             "columnOrder": [
@@ -924,15 +938,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "13359fdf-964f-441c-8d49-dcacd44d74a9"
-                                        ],
                                         "layerId": "7bd679f9-8a5b-4906-beaa-750102e3a26f",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "d0c28963-3b20-44ed-bd81-668ccef65e64",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "d0c28963-3b20-44ed-bd81-668ccef65e64"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "13359fdf-964f-441c-8d49-dcacd44d74a9"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -955,7 +972,7 @@
                 "panelIndex": "185e6cd3-4cf8-45fd-937e-77abd9e6aad7",
                 "title": "Distribution of Model Breach Alerts by Targeted Vendor [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -974,7 +991,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c8ea502e-ae28-47dd-9b90-484d50083243": {
                                             "columnOrder": [
@@ -1060,7 +1077,7 @@
                 "panelIndex": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0",
                 "title": "Top 10 Device Host ID with Highest Model Breach [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1079,7 +1096,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "88c07c59-c625-4652-8156-54991d0869d8": {
                                             "columnOrder": [
@@ -1149,6 +1166,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -1173,7 +1191,7 @@
                 "panelIndex": "889bb859-0938-46a4-b078-30f5fedd10a7",
                 "title": "Distribution of Model Breach Alerts by Antigena Action [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1192,7 +1210,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "68e57e92-bad9-44bd-8022-16b46d218096": {
                                             "columnOrder": [
@@ -1260,6 +1278,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "line",
@@ -1284,7 +1303,7 @@
                 "panelIndex": "c6560c58-be58-4718-abed-0356a2ba3b09",
                 "title": "Model Throttle Over Time [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1359,7 +1378,7 @@
                 "panelIndex": "12736f17-d97c-4f4c-a66b-5eba7c2fec9c",
                 "title": "Top Mitre Techniques [Logs Darktrace]",
                 "type": "visualization",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1375,17 +1394,18 @@
                 "panelIndex": "e9b4f5f5-d478-403d-a78e-9e39ad3486f0",
                 "panelRefName": "panel_e9b4f5f5-d478-403d-a78e-9e39ad3486f0",
                 "type": "search",
-                "version": "8.2.1"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Darktrace] Model Breach Alerts Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.2.1",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:11:37.771Z",
     "id": "darktrace-da768d80-1399-11ed-bdc1-9f13147efcf8",
     "migrationVersion": {
-        "dashboard": "8.2.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/darktrace/kibana/dashboard/darktrace-da768d80-1399-11ed-bdc1-9f13147efcf8.json
+++ b/packages/darktrace/kibana/dashboard/darktrace-da768d80-1399-11ed-bdc1-9f13147efcf8.json
@@ -985,111 +985,6 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-c8ea502e-ae28-47dd-9b90-484d50083243",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "c8ea502e-ae28-47dd-9b90-484d50083243": {
-                                            "columnOrder": [
-                                                "0e81fce6-dd05-4dcb-9cc1-1bfedfd001d1",
-                                                "dbd63d7d-3048-4f3e-a068-d891e14f517b"
-                                            ],
-                                            "columns": {
-                                                "0e81fce6-dd05-4dcb-9cc1-1bfedfd001d1": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Device Host ID",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "dbd63d7d-3048-4f3e-a068-d891e14f517b",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "host.id"
-                                                },
-                                                "dbd63d7d-3048-4f3e-a068-d891e14f517b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "darktrace.model_breach_alert.pbid"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset : \"darktrace.model_breach_alert\""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "alignment": "left",
-                                        "columnId": "0e81fce6-dd05-4dcb-9cc1-1bfedfd001d1",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "dbd63d7d-3048-4f3e-a068-d891e14f517b",
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "c8ea502e-ae28-47dd-9b90-484d50083243",
-                                "layerType": "data"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0",
-                    "w": 24,
-                    "x": 24,
-                    "y": 60
-                },
-                "panelIndex": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0",
-                "title": "Top 10 Device Host ID with Highest Model Breach [Logs Darktrace]",
-                "type": "lens",
-                "version": "8.7.1"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-88c07c59-c625-4652-8156-54991d0869d8",
                                 "type": "index-pattern"
                             }
@@ -1190,6 +1085,111 @@
                 },
                 "panelIndex": "889bb859-0938-46a4-b078-30f5fedd10a7",
                 "title": "Distribution of Model Breach Alerts by Antigena Action [Logs Darktrace]",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-c8ea502e-ae28-47dd-9b90-484d50083243",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "c8ea502e-ae28-47dd-9b90-484d50083243": {
+                                            "columnOrder": [
+                                                "0e81fce6-dd05-4dcb-9cc1-1bfedfd001d1",
+                                                "dbd63d7d-3048-4f3e-a068-d891e14f517b"
+                                            ],
+                                            "columns": {
+                                                "0e81fce6-dd05-4dcb-9cc1-1bfedfd001d1": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Device Host ID",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "dbd63d7d-3048-4f3e-a068-d891e14f517b",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "host.id"
+                                                },
+                                                "dbd63d7d-3048-4f3e-a068-d891e14f517b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "unique_count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "darktrace.model_breach_alert.pbid"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset : \"darktrace.model_breach_alert\""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "alignment": "left",
+                                        "columnId": "0e81fce6-dd05-4dcb-9cc1-1bfedfd001d1",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "dbd63d7d-3048-4f3e-a068-d891e14f517b",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "c8ea502e-ae28-47dd-9b90-484d50083243",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0",
+                    "w": 24,
+                    "x": 24,
+                    "y": 60
+                },
+                "panelIndex": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0",
+                "title": "Top 10 Device Host ID with Highest Model Breach [Logs Darktrace]",
                 "type": "lens",
                 "version": "8.7.1"
             },
@@ -1307,77 +1307,138 @@
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [
-                                {
-                                    "enabled": true,
-                                    "id": "1",
-                                    "params": {
-                                        "customLabel": "Tag Cloud",
-                                        "emptyAsNull": false,
-                                        "field": "darktrace.model_breach_alert.pbid"
-                                    },
-                                    "schema": "metric",
-                                    "type": "cardinality"
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-0ec8ccf8-0e4f-407a-bb36-2a023091372d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "0ec8ccf8-0e4f-407a-bb36-2a023091372d": {
+                                            "columnOrder": [
+                                                "efb215c1-4adc-4670-921e-792eaea510ac",
+                                                "6b1f5241-4a07-4f2f-9086-690ed4c7b7a6"
+                                            ],
+                                            "columns": {
+                                                "6b1f5241-4a07-4f2f-9086-690ed4c7b7a6": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "efb215c1-4adc-4670-921e-792eaea510ac": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Mitre Techniques",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "6b1f5241-4a07-4f2f-9086-690ed4c7b7a6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "threat.technique.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
                                 },
-                                {
-                                    "enabled": true,
-                                    "id": "2",
-                                    "params": {
-                                        "customLabel": "Mitre Techniques",
-                                        "field": "threat.technique.name",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": false,
-                                        "otherBucketLabel": "Other",
-                                        "size": 10
-                                    },
-                                    "schema": "segment",
-                                    "type": "terms"
+                                "textBased": {
+                                    "layers": {}
                                 }
-                            ],
-                            "searchSource": {
-                                "filter": [],
-                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": "data_stream.dataset : \"darktrace.model_breach_alert\""
-                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "6b1f5241-4a07-4f2f-9086-690ed4c7b7a6"
+                                        ],
+                                        "layerId": "0ec8ccf8-0e4f-407a-bb36-2a023091372d",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "efb215c1-4adc-4670-921e-792eaea510ac"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
                             }
                         },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "maxFontSize": 72,
-                            "minFontSize": 18,
-                            "orientation": "single",
-                            "palette": {
-                                "name": "default",
-                                "type": "palette"
-                            },
-                            "scale": "linear",
-                            "showLabel": true
-                        },
                         "title": "",
-                        "type": "tagcloud",
-                        "uiState": {}
-                    }
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 23,
-                    "i": "12736f17-d97c-4f4c-a66b-5eba7c2fec9c",
+                    "i": "d0dcf71d-0e76-407c-b9c2-be378b9f23d3",
                     "w": 48,
                     "x": 0,
                     "y": 94
                 },
-                "panelIndex": "12736f17-d97c-4f4c-a66b-5eba7c2fec9c",
+                "panelIndex": "d0dcf71d-0e76-407c-b9c2-be378b9f23d3",
                 "title": "Top Mitre Techniques [Logs Darktrace]",
-                "type": "visualization",
+                "type": "lens",
                 "version": "8.7.1"
             },
             {
@@ -1402,7 +1463,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-12T04:11:37.771Z",
+    "created_at": "2023-07-12T04:15:47.528Z",
     "id": "darktrace-da768d80-1399-11ed-bdc1-9f13147efcf8",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -1505,22 +1566,22 @@
         },
         {
             "id": "logs-*",
-            "name": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0:indexpattern-datasource-layer-c8ea502e-ae28-47dd-9b90-484d50083243",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "889bb859-0938-46a4-b078-30f5fedd10a7:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
             "name": "889bb859-0938-46a4-b078-30f5fedd10a7:indexpattern-datasource-layer-88c07c59-c625-4652-8156-54991d0869d8",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "7c6faaf4-5d0c-49a1-b1d2-605f18e675b0:indexpattern-datasource-layer-c8ea502e-ae28-47dd-9b90-484d50083243",
             "type": "index-pattern"
         },
         {
@@ -1535,7 +1596,7 @@
         },
         {
             "id": "logs-*",
-            "name": "12736f17-d97c-4f4c-a66b-5eba7c2fec9c:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "name": "d0dcf71d-0e76-407c-b9c2-be378b9f23d3:indexpattern-datasource-layer-0ec8ccf8-0e4f-407a-bb36-2a023091372d",
             "type": "index-pattern"
         },
         {

--- a/packages/darktrace/kibana/dashboard/darktrace-eb643d20-13a5-11ed-bdc1-9f13147efcf8.json
+++ b/packages/darktrace/kibana/dashboard/darktrace-eb643d20-13a5-11ed-bdc1-9f13147efcf8.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Darktrace AI Analyst Alerts Overview.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [],
@@ -14,6 +13,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -39,7 +40,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1f84b818-192c-4dca-b929-1884e060576b": {
                                             "columnOrder": [
@@ -94,12 +95,15 @@
                             "visualization": {
                                 "accessor": "367e5418-6e25-45f2-b5fc-6ddd3618b869",
                                 "layerId": "1f84b818-192c-4dca-b929-1884e060576b",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -114,7 +118,7 @@
                 "panelIndex": "e28c7c69-2ae8-46fd-b361-38be020491a8",
                 "title": "Count of User Triggered AI Analyst Investigation [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -138,7 +142,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1f84b818-192c-4dca-b929-1884e060576b": {
                                             "columnOrder": [
@@ -193,12 +197,15 @@
                             "visualization": {
                                 "accessor": "367e5418-6e25-45f2-b5fc-6ddd3618b869",
                                 "layerId": "1f84b818-192c-4dca-b929-1884e060576b",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -213,7 +220,7 @@
                 "panelIndex": "be1b9c5a-2ea0-48ac-8ad6-221769ff83f9",
                 "title": "Count of Externally Triggered AI Analyst Investigation [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -237,7 +244,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1f84b818-192c-4dca-b929-1884e060576b": {
                                             "columnOrder": [
@@ -292,12 +299,15 @@
                             "visualization": {
                                 "accessor": "367e5418-6e25-45f2-b5fc-6ddd3618b869",
                                 "layerId": "1f84b818-192c-4dca-b929-1884e060576b",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -312,7 +322,7 @@
                 "panelIndex": "034d5870-b571-4276-9fad-1495a3665eed",
                 "title": "Count of Acknowledged AI Analyst Alerts [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -331,7 +341,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "66afac91-ca1e-4a4a-ab0d-e18a2903ace7": {
                                             "columnOrder": [
@@ -388,15 +398,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "6e2b5d5b-0584-412f-a87f-b60279d2173d"
-                                        ],
                                         "layerId": "66afac91-ca1e-4a4a-ab0d-e18a2903ace7",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "8f546d14-cc1d-4d80-8cec-8e326bfd19d1",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "8f546d14-cc1d-4d80-8cec-8e326bfd19d1"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "6e2b5d5b-0584-412f-a87f-b60279d2173d"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -419,7 +432,7 @@
                 "panelIndex": "65f35405-87eb-4a98-a0c2-2e3c7426cb28",
                 "title": "Distribution of AI Analyst Alerts by Behavior Category [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -438,7 +451,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "effe003f-604a-49a3-a903-d4d2c75df944": {
                                             "columnOrder": [
@@ -507,6 +520,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -531,7 +545,7 @@
                 "panelIndex": "8882d78e-7df8-4d33-b7b5-e21f5d25dfe7",
                 "title": "Distribution of AI Analyst Alerts by Summariser [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -550,7 +564,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "dea45bd8-269e-48c4-98d3-fc47717ae139": {
                                             "columnOrder": [
@@ -637,7 +651,7 @@
                 "panelIndex": "6b003410-fd00-4dc5-b9c7-8bd1f711ffbe",
                 "title": "Top 10 AI Analyst Alerts with Highest Score [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -656,7 +670,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "3bb3b1dd-30aa-46d6-8a14-32c14c706f47": {
                                             "columnOrder": [
@@ -741,7 +755,7 @@
                 "panelIndex": "930d2983-f872-4001-ba45-b44aee791167",
                 "title": "Top 10 BreachDevices Hostname with Highest AI Analyst Alerts [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -760,7 +774,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9eda772e-1fbd-4296-a543-8bbd18b2359a": {
                                             "columnOrder": [
@@ -847,7 +861,7 @@
                 "panelIndex": "7e4d0098-0cc8-403d-aaca-92758d697950",
                 "title": "Top 10 AI Analyst Alerts with Highest Group Score [Logs Darktrace]",
                 "type": "lens",
-                "version": "8.2.1"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -863,17 +877,18 @@
                 "panelIndex": "4ce4eb50-af35-423a-b20f-61a715aa4388",
                 "panelRefName": "panel_4ce4eb50-af35-423a-b20f-61a715aa4388",
                 "type": "search",
-                "version": "8.2.1"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Darktrace] AI Analyst Alerts Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.2.1",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:11:46.485Z",
     "id": "darktrace-eb643d20-13a5-11ed-bdc1-9f13147efcf8",
     "migrationVersion": {
-        "dashboard": "8.2.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/darktrace/kibana/search/darktrace-31a3f8a0-13a3-11ed-bdc1-9f13147efcf8.json
+++ b/packages/darktrace/kibana/search/darktrace-31a3f8a0-13a3-11ed-bdc1-9f13147efcf8.json
@@ -28,7 +28,8 @@
         ],
         "title": "Model Breach Alerts Essential Details [Logs Darktrace]"
     },
-    "coreMigrationVersion": "8.2.1",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:10:39.307Z",
     "id": "darktrace-31a3f8a0-13a3-11ed-bdc1-9f13147efcf8",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/darktrace/kibana/search/darktrace-c0e40350-13aa-11ed-bdc1-9f13147efcf8.json
+++ b/packages/darktrace/kibana/search/darktrace-c0e40350-13aa-11ed-bdc1-9f13147efcf8.json
@@ -28,7 +28,8 @@
         ],
         "title": "AI Analyst Alerts Essential Details [Logs Darktrace]"
     },
-    "coreMigrationVersion": "8.2.1",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:10:39.307Z",
     "id": "darktrace-c0e40350-13aa-11ed-bdc1-9f13147efcf8",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/darktrace/kibana/search/darktrace-fbf9cfc0-13b3-11ed-bdc1-9f13147efcf8.json
+++ b/packages/darktrace/kibana/search/darktrace-fbf9cfc0-13b3-11ed-bdc1-9f13147efcf8.json
@@ -29,7 +29,8 @@
         ],
         "title": "System Status Alerts Essential Details [Logs Darktrace]"
     },
-    "coreMigrationVersion": "8.2.1",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:10:39.307Z",
     "id": "darktrace-fbf9cfc0-13b3-11ed-bdc1-9f13147efcf8",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/darktrace/manifest.yml
+++ b/packages/darktrace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: darktrace
 title: Darktrace
-version: "1.5.0"
+version: "1.6.0"
 description: Collect logs from Darktrace with Elastic Agent.
 type: integration
 categories:

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Convert visualizations to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6924
 - version: "1.5.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/infoblox_bloxone_ddi/kibana/dashboard/infoblox_bloxone_ddi-85daef90-0ce7-11ed-8a96-d11b53f3d359.json
+++ b/packages/infoblox_bloxone_ddi/kibana/dashboard/infoblox_bloxone_ddi-85daef90-0ce7-11ed-8a96-d11b53f3d359.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Overview of Infoblox BloxOne DDI DHCP Lease.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -56,7 +57,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0f39755d-9919-4b22-baf7-aaef264be212": {
                                             "columnOrder": [
@@ -90,7 +91,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -119,6 +120,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -149,7 +151,7 @@
                 "panelIndex": "787837bf-ae0a-4079-a028-2e31a1e3774e",
                 "title": "Distribution of Events by Protocol [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -168,7 +170,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "6c6f049f-acb4-4fcb-a794-5bc75829aa4c": {
                                             "columnOrder": [
@@ -183,7 +185,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "5575e5c2-6223-4317-9a33-5370ed22f610": {
                                                     "customLabel": true,
@@ -227,7 +229,9 @@
                                     }
                                 ],
                                 "layerId": "6c6f049f-acb4-4fcb-a794-5bc75829aa4c",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -247,7 +251,7 @@
                 "panelIndex": "96e5e038-7865-4a0a-bdd3-8b915c7be91b",
                 "title": "Top 10 Host Name [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -266,7 +270,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "19f9c3d5-3fd4-4142-92e2-1b3c57af397a": {
                                             "columnOrder": [
@@ -281,7 +285,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "f1f10540-9928-411e-afd6-9deed825c323": {
                                                     "customLabel": true,
@@ -317,15 +321,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "f1f10540-9928-411e-afd6-9deed825c323"
-                                        ],
                                         "layerId": "19f9c3d5-3fd4-4142-92e2-1b3c57af397a",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "17c881a1-b60e-430e-9836-de551602c8c3",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "17c881a1-b60e-430e-9836-de551602c8c3"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "f1f10540-9928-411e-afd6-9deed825c323"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -348,7 +355,7 @@
                 "panelIndex": "9baea1e0-7803-4bbe-b4e2-ed03e1589afa",
                 "title": "Distribution of Events by Type [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -367,7 +374,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "e0e5694c-e3bb-4186-9f26-7e734c94ad83": {
                                             "columnOrder": [
@@ -382,7 +389,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "bfb244af-5bbc-4f29-a50b-6d4bbabc1fcb": {
                                                     "customLabel": true,
@@ -418,15 +425,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "bfb244af-5bbc-4f29-a50b-6d4bbabc1fcb"
-                                        ],
                                         "layerId": "e0e5694c-e3bb-4186-9f26-7e734c94ad83",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "a7b437d6-9d78-4392-980b-a8548cb5ac20",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "a7b437d6-9d78-4392-980b-a8548cb5ac20"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "bfb244af-5bbc-4f29-a50b-6d4bbabc1fcb"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -449,7 +459,7 @@
                 "panelIndex": "d9edc7fd-4587-4423-9f62-bb383b52ef28",
                 "title": "Distribution of Events by Host [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -468,7 +478,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "4f508d4b-b035-447c-98ea-d2072e82dd85": {
                                             "columnOrder": [
@@ -502,7 +512,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -531,6 +541,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -561,17 +572,18 @@
                 "panelIndex": "68968f24-d04d-4f57-a575-4a82672e67eb",
                 "title": "Distribution of Events by State [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Infoblox BloxOne DDI] DHCP Lease",
         "version": 1
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:00:33.194Z",
     "id": "infoblox_bloxone_ddi-85daef90-0ce7-11ed-8a96-d11b53f3d359",
     "migrationVersion": {
-        "dashboard": "7.17.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/infoblox_bloxone_ddi/kibana/dashboard/infoblox_bloxone_ddi-b8497140-0cdd-11ed-8a96-d11b53f3d359.json
+++ b/packages/infoblox_bloxone_ddi/kibana/dashboard/infoblox_bloxone_ddi-b8497140-0cdd-11ed-8a96-d11b53f3d359.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Overview of Infoblox BloxOne DDI DNS Data.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -56,7 +57,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "492dce9b-ecc9-466a-ad17-c801a56b2578": {
                                             "columnOrder": [
@@ -71,7 +72,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "f5b2adb7-c7f0-47d1-afef-cffbe74cbed3": {
                                                     "customLabel": true,
@@ -119,6 +120,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -149,7 +151,7 @@
                 "panelIndex": "d0d0f6b9-d632-47de-bcc6-54bce4e679f2",
                 "title": "Distribution of Events by TTL Action [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -168,7 +170,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "4948d9b6-bab5-48f2-a031-46e87a884637": {
                                             "columnOrder": [
@@ -183,7 +185,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "eb2e31f6-4e2c-4eaf-8120-fa19e2db7008": {
                                                     "customLabel": true,
@@ -227,7 +229,9 @@
                                     }
                                 ],
                                 "layerId": "4948d9b6-bab5-48f2-a031-46e87a884637",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -247,7 +251,7 @@
                 "panelIndex": "7eb4f1b6-29ea-45f9-bab5-a0343594726b",
                 "title": "Top 10 TTL Source Name [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -266,7 +270,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c0b7ca44-dfc2-4e69-9fdf-a67439d1b290": {
                                             "columnOrder": [
@@ -281,7 +285,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "af4e6514-1ab8-4963-994e-f25bee46936b": {
                                                     "customLabel": true,
@@ -317,15 +321,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "af4e6514-1ab8-4963-994e-f25bee46936b"
-                                        ],
                                         "layerId": "c0b7ca44-dfc2-4e69-9fdf-a67439d1b290",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "83233299-085a-4f13-8916-0f254e2fbb7a",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "83233299-085a-4f13-8916-0f254e2fbb7a"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "af4e6514-1ab8-4963-994e-f25bee46936b"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -348,7 +355,7 @@
                 "panelIndex": "a8079745-b78b-4daa-bb29-638e498e4c96",
                 "title": "Distribution of Events by DNS Absolute Zone Name [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -367,7 +374,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "040c65c3-7b12-43b0-bfa5-e2c535634de6": {
                                             "columnOrder": [
@@ -401,7 +408,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -418,15 +425,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "232a8505-70be-447c-9286-218aeaabddc7"
-                                        ],
                                         "layerId": "040c65c3-7b12-43b0-bfa5-e2c535634de6",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "ec8a44d6-1b97-4077-9e93-986973e7acff",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "ec8a44d6-1b97-4077-9e93-986973e7acff"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "232a8505-70be-447c-9286-218aeaabddc7"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -449,7 +459,7 @@
                 "panelIndex": "fecabbc6-727d-4798-8eaa-f5f553a53d47",
                 "title": "Distribution of Events by Type [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -468,7 +478,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7db7df97-c91b-417a-a146-72c6f2ac8d91": {
                                             "columnOrder": [
@@ -502,7 +512,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -519,15 +529,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "5a0c5a1b-a645-4579-a7b4-d24d4d128175"
-                                        ],
                                         "layerId": "7db7df97-c91b-417a-a146-72c6f2ac8d91",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "e1bea059-147f-4dea-a55f-f3d1a5f41e2e",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "e1bea059-147f-4dea-a55f-f3d1a5f41e2e"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "5a0c5a1b-a645-4579-a7b4-d24d4d128175"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -550,7 +563,7 @@
                 "panelIndex": "63226a08-6f74-4817-9a08-21d93d3dc00f",
                 "title": "Distribution of Events by View Name [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -569,7 +582,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a6b9c902-06c7-4274-8831-8fab7e860319": {
                                             "columnOrder": [
@@ -603,7 +616,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -628,7 +641,9 @@
                                     }
                                 ],
                                 "layerId": "a6b9c902-06c7-4274-8831-8fab7e860319",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -648,7 +663,7 @@
                 "panelIndex": "8f0234c4-f3f1-48c8-8f43-4731cd958b70",
                 "title": "Top 10 Host Address [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -667,7 +682,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1cb8734b-97ec-4693-916c-950178d12555": {
                                             "columnOrder": [
@@ -682,7 +697,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "9a412a97-ba89-4765-8f22-0413ec2db942": {
                                                     "customLabel": true,
@@ -718,15 +733,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "9a412a97-ba89-4765-8f22-0413ec2db942"
-                                        ],
                                         "layerId": "1cb8734b-97ec-4693-916c-950178d12555",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "5324359a-19f9-4039-be9b-2817abe8d788",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "5324359a-19f9-4039-be9b-2817abe8d788"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "9a412a97-ba89-4765-8f22-0413ec2db942"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -749,7 +767,7 @@
                 "panelIndex": "a549ae88-b384-4a37-bbe9-8d5fd54f1a2b",
                 "title": "Distribution of Events by Resource Record Value [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -768,7 +786,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "42c0d34a-142e-4761-8619-137862ca3e49": {
                                             "columnOrder": [
@@ -783,7 +801,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "e47e7765-58a0-4694-ba84-1c973f735455": {
                                                     "customLabel": true,
@@ -831,6 +849,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -861,7 +880,7 @@
                 "panelIndex": "ab1a9322-c074-44d4-a12c-d6b4d394b8fd",
                 "title": "Distribution of Events by Canonical Owner Name [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -880,7 +899,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9011083b-774e-4cc5-a099-ac6130fce672": {
                                             "columnOrder": [
@@ -895,7 +914,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "b9a3ffe3-6c09-4a3f-bcb8-cff54b24a9b1": {
                                                     "customLabel": true,
@@ -931,15 +950,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "b9a3ffe3-6c09-4a3f-bcb8-cff54b24a9b1"
-                                        ],
                                         "layerId": "9011083b-774e-4cc5-a099-ac6130fce672",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "27a04a1c-883b-4514-bf1d-0f51885ed8f6",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "27a04a1c-883b-4514-bf1d-0f51885ed8f6"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "b9a3ffe3-6c09-4a3f-bcb8-cff54b24a9b1"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -962,17 +984,18 @@
                 "panelIndex": "00a91cfd-1761-4308-8443-b2a2208c8630",
                 "title": "Distribution of Events by Resource Record Type [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Infoblox BloxOne DDI] DNS Data",
         "version": 1
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:00:42.067Z",
     "id": "infoblox_bloxone_ddi-b8497140-0cdd-11ed-8a96-d11b53f3d359",
     "migrationVersion": {
-        "dashboard": "7.17.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/infoblox_bloxone_ddi/kibana/dashboard/infoblox_bloxone_ddi-d3f8a270-0ce3-11ed-8a96-d11b53f3d359.json
+++ b/packages/infoblox_bloxone_ddi/kibana/dashboard/infoblox_bloxone_ddi-d3f8a270-0ce3-11ed-8a96-d11b53f3d359.json
@@ -359,75 +359,138 @@
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [
-                                {
-                                    "enabled": true,
-                                    "id": "1",
-                                    "params": {
-                                        "customLabel": ""
-                                    },
-                                    "schema": "metric",
-                                    "type": "count"
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-d90ac07a-579d-497e-b3b4-10913e5174d3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "d90ac07a-579d-497e-b3b4-10913e5174d3": {
+                                            "columnOrder": [
+                                                "ac666f11-85af-4d06-b512-3973d0033bf0",
+                                                "01cd35f7-1488-4e41-98c8-59521158d979"
+                                            ],
+                                            "columns": {
+                                                "01cd35f7-1488-4e41-98c8-59521158d979": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "ac666f11-85af-4d06-b512-3973d0033bf0": {
+                                                    "customLabel": true,
+                                                    "dataType": "ip",
+                                                    "isBucketed": true,
+                                                    "label": "Custom Root Name Server Address",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "01cd35f7-1488-4e41-98c8-59521158d979",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "infoblox_bloxone_ddi.dns_config.custom_root_ns.address"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
                                 },
-                                {
-                                    "enabled": true,
-                                    "id": "2",
-                                    "params": {
-                                        "customLabel": "Custom Root Name Server Address",
-                                        "field": "infoblox_bloxone_ddi.dns_config.custom_root_ns.address",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": true,
-                                        "otherBucketLabel": "Other",
-                                        "size": 20
-                                    },
-                                    "schema": "segment",
-                                    "type": "terms"
+                                "textBased": {
+                                    "layers": {}
                                 }
-                            ],
-                            "searchSource": {
-                                "filter": [],
-                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "01cd35f7-1488-4e41-98c8-59521158d979"
+                                        ],
+                                        "layerId": "d90ac07a-579d-497e-b3b4-10913e5174d3",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "ac666f11-85af-4d06-b512-3973d0033bf0"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
                             }
                         },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "maxFontSize": 72,
-                            "minFontSize": 18,
-                            "orientation": "single",
-                            "palette": {
-                                "name": "default",
-                                "type": "palette"
-                            },
-                            "scale": "linear",
-                            "showLabel": true
-                        },
                         "title": "",
-                        "type": "tagcloud",
-                        "uiState": {}
-                    }
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "9d6f4983-8608-429b-95e7-56117041b778",
+                    "i": "dd7a25f6-48ce-404d-8f68-cbfc6d8928df",
                     "w": 24,
                     "x": 24,
                     "y": 15
                 },
-                "panelIndex": "9d6f4983-8608-429b-95e7-56117041b778",
+                "panelIndex": "dd7a25f6-48ce-404d-8f68-cbfc6d8928df",
                 "title": "Top Custom Root Name Server Address [Logs Infoblox BloxOne DDI]",
-                "type": "visualization",
+                "type": "lens",
                 "version": "8.7.1"
             },
             {
@@ -554,106 +617,6 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-6b2013f5-e5d1-45e6-8760-439e960800f3",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "6b2013f5-e5d1-45e6-8760-439e960800f3": {
-                                            "columnOrder": [
-                                                "bed778ca-a359-43be-ad4c-5e32e7ba22d8",
-                                                "6121b332-c55b-4b89-b3d3-45dbd76c1cfe"
-                                            ],
-                                            "columns": {
-                                                "6121b332-c55b-4b89-b3d3-45dbd76c1cfe": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count",
-                                                    "operationType": "count",
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "bed778ca-a359-43be-ad4c-5e32e7ba22d8": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Outgoing Query Source",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "6121b332-c55b-4b89-b3d3-45dbd76c1cfe",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "infoblox_bloxone_ddi.dns_config.inheritance.sources.add_edns.option_in.outgoing_query.source"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "bed778ca-a359-43be-ad4c-5e32e7ba22d8",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "6121b332-c55b-4b89-b3d3-45dbd76c1cfe",
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "6b2013f5-e5d1-45e6-8760-439e960800f3",
-                                "layerType": "data",
-                                "rowHeight": "single",
-                                "rowHeightLines": 1
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "3ef011d9-9870-4357-bf7b-8b4baa0ae570",
-                    "w": 24,
-                    "x": 24,
-                    "y": 30
-                },
-                "panelIndex": "3ef011d9-9870-4357-bf7b-8b4baa0ae570",
-                "title": "Top 10 Outgoing Query Source [Logs Infoblox BloxOne DDI]",
-                "type": "lens",
-                "version": "8.7.1"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-4f221e65-f5b8-446f-90d3-a05571f889ed",
                                 "type": "index-pattern"
                             }
@@ -744,6 +707,106 @@
                 },
                 "panelIndex": "2f7542b5-9c17-4e1c-944d-3820afa497ce",
                 "title": "Distribution of Events by Zone Authority Master Name [Logs Infoblox BloxOne DDI]",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-6b2013f5-e5d1-45e6-8760-439e960800f3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "6b2013f5-e5d1-45e6-8760-439e960800f3": {
+                                            "columnOrder": [
+                                                "bed778ca-a359-43be-ad4c-5e32e7ba22d8",
+                                                "6121b332-c55b-4b89-b3d3-45dbd76c1cfe"
+                                            ],
+                                            "columns": {
+                                                "6121b332-c55b-4b89-b3d3-45dbd76c1cfe": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "bed778ca-a359-43be-ad4c-5e32e7ba22d8": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Outgoing Query Source",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "6121b332-c55b-4b89-b3d3-45dbd76c1cfe",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "infoblox_bloxone_ddi.dns_config.inheritance.sources.add_edns.option_in.outgoing_query.source"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "bed778ca-a359-43be-ad4c-5e32e7ba22d8",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "6121b332-c55b-4b89-b3d3-45dbd76c1cfe",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "6b2013f5-e5d1-45e6-8760-439e960800f3",
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "3ef011d9-9870-4357-bf7b-8b4baa0ae570",
+                    "w": 24,
+                    "x": 24,
+                    "y": 30
+                },
+                "panelIndex": "3ef011d9-9870-4357-bf7b-8b4baa0ae570",
+                "title": "Top 10 Outgoing Query Source [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
                 "version": "8.7.1"
             },
@@ -873,7 +936,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-12T04:00:52.018Z",
+    "created_at": "2023-07-12T04:05:54.651Z",
     "id": "infoblox_bloxone_ddi-d3f8a270-0ce3-11ed-8a96-d11b53f3d359",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -916,7 +979,7 @@
         },
         {
             "id": "logs-*",
-            "name": "9d6f4983-8608-429b-95e7-56117041b778:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "name": "dd7a25f6-48ce-404d-8f68-cbfc6d8928df:indexpattern-datasource-layer-d90ac07a-579d-497e-b3b4-10913e5174d3",
             "type": "index-pattern"
         },
         {
@@ -931,22 +994,22 @@
         },
         {
             "id": "logs-*",
-            "name": "3ef011d9-9870-4357-bf7b-8b4baa0ae570:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "3ef011d9-9870-4357-bf7b-8b4baa0ae570:indexpattern-datasource-layer-6b2013f5-e5d1-45e6-8760-439e960800f3",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "2f7542b5-9c17-4e1c-944d-3820afa497ce:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
             "name": "2f7542b5-9c17-4e1c-944d-3820afa497ce:indexpattern-datasource-layer-4f221e65-f5b8-446f-90d3-a05571f889ed",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "3ef011d9-9870-4357-bf7b-8b4baa0ae570:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "3ef011d9-9870-4357-bf7b-8b4baa0ae570:indexpattern-datasource-layer-6b2013f5-e5d1-45e6-8760-439e960800f3",
             "type": "index-pattern"
         },
         {

--- a/packages/infoblox_bloxone_ddi/kibana/dashboard/infoblox_bloxone_ddi-d3f8a270-0ce3-11ed-8a96-d11b53f3d359.json
+++ b/packages/infoblox_bloxone_ddi/kibana/dashboard/infoblox_bloxone_ddi-d3f8a270-0ce3-11ed-8a96-d11b53f3d359.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Overview of Infoblox BloxOne DDI DNS Config.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -56,7 +57,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "cba386eb-2f07-4c35-9a1c-57937a5d37db": {
                                             "columnOrder": [
@@ -71,7 +72,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "46922848-22a1-4583-add0-66c83d05e7fc": {
                                                     "customLabel": true,
@@ -115,7 +116,9 @@
                                     }
                                 ],
                                 "layerId": "cba386eb-2f07-4c35-9a1c-57937a5d37db",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -135,7 +138,7 @@
                 "panelIndex": "8a5670b8-9772-40e6-adc9-743fddfcb93a",
                 "title": "Top 10 Custom Root Name Server FQDN [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -154,7 +157,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "49c44c59-cb39-48ca-8c38-6d604857fae7": {
                                             "columnOrder": [
@@ -188,7 +191,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -205,15 +208,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "6945ac46-ff4f-4d1c-9314-1e8ddbf0d3a6"
-                                        ],
                                         "layerId": "49c44c59-cb39-48ca-8c38-6d604857fae7",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "707209ce-b61a-4765-9303-530ed1a26b33",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "707209ce-b61a-4765-9303-530ed1a26b33"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "6945ac46-ff4f-4d1c-9314-1e8ddbf0d3a6"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -236,7 +242,7 @@
                 "panelIndex": "9367e11d-a6ff-4e4d-8c91-ab8c3aa3bd28",
                 "title": "Distribution of Events by Outgoing Query Action [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -255,7 +261,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "dd5c94ed-e107-49e3-ab06-d9cb924653ed": {
                                             "columnOrder": [
@@ -270,7 +276,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "cc7b0f96-eddc-4c03-84fc-3d4d28167d63": {
                                                     "customLabel": true,
@@ -318,6 +324,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -348,7 +355,7 @@
                 "panelIndex": "d6f2c59a-ce94-4356-98af-91e7bc6cceed",
                 "title": "Distribution of Events by ECS Block Action [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -386,7 +393,7 @@
                             ],
                             "searchSource": {
                                 "filter": [],
-                                "index": "logs-*",
+                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                                 "query": {
                                     "language": "kuery",
                                     "query": ""
@@ -421,7 +428,7 @@
                 "panelIndex": "9d6f4983-8608-429b-95e7-56117041b778",
                 "title": "Top Custom Root Name Server Address [Logs Infoblox BloxOne DDI]",
                 "type": "visualization",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -440,7 +447,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "eb849a44-0dfe-427d-99dd-be95e3050965": {
                                             "columnOrder": [
@@ -474,7 +481,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -503,6 +510,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -533,7 +541,7 @@
                 "panelIndex": "f6643ae2-2e62-46ae-a200-5012ac25de36",
                 "title": "Distribution of Events by ECS Zone Access [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -552,7 +560,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "6b2013f5-e5d1-45e6-8760-439e960800f3": {
                                             "columnOrder": [
@@ -567,7 +575,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "bed778ca-a359-43be-ad4c-5e32e7ba22d8": {
                                                     "customLabel": true,
@@ -611,7 +619,9 @@
                                     }
                                 ],
                                 "layerId": "6b2013f5-e5d1-45e6-8760-439e960800f3",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -631,7 +641,7 @@
                 "panelIndex": "3ef011d9-9870-4357-bf7b-8b4baa0ae570",
                 "title": "Top 10 Outgoing Query Source [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -650,7 +660,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "4f221e65-f5b8-446f-90d3-a05571f889ed": {
                                             "columnOrder": [
@@ -665,7 +675,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "8235e883-949c-4216-ba74-cd53c5ad3b41": {
                                                     "customLabel": true,
@@ -701,15 +711,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "8235e883-949c-4216-ba74-cd53c5ad3b41"
-                                        ],
                                         "layerId": "4f221e65-f5b8-446f-90d3-a05571f889ed",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "33c6bac1-bfb5-4b6c-a4e5-e85a5193621c",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "33c6bac1-bfb5-4b6c-a4e5-e85a5193621c"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "8235e883-949c-4216-ba74-cd53c5ad3b41"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -732,7 +745,7 @@
                 "panelIndex": "2f7542b5-9c17-4e1c-944d-3820afa497ce",
                 "title": "Distribution of Events by Zone Authority Master Name [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -751,7 +764,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "ca4bfffe-6a9f-413a-869c-58d1646363f2": {
                                             "columnOrder": [
@@ -766,7 +779,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "f15cb334-4cde-4a69-ac70-14739f098e98": {
                                                     "customLabel": true,
@@ -802,15 +815,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "f15cb334-4cde-4a69-ac70-14739f098e98"
-                                        ],
                                         "layerId": "ca4bfffe-6a9f-413a-869c-58d1646363f2",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "5f223db3-7560-49ec-a024-7266360e5e5f",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "5f223db3-7560-49ec-a024-7266360e5e5f"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "f15cb334-4cde-4a69-ac70-14739f098e98"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -833,7 +849,7 @@
                 "panelIndex": "2c27ed27-b814-4462-bd64-e99cd0d4f363",
                 "title": "Distribution of Events by Default TTL source [Logs Infoblox BloxOne DDI]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -849,17 +865,18 @@
                 "panelIndex": "f288d1dd-c4dc-472c-a7ac-6c5173b348a1",
                 "panelRefName": "panel_f288d1dd-c4dc-472c-a7ac-6c5173b348a1",
                 "type": "search",
-                "version": "7.17.0"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Infoblox BloxOne DDI] DNS Config",
         "version": 1
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:00:52.018Z",
     "id": "infoblox_bloxone_ddi-d3f8a270-0ce3-11ed-8a96-d11b53f3d359",
     "migrationVersion": {
-        "dashboard": "7.17.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/infoblox_bloxone_ddi/kibana/search/infoblox_bloxone_ddi-86860980-34f0-11ed-a2eb-7fc0c8a128fe.json
+++ b/packages/infoblox_bloxone_ddi/kibana/search/infoblox_bloxone_ddi-86860980-34f0-11ed-a2eb-7fc0c8a128fe.json
@@ -26,10 +26,11 @@
         ],
         "title": "DNS Config Events by Protocol Zone [Logs Infoblox BloxOne DDI]"
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T03:59:42.787Z",
     "id": "infoblox_bloxone_ddi-86860980-34f0-11ed-a2eb-7fc0c8a128fe",
     "migrationVersion": {
-        "search": "7.9.3"
+        "search": "8.0.0"
     },
     "references": [
         {

--- a/packages/infoblox_bloxone_ddi/manifest.yml
+++ b/packages/infoblox_bloxone_ddi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: infoblox_bloxone_ddi
 title: Infoblox BloxOne DDI
-version: "1.5.0"
+version: "1.6.0"
 description: Collect logs from Infoblox BloxOne DDI with Elastic Agent.
 type: integration
 categories:

--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.4.0"
   changes:
-    - description: Convert vizualisations to lens.
+    - description: Convert visualizations to lens.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6924
 - version: "1.3.0"

--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Convert vizualisations to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6924
 - version: "1.3.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/jamf_compliance_reporter/kibana/dashboard/jamf_compliance_reporter-8351fc80-b58c-11ec-a813-df29637f29df.json
+++ b/packages/jamf_compliance_reporter/kibana/dashboard/jamf_compliance_reporter-8351fc80-b58c-11ec-a813-df29637f29df.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "This dashboard shows audit logs collected by the Jamf Compliance Reporter integration.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -57,6 +56,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -78,7 +79,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "75d7a5a3-51eb-4651-919f-aa2e631f733a": {
                                             "columnOrder": [
@@ -112,7 +113,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -157,6 +158,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar",
@@ -191,7 +193,7 @@
                 "panelIndex": "31b29984-3ac9-42a8-a953-a9d3bd62ac7e",
                 "title": "Distribution of Audit Events by Return Description [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -211,7 +213,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a9476fe9-d7bc-4cf9-9974-39a2c4602cfd": {
                                             "columnOrder": [
@@ -245,7 +247,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -262,15 +264,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "7d2929e4-764e-45a0-8242-966ca8499b94"
-                                        ],
                                         "layerId": "a9476fe9-d7bc-4cf9-9974-39a2c4602cfd",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "9fa49f57-f6e3-4c76-b37b-1bc5d6bc72f8",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "9fa49f57-f6e3-4c76-b37b-1bc5d6bc72f8"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "7d2929e4-764e-45a0-8242-966ca8499b94"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -293,7 +298,7 @@
                 "panelIndex": "e4990652-7cd9-495d-abef-683a370b7c76",
                 "title": "Distribution of Audit Events by Host OS Version [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -313,7 +318,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "21b86cfe-db52-415d-82ed-c8b87d2224ee": {
                                             "columnOrder": [
@@ -347,7 +352,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -372,7 +377,9 @@
                                     }
                                 ],
                                 "layerId": "21b86cfe-db52-415d-82ed-c8b87d2224ee",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
@@ -392,7 +399,7 @@
                 "panelIndex": "413d94dd-512a-46cc-b635-38f52627cd67",
                 "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -412,7 +419,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "602a9bc7-89cd-42de-91ef-3ae97c4d8c47": {
                                             "columnOrder": [
@@ -446,7 +453,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -463,15 +470,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "1ecde91a-d905-4e8e-827f-a41af5b2e675"
-                                        ],
                                         "layerId": "602a9bc7-89cd-42de-91ef-3ae97c4d8c47",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "baa8de65-deac-4cf8-99e8-470b82de1c19",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "baa8de65-deac-4cf8-99e8-470b82de1c19"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "1ecde91a-d905-4e8e-827f-a41af5b2e675"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -494,7 +504,7 @@
                 "panelIndex": "3519cad4-7e76-4459-b44d-80623cabbcfb",
                 "title": "Distribution of Audit Events by Event Name [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -514,7 +524,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0ac4d2d0-01d2-41ec-a398-f70992b9cdc5": {
                                             "columnOrder": [
@@ -529,7 +539,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "44ed01c4-ebd8-4de7-9c6d-28c6bb7df5bb": {
                                                     "customLabel": true,
@@ -571,7 +581,9 @@
                                     }
                                 ],
                                 "layerId": "0ac4d2d0-01d2-41ec-a398-f70992b9cdc5",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Group Name [Logs Jamf Compliance Reporter]",
@@ -591,7 +603,7 @@
                 "panelIndex": "186d3b1c-415b-43d7-9ad7-21238d2b07ef",
                 "title": "Top 10 Group Name [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -611,7 +623,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "3ecddbbb-2392-457a-ab8f-965a26f154db": {
                                             "columnOrder": [
@@ -645,7 +657,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -668,7 +680,9 @@
                                     }
                                 ],
                                 "layerId": "3ecddbbb-2392-457a-ab8f-965a26f154db",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 User Name [Logs Jamf Compliance Reporter]",
@@ -688,7 +702,7 @@
                 "panelIndex": "05f51b9b-ec7b-4834-99f7-68e797bc4fe2",
                 "title": "Top 10 User Name [Logs Jamf Compliance Reporter] ",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -708,7 +722,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "54f391c9-12b8-4305-93dd-6710d4c2458d": {
                                             "columnOrder": [
@@ -723,7 +737,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "7af571ef-1ae1-456a-92d5-eb4ed16f2d3f": {
                                                     "customLabel": true,
@@ -768,7 +782,9 @@
                                     }
                                 ],
                                 "layerId": "54f391c9-12b8-4305-93dd-6710d4c2458d",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Event Score [Logs Jamf Compliance Reporter]",
@@ -788,7 +804,7 @@
                 "panelIndex": "83d65eb5-0d74-43ca-bbe9-ab5ec1aaec46",
                 "title": "Top 10 Event Score [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -808,7 +824,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "b3d2bd68-514b-486f-8741-933a0f0f1242": {
                                             "columnOrder": [
@@ -842,7 +858,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -867,7 +883,9 @@
                                     }
                                 ],
                                 "layerId": "b3d2bd68-514b-486f-8741-933a0f0f1242",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Process User Name for AUE_KILL and AUE_TASK Audit Events [Logs Jamf Compliance Reporter]",
@@ -887,17 +905,18 @@
                 "panelIndex": "d8a48988-c438-4031-b66b-297d6bbc3628",
                 "title": "Top 10 Process User Name for AUE_KILL and AUE_TASK Audit Events [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Jamf Compliance Reporter] Audit",
         "version": 1
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:23:40.069Z",
     "id": "jamf_compliance_reporter-8351fc80-b58c-11ec-a813-df29637f29df",
     "migrationVersion": {
-        "dashboard": "7.17.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/jamf_compliance_reporter/kibana/dashboard/jamf_compliance_reporter-dd0ea730-b557-11ec-a813-df29637f29df.json
+++ b/packages/jamf_compliance_reporter/kibana/dashboard/jamf_compliance_reporter-dd0ea730-b557-11ec-a813-df29637f29df.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "This dashboard shows events logs collected by the Jamf Compliance Reporter integration.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -57,6 +56,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -78,7 +79,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "dcd69ebb-72a3-4bc6-8a68-aca6570839c4": {
                                             "columnOrder": [
@@ -92,7 +93,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "24d71291-5bf6-4b24-8093-d41a22d03ccb": {
                                                     "customLabel": true,
@@ -128,15 +129,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "24d71291-5bf6-4b24-8093-d41a22d03ccb"
-                                        ],
                                         "layerId": "dcd69ebb-72a3-4bc6-8a68-aca6570839c4",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "218ddc14-154c-4fa9-bd43-d9206d2ec7f7",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "218ddc14-154c-4fa9-bd43-d9206d2ec7f7"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "24d71291-5bf6-4b24-8093-d41a22d03ccb"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -159,7 +163,7 @@
                 "panelIndex": "f28205e4-886e-4779-a8ea-db77dba9a68c",
                 "title": "Distribution of Events by OS Version [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -179,7 +183,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7c7ea45e-c87f-4cb2-b9d6-89a48ce29ff1": {
                                             "columnOrder": [
@@ -212,7 +216,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -229,15 +233,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "0e74bed0-d28e-4e06-a2d5-82307342929f"
-                                        ],
                                         "layerId": "7c7ea45e-c87f-4cb2-b9d6-89a48ce29ff1",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "9679ae52-ab95-4f5d-b3ae-6fa541a740e2",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "9679ae52-ab95-4f5d-b3ae-6fa541a740e2"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "0e74bed0-d28e-4e06-a2d5-82307342929f"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -260,7 +267,7 @@
                 "panelIndex": "d6fd6b7c-d5ff-45ba-b34c-5e17f1d877e1",
                 "title": "Distribution of Audio-Video Device Events by Device Status [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -280,7 +287,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "21cb8b72-ef0b-4afc-8b9f-6a0c7cc17217": {
                                             "columnOrder": [
@@ -313,7 +320,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -330,15 +337,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "0921b26e-7205-46b3-a34b-919c037be1e8"
-                                        ],
                                         "layerId": "21cb8b72-ef0b-4afc-8b9f-6a0c7cc17217",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "f55e245c-4b5c-45be-a2c1-f25f1acdc0aa",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "f55e245c-4b5c-45be-a2c1-f25f1acdc0aa"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "0921b26e-7205-46b3-a34b-919c037be1e8"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -361,7 +371,7 @@
                 "panelIndex": "d73f23b2-bd81-4c6f-86dd-bf792212a813",
                 "title": "Distribution of Audit Class Verification Info Events by Restored Default [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -381,7 +391,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7b72f6ca-f0b1-4c09-b1ff-11990af5c585": {
                                             "columnOrder": [
@@ -395,7 +405,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "b49b1b2a-c3cd-4bcf-88c2-4c4a356b72cf": {
                                                     "customLabel": true,
@@ -431,15 +441,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "b49b1b2a-c3cd-4bcf-88c2-4c4a356b72cf"
-                                        ],
                                         "layerId": "7b72f6ca-f0b1-4c09-b1ff-11990af5c585",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "5bae7737-7914-41f8-bcfd-e67162193c46",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "5bae7737-7914-41f8-bcfd-e67162193c46"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "b49b1b2a-c3cd-4bcf-88c2-4c4a356b72cf"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -462,7 +475,7 @@
                 "panelIndex": "18a9850d-21a1-45ea-85c3-a9c78f764f46",
                 "title": "Distribution of Events by Item Created [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -482,7 +495,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "81b3e742-4ad8-4120-9b3b-a9893773795a": {
                                             "columnOrder": [
@@ -496,7 +509,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "86771b4a-0cac-452c-b89e-0f8aa2c65c78": {
                                                     "customLabel": true,
@@ -532,15 +545,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "86771b4a-0cac-452c-b89e-0f8aa2c65c78"
-                                        ],
                                         "layerId": "81b3e742-4ad8-4120-9b3b-a9893773795a",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "20349cf6-37d1-4aaf-ba3d-f572e756e36d",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "20349cf6-37d1-4aaf-ba3d-f572e756e36d"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "86771b4a-0cac-452c-b89e-0f8aa2c65c78"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -563,7 +579,7 @@
                 "panelIndex": "f990bb47-c91a-4c84-88c2-0ed775024099",
                 "title": "Distribution of Events by Item Removed [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -583,7 +599,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "ad610b62-5183-4e71-86d4-52beca5327d7": {
                                             "columnOrder": [
@@ -616,7 +632,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -633,15 +649,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "2f2be0d6-224d-4a5a-bcc2-d6b62913955b"
-                                        ],
                                         "layerId": "ad610b62-5183-4e71-86d4-52beca5327d7",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "9608dee3-3f0b-4eaa-9af8-9b1d6ca38b38",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "9608dee3-3f0b-4eaa-9af8-9b1d6ca38b38"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "2f2be0d6-224d-4a5a-bcc2-d6b62913955b"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -664,7 +683,7 @@
                 "panelIndex": "c80a59ad-5830-4463-9978-642de750f3ff",
                 "title": "Distribution of Events by Item is File [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -684,7 +703,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "46eadc93-b435-41bd-8d5b-f31b5f6353e2": {
                                             "columnOrder": [
@@ -717,7 +736,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -734,15 +753,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "76bd9f5a-bbec-4a66-a070-df50aefd7bc4"
-                                        ],
                                         "layerId": "46eadc93-b435-41bd-8d5b-f31b5f6353e2",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "7ee52937-5505-4880-9489-4386bf2f5f43",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "7ee52937-5505-4880-9489-4386bf2f5f43"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "76bd9f5a-bbec-4a66-a070-df50aefd7bc4"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -765,7 +787,7 @@
                 "panelIndex": "2ba7af74-63e2-46b7-a37f-63415014804d",
                 "title": "Distribution of Events by Item is Directory [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -785,7 +807,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "e218b2a3-f801-4263-b10c-0d0a5c871703": {
                                             "columnOrder": [
@@ -818,7 +840,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -835,15 +857,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "233cd86a-9b66-4ddc-a4e6-b4e0cb2a12b3"
-                                        ],
                                         "layerId": "e218b2a3-f801-4263-b10c-0d0a5c871703",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "2471e331-80ae-4d1c-befa-d5f5bf38c5fc",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "2471e331-80ae-4d1c-befa-d5f5bf38c5fc"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "233cd86a-9b66-4ddc-a4e6-b4e0cb2a12b3"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -866,7 +891,7 @@
                 "panelIndex": "c294926e-9b33-4805-8ef9-bd4bcc2634d1",
                 "title": "Distribution of Events by User Dropped [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -886,7 +911,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a031233f-898d-4756-bf10-f33c73a72081": {
                                             "columnOrder": [
@@ -901,7 +926,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "78e02bc2-9a25-4182-b865-96e07cb92680": {
                                                     "customLabel": true,
@@ -965,6 +990,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar",
@@ -999,7 +1025,7 @@
                 "panelIndex": "a2a956f4-162b-47db-908e-dd1027c6f00c",
                 "title": "Distribution of Hardware Events by IO Power Management Device Power State [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1019,7 +1045,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0ad21e03-f895-413e-a7e0-55a45a77146c": {
                                             "columnOrder": [
@@ -1034,7 +1060,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "fa04e8b1-655f-4f3b-b7b7-501ddc9fc324": {
                                                     "customLabel": true,
@@ -1070,15 +1096,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "fa04e8b1-655f-4f3b-b7b7-501ddc9fc324"
-                                        ],
                                         "layerId": "0ad21e03-f895-413e-a7e0-55a45a77146c",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "a64a0339-f186-471d-9e43-a3b1559e89a7",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "a64a0339-f186-471d-9e43-a3b1559e89a7"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "fa04e8b1-655f-4f3b-b7b7-501ddc9fc324"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1101,7 +1130,7 @@
                 "panelIndex": "e2121f67-3794-4e56-a0f5-5bdd6fb1213b",
                 "title": "Distribution of Hardware Events by Device Status [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1121,7 +1150,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "d31c80d7-fb2d-4cd8-8aef-59543b605404": {
                                             "columnOrder": [
@@ -1136,7 +1165,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "c8fe4889-0293-4464-b8b4-c8f92c638cec": {
                                                     "customLabel": true,
@@ -1172,15 +1201,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "c8fe4889-0293-4464-b8b4-c8f92c638cec"
-                                        ],
                                         "layerId": "d31c80d7-fb2d-4cd8-8aef-59543b605404",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "42386a24-c912-46b5-8a86-27c1496123fc",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "42386a24-c912-46b5-8a86-27c1496123fc"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "c8fe4889-0293-4464-b8b4-c8f92c638cec"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1203,7 +1235,7 @@
                 "panelIndex": "81f9f687-beb7-454d-8ed4-ea234a2c3272",
                 "title": "Distribution of License Info Events by License Status [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1223,7 +1255,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "795c6a4c-3830-4cb3-be63-b55780d773d7": {
                                             "columnOrder": [
@@ -1238,7 +1270,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "985125ce-3b93-4b72-a077-0b3f200f0dbf": {
                                                     "customLabel": true,
@@ -1274,15 +1306,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "985125ce-3b93-4b72-a077-0b3f200f0dbf"
-                                        ],
                                         "layerId": "795c6a4c-3830-4cb3-be63-b55780d773d7",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "357042c6-1675-414e-ba3e-6c74b1a6c740",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "357042c6-1675-414e-ba3e-6c74b1a6c740"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "985125ce-3b93-4b72-a077-0b3f200f0dbf"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1305,7 +1340,7 @@
                 "panelIndex": "51aeea4e-4bb1-4ce2-8738-dc582041496d",
                 "title": "Distribution of License Info Events by License Type [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1325,7 +1360,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "ae3e7f06-1bed-44cc-9880-7ff89d7743df": {
                                             "columnOrder": [
@@ -1359,7 +1394,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -1376,15 +1411,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "3968784a-d4fb-4b89-9abd-250a07b2266c"
-                                        ],
                                         "layerId": "ae3e7f06-1bed-44cc-9880-7ff89d7743df",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "d80ef2e1-cf94-4904-8ef7-207328f5a502",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "d80ef2e1-cf94-4904-8ef7-207328f5a502"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "3968784a-d4fb-4b89-9abd-250a07b2266c"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1407,7 +1445,7 @@
                 "panelIndex": "16a293c0-18f7-4ffb-b8f6-6e60afd5c4ac",
                 "title": "Distribution of Prohibited App Blocked Events by Header Action [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1427,7 +1465,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "19353d2e-e7a5-425f-85f3-b7333b0abf21": {
                                             "columnOrder": [
@@ -1442,7 +1480,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "4ffd24ec-c9ee-4d29-873b-896ef7c4096b": {
                                                     "customLabel": true,
@@ -1478,15 +1516,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "4ffd24ec-c9ee-4d29-873b-896ef7c4096b"
-                                        ],
                                         "layerId": "19353d2e-e7a5-425f-85f3-b7333b0abf21",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "219edb2a-c4b4-42ce-824c-6e3437097d35",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "219edb2a-c4b4-42ce-824c-6e3437097d35"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "4ffd24ec-c9ee-4d29-873b-896ef7c4096b"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1509,7 +1550,7 @@
                 "panelIndex": "0379b610-4693-47f0-b86d-77fd3edee591",
                 "title": "Distribution of Preference List Events by Audit Level [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1529,7 +1570,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "479ee952-5f14-4578-8a20-de63e17627c5": {
                                             "columnOrder": [
@@ -1563,7 +1604,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -1608,6 +1649,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar",
@@ -1642,7 +1684,7 @@
                 "panelIndex": "03a41353-2e3c-4a6c-9593-2b9a0a5f0e1a",
                 "title": "Distribution of Preference List Events by License Version [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1662,7 +1704,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "b4273567-51c1-40d5-abd8-8e33f06e1dcd": {
                                             "columnOrder": [
@@ -1677,7 +1719,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "c14d4d84-ff8e-4553-bf3e-75b0e5ca8005": {
                                                     "customLabel": true,
@@ -1741,6 +1783,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar",
@@ -1775,7 +1818,7 @@
                 "panelIndex": "d44ee3a0-59e0-46e1-85c8-c70c33353029",
                 "title": "Distribution of Preference List Events by License Type [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1795,7 +1838,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "e5f2943e-d6a7-4eb5-adf4-965ed238082c": {
                                             "columnOrder": [
@@ -1829,7 +1872,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -1846,15 +1889,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "1a74900b-aa29-4baa-a390-877af62b93b0"
-                                        ],
                                         "layerId": "e5f2943e-d6a7-4eb5-adf4-965ed238082c",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "87b7cdc9-a3fe-4b6a-aba5-8e59ae730fa4",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "87b7cdc9-a3fe-4b6a-aba5-8e59ae730fa4"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "1a74900b-aa29-4baa-a390-877af62b93b0"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1877,7 +1923,7 @@
                 "panelIndex": "8d99b054-cbe9-43cb-9977-7367eb5085c3",
                 "title": "Distribution of Print Events Information by Job State [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1897,7 +1943,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "ad2d2003-f5ae-4aa9-a78e-680c8bcba23c": {
                                             "columnOrder": [
@@ -1931,7 +1977,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -1956,7 +2002,9 @@
                                     }
                                 ],
                                 "layerId": "ad2d2003-f5ae-4aa9-a78e-680c8bcba23c",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
@@ -1976,7 +2024,7 @@
                 "panelIndex": "6f1b595d-131c-481b-a60b-8a32f6cf6042",
                 "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1996,7 +2044,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "4b411163-e685-45c0-a1b0-756ce6d0a1eb": {
                                             "columnOrder": [
@@ -2030,7 +2078,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -2055,7 +2103,9 @@
                                     }
                                 ],
                                 "layerId": "4b411163-e685-45c0-a1b0-756ce6d0a1eb",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Audio Device Manufacturer of Audio-Video Device Events [Logs Jamf Compliance Reporter]",
@@ -2075,7 +2125,7 @@
                 "panelIndex": "0bb50df3-d3d2-4f48-962a-0085fb070327",
                 "title": "Top 10 Audio Device Manufacturer of Audio-Video Device Events [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -2095,7 +2145,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9784b039-9999-4347-bbe5-b6429a3bc2eb": {
                                             "columnOrder": [
@@ -2129,7 +2179,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -2152,7 +2202,9 @@
                                     }
                                 ],
                                 "layerId": "9784b039-9999-4347-bbe5-b6429a3bc2eb",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 USB Vendor Name of Hardware Events [Logs Jamf Compliance Reporter]",
@@ -2172,7 +2224,7 @@
                 "panelIndex": "592418e3-3172-448b-915e-0d12808b46d7",
                 "title": "Top 10 USB Vendor Name of Hardware Events [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -2192,7 +2244,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f0047360-8ac5-42d2-b35f-fe490b61d3a7": {
                                             "columnOrder": [
@@ -2207,7 +2259,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "c1044f5d-5db2-4c8f-9434-ff6e6dc9b8d7": {
                                                     "customLabel": true,
@@ -2251,7 +2303,9 @@
                                     }
                                 ],
                                 "layerId": "f0047360-8ac5-42d2-b35f-fe490b61d3a7",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 USB Product Name of Hardware Events [Logs Jamf Compliance Reporter]",
@@ -2271,7 +2325,7 @@
                 "panelIndex": "e87863af-fbee-466c-a3e8-a5880304a82a",
                 "title": "Top 10 USB Product Name of Hardware Events [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -2291,7 +2345,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "97ddbe50-1740-4998-b2ba-ff5e13a64e36": {
                                             "columnOrder": [
@@ -2306,7 +2360,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "e3a1bfeb-104f-4dd9-9f71-8326afccd2c2": {
                                                     "customLabel": true,
@@ -2348,7 +2402,9 @@
                                     }
                                 ],
                                 "layerId": "97ddbe50-1740-4998-b2ba-ff5e13a64e36",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Quarantine Agent Bundle Identifier of Gatekeeper Quarantine Log Events [Logs Jamf Compliance Reporter]",
@@ -2368,7 +2424,7 @@
                 "panelIndex": "b274f4a7-d788-4ff4-81ea-aed7756fedf9",
                 "title": "Top 10 Quarantine Agent Bundle Identifier of Gatekeeper Quarantine Log Events [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -2388,7 +2444,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "6dba6e01-ce8c-4bb4-be06-6d9ee868f043": {
                                             "columnOrder": [
@@ -2422,7 +2478,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -2445,7 +2501,9 @@
                                     }
                                 ],
                                 "layerId": "6dba6e01-ce8c-4bb4-be06-6d9ee868f043",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Quarantine Agent Name of Gatekeeper Quarantine Log Events [Logs Jamf Compliance Reporter]",
@@ -2465,7 +2523,7 @@
                 "panelIndex": "5049dc95-bcb6-4e0e-8919-422050d8a54c",
                 "title": "Top 10 Quarantine Agent Name of Gatekeeper Quarantine Log Events [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -2485,7 +2543,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7e99d2b3-a231-4553-a927-3553d056cc16": {
                                             "columnOrder": [
@@ -2500,7 +2558,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "a0bea5bf-3444-46db-b6f0-953d21c31e16": {
                                                     "customLabel": true,
@@ -2542,7 +2600,9 @@
                                     }
                                 ],
                                 "layerId": "7e99d2b3-a231-4553-a927-3553d056cc16",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Device Class of Hardware Events [Logs Jamf Compliance Reporter]",
@@ -2562,7 +2622,7 @@
                 "panelIndex": "b26730ed-d34f-4ebe-8739-d6fc5fc220fa",
                 "title": "Top 10 Device Class of Hardware Events [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -2582,7 +2642,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c8a0c482-513b-4fca-8b1e-198b6c35a7d7": {
                                             "columnOrder": [
@@ -2616,7 +2676,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -2639,7 +2699,9 @@
                                     }
                                 ],
                                 "layerId": "c8a0c482-513b-4fca-8b1e-198b6c35a7d7",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Remote Endpoint Type by AWSKinesis Region of Preference List Events [Logs Jamf Compliance Reporter]",
@@ -2659,17 +2721,18 @@
                 "panelIndex": "bb689dd4-ecdd-4b67-a91e-289347474dc2",
                 "title": "Top 10 Remote Endpoint Type by AWSKinesis Region of Preference List Events [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Jamf Compliance Reporter] Event",
         "version": 1
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:23:46.565Z",
     "id": "jamf_compliance_reporter-dd0ea730-b557-11ec-a813-df29637f29df",
     "migrationVersion": {
-        "dashboard": "7.17.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/jamf_compliance_reporter/kibana/dashboard/jamf_compliance_reporter-dd28ec80-b584-11ec-a813-df29637f29df.json
+++ b/packages/jamf_compliance_reporter/kibana/dashboard/jamf_compliance_reporter-dd28ec80-b584-11ec-a813-df29637f29df.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "This dashboard shows app metrics logs collected by the Jamf Compliance Reporter integration.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -57,6 +56,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -138,7 +139,7 @@
                 },
                 "panelIndex": "4dd382d1-e84a-4351-bced-36a6625b3e8e",
                 "type": "visualization",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -158,7 +159,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "e3280c4e-9935-45c1-8716-c6be28f1b2bf": {
                                             "columnOrder": [
@@ -192,7 +193,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -209,15 +210,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "bc98875f-49d7-4a57-829e-5cb7ccb143d3"
-                                        ],
                                         "layerId": "e3280c4e-9935-45c1-8716-c6be28f1b2bf",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "d388bcb3-cead-43bb-b177-34082d218734",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "d388bcb3-cead-43bb-b177-34082d218734"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "bc98875f-49d7-4a57-829e-5cb7ccb143d3"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -240,7 +244,7 @@
                 "panelIndex": "4a142331-39c2-428e-af3c-b693e89e68eb",
                 "title": "Distribution of App Metrics Events by Host OS Version [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -259,7 +263,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "47994ee6-4086-45d0-9b05-3607e2aff799": {
                                             "columnOrder": [
@@ -274,7 +278,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "2075f97d-4358-41ce-a75b-e1e1d8284ce4": {
                                                     "customLabel": true,
@@ -318,7 +322,9 @@
                                     }
                                 ],
                                 "layerId": "47994ee6-4086-45d0-9b05-3607e2aff799",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
@@ -338,7 +344,7 @@
                 "panelIndex": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af",
                 "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -358,7 +364,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "6aeac12b-c950-45ee-b62d-e16771eec500": {
                                             "columnOrder": [
@@ -417,7 +423,9 @@
                                     }
                                 ],
                                 "layerId": "6aeac12b-c950-45ee-b62d-e16771eec500",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Max CPU Utilization per Host [Logs Jamf Compliance Reporter]",
@@ -437,17 +445,18 @@
                 "panelIndex": "74afe262-2bf2-4ea8-966c-2c51b623f27d",
                 "title": "Max CPU Utilization per Host [Logs Jamf Compliance Reporter]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Jamf Compliance Reporter] App Metrics",
         "version": 1
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:23:54.696Z",
     "id": "jamf_compliance_reporter-dd28ec80-b584-11ec-a813-df29637f29df",
     "migrationVersion": {
-        "dashboard": "7.17.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/jamf_compliance_reporter/kibana/dashboard/jamf_compliance_reporter-dd28ec80-b584-11ec-a813-df29637f29df.json
+++ b/packages/jamf_compliance_reporter/kibana/dashboard/jamf_compliance_reporter-dd28ec80-b584-11ec-a813-df29637f29df.json
@@ -63,82 +63,155 @@
         "panelsJSON": [
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-98ded84f-8942-4d53-a0c5-c1ca5bfa84a6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "cd579c6a-c1f0-4eed-a6af-36498a58e62d",
+                                "type": "index-pattern"
                             }
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 0,
-                            "id": "fa25f9df-c199-49e4-b929-cfcedeadcf54",
-                            "index_pattern": "logs-*",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "formatter": "number",
-                                    "id": "ccb0ffc8-0599-411d-a5e9-7cc3908789ab",
-                                    "label": "CPU Percentage",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "field": "jamf_compliance_reporter.log.app_metric_info.cpu_percentage",
-                                            "id": "a832b9ad-31a4-4800-a774-ff440e3293a6",
-                                            "type": "avg"
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "98ded84f-8942-4d53-a0c5-c1ca5bfa84a6": {
+                                            "columnOrder": [
+                                                "4826251a-bce6-47d1-8184-8c793e6fc02b",
+                                                "4ee42989-e0d1-4b1f-adcf-9fe45ac93526"
+                                            ],
+                                            "columns": {
+                                                "4826251a-bce6-47d1-8184-8c793e6fc02b": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "4ee42989-e0d1-4b1f-adcf-9fe45ac93526": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "CPU Percentage",
+                                                    "operationType": "median",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "jamf_compliance_reporter.log.app_metric_info.cpu_percentage"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
                                         }
-                                    ],
-                                    "override_index_pattern": 0,
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
                                     },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "series_drop_last_bucket": 0,
-                                    "split_mode": "everything",
-                                    "stacked": "none",
-                                    "time_range_mode": "entire_time_range"
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "cd579c6a-c1f0-4eed-a6af-36498a58e62d",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "jamf_compliance_reporter.log"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "jamf_compliance_reporter.log"
+                                        }
+                                    }
                                 }
                             ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "emphasizeFitting": true,
+                                "fittingFunction": "Zero",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "4ee42989-e0d1-4b1f-adcf-9fe45ac93526"
+                                        ],
+                                        "layerId": "98ded84f-8942-4d53-a0c5-c1ca5bfa84a6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "4826251a-bce6-47d1-8184-8c793e6fc02b"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
                         },
-                        "title": "CPU Utilization Over Time [Logs Jamf Compliance Reporter]",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "4dd382d1-e84a-4351-bced-36a6625b3e8e",
+                    "i": "26b820bb-5de0-4979-a8a4-2f992aabe4e3",
                     "w": 24,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "4dd382d1-e84a-4351-bced-36a6625b3e8e",
-                "type": "visualization",
+                "panelIndex": "26b820bb-5de0-4979-a8a4-2f992aabe4e3",
+                "title": "CPU Utilization Over Time [Logs Jamf Compliance Reporter]",
+                "type": "lens",
                 "version": "8.7.1"
             },
             {
@@ -249,106 +322,6 @@
             {
                 "embeddableConfig": {
                     "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-47994ee6-4086-45d0-9b05-3607e2aff799",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "47994ee6-4086-45d0-9b05-3607e2aff799": {
-                                            "columnOrder": [
-                                                "2075f97d-4358-41ce-a75b-e1e1d8284ce4",
-                                                "00c36b12-671f-424b-9768-895bce4a69e3"
-                                            ],
-                                            "columns": {
-                                                "00c36b12-671f-424b-9768-895bce4a69e3": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count",
-                                                    "operationType": "count",
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "2075f97d-4358-41ce-a75b-e1e1d8284ce4": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Host Name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "00c36b12-671f-424b-9768-895bce4a69e3",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "host.hostname"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "2075f97d-4358-41ce-a75b-e1e1d8284ce4",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "00c36b12-671f-424b-9768-895bce4a69e3",
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "47994ee6-4086-45d0-9b05-3607e2aff799",
-                                "layerType": "data",
-                                "rowHeight": "single",
-                                "rowHeightLines": 1
-                            }
-                        },
-                        "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af",
-                    "w": 24,
-                    "x": 0,
-                    "y": 15
-                },
-                "panelIndex": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af",
-                "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
-                "type": "lens",
-                "version": "8.7.1"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
                         "description": "",
                         "references": [
                             {
@@ -446,6 +419,106 @@
                 "title": "Max CPU Utilization per Host [Logs Jamf Compliance Reporter]",
                 "type": "lens",
                 "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-47994ee6-4086-45d0-9b05-3607e2aff799",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "47994ee6-4086-45d0-9b05-3607e2aff799": {
+                                            "columnOrder": [
+                                                "2075f97d-4358-41ce-a75b-e1e1d8284ce4",
+                                                "00c36b12-671f-424b-9768-895bce4a69e3"
+                                            ],
+                                            "columns": {
+                                                "00c36b12-671f-424b-9768-895bce4a69e3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "2075f97d-4358-41ce-a75b-e1e1d8284ce4": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Host Name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "00c36b12-671f-424b-9768-895bce4a69e3",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "host.hostname"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "2075f97d-4358-41ce-a75b-e1e1d8284ce4",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "00c36b12-671f-424b-9768-895bce4a69e3",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "47994ee6-4086-45d0-9b05-3607e2aff799",
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
+                            }
+                        },
+                        "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af",
+                    "w": 24,
+                    "x": 0,
+                    "y": 15
+                },
+                "panelIndex": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af",
+                "title": "Top 10 Host Name [Logs Jamf Compliance Reporter]",
+                "type": "lens",
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
@@ -453,7 +526,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-12T04:23:54.696Z",
+    "created_at": "2023-07-12T04:28:43.049Z",
     "id": "jamf_compliance_reporter-dd28ec80-b584-11ec-a813-df29637f29df",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -471,6 +544,16 @@
         },
         {
             "id": "logs-*",
+            "name": "26b820bb-5de0-4979-a8a4-2f992aabe4e3:indexpattern-datasource-layer-98ded84f-8942-4d53-a0c5-c1ca5bfa84a6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "26b820bb-5de0-4979-a8a4-2f992aabe4e3:cd579c6a-c1f0-4eed-a6af-36498a58e62d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
             "name": "4a142331-39c2-428e-af3c-b693e89e68eb:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
@@ -481,22 +564,22 @@
         },
         {
             "id": "logs-*",
-            "name": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af:indexpattern-datasource-layer-47994ee6-4086-45d0-9b05-3607e2aff799",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "74afe262-2bf2-4ea8-966c-2c51b623f27d:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
             "name": "74afe262-2bf2-4ea8-966c-2c51b623f27d:indexpattern-datasource-layer-6aeac12b-c950-45ee-b62d-e16771eec500",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "d2f744c1-549b-4f27-aa67-f5a7ddaa85af:indexpattern-datasource-layer-47994ee6-4086-45d0-9b05-3607e2aff799",
             "type": "index-pattern"
         }
     ],

--- a/packages/jamf_compliance_reporter/manifest.yml
+++ b/packages/jamf_compliance_reporter/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: jamf_compliance_reporter
 title: Jamf Compliance Reporter
-version: "1.3.0"
+version: "1.4.0"
 license: basic
 description: Collect logs from Jamf Compliance Reporter with Elastic Agent.
 type: integration
@@ -9,7 +9,7 @@ categories:
   - security
 release: ga
 conditions:
-  kibana.version: ^7.17.0 || ^8.0.0
+  kibana.version: ^8.7.1
 screenshots:
   - src: /img/jamf-compliance-reporter-screenshot.png
     title: Jamf Compliance Reporter Screenshot

--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Convert visualizations to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6924
 - version: "1.14.0"
   changes:
     - description: Document valid duration units.

--- a/packages/ti_abusech/kibana/dashboard/ti_abusech-2457fb50-3bc3-11ec-ae8c-7d00429ad420.json
+++ b/packages/ti_abusech/kibana/dashboard/ti_abusech-2457fb50-3bc3-11ec-ae8c-7d00429ad420.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Dashboard providing statistics about URL type indicators from the AbuseCH integration",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -76,6 +75,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -116,7 +117,7 @@
                 "panelIndex": "4c3ed6e1-8b4e-4eab-8d84-70ed4f506216",
                 "title": "Files Navigation Textbox [Logs AbuseCH]",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -135,7 +136,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "88a112e1-6da1-49d3-9177-19f98280c200": {
                                             "columnOrder": [
@@ -165,12 +166,15 @@
                             "visualization": {
                                 "accessor": "604f1693-15a6-437d-af69-03588db8e471",
                                 "layerId": "88a112e1-6da1-49d3-9177-19f98280c200",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -185,7 +189,7 @@
                 "panelIndex": "c7c6e8dc-b649-434c-9650-8a1564d4d676",
                 "title": "Unique Ports [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -204,7 +208,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a6fa56f8-32fa-405d-8771-dade4fe75d62": {
                                             "columnOrder": [
@@ -234,12 +238,15 @@
                             "visualization": {
                                 "accessor": "848c463b-bbc1-4b6a-af3e-76d844eb3cc5",
                                 "layerId": "a6fa56f8-32fa-405d-8771-dade4fe75d62",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -254,7 +261,7 @@
                 "panelIndex": "73a752f9-bde5-4396-8ede-e9e77a37182d",
                 "title": "Unique File Extensions [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -273,7 +280,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c94400ee-a135-4a99-9693-5879d29f7aad": {
                                             "columnOrder": [
@@ -303,12 +310,15 @@
                             "visualization": {
                                 "accessor": "2934249f-fce5-4637-87ff-d2596d1b6ec5",
                                 "layerId": "c94400ee-a135-4a99-9693-5879d29f7aad",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -323,7 +333,7 @@
                 "panelIndex": "02f1732b-a981-4fba-8b27-b944f2f3c98c",
                 "title": "Unique Domains [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -342,7 +352,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "72aa700a-49b6-4a2f-b380-24ebe7124ec1": {
                                             "columnOrder": [
@@ -360,7 +370,7 @@
                                                     "label": "Indicators on Spamhaus DBL",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -376,12 +386,15 @@
                             "visualization": {
                                 "accessor": "0389e125-4ae6-412a-a4af-2fa28f18c412",
                                 "layerId": "72aa700a-49b6-4a2f-b380-24ebe7124ec1",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -396,7 +409,7 @@
                 "panelIndex": "8272f9f8-d835-4e4c-9e63-7cdbfb14d190",
                 "title": "Spamhaus Count [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -415,7 +428,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "4fe4b45f-8f52-4794-a386-8e3f6352aa25": {
                                             "columnOrder": [
@@ -433,7 +446,7 @@
                                                     "label": "Indicators on SURBL",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -449,12 +462,15 @@
                             "visualization": {
                                 "accessor": "e7b09852-9ec8-4a42-a3c7-faf909c1997a",
                                 "layerId": "4fe4b45f-8f52-4794-a386-8e3f6352aa25",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -469,7 +485,7 @@
                 "panelIndex": "7c8e2070-5b71-4eb5-ae52-e95ef5a17ba6",
                 "title": "Surbl Counter [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -488,7 +504,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "8f36a8c1-19df-4eba-8fa5-4f259d349375": {
                                             "columnOrder": [
@@ -506,7 +522,7 @@
                                                     "label": "URL's Online",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -522,12 +538,15 @@
                             "visualization": {
                                 "accessor": "efd6bc64-ffcd-42fe-8218-0795986addc4",
                                 "layerId": "8f36a8c1-19df-4eba-8fa5-4f259d349375",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -542,7 +561,7 @@
                 "panelIndex": "a96389e6-d361-457e-afc1-0dbdb35ee7e0",
                 "title": "URLs Online [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -561,7 +580,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "471ad94f-c181-4ffb-a640-1666974adb33": {
                                             "columnOrder": [
@@ -579,7 +598,7 @@
                                                     "label": "URL's Offline",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -595,12 +614,15 @@
                             "visualization": {
                                 "accessor": "8cd8034f-16bf-4a7a-b816-950498dc1f90",
                                 "layerId": "471ad94f-c181-4ffb-a640-1666974adb33",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -615,7 +637,7 @@
                 "panelIndex": "b2904153-3afd-41a7-8f5f-01b76b8346ec",
                 "title": "URLs Offline [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -634,7 +656,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0f63318a-a857-4d83-89ce-a94e2242b79e": {
                                             "columnOrder": [
@@ -648,7 +670,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "df0791a6-247c-4434-a43a-fdea7577ca34": {
                                                     "dataType": "string",
@@ -683,15 +705,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "df0791a6-247c-4434-a43a-fdea7577ca34"
-                                        ],
                                         "layerId": "0f63318a-a857-4d83-89ce-a94e2242b79e",
                                         "layerType": "data",
                                         "legendDisplay": "show",
-                                        "metric": "77a48096-02aa-4b7a-8a7b-131fc38988bd",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "77a48096-02aa-4b7a-8a7b-131fc38988bd"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "df0791a6-247c-4434-a43a-fdea7577ca34"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -714,7 +739,7 @@
                 "panelIndex": "ab7ab31c-e76f-4613-b17d-fdd909f17e0d",
                 "title": "Percentage of URL Schema used [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -733,7 +758,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9fa49c4c-5544-472d-afce-e51d6a5687fe": {
                                             "columnOrder": [
@@ -765,7 +790,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -782,16 +807,19 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "15e2b5ad-2040-4253-89a6-60f085c66f86",
-                                            "15e2b5ad-2040-4253-89a6-60f085c66f86"
-                                        ],
                                         "layerId": "9fa49c4c-5544-472d-afce-e51d6a5687fe",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "b9a631fe-5f49-4db2-a076-bcbf5410aec9",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "b9a631fe-5f49-4db2-a076-bcbf5410aec9"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "15e2b5ad-2040-4253-89a6-60f085c66f86",
+                                            "15e2b5ad-2040-4253-89a6-60f085c66f86"
+                                        ]
                                     }
                                 ],
                                 "shape": "treemap"
@@ -814,7 +842,7 @@
                 "panelIndex": "fda93ed1-72f0-4489-80b7-9e69d14f30aa",
                 "title": "Most Popular File Extensions [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -833,7 +861,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "db89074c-e1fe-4091-bdb1-e42a36e82bac": {
                                             "columnOrder": [
@@ -848,7 +876,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "b284ea2a-a2cd-4d08-bf44-fc73c08b5694": {
                                                     "customLabel": true,
@@ -892,7 +920,9 @@
                                     }
                                 ],
                                 "layerId": "db89074c-e1fe-4091-bdb1-e42a36e82bac",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -912,17 +942,18 @@
                 "panelIndex": "8994501a-1550-4cf2-857f-d6b6491ffb62",
                 "title": "Most Popular Domains [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs AbuseCH] URLs",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:34:57.156Z",
     "id": "ti_abusech-2457fb50-3bc3-11ec-ae8c-7d00429ad420",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -1037,7 +1068,7 @@
         },
         {
             "id": "ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
-            "name": "tag-ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
+            "name": "tag-ref-ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
             "type": "tag"
         }
     ],

--- a/packages/ti_abusech/kibana/dashboard/ti_abusech-6a90c980-3b32-11ec-ae50-2fdf1e96c6a6.json
+++ b/packages/ti_abusech/kibana/dashboard/ti_abusech-6a90c980-3b32-11ec-ae50-2fdf1e96c6a6.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Dashboard providing statistics about file type indicators from the AbuseCH integration",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -97,6 +96,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -135,7 +136,7 @@
                 },
                 "panelIndex": "09ba3dc0-e2e2-4799-b47f-bb919bf290a1",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -158,7 +159,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "98786f76-dac4-4fc7-9cad-8bfce17bd00d": {
                                             "columnOrder": [
@@ -188,11 +189,14 @@
                             "visualization": {
                                 "accessor": "8622e147-406f-4711-8f68-e2425614106e",
                                 "layerId": "98786f76-dac4-4fc7-9cad-8bfce17bd00d",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique File Types [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -207,7 +211,7 @@
                 "panelIndex": "31ea16d1-7591-42a7-b773-6fca00e5db14",
                 "title": "Unique File Types [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -230,7 +234,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "b83c382d-fab9-4e60-a632-475e221cc20c": {
                                             "columnOrder": [
@@ -260,11 +264,14 @@
                             "visualization": {
                                 "accessor": "eda3c6d9-dacb-4e5e-b977-50104f76e91a",
                                 "layerId": "b83c382d-fab9-4e60-a632-475e221cc20c",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique MD5 [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -279,7 +286,7 @@
                 "panelIndex": "4d3e11dc-c4cc-4373-bb83-3d39fe6ffa98",
                 "title": "Unique MD5 [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -302,7 +309,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "85ad73b3-3b76-49f1-ad20-6256b58918f8": {
                                             "columnOrder": [
@@ -332,11 +339,14 @@
                             "visualization": {
                                 "accessor": "289bd005-bdd2-4f3b-83b9-ad6ae52a9ed3",
                                 "layerId": "85ad73b3-3b76-49f1-ad20-6256b58918f8",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique SHA1 [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -351,7 +361,7 @@
                 "panelIndex": "e9b6f0ad-5e6b-44da-923e-dc0d5ccfdfea",
                 "title": "Unique SHA1 [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -374,7 +384,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "49b7070a-f1d3-46e1-a980-2f6d6d130167": {
                                             "columnOrder": [
@@ -404,11 +414,14 @@
                             "visualization": {
                                 "accessor": "b6c5e221-88ff-490e-bd3e-188b3e0dd1f4",
                                 "layerId": "49b7070a-f1d3-46e1-a980-2f6d6d130167",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique SHA256 [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -423,7 +436,7 @@
                 "panelIndex": "93e32abe-87e3-469e-b7e9-a7ef7dfa2cce",
                 "title": "Unique SHA256 [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -446,7 +459,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "12768311-834b-48d5-8aad-d17d139c2ae5": {
                                             "columnOrder": [
@@ -476,11 +489,14 @@
                             "visualization": {
                                 "accessor": "0255894e-dd88-4eb1-b21b-0cccecb2cd1b",
                                 "layerId": "12768311-834b-48d5-8aad-d17d139c2ae5",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique TLSH [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -495,7 +511,7 @@
                 "panelIndex": "b77edd3f-b171-4e61-b519-169b5aade031",
                 "title": "Unique TLSH [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -518,7 +534,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9070dc46-c06d-4b64-a2c5-7b6d4056a14d": {
                                             "columnOrder": [
@@ -548,11 +564,14 @@
                             "visualization": {
                                 "accessor": "f1bdf831-1fd2-4dc8-b1f9-c6e05d93b801",
                                 "layerId": "9070dc46-c06d-4b64-a2c5-7b6d4056a14d",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique Imphash [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -567,7 +586,7 @@
                 "panelIndex": "f9eb44f8-6174-4b12-a8ca-5c542687006b",
                 "title": "Unique Imphash [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -590,7 +609,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "e27d5a76-ae51-44fa-b17e-e486bbc01b56": {
                                             "columnOrder": [
@@ -620,11 +639,14 @@
                             "visualization": {
                                 "accessor": "b5cdfd94-1e22-4673-8216-59aca2131761",
                                 "layerId": "e27d5a76-ae51-44fa-b17e-e486bbc01b56",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique SSDEEP [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -639,7 +661,7 @@
                 "panelIndex": "c9d59178-9b19-4255-8098-653cb30f3d09",
                 "title": "Unique SSDEEP [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -662,7 +684,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "118b51de-bd55-4ed6-b916-c939ad73b2c3": {
                                             "columnOrder": [
@@ -696,7 +718,7 @@
                                                     "label": "Countries",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -713,15 +735,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "1ada77b6-5741-44ff-a00d-4653fca22f84"
-                                        ],
                                         "layerId": "118b51de-bd55-4ed6-b916-c939ad73b2c3",
                                         "layerType": "data",
                                         "legendDisplay": "show",
-                                        "metric": "dcc2a7b9-e44b-4681-ba02-bdea442ca9a5",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "dcc2a7b9-e44b-4681-ba02-bdea442ca9a5"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "1ada77b6-5741-44ff-a00d-4653fca22f84"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -743,7 +768,7 @@
                 "panelIndex": "6189e979-9121-4247-9942-fa7a3cc3839c",
                 "title": "Top Countries [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -766,7 +791,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "222b3ad0-2e5d-46a0-ae3d-f6a0b15ac2c8": {
                                             "columnOrder": [
@@ -798,7 +823,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -815,15 +840,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "06b603cb-c9fb-493a-9ca4-e6502ca12054"
-                                        ],
                                         "layerId": "222b3ad0-2e5d-46a0-ae3d-f6a0b15ac2c8",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "de0e531b-dda7-461f-9783-3ab9267d202e",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "de0e531b-dda7-461f-9783-3ab9267d202e"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "06b603cb-c9fb-493a-9ca4-e6502ca12054"
+                                        ]
                                     }
                                 ],
                                 "shape": "treemap"
@@ -845,7 +873,7 @@
                 "panelIndex": "5f1d0cf1-c331-4495-99d5-5e80d023c482",
                 "title": "File Types [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -882,7 +910,7 @@
                             ],
                             "searchSource": {
                                 "filter": [],
-                                "index": "logs-*",
+                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                                 "query": {
                                     "language": "kuery",
                                     "query": ""
@@ -915,7 +943,7 @@
                 },
                 "panelIndex": "d1788a2e-c400-4d7b-9251-a8e5a806b6ef",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -938,7 +966,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "06d9ac79-2055-437e-892c-de9ee07fe674": {
                                             "columnOrder": [
@@ -972,7 +1000,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -997,7 +1025,9 @@
                                     }
                                 ],
                                 "layerId": "06d9ac79-2055-437e-892c-de9ee07fe674",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Most popular file names [Logs AbuseCH]",
@@ -1016,17 +1046,18 @@
                 "panelIndex": "b733385b-14f8-4469-b777-86d0139cc56b",
                 "title": "Most popular file names [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs AbuseCH] Files",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:35:06.295Z",
     "id": "ti_abusech-6a90c980-3b32-11ec-ae50-2fdf1e96c6a6",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -1151,7 +1182,7 @@
         },
         {
             "id": "ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
-            "name": "tag-ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
+            "name": "tag-ref-ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
             "type": "tag"
         }
     ],

--- a/packages/ti_abusech/kibana/dashboard/ti_abusech-6a90c980-3b32-11ec-ae50-2fdf1e96c6a6.json
+++ b/packages/ti_abusech/kibana/dashboard/ti_abusech-6a90c980-3b32-11ec-ae50-2fdf1e96c6a6.json
@@ -877,72 +877,138 @@
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [
-                                {
-                                    "enabled": true,
-                                    "id": "1",
-                                    "params": {
-                                        "customLabel": "Based on count"
-                                    },
-                                    "schema": "metric",
-                                    "type": "count"
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-57bbc243-2446-489f-8e6d-0ce51e157004",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "57bbc243-2446-489f-8e6d-0ce51e157004": {
+                                            "columnOrder": [
+                                                "098d4581-8d35-4db1-9902-f74022d3b75d",
+                                                "443ed6a7-aff3-4f30-ad3e-e992809a4a40"
+                                            ],
+                                            "columns": {
+                                                "098d4581-8d35-4db1-9902-f74022d3b75d": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Most seen indicator tags",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "443ed6a7-aff3-4f30-ad3e-e992809a4a40",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "abusech.malwarebazaar.tags"
+                                                },
+                                                "443ed6a7-aff3-4f30-ad3e-e992809a4a40": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
                                 },
-                                {
-                                    "enabled": true,
-                                    "id": "2",
-                                    "params": {
-                                        "customLabel": "Most seen indicator tags",
-                                        "field": "abusech.malwarebazaar.tags",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": false,
-                                        "otherBucketLabel": "Other",
-                                        "size": 5
-                                    },
-                                    "schema": "segment",
-                                    "type": "terms"
+                                "textBased": {
+                                    "layers": {}
                                 }
-                            ],
-                            "searchSource": {
-                                "filter": [],
-                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "443ed6a7-aff3-4f30-ad3e-e992809a4a40"
+                                        ],
+                                        "layerId": "57bbc243-2446-489f-8e6d-0ce51e157004",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "098d4581-8d35-4db1-9902-f74022d3b75d"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
                             }
                         },
-                        "description": "",
-                        "params": {
-                            "maxFontSize": 72,
-                            "minFontSize": 18,
-                            "orientation": "single",
-                            "palette": {
-                                "name": "default",
-                                "type": "palette"
-                            },
-                            "scale": "linear",
-                            "showLabel": true
-                        },
-                        "title": "Most seen indicator tags [Logs AbuseCH]",
-                        "type": "tagcloud",
-                        "uiState": {}
-                    }
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 19,
-                    "i": "d1788a2e-c400-4d7b-9251-a8e5a806b6ef",
+                    "i": "1f92363c-a693-4950-81cd-d8da6f5832ea",
                     "w": 20,
                     "x": 7,
                     "y": 27
                 },
-                "panelIndex": "d1788a2e-c400-4d7b-9251-a8e5a806b6ef",
-                "type": "visualization",
+                "panelIndex": "1f92363c-a693-4950-81cd-d8da6f5832ea",
+                "title": "Most seen indicator tags [Logs AbuseCH]",
+                "type": "lens",
                 "version": "8.7.1"
             },
             {
@@ -1054,7 +1120,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-12T04:35:06.295Z",
+    "created_at": "2023-07-12T04:38:30.112Z",
     "id": "ti_abusech-6a90c980-3b32-11ec-ae50-2fdf1e96c6a6",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -1167,7 +1233,7 @@
         },
         {
             "id": "logs-*",
-            "name": "d1788a2e-c400-4d7b-9251-a8e5a806b6ef:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "name": "1f92363c-a693-4950-81cd-d8da6f5832ea:indexpattern-datasource-layer-57bbc243-2446-489f-8e6d-0ce51e157004",
             "type": "index-pattern"
         },
         {

--- a/packages/ti_abusech/kibana/dashboard/ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6.json
+++ b/packages/ti_abusech/kibana/dashboard/ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Dashboard providing statistics about indicators ingested from the AbuseCH integration",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -76,6 +75,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -114,7 +115,7 @@
                 },
                 "panelIndex": "555e9e6c-04e9-4022-b6df-bda07dde30c4",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -131,7 +132,7 @@
                                         "meta": {
                                             "alias": null,
                                             "disabled": false,
-                                            "index": "logs-*",
+                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
                                             "key": "event.dataset",
                                             "negate": false,
                                             "params": [
@@ -171,7 +172,7 @@
                                         "meta": {
                                             "alias": null,
                                             "disabled": false,
-                                            "index": "logs-*",
+                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
                                             "key": "event.kind",
                                             "negate": false,
                                             "params": {
@@ -259,7 +260,7 @@
                 },
                 "panelIndex": "e971fedd-6afd-4d03-93ac-d0c751acc254",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -283,7 +284,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "070f5dbc-7687-4e97-9a57-5542b401c13f": {
                                             "columnOrder": [
@@ -297,7 +298,7 @@
                                                     "label": "Total Indicators",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -313,11 +314,14 @@
                             "visualization": {
                                 "accessor": "1e352b49-3b83-44a6-98fe-8703d30f2517",
                                 "layerId": "070f5dbc-7687-4e97-9a57-5542b401c13f",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Total Indicators [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {}
                 },
@@ -330,7 +334,7 @@
                 },
                 "panelIndex": "d37eb797-f273-43c2-9004-b947891cce55",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -353,7 +357,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "df8e3a91-700b-428a-a763-525076e4d3c8": {
                                             "columnOrder": [
@@ -383,11 +387,14 @@
                             "visualization": {
                                 "accessor": "e4f78e2f-f0a7-4cc6-96d0-af607ffbf326",
                                 "layerId": "df8e3a91-700b-428a-a763-525076e4d3c8",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Total Datastreams [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -402,7 +409,7 @@
                 "panelIndex": "6509dcc9-bb9c-4c1f-80e9-612f67ada340",
                 "title": "Total Datastreams [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -425,7 +432,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1e757dc0-2e6d-4bd2-aa38-7da9133ca960": {
                                             "columnOrder": [
@@ -439,7 +446,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "66779b74-d127-4249-93e4-b8cd9c39b91f": {
                                                     "dataType": "string",
@@ -490,12 +497,13 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right",
                                     "showSingleSeries": false
                                 },
                                 "preferredSeriesType": "bar_horizontal",
                                 "title": "Empty XY chart",
-                                "valueLabels": "inside",
+                                "valueLabels": "show",
                                 "xTitle": "Providers",
                                 "yLeftExtent": {
                                     "mode": "full"
@@ -522,7 +530,7 @@
                 "panelIndex": "86d83606-4176-44b1-b3f3-011d5b5b4b58",
                 "title": "Total Indicators per Provider [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -545,7 +553,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "682732d8-8691-4c5a-bf89-de8e30d71dfb": {
                                             "columnOrder": [
@@ -559,7 +567,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "dd629c44-e7db-438e-8656-340b94fd30d8": {
                                                     "customLabel": true,
@@ -595,17 +603,20 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "dd629c44-e7db-438e-8656-340b94fd30d8"
-                                        ],
                                         "layerId": "682732d8-8691-4c5a-bf89-de8e30d71dfb",
                                         "layerType": "data",
                                         "legendDisplay": "show",
                                         "legendPosition": "right",
-                                        "metric": "bad802d8-b23f-4ef4-8dcf-4e92170595a7",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "bad802d8-b23f-4ef4-8dcf-4e92170595a7"
+                                        ],
                                         "nestedLegend": false,
                                         "numberDisplay": "percent",
                                         "percentDecimals": 2,
+                                        "primaryGroups": [
+                                            "dd629c44-e7db-438e-8656-340b94fd30d8"
+                                        ],
                                         "truncateLegend": true
                                     }
                                 ],
@@ -627,7 +638,7 @@
                 },
                 "panelIndex": "f654c447-12d2-41a4-9091-06169af11ba5",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -650,7 +661,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c1cee622-e3dd-4d6b-a28a-0fb19dc2c7b7": {
                                             "columnOrder": [
@@ -665,7 +676,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "4d7ca99c-8a53-4a7f-96db-409251c0e391": {
                                                     "dataType": "string",
@@ -691,6 +702,7 @@
                                                     "label": "@timestamp",
                                                     "operationType": "date_histogram",
                                                     "params": {
+                                                        "includeEmptyRows": true,
                                                         "interval": "30s"
                                                     },
                                                     "scale": "interval",
@@ -732,6 +744,7 @@
                                 "legend": {
                                     "isInside": false,
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "bottom",
                                     "shouldTruncate": false,
                                     "showSingleSeries": true
@@ -765,17 +778,18 @@
                 },
                 "panelIndex": "aab4fac0-d39c-4521-aa9b-0a49d5938e9e",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs AbuseCH] Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:35:16.189Z",
     "id": "ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -865,7 +879,7 @@
         },
         {
             "id": "ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
-            "name": "tag-ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
+            "name": "tag-ref-ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
             "type": "tag"
         }
     ],

--- a/packages/ti_abusech/kibana/tag/ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6.json
+++ b/packages/ti_abusech/kibana/tag/ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6.json
@@ -4,7 +4,8 @@
         "description": "",
         "name": "AbuseCH"
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:34:22.575Z",
     "id": "ti_abusech-73511520-3b32-11ec-ae50-2fdf1e96c6a6",
     "migrationVersion": {
         "tag": "8.0.0"

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: AbuseCH
-version: "1.14.0"
+version: "1.15.0"
 release: ga
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Convert visualizations to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6924
 - version: "1.15.0"
   changes:
     - description: Document valid duration units.

--- a/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-63c9fee0-5bea-11ec-9302-152fd766c738.json
+++ b/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-63c9fee0-5bea-11ec-9302-152fd766c738.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Dashboard providing statistics about file type indicators from the Cybersixgill integration",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -78,6 +77,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -116,7 +117,7 @@
                 },
                 "panelIndex": "09ba3dc0-e2e2-4799-b47f-bb919bf290a1",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -135,7 +136,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "98786f76-dac4-4fc7-9cad-8bfce17bd00d": {
                                             "columnOrder": [
@@ -165,12 +166,15 @@
                             "visualization": {
                                 "accessor": "8622e147-406f-4711-8f68-e2425614106e",
                                 "layerId": "98786f76-dac4-4fc7-9cad-8bfce17bd00d",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique File Types [Logs AbuseCH]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -185,7 +189,7 @@
                 "panelIndex": "31ea16d1-7591-42a7-b773-6fca00e5db14",
                 "title": "Unique File Types [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -208,7 +212,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "b83c382d-fab9-4e60-a632-475e221cc20c": {
                                             "columnOrder": [
@@ -238,11 +242,14 @@
                             "visualization": {
                                 "accessor": "eda3c6d9-dacb-4e5e-b977-50104f76e91a",
                                 "layerId": "b83c382d-fab9-4e60-a632-475e221cc20c",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique MD5 [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -257,7 +264,7 @@
                 "panelIndex": "4d3e11dc-c4cc-4373-bb83-3d39fe6ffa98",
                 "title": "Unique MD5 [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -276,7 +283,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "22fbfeae-5b51-4d9d-b463-0d0dcb36e05d": {
                                             "columnOrder": [
@@ -308,7 +315,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -325,15 +332,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "27d0558e-428b-40a7-aea7-4195a095ff3f"
-                                        ],
                                         "layerId": "22fbfeae-5b51-4d9d-b463-0d0dcb36e05d",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "4e91e0ea-9ccc-43cf-b81c-513d9f18ead7",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "4e91e0ea-9ccc-43cf-b81c-513d9f18ead7"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "27d0558e-428b-40a7-aea7-4195a095ff3f"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -356,7 +366,7 @@
                 "panelIndex": "c66ad183-f4f0-4605-b35d-85b7038403fd",
                 "title": "Mitre Tactics ID [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -375,7 +385,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9722683d-8451-450c-b62c-8f28e7263f1b": {
                                             "columnOrder": [
@@ -389,7 +399,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "4e60dfd6-afe5-47dc-a5a0-3cfdb62f01dd": {
                                                     "dataType": "string",
@@ -424,15 +434,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "4e60dfd6-afe5-47dc-a5a0-3cfdb62f01dd"
-                                        ],
                                         "layerId": "9722683d-8451-450c-b62c-8f28e7263f1b",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "0ceb1563-e3cd-4a98-a469-737bee1cb9ef",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "0ceb1563-e3cd-4a98-a469-737bee1cb9ef"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "4e60dfd6-afe5-47dc-a5a0-3cfdb62f01dd"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -455,7 +468,7 @@
                 "panelIndex": "fcc44298-dfb6-4bd4-a63d-e845ce3eb859",
                 "title": "Mitre Tactics Name [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -478,7 +491,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "85ad73b3-3b76-49f1-ad20-6256b58918f8": {
                                             "columnOrder": [
@@ -508,11 +521,14 @@
                             "visualization": {
                                 "accessor": "289bd005-bdd2-4f3b-83b9-ad6ae52a9ed3",
                                 "layerId": "85ad73b3-3b76-49f1-ad20-6256b58918f8",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique SHA1 [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -527,7 +543,7 @@
                 "panelIndex": "e9b6f0ad-5e6b-44da-923e-dc0d5ccfdfea",
                 "title": "Unique SHA1 [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -550,7 +566,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "49b7070a-f1d3-46e1-a980-2f6d6d130167": {
                                             "columnOrder": [
@@ -580,11 +596,14 @@
                             "visualization": {
                                 "accessor": "b6c5e221-88ff-490e-bd3e-188b3e0dd1f4",
                                 "layerId": "49b7070a-f1d3-46e1-a980-2f6d6d130167",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unique SHA256 [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -599,7 +618,7 @@
                 "panelIndex": "93e32abe-87e3-469e-b7e9-a7ef7dfa2cce",
                 "title": "Unique SHA256 [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -618,7 +637,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9646600b-883b-40d0-af92-d25f7fb3fcf6": {
                                             "columnOrder": [
@@ -633,7 +652,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "b21fdfe6-05b1-474f-9748-1923a4c16ebe": {
                                                     "customLabel": true,
@@ -677,7 +696,9 @@
                                     }
                                 ],
                                 "layerId": "9646600b-883b-40d0-af92-d25f7fb3fcf6",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -697,7 +718,7 @@
                 "panelIndex": "0638c316-a573-412f-b3c4-f72dde07c6e8",
                 "title": "Top Feeds [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -733,7 +754,7 @@
                             ],
                             "searchSource": {
                                 "filter": [],
-                                "index": "logs-*",
+                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                                 "query": {
                                     "language": "kuery",
                                     "query": ""
@@ -768,7 +789,7 @@
                 "panelIndex": "463b3747-56ee-425d-a2ac-a94a44b4995e",
                 "title": "File Tags [Logs Cybersixgill]",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -787,7 +808,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "d9757b54-ffa7-45da-b31b-1387c4a2d26e": {
                                             "columnOrder": [
@@ -801,7 +822,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "af192ae4-c012-49db-b768-85d876f2688e": {
                                                     "dataType": "string",
@@ -836,15 +857,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "af192ae4-c012-49db-b768-85d876f2688e"
-                                        ],
                                         "layerId": "d9757b54-ffa7-45da-b31b-1387c4a2d26e",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "5e611ce4-0c5a-4e10-b87e-30c88affa80e",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "5e611ce4-0c5a-4e10-b87e-30c88affa80e"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "af192ae4-c012-49db-b768-85d876f2688e"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -867,17 +891,18 @@
                 "panelIndex": "256a7b33-485f-4715-90f3-768bea61d23e",
                 "title": "Confidence Levels [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Cybersixgill] Files",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:46:18.260Z",
     "id": "ti_cybersixgill-63c9fee0-5bea-11ec-9302-152fd766c738",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -982,7 +1007,7 @@
         },
         {
             "id": "ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
-            "name": "tag-ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
+            "name": "tag-ref-ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
             "type": "tag"
         }
     ],

--- a/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-63c9fee0-5bea-11ec-9302-152fd766c738.json
+++ b/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-63c9fee0-5bea-11ec-9302-152fd766c738.json
@@ -722,73 +722,140 @@
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [
-                                {
-                                    "enabled": true,
-                                    "id": "1",
-                                    "params": {},
-                                    "schema": "metric",
-                                    "type": "count"
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-47467d31-035d-46ff-a9ed-783523f2c423",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "47467d31-035d-46ff-a9ed-783523f2c423": {
+                                            "columnOrder": [
+                                                "39fa0863-61e1-4972-8289-0629b8bc2b83",
+                                                "f943b105-5dba-4d9a-af11-c0a2527aa993"
+                                            ],
+                                            "columns": {
+                                                "39fa0863-61e1-4972-8289-0629b8bc2b83": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Tags",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [
+                                                            "forwarded|preserve_original_event|cybersixgill-threat"
+                                                        ],
+                                                        "excludeIsRegex": true,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f943b105-5dba-4d9a-af11-c0a2527aa993",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "tags"
+                                                },
+                                                "f943b105-5dba-4d9a-af11-c0a2527aa993": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
                                 },
-                                {
-                                    "enabled": true,
-                                    "id": "2",
-                                    "params": {
-                                        "exclude": "forwarded|preserve_original_event|cybersixgill-threat",
-                                        "field": "tags",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": false,
-                                        "otherBucketLabel": "Other",
-                                        "size": 10
-                                    },
-                                    "schema": "segment",
-                                    "type": "terms"
+                                "textBased": {
+                                    "layers": {}
                                 }
-                            ],
-                            "searchSource": {
-                                "filter": [],
-                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f943b105-5dba-4d9a-af11-c0a2527aa993"
+                                        ],
+                                        "layerId": "47467d31-035d-46ff-a9ed-783523f2c423",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "39fa0863-61e1-4972-8289-0629b8bc2b83"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
                             }
                         },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "maxFontSize": 72,
-                            "minFontSize": 18,
-                            "orientation": "single",
-                            "palette": {
-                                "name": "default",
-                                "type": "palette"
-                            },
-                            "scale": "linear",
-                            "showLabel": true
-                        },
                         "title": "",
-                        "type": "tagcloud",
-                        "uiState": {}
-                    }
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 19,
-                    "i": "463b3747-56ee-425d-a2ac-a94a44b4995e",
+                    "i": "6866585e-4589-4a7e-9763-3b2493f488e7",
                     "w": 14,
                     "x": 18,
                     "y": 16
                 },
-                "panelIndex": "463b3747-56ee-425d-a2ac-a94a44b4995e",
+                "panelIndex": "6866585e-4589-4a7e-9763-3b2493f488e7",
                 "title": "File Tags [Logs Cybersixgill]",
-                "type": "visualization",
+                "type": "lens",
                 "version": "8.7.1"
             },
             {
@@ -899,7 +966,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-12T04:46:18.260Z",
+    "created_at": "2023-07-12T04:51:38.930Z",
     "id": "ti_cybersixgill-63c9fee0-5bea-11ec-9302-152fd766c738",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -992,7 +1059,7 @@
         },
         {
             "id": "logs-*",
-            "name": "463b3747-56ee-425d-a2ac-a94a44b4995e:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "name": "6866585e-4589-4a7e-9763-3b2493f488e7:indexpattern-datasource-layer-47467d31-035d-46ff-a9ed-783523f2c423",
             "type": "index-pattern"
         },
         {

--- a/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-717013b0-5bed-11ec-9302-152fd766c738.json
+++ b/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-717013b0-5bed-11ec-9302-152fd766c738.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Dashboard providing statistics about URL type indicators from the Cybersixgill Darkfeed integration",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -78,6 +77,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -118,7 +119,7 @@
                 "panelIndex": "4c3ed6e1-8b4e-4eab-8d84-70ed4f506216",
                 "title": "Files Navigation Textbox [Logs AbuseCH]",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -137,7 +138,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a6fa56f8-32fa-405d-8771-dade4fe75d62": {
                                             "columnOrder": [
@@ -167,12 +168,15 @@
                             "visualization": {
                                 "accessor": "848c463b-bbc1-4b6a-af3e-76d844eb3cc5",
                                 "layerId": "a6fa56f8-32fa-405d-8771-dade4fe75d62",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -187,7 +191,7 @@
                 "panelIndex": "73a752f9-bde5-4396-8ede-e9e77a37182d",
                 "title": "Unique File Extensions [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -206,7 +210,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c94400ee-a135-4a99-9693-5879d29f7aad": {
                                             "columnOrder": [
@@ -236,12 +240,15 @@
                             "visualization": {
                                 "accessor": "2934249f-fce5-4637-87ff-d2596d1b6ec5",
                                 "layerId": "c94400ee-a135-4a99-9693-5879d29f7aad",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -256,7 +263,7 @@
                 "panelIndex": "02f1732b-a981-4fba-8b27-b944f2f3c98c",
                 "title": "Unique Domains [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -275,7 +282,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "db89074c-e1fe-4091-bdb1-e42a36e82bac": {
                                             "columnOrder": [
@@ -290,7 +297,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "b284ea2a-a2cd-4d08-bf44-fc73c08b5694": {
                                                     "customLabel": true,
@@ -334,7 +341,9 @@
                                     }
                                 ],
                                 "layerId": "db89074c-e1fe-4091-bdb1-e42a36e82bac",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -354,7 +363,7 @@
                 "panelIndex": "8994501a-1550-4cf2-857f-d6b6491ffb62",
                 "title": "Most Popular Domains [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -373,7 +382,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0f63318a-a857-4d83-89ce-a94e2242b79e": {
                                             "columnOrder": [
@@ -387,7 +396,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "df0791a6-247c-4434-a43a-fdea7577ca34": {
                                                     "dataType": "string",
@@ -422,15 +431,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "df0791a6-247c-4434-a43a-fdea7577ca34"
-                                        ],
                                         "layerId": "0f63318a-a857-4d83-89ce-a94e2242b79e",
                                         "layerType": "data",
                                         "legendDisplay": "show",
-                                        "metric": "77a48096-02aa-4b7a-8a7b-131fc38988bd",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "77a48096-02aa-4b7a-8a7b-131fc38988bd"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "df0791a6-247c-4434-a43a-fdea7577ca34"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -453,7 +465,7 @@
                 "panelIndex": "ab7ab31c-e76f-4613-b17d-fdd909f17e0d",
                 "title": "Percentage of URL Schema used [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -472,7 +484,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9fa49c4c-5544-472d-afce-e51d6a5687fe": {
                                             "columnOrder": [
@@ -504,7 +516,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -521,16 +533,19 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "15e2b5ad-2040-4253-89a6-60f085c66f86",
-                                            "15e2b5ad-2040-4253-89a6-60f085c66f86"
-                                        ],
                                         "layerId": "9fa49c4c-5544-472d-afce-e51d6a5687fe",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "b9a631fe-5f49-4db2-a076-bcbf5410aec9",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "b9a631fe-5f49-4db2-a076-bcbf5410aec9"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "15e2b5ad-2040-4253-89a6-60f085c66f86",
+                                            "15e2b5ad-2040-4253-89a6-60f085c66f86"
+                                        ]
                                     }
                                 ],
                                 "shape": "treemap"
@@ -553,7 +568,7 @@
                 "panelIndex": "fda93ed1-72f0-4489-80b7-9e69d14f30aa",
                 "title": "Most Popular File Extensions [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -572,7 +587,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "22fbfeae-5b51-4d9d-b463-0d0dcb36e05d": {
                                             "columnOrder": [
@@ -604,7 +619,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -621,15 +636,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "27d0558e-428b-40a7-aea7-4195a095ff3f"
-                                        ],
                                         "layerId": "22fbfeae-5b51-4d9d-b463-0d0dcb36e05d",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "4e91e0ea-9ccc-43cf-b81c-513d9f18ead7",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "4e91e0ea-9ccc-43cf-b81c-513d9f18ead7"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "27d0558e-428b-40a7-aea7-4195a095ff3f"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -652,7 +670,7 @@
                 "panelIndex": "08fe9c8a-d5d8-4c8f-ab42-b0cfb0390008",
                 "title": "Mitre Tactics ID [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -671,7 +689,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9722683d-8451-450c-b62c-8f28e7263f1b": {
                                             "columnOrder": [
@@ -685,7 +703,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "4e60dfd6-afe5-47dc-a5a0-3cfdb62f01dd": {
                                                     "dataType": "string",
@@ -720,15 +738,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "4e60dfd6-afe5-47dc-a5a0-3cfdb62f01dd"
-                                        ],
                                         "layerId": "9722683d-8451-450c-b62c-8f28e7263f1b",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "0ceb1563-e3cd-4a98-a469-737bee1cb9ef",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "0ceb1563-e3cd-4a98-a469-737bee1cb9ef"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "4e60dfd6-afe5-47dc-a5a0-3cfdb62f01dd"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -751,17 +772,18 @@
                 "panelIndex": "a828d701-6a36-4401-8b35-419b4454c6fc",
                 "title": "Mitre Tactics Name [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Cybersixgill] URLs",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:46:26.520Z",
     "id": "ti_cybersixgill-717013b0-5bed-11ec-9302-152fd766c738",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -851,7 +873,7 @@
         },
         {
             "id": "ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
-            "name": "tag-ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
+            "name": "tag-ref-ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
             "type": "tag"
         }
     ],

--- a/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-c75353f0-5be8-11ec-9302-152fd766c738.json
+++ b/packages/ti_cybersixgill/kibana/dashboard/ti_cybersixgill-c75353f0-5be8-11ec-9302-152fd766c738.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "Dashboard providing statistics about indicators ingested from the Cybersixgill Darkfeed integration",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -57,6 +56,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -95,7 +96,7 @@
                 },
                 "panelIndex": "555e9e6c-04e9-4022-b6df-bda07dde30c4",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -113,7 +114,7 @@
                                         "meta": {
                                             "alias": null,
                                             "disabled": false,
-                                            "index": "logs-*",
+                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
                                             "key": "event.dataset",
                                             "negate": false,
                                             "params": [
@@ -153,7 +154,7 @@
                                         "meta": {
                                             "alias": null,
                                             "disabled": false,
-                                            "index": "logs-*",
+                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
                                             "key": "event.kind",
                                             "negate": false,
                                             "params": {
@@ -242,7 +243,7 @@
                 "panelIndex": "e971fedd-6afd-4d03-93ac-d0c751acc254",
                 "title": "Feed and Indicator Selector [Logs Cybersixgill]",
                 "type": "visualization",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -266,7 +267,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "070f5dbc-7687-4e97-9a57-5542b401c13f": {
                                             "columnOrder": [
@@ -280,7 +281,7 @@
                                                     "label": "Total Indicators",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -296,11 +297,14 @@
                             "visualization": {
                                 "accessor": "1e352b49-3b83-44a6-98fe-8703d30f2517",
                                 "layerId": "070f5dbc-7687-4e97-9a57-5542b401c13f",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Total Indicators [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -315,7 +319,7 @@
                 "panelIndex": "d37eb797-f273-43c2-9004-b947891cce55",
                 "title": "Total Indicators [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -338,7 +342,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1e757dc0-2e6d-4bd2-aa38-7da9133ca960": {
                                             "columnOrder": [
@@ -352,7 +356,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "66779b74-d127-4249-93e4-b8cd9c39b91f": {
                                                     "dataType": "string",
@@ -403,12 +407,13 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right",
                                     "showSingleSeries": false
                                 },
                                 "preferredSeriesType": "bar_horizontal",
                                 "title": "Empty XY chart",
-                                "valueLabels": "inside",
+                                "valueLabels": "show",
                                 "xTitle": "Providers",
                                 "yLeftExtent": {
                                     "mode": "full"
@@ -435,7 +440,7 @@
                 "panelIndex": "86d83606-4176-44b1-b3f3-011d5b5b4b58",
                 "title": "Total Indicators per Provider [Logs AbuseCH]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -454,7 +459,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "720e8ef8-eec8-4aff-abe0-c14c0bab64db": {
                                             "columnOrder": [
@@ -486,7 +491,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -503,15 +508,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "62778b77-cc47-48e1-8648-02ffd9ed8b72"
-                                        ],
                                         "layerId": "720e8ef8-eec8-4aff-abe0-c14c0bab64db",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "8e35c18d-ceea-4462-b205-daf206f180cc",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "8e35c18d-ceea-4462-b205-daf206f180cc"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "62778b77-cc47-48e1-8648-02ffd9ed8b72"
+                                        ]
                                     }
                                 ],
                                 "shape": "donut"
@@ -534,7 +542,7 @@
                 "panelIndex": "f3141aca-8e35-48a7-9ac8-cc43fa1a47c0",
                 "title": "Mitre Tactics [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -557,7 +565,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "df8e3a91-700b-428a-a763-525076e4d3c8": {
                                             "columnOrder": [
@@ -587,11 +595,14 @@
                             "visualization": {
                                 "accessor": "e4f78e2f-f0a7-4cc6-96d0-af607ffbf326",
                                 "layerId": "df8e3a91-700b-428a-a763-525076e4d3c8",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Total Datastreams [Logs AbuseCH]",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -606,7 +617,7 @@
                 "panelIndex": "6509dcc9-bb9c-4c1f-80e9-612f67ada340",
                 "title": "Total Datastreams [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -629,7 +640,7 @@
                         },
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c1cee622-e3dd-4d6b-a28a-0fb19dc2c7b7": {
                                             "columnOrder": [
@@ -644,7 +655,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "4d7ca99c-8a53-4a7f-96db-409251c0e391": {
                                                     "dataType": "string",
@@ -670,6 +681,7 @@
                                                     "label": "@timestamp",
                                                     "operationType": "date_histogram",
                                                     "params": {
+                                                        "includeEmptyRows": true,
                                                         "interval": "30s"
                                                     },
                                                     "scale": "interval",
@@ -711,6 +723,7 @@
                                 "legend": {
                                     "isInside": false,
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "bottom",
                                     "shouldTruncate": false,
                                     "showSingleSeries": true
@@ -745,17 +758,18 @@
                 "panelIndex": "aab4fac0-d39c-4521-aa9b-0a49d5938e9e",
                 "title": "Indicators ingested per Datastream [Logs Cybersixgill]",
                 "type": "lens",
-                "version": "8.0.0-SNAPSHOT"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Cybersixgill] Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:46:34.989Z",
     "id": "ti_cybersixgill-c75353f0-5be8-11ec-9302-152fd766c738",
     "migrationVersion": {
-        "dashboard": "8.0.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -845,7 +859,7 @@
         },
         {
             "id": "ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
-            "name": "tag-ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
+            "name": "tag-ref-ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
             "type": "tag"
         }
     ],

--- a/packages/ti_cybersixgill/kibana/tag/ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738.json
+++ b/packages/ti_cybersixgill/kibana/tag/ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738.json
@@ -4,7 +4,8 @@
         "description": "",
         "name": "Cybersixgill"
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:45:21.934Z",
     "id": "ti_cybersixgill-7186bf10-5be4-11ec-9302-152fd766c738",
     "migrationVersion": {
         "tag": "8.0.0"

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.15.0"
+version: "1.16.0"
 release: ga
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration

--- a/packages/zscaler_zpa/changelog.yml
+++ b/packages/zscaler_zpa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Convert visualizations to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6924
 - version: "1.9.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-34f0b8a0-3a71-11ed-9e41-155bc0d23bc2.json
+++ b/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-34f0b8a0-3a71-11ed-9e41-155bc0d23bc2.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "This dashboard shows Browser Access Logs collected by the Zscaler ZPA integration.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -56,7 +57,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "cdda45ef-7a1f-46e6-82f5-b5b98d330527": {
                                             "columnOrder": [
@@ -90,7 +91,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -107,15 +108,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "7db7ef17-e874-4258-b032-bed5d1ca4d5f"
-                                        ],
                                         "layerId": "cdda45ef-7a1f-46e6-82f5-b5b98d330527",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "d41f24af-68d7-4d59-9bb3-a09ddd968736",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "d41f24af-68d7-4d59-9bb3-a09ddd968736"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "7db7ef17-e874-4258-b032-bed5d1ca4d5f"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -138,7 +142,7 @@
                 "panelIndex": "f069080b-5169-4c41-b661-304e5c5dfa2d",
                 "title": "Distribution of Browser Access by Exporter [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -157,7 +161,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "d25f382e-b54c-4dc5-803a-2fd115dd0c50": {
                                             "columnOrder": [
@@ -191,7 +195,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -208,15 +212,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "22a93c56-da24-4135-9329-3b95ceb3da3f"
-                                        ],
                                         "layerId": "d25f382e-b54c-4dc5-803a-2fd115dd0c50",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "b7c7cc2c-2d63-44bd-9505-70a3d0232be0",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "b7c7cc2c-2d63-44bd-9505-70a3d0232be0"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "22a93c56-da24-4135-9329-3b95ceb3da3f"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -239,7 +246,7 @@
                 "panelIndex": "7140a23f-4aa7-43fc-a99a-bba55d790c4f",
                 "title": "Distribution of Browser Access by Browser [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -258,7 +265,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9559af19-50aa-43e3-aef6-6ddd99985176": {
                                             "columnOrder": [
@@ -293,7 +300,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "67671e08-8621-4da6-af65-d1a9b6f66dad": {
                                                     "customLabel": true,
@@ -329,16 +336,19 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "1392dce2-163a-4359-8f11-3cd3395efc4b",
-                                            "67671e08-8621-4da6-af65-d1a9b6f66dad"
-                                        ],
                                         "layerId": "9559af19-50aa-43e3-aef6-6ddd99985176",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "63992bdc-dc89-4c9b-bfa4-e8ab33adfbc7",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "63992bdc-dc89-4c9b-bfa4-e8ab33adfbc7"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "1392dce2-163a-4359-8f11-3cd3395efc4b",
+                                            "67671e08-8621-4da6-af65-d1a9b6f66dad"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -361,13 +371,13 @@
                 "panelIndex": "8e452830-b278-4562-b994-fd6070cd6378",
                 "title": "Distribution of OS across User [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
                         "description": "",
-                        "layerListJSON": "[{\"alpha\":1,\"id\":\"44962ab1-9a18-493c-a7c4-4408f7df2ca7\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\"},\"style\":{\"type\":\"TILE\"},\"type\":\"VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"0a3d538b-2454-4860-aa46-46f706c738b1\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyForceRefresh\":true,\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"geoField\":\"client.geo.location\",\"id\":\"aab6b218-afd7-47cf-825f-a39f7b57b1fe\",\"metrics\":[{\"type\":\"count\"}],\"requestType\":\"heatmap\",\"resolution\":\"COARSE\",\"type\":\"ES_GEO_GRID\",\"indexPatternId\":\"logs-*\"},\"style\":{\"colorRampName\":\"theclassic\",\"type\":\"HEATMAP\"},\"type\":\"HEATMAP\",\"visible\":true}]",
+                        "layerListJSON": "[{\"alpha\":1,\"id\":\"44962ab1-9a18-493c-a7c4-4408f7df2ca7\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\",\"lightModeDefault\":\"road_map\"},\"style\":{\"type\":\"TILE\"},\"type\":\"EMS_VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"0a3d538b-2454-4860-aa46-46f706c738b1\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyForceRefresh\":true,\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"geoField\":\"client.geo.location\",\"id\":\"aab6b218-afd7-47cf-825f-a39f7b57b1fe\",\"metrics\":[{\"type\":\"count\"}],\"requestType\":\"heatmap\",\"resolution\":\"COARSE\",\"type\":\"ES_GEO_GRID\",\"indexPatternRefName\":\"layer_1_source_index_pattern\"},\"style\":{\"colorRampName\":\"theclassic\",\"type\":\"HEATMAP\"},\"type\":\"HEATMAP\",\"visible\":true}]",
                         "mapStateJSON": "{\"zoom\":0.77,\"center\":{\"lon\":84.58721,\"lat\":30.6405},\"timeFilters\":{\"from\":\"now-5y\",\"to\":\"now\"},\"refreshConfig\":{\"isPaused\":true,\"interval\":0},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"settings\":{\"autoFitToDataBounds\":false,\"backgroundColor\":\"#ffffff\",\"disableInteractive\":false,\"disableTooltipControl\":false,\"hideToolbarOverlay\":false,\"hideLayerControl\":false,\"hideViewControl\":false,\"initialLocation\":\"LAST_SAVED_LOCATION\",\"fixedLocation\":{\"lat\":0,\"lon\":0,\"zoom\":2},\"browserLocation\":{\"zoom\":2},\"maxZoom\":24,\"minZoom\":0,\"showScaleControl\":false,\"showSpatialFilters\":true,\"showTimesliderToggleButton\":true,\"spatialFiltersAlpa\":0.3,\"spatialFiltersFillColor\":\"#DA8B45\",\"spatialFiltersLineColor\":\"#DA8B45\"}}",
                         "title": "[Zscaler][ZPA] Browser Access Events by Region",
                         "uiStateJSON": "{\"isLayerTOCOpen\":true,\"openTOCDetails\":[]}"
@@ -399,17 +409,18 @@
                 "panelIndex": "3faea99d-8970-4c4b-8c11-16737fb1f643",
                 "title": "Browser Access Events by Region [Logs Zscaler ZPA]",
                 "type": "map",
-                "version": "7.16.2"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Zscaler ZPA] Browser Access Logs",
         "version": 1
     },
-    "coreMigrationVersion": "7.16.2",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:57:29.062Z",
     "id": "zscaler_zpa-34f0b8a0-3a71-11ed-9e41-155bc0d23bc2",
     "migrationVersion": {
-        "dashboard": "7.16.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-3b709f70-3a98-11ed-9e41-155bc0d23bc2.json
+++ b/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-3b709f70-3a98-11ed-9e41-155bc0d23bc2.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "This dashboard shows User Activity and Status Logs collected by the Zscaler ZPA integration.\n",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -49,6 +48,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -74,7 +75,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "b057dead-b005-4462-b395-d27f7ac78327": {
                                             "columnOrder": [
@@ -88,7 +89,7 @@
                                                     "label": "Total Users",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -104,7 +105,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -126,12 +127,15 @@
                             "visualization": {
                                 "accessor": "083be347-4383-4ce2-b466-6a93dfce867d",
                                 "layerId": "b057dead-b005-4462-b395-d27f7ac78327",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -146,7 +150,7 @@
                 "panelIndex": "02c9d04f-388e-4aeb-bf53-dc3c4201ac89",
                 "title": "Total Users [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -170,7 +174,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f6c8b136-deb3-4b5d-ba28-8335cad05127": {
                                             "columnOrder": [
@@ -185,7 +189,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "efb3640b-c682-4e3c-8c3c-f81ada82c369": {
                                                     "customLabel": true,
@@ -220,7 +224,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -243,15 +247,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "efb3640b-c682-4e3c-8c3c-f81ada82c369"
-                                        ],
                                         "layerId": "f6c8b136-deb3-4b5d-ba28-8335cad05127",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "90e9028c-ca65-4690-897a-377431ca211e",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "90e9028c-ca65-4690-897a-377431ca211e"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "efb3640b-c682-4e3c-8c3c-f81ada82c369"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -274,7 +281,7 @@
                 "panelIndex": "46efd498-aa94-46cf-943e-bcc12e74928c",
                 "title": "Distribution of Users by Connection Status [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -298,7 +305,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "5bbce317-b56b-4695-bac0-7340665c9ff8": {
                                             "columnOrder": [
@@ -332,7 +339,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -348,7 +355,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -371,15 +378,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "29ae9a72-ef14-4376-97cb-2c67d9554218"
-                                        ],
                                         "layerId": "5bbce317-b56b-4695-bac0-7340665c9ff8",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "716118c4-a649-408e-8c7f-a481ab09bc92",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "716118c4-a649-408e-8c7f-a481ab09bc92"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "29ae9a72-ef14-4376-97cb-2c67d9554218"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -402,7 +412,7 @@
                 "panelIndex": "54c63d27-7daf-4370-b7ad-dccc6c5efc46",
                 "title": "Distribution of User by Session Status [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -426,7 +436,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "abf9ee3a-3e3e-495a-9f66-ed7b29420d77": {
                                             "columnOrder": [
@@ -441,7 +451,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "e9f66119-f56b-41e4-aabf-bdb9361d0826": {
                                                     "customLabel": true,
@@ -476,7 +486,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -499,15 +509,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "e9f66119-f56b-41e4-aabf-bdb9361d0826"
-                                        ],
                                         "layerId": "abf9ee3a-3e3e-495a-9f66-ed7b29420d77",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "e9175e89-5e1e-4f11-8812-56093624bdf7",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "e9175e89-5e1e-4f11-8812-56093624bdf7"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "e9f66119-f56b-41e4-aabf-bdb9361d0826"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -530,7 +543,7 @@
                 "panelIndex": "fc4e5d4a-ef17-4fc4-90dd-8a9869aba15c",
                 "title": "Distribution of User by Client Type [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -554,7 +567,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "798e7ae8-6819-4df4-ab28-7cdb722c8ca5": {
                                             "columnOrder": [
@@ -569,7 +582,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "6bdd00fb-4b03-4f8e-834c-b120a71ae15e": {
                                                     "customLabel": true,
@@ -604,7 +617,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -655,6 +668,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_horizontal_stacked",
@@ -689,7 +703,7 @@
                 "panelIndex": "e21be368-485f-48b0-8772-405c6ec54236",
                 "title": "Top Countries with Users [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -718,7 +732,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c5fb4b55-b45b-4508-937f-a05012968d5e": {
                                             "columnOrder": [
@@ -752,7 +766,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -768,7 +782,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -789,7 +803,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "zscaler_zpa.user_activity.connection.status",
                                         "negate": false,
                                         "params": {
@@ -818,7 +832,9 @@
                                     }
                                 ],
                                 "layerId": "c5fb4b55-b45b-4508-937f-a05012968d5e",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -838,7 +854,7 @@
                 "panelIndex": "b0663650-c22b-4880-bae3-0461951511e8",
                 "title": "Top 10 Active Users [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -862,7 +878,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c78bfb28-6660-4968-ac9b-8b811d72e376": {
                                             "columnOrder": [
@@ -878,7 +894,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "9bcf224f-51d7-4b58-baa7-4505e4cdc0ab": {
                                                     "customLabel": true,
@@ -932,7 +948,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -967,7 +983,9 @@
                                     }
                                 ],
                                 "layerId": "c78bfb28-6660-4968-ac9b-8b811d72e376",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -987,7 +1005,7 @@
                 "panelIndex": "266bf198-31ab-4470-b83c-c36dddf97817",
                 "title": "Distribution of Users per Application (Top 10) [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1011,7 +1029,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f19c6fb4-8fae-40a3-adb3-ae6c447bb275": {
                                             "columnOrder": [
@@ -1026,7 +1044,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "ced296a3-39da-4192-bf4c-5304b0924cb1": {
                                                     "customLabel": true,
@@ -1061,7 +1079,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -1092,7 +1110,9 @@
                                     }
                                 ],
                                 "layerId": "f19c6fb4-8fae-40a3-adb3-ae6c447bb275",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -1112,7 +1132,7 @@
                 "panelIndex": "ae90d135-6ca3-4af3-8222-dea614e5e746",
                 "title": "Top 10 AppGroups [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1130,7 +1150,7 @@
                                         "meta": {
                                             "alias": null,
                                             "disabled": false,
-                                            "index": "logs-*",
+                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
                                             "key": "zscaler_zpa.user_activity.connector_zen_setup_time",
                                             "negate": false,
                                             "type": "exists",
@@ -1149,7 +1169,7 @@
                                         "meta": {
                                             "alias": null,
                                             "disabled": false,
-                                            "index": "logs-*",
+                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
                                             "key": "zscaler_zpa.user_activity.connection.setup_time",
                                             "negate": false,
                                             "type": "exists",
@@ -1168,7 +1188,7 @@
                                         "meta": {
                                             "alias": null,
                                             "disabled": false,
-                                            "index": "logs-*",
+                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
                                             "key": "zscaler_zpa.user_activity.server_setup_time",
                                             "negate": false,
                                             "type": "exists",
@@ -1291,7 +1311,7 @@
                 "panelIndex": "f2485352-f2fd-4321-a629-5763dfd34dbb",
                 "title": "Slowest Applications [Logs Zscaler ZPA]",
                 "type": "visualization",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1320,7 +1340,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "fbf1c4c1-78da-42df-b707-53b37efd5309": {
                                             "columnOrder": [
@@ -1370,7 +1390,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -1391,7 +1411,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "zscaler_zpa.user_activity.server_setup_time",
                                         "negate": false,
                                         "type": "exists"
@@ -1419,7 +1439,9 @@
                                     }
                                 ],
                                 "layerId": "fbf1c4c1-78da-42df-b707-53b37efd5309",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -1439,13 +1461,13 @@
                 "panelIndex": "b9cc9ecc-bfcd-437f-9f5d-2d00d7bc72df",
                 "title": "Slowest Connector Server [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
                         "description": "",
-                        "layerListJSON": "[{\"alpha\":1,\"id\":\"31d17945-828a-4b1e-9d63-5ff628cae1b3\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\"},\"style\":{\"type\":\"TILE\"},\"type\":\"VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"0a3d538b-2454-4860-aa46-46f706c738b1\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyForceRefresh\":true,\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"geoField\":\"client.geo.location\",\"id\":\"aab6b218-afd7-47cf-825f-a39f7b57b1fe\",\"metrics\":[{\"type\":\"count\"}],\"requestType\":\"heatmap\",\"resolution\":\"COARSE\",\"type\":\"ES_GEO_GRID\",\"indexPatternId\":\"logs-*\"},\"style\":{\"colorRampName\":\"theclassic\",\"type\":\"HEATMAP\"},\"type\":\"HEATMAP\",\"visible\":true}]",
+                        "layerListJSON": "[{\"alpha\":1,\"id\":\"31d17945-828a-4b1e-9d63-5ff628cae1b3\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\",\"lightModeDefault\":\"road_map\"},\"style\":{\"type\":\"TILE\"},\"type\":\"EMS_VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"0a3d538b-2454-4860-aa46-46f706c738b1\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyForceRefresh\":true,\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"geoField\":\"client.geo.location\",\"id\":\"aab6b218-afd7-47cf-825f-a39f7b57b1fe\",\"metrics\":[{\"type\":\"count\"}],\"requestType\":\"heatmap\",\"resolution\":\"COARSE\",\"type\":\"ES_GEO_GRID\",\"indexPatternRefName\":\"layer_1_source_index_pattern\"},\"style\":{\"colorRampName\":\"theclassic\",\"type\":\"HEATMAP\"},\"type\":\"HEATMAP\",\"visible\":true}]",
                         "mapStateJSON": "{\"zoom\":1.06,\"center\":{\"lon\":-2.31842,\"lat\":-20.26942},\"timeFilters\":{\"from\":\"now-15y\",\"to\":\"now\"},\"refreshConfig\":{\"isPaused\":true,\"interval\":0},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"settings\":{\"autoFitToDataBounds\":false,\"backgroundColor\":\"#ffffff\",\"disableInteractive\":false,\"disableTooltipControl\":false,\"hideToolbarOverlay\":false,\"hideLayerControl\":false,\"hideViewControl\":false,\"initialLocation\":\"LAST_SAVED_LOCATION\",\"fixedLocation\":{\"lat\":0,\"lon\":0,\"zoom\":2},\"browserLocation\":{\"zoom\":2},\"maxZoom\":24,\"minZoom\":0,\"showScaleControl\":false,\"showSpatialFilters\":true,\"showTimesliderToggleButton\":true,\"spatialFiltersAlpa\":0.3,\"spatialFiltersFillColor\":\"#DA8B45\",\"spatialFiltersLineColor\":\"#DA8B45\"}}",
                         "title": "[Zscaler][ZPA] Users by region",
                         "uiStateJSON": "{\"isLayerTOCOpen\":true,\"openTOCDetails\":[]}"
@@ -1477,17 +1499,18 @@
                 "panelIndex": "15fb12a8-4756-45a9-96d7-9cb7e721e5b2",
                 "title": "Users by region [Logs Zscaler ZPA]",
                 "type": "map",
-                "version": "7.16.2"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Zscaler ZPA] User Activity and Status Logs",
         "version": 1
     },
-    "coreMigrationVersion": "7.16.2",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:57:53.292Z",
     "id": "zscaler_zpa-3b709f70-3a98-11ed-9e41-155bc0d23bc2",
     "migrationVersion": {
-        "dashboard": "7.16.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-3b709f70-3a98-11ed-9e41-155bc0d23bc2.json
+++ b/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-3b709f70-3a98-11ed-9e41-155bc0d23bc2.json
@@ -1388,7 +1388,7 @@
                                 }
                             }
                         },
-                        "title": "[Zscaler][ZPA] Slowest Applications (converted)",
+                        "title": "[Zscaler][ZPA] Slowest Applications",
                         "type": "lens",
                         "visualizationType": "lnsDatatable"
                     },

--- a/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-3b709f70-3a98-11ed-9e41-155bc0d23bc2.json
+++ b/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-3b709f70-3a98-11ed-9e41-155bc0d23bc2.json
@@ -1136,170 +1136,264 @@
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [
-                                    {
-                                        "$state": {
-                                            "store": "appState"
-                                        },
-                                        "meta": {
-                                            "alias": null,
-                                            "disabled": false,
-                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                                            "key": "zscaler_zpa.user_activity.connector_zen_setup_time",
-                                            "negate": false,
-                                            "type": "exists",
-                                            "value": "exists"
-                                        },
-                                        "query": {
-                                            "exists": {
-                                                "field": "zscaler_zpa.user_activity.connector_zen_setup_time"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "$state": {
-                                            "store": "appState"
-                                        },
-                                        "meta": {
-                                            "alias": null,
-                                            "disabled": false,
-                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
-                                            "key": "zscaler_zpa.user_activity.connection.setup_time",
-                                            "negate": false,
-                                            "type": "exists",
-                                            "value": "exists"
-                                        },
-                                        "query": {
-                                            "exists": {
-                                                "field": "zscaler_zpa.user_activity.connection.setup_time"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "$state": {
-                                            "store": "appState"
-                                        },
-                                        "meta": {
-                                            "alias": null,
-                                            "disabled": false,
-                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
-                                            "key": "zscaler_zpa.user_activity.server_setup_time",
-                                            "negate": false,
-                                            "type": "exists",
-                                            "value": "exists"
-                                        },
-                                        "query": {
-                                            "exists": {
-                                                "field": "zscaler_zpa.user_activity.server_setup_time"
-                                            }
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-61d39368-0943-4997-b7e0-1a7b5b3dfc01",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "e6888867-04e8-4d32-a1c4-a73603fe19e1",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "0a5dc661-381e-4c9b-ad56-bb5a32482fa7",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "731b0880-93fa-46ee-9ce4-5ec88c8af12f",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "61d39368-0943-4997-b7e0-1a7b5b3dfc01": {
+                                            "columnOrder": [
+                                                "1e6343ff-1121-4ec5-9f63-27a6479b00ef",
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7d",
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX3",
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX2",
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX1",
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX0"
+                                            ],
+                                            "columns": {
+                                                "1e6343ff-1121-4ec5-9f63-27a6479b00ef": {
+                                                    "customLabel": true,
+                                                    "dataType": "ip",
+                                                    "isBucketed": true,
+                                                    "label": "Client IP",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "client.ip"
+                                                },
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7d": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Application Setup Time (in microseconds)",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "formula": "average(zscaler_zpa.user_activity.server_setup_time) + average(zscaler_zpa.user_activity.connection.setup_time) + average(zscaler_zpa.user_activity.connector_zen_setup_time)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "470d72f2-1e84-40a6-9285-8f12ebb65f7dX3"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of average(zscaler_zpa.user_activity.server_setup_time) + average(zscaler_zpa.user_activity.connection.setup_time) + average(zscaler_zpa.user_activity.connector_zen_setup_time)",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "zscaler_zpa.user_activity.server_setup_time"
+                                                },
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of average(zscaler_zpa.user_activity.server_setup_time) + average(zscaler_zpa.user_activity.connection.setup_time) + average(zscaler_zpa.user_activity.connector_zen_setup_time)",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "zscaler_zpa.user_activity.connection.setup_time"
+                                                },
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of average(zscaler_zpa.user_activity.server_setup_time) + average(zscaler_zpa.user_activity.connection.setup_time) + average(zscaler_zpa.user_activity.connector_zen_setup_time)",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "zscaler_zpa.user_activity.connector_zen_setup_time"
+                                                },
+                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of average(zscaler_zpa.user_activity.server_setup_time) + average(zscaler_zpa.user_activity.connection.setup_time) + average(zscaler_zpa.user_activity.connector_zen_setup_time)",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                {
+                                                                    "args": [
+                                                                        "470d72f2-1e84-40a6-9285-8f12ebb65f7dX0",
+                                                                        "470d72f2-1e84-40a6-9285-8f12ebb65f7dX1"
+                                                                    ],
+                                                                    "name": "add",
+                                                                    "type": "function"
+                                                                },
+                                                                "470d72f2-1e84-40a6-9285-8f12ebb65f7dX2"
+                                                            ],
+                                                            "location": {
+                                                                "max": 173,
+                                                                "min": 0
+                                                            },
+                                                            "name": "add",
+                                                            "text": "average(zscaler_zpa.user_activity.server_setup_time) + average(zscaler_zpa.user_activity.connection.setup_time) + average(zscaler_zpa.user_activity.connector_zen_setup_time)",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "470d72f2-1e84-40a6-9285-8f12ebb65f7dX0",
+                                                        "470d72f2-1e84-40a6-9285-8f12ebb65f7dX1",
+                                                        "470d72f2-1e84-40a6-9285-8f12ebb65f7dX2"
+                                                    ],
+                                                    "scale": "ratio"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
                                         }
                                     }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "e6888867-04e8-4d32-a1c4-a73603fe19e1",
+                                        "key": "zscaler_zpa.user_activity.connector_zen_setup_time",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "zscaler_zpa.user_activity.connector_zen_setup_time"
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "0a5dc661-381e-4c9b-ad56-bb5a32482fa7",
+                                        "key": "zscaler_zpa.user_activity.connection.setup_time",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "zscaler_zpa.user_activity.connection.setup_time"
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "731b0880-93fa-46ee-9ce4-5ec88c8af12f",
+                                        "key": "zscaler_zpa.user_activity.server_setup_time",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "zscaler_zpa.user_activity.server_setup_time"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "data_stream.dataset : \"zscaler_zpa.user_activity\""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "alignment": "left",
+                                        "colorMode": "none",
+                                        "columnId": "1e6343ff-1121-4ec5-9f63-27a6479b00ef"
+                                    },
+                                    {
+                                        "alignment": "left",
+                                        "colorMode": "none",
+                                        "columnId": "470d72f2-1e84-40a6-9285-8f12ebb65f7d"
+                                    }
                                 ],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": "data_stream.dataset : \"zscaler_zpa.user_activity\""
+                                "layerId": "61d39368-0943-4997-b7e0-1a7b5b3dfc01",
+                                "layerType": "data",
+                                "sorting": {
+                                    "columnId": "1e6343ff-1121-4ec5-9f63-27a6479b00ef"
                                 }
                             }
                         },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "bar_color_rules": [
-                                {
-                                    "id": "4ac99360-4dd5-11ec-9c7f-599fe68d9667"
-                                }
-                            ],
-                            "drop_last_bucket": 0,
-                            "id": "81cebc93-9e11-4079-9241-baa103cd5db6",
-                            "index_pattern_ref_name": "metrics_f2485352-f2fd-4321-a629-5763dfd34dbb_0_index_pattern",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "pivot_id": "client.ip",
-                            "pivot_label": "Client IP",
-                            "pivot_type": "string",
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "formatter": "default",
-                                    "hidden": false,
-                                    "id": "a5e34d80-4dd6-11ec-9c7f-599fe68d9667",
-                                    "label": "Application Setup Time (in microseconds)",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "field": "zscaler_zpa.user_activity.server_setup_time",
-                                            "id": "1c4724b0-4dfa-11ec-9c7f-599fe68d9667",
-                                            "type": "avg"
-                                        },
-                                        {
-                                            "field": "zscaler_zpa.user_activity.connection.setup_time",
-                                            "id": "5adf7740-4dfa-11ec-9c7f-599fe68d9667",
-                                            "type": "avg"
-                                        },
-                                        {
-                                            "field": "zscaler_zpa.user_activity.connector_zen_setup_time",
-                                            "id": "6f1124c0-4dfa-11ec-9c7f-599fe68d9667",
-                                            "type": "avg"
-                                        },
-                                        {
-                                            "id": "7956fef0-4dfa-11ec-9c7f-599fe68d9667",
-                                            "script": "params.a + params.b + params.c",
-                                            "type": "math",
-                                            "variables": [
-                                                {
-                                                    "field": "1c4724b0-4dfa-11ec-9c7f-599fe68d9667",
-                                                    "id": "7ad8bcf0-4dfa-11ec-9c7f-599fe68d9667",
-                                                    "name": "a"
-                                                },
-                                                {
-                                                    "field": "5adf7740-4dfa-11ec-9c7f-599fe68d9667",
-                                                    "id": "80181f30-4dfa-11ec-9c7f-599fe68d9667",
-                                                    "name": "b"
-                                                },
-                                                {
-                                                    "field": "6f1124c0-4dfa-11ec-9c7f-599fe68d9667",
-                                                    "id": "81c5f640-4dfa-11ec-9c7f-599fe68d9667",
-                                                    "name": "c"
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "split_mode": "everything",
-                                    "stacked": "none",
-                                    "time_range_mode": "entire_time_range"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "table",
-                            "use_kibana_indexes": true
-                        },
-                        "title": "[Zscaler][ZPA] Slowest Applications",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
+                        "title": "[Zscaler][ZPA] Slowest Applications (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 15,
@@ -1309,8 +1403,8 @@
                     "y": 65
                 },
                 "panelIndex": "f2485352-f2fd-4321-a629-5763dfd34dbb",
-                "title": "Slowest Applications [Logs Zscaler ZPA]",
-                "type": "visualization",
+                "title": "[Zscaler][ZPA] Slowest Applications",
+                "type": "lens",
                 "version": "8.7.1"
             },
             {
@@ -1507,7 +1601,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-12T04:57:53.292Z",
+    "created_at": "2023-07-12T04:59:37.334Z",
     "id": "zscaler_zpa-3b709f70-3a98-11ed-9e41-155bc0d23bc2",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -1645,22 +1739,22 @@
         },
         {
             "id": "logs-*",
-            "name": "f2485352-f2fd-4321-a629-5763dfd34dbb:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "name": "f2485352-f2fd-4321-a629-5763dfd34dbb:indexpattern-datasource-layer-61d39368-0943-4997-b7e0-1a7b5b3dfc01",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "f2485352-f2fd-4321-a629-5763dfd34dbb:kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+            "name": "f2485352-f2fd-4321-a629-5763dfd34dbb:e6888867-04e8-4d32-a1c4-a73603fe19e1",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "f2485352-f2fd-4321-a629-5763dfd34dbb:kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
+            "name": "f2485352-f2fd-4321-a629-5763dfd34dbb:0a5dc661-381e-4c9b-ad56-bb5a32482fa7",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "f2485352-f2fd-4321-a629-5763dfd34dbb:metrics_f2485352-f2fd-4321-a629-5763dfd34dbb_0_index_pattern",
+            "name": "f2485352-f2fd-4321-a629-5763dfd34dbb:731b0880-93fa-46ee-9ce4-5ec88c8af12f",
             "type": "index-pattern"
         },
         {

--- a/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-893ef040-3a88-11ed-9e41-155bc0d23bc2.json
+++ b/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-893ef040-3a88-11ed-9e41-155bc0d23bc2.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "This dashboard shows App Connector Status Logs collected by the Zscaler ZPA integration.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -56,7 +57,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "71315a2c-1062-4780-b763-c2b372d80193": {
                                             "columnOrder": [
@@ -70,7 +71,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             }
                                         }
@@ -85,12 +86,15 @@
                             "visualization": {
                                 "accessor": "302faced-3e0e-4499-88da-15fc6fbc2818",
                                 "layerId": "71315a2c-1062-4780-b763-c2b372d80193",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -105,7 +109,7 @@
                 "panelIndex": "18145f05-d996-46b0-a824-ea77aa25064a",
                 "title": "Total App Connectors [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -124,7 +128,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "877447c2-e230-4017-8615-7e8f2c35fbad": {
                                             "columnOrder": [
@@ -139,7 +143,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "3113d320-32bd-40f4-9f86-745409a0a9df": {
                                                     "customLabel": true,
@@ -181,7 +185,9 @@
                                     }
                                 ],
                                 "layerId": "877447c2-e230-4017-8615-7e8f2c35fbad",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -201,7 +207,7 @@
                 "panelIndex": "cd828278-e5b5-40a7-8191-dbfca4b7cff5",
                 "title": "Top 10 ZEN with Frequent Usage [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -220,7 +226,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1943d23c-54c2-4a13-83fa-3df1b0ccd9d4": {
                                             "columnOrder": [
@@ -254,7 +260,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -277,7 +283,9 @@
                                     }
                                 ],
                                 "layerId": "1943d23c-54c2-4a13-83fa-3df1b0ccd9d4",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -297,7 +305,7 @@
                 "panelIndex": "1d31f0ac-7353-41b7-8057-56a4a2a6716b",
                 "title": "Top 10 Connectors by Name [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -316,7 +324,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "4168c43c-28f9-4ffa-a1d2-a5989c490d72": {
                                             "columnOrder": [
@@ -359,6 +367,7 @@
                                                     "label": "@timestamp",
                                                     "operationType": "date_histogram",
                                                     "params": {
+                                                        "includeEmptyRows": true,
                                                         "interval": "auto"
                                                     },
                                                     "scale": "interval",
@@ -408,6 +417,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "line",
@@ -442,7 +452,7 @@
                 "panelIndex": "cef662eb-f8b5-4998-a4b6-a9877b731e27",
                 "title": "CPU Utilization by Connector Over Time [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -461,7 +471,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "4168c43c-28f9-4ffa-a1d2-a5989c490d72": {
                                             "columnOrder": [
@@ -504,6 +514,7 @@
                                                     "label": "@timestamp",
                                                     "operationType": "date_histogram",
                                                     "params": {
+                                                        "includeEmptyRows": true,
                                                         "interval": "auto"
                                                     },
                                                     "scale": "interval",
@@ -553,6 +564,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "line",
@@ -587,7 +599,7 @@
                 "panelIndex": "02d9645a-7b0a-44da-b915-58c901ea0d3c",
                 "title": "Memory Utilization by Connector Over Time [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -606,7 +618,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "963d92b1-a9e0-4c39-842e-e202f72e0110": {
                                             "columnOrder": [
@@ -640,7 +652,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -685,6 +697,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_horizontal_stacked",
@@ -719,7 +732,7 @@
                 "panelIndex": "72ba98f0-08f1-486f-8150-53fad9b25fff",
                 "title": "Distribution of App Connector Status by Session Type [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -738,7 +751,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "93b89030-71b2-419d-92c4-6023f99b1503": {
                                             "columnOrder": [
@@ -813,7 +826,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "aa3ba0e8-495f-466e-a7c9-b79202245a09": {
                                                     "customLabel": true,
@@ -869,7 +882,9 @@
                                     }
                                 ],
                                 "layerId": "93b89030-71b2-419d-92c4-6023f99b1503",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -889,7 +904,7 @@
                 "panelIndex": "ff9ec9f6-5a8b-46c3-91bb-c930c6ddd44d",
                 "title": "Distribution of App Connector by Session Type, Session Status, OS Platform [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -908,7 +923,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "e92e1e53-f00a-4def-b2fb-50882e25d4e6": {
                                             "columnOrder": [
@@ -923,7 +938,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "c1e1a7cb-c9a1-48ff-b690-dfe52500e56c": {
                                                     "customLabel": true,
@@ -967,7 +982,9 @@
                                     }
                                 ],
                                 "layerId": "e92e1e53-f00a-4def-b2fb-50882e25d4e6",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -987,13 +1004,13 @@
                 "panelIndex": "d5bee67f-b12a-46ee-bc91-e57386cc89f2",
                 "title": "Top 10 Connector Name [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
                         "description": "",
-                        "layerListJSON": "[{\"alpha\":1,\"id\":\"3099042d-0154-49b6-8c0c-f492730c5835\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\"},\"style\":{\"type\":\"TILE\"},\"type\":\"VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"0a3d538b-2454-4860-aa46-46f706c738b1\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyForceRefresh\":true,\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"geoField\":\"observer.geo.location\",\"id\":\"aab6b218-afd7-47cf-825f-a39f7b57b1fe\",\"metrics\":[{\"type\":\"count\"}],\"requestType\":\"heatmap\",\"resolution\":\"COARSE\",\"type\":\"ES_GEO_GRID\",\"indexPatternId\":\"logs-*\"},\"style\":{\"colorRampName\":\"theclassic\",\"type\":\"HEATMAP\"},\"type\":\"HEATMAP\",\"visible\":true}]",
+                        "layerListJSON": "[{\"alpha\":1,\"id\":\"3099042d-0154-49b6-8c0c-f492730c5835\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\",\"lightModeDefault\":\"road_map\"},\"style\":{\"type\":\"TILE\"},\"type\":\"EMS_VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"0a3d538b-2454-4860-aa46-46f706c738b1\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyForceRefresh\":true,\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"geoField\":\"observer.geo.location\",\"id\":\"aab6b218-afd7-47cf-825f-a39f7b57b1fe\",\"metrics\":[{\"type\":\"count\"}],\"requestType\":\"heatmap\",\"resolution\":\"COARSE\",\"type\":\"ES_GEO_GRID\",\"indexPatternRefName\":\"layer_1_source_index_pattern\"},\"style\":{\"colorRampName\":\"theclassic\",\"type\":\"HEATMAP\"},\"type\":\"HEATMAP\",\"visible\":true}]",
                         "mapStateJSON": "{\"zoom\":0.15,\"center\":{\"lon\":-130.09157,\"lat\":0},\"timeFilters\":{\"from\":\"now-50y\",\"to\":\"now\"},\"refreshConfig\":{\"isPaused\":true,\"interval\":0},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"settings\":{\"autoFitToDataBounds\":false,\"backgroundColor\":\"#ffffff\",\"disableInteractive\":false,\"disableTooltipControl\":false,\"hideToolbarOverlay\":false,\"hideLayerControl\":false,\"hideViewControl\":false,\"initialLocation\":\"LAST_SAVED_LOCATION\",\"fixedLocation\":{\"lat\":0,\"lon\":0,\"zoom\":2},\"browserLocation\":{\"zoom\":2},\"maxZoom\":24,\"minZoom\":0,\"showScaleControl\":false,\"showSpatialFilters\":true,\"showTimesliderToggleButton\":true,\"spatialFiltersAlpa\":0.3,\"spatialFiltersFillColor\":\"#DA8B45\",\"spatialFiltersLineColor\":\"#DA8B45\"}}",
                         "title": "[Zscaler][ZPA] App Connectors by region",
                         "uiStateJSON": "{\"isLayerTOCOpen\":true,\"openTOCDetails\":[]}"
@@ -1025,13 +1042,13 @@
                 "panelIndex": "797f632e-80e5-446f-b760-ad2682841a99",
                 "title": "App Connectors by Region [Logs Zscaler ZPA]",
                 "type": "map",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
                         "description": "",
-                        "layerListJSON": "[{\"alpha\":1,\"id\":\"72f12276-ca0b-455c-a518-bf4493c7d673\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\"},\"style\":{\"type\":\"TILE\"},\"type\":\"VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"0a3d538b-2454-4860-aa46-46f706c738b1\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyForceRefresh\":true,\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"geoField\":\"observer.geo.location\",\"id\":\"aab6b218-afd7-47cf-825f-a39f7b57b1fe\",\"metrics\":[{\"field\":\"zscaler_zpa.app_connector_status.connector.group\",\"type\":\"cardinality\"}],\"requestType\":\"heatmap\",\"resolution\":\"COARSE\",\"type\":\"ES_GEO_GRID\",\"indexPatternId\":\"logs-*\"},\"style\":{\"colorRampName\":\"theclassic\",\"type\":\"HEATMAP\"},\"type\":\"HEATMAP\",\"visible\":true}]",
+                        "layerListJSON": "[{\"alpha\":1,\"id\":\"72f12276-ca0b-455c-a518-bf4493c7d673\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\",\"lightModeDefault\":\"road_map\"},\"style\":{\"type\":\"TILE\"},\"type\":\"EMS_VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"0a3d538b-2454-4860-aa46-46f706c738b1\",\"includeInFitToBounds\":true,\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyForceRefresh\":true,\"applyGlobalQuery\":true,\"applyGlobalTime\":true,\"geoField\":\"observer.geo.location\",\"id\":\"aab6b218-afd7-47cf-825f-a39f7b57b1fe\",\"metrics\":[{\"field\":\"zscaler_zpa.app_connector_status.connector.group\",\"type\":\"cardinality\"}],\"requestType\":\"heatmap\",\"resolution\":\"COARSE\",\"type\":\"ES_GEO_GRID\",\"indexPatternRefName\":\"layer_1_source_index_pattern\"},\"style\":{\"colorRampName\":\"theclassic\",\"type\":\"HEATMAP\"},\"type\":\"HEATMAP\",\"visible\":true}]",
                         "mapStateJSON": "{\"zoom\":0.69,\"center\":{\"lon\":-81.88323,\"lat\":20.96631},\"timeFilters\":{\"from\":\"now-15y\",\"to\":\"now\"},\"refreshConfig\":{\"isPaused\":true,\"interval\":0},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"settings\":{\"autoFitToDataBounds\":false,\"backgroundColor\":\"#ffffff\",\"disableInteractive\":false,\"disableTooltipControl\":false,\"hideToolbarOverlay\":false,\"hideLayerControl\":false,\"hideViewControl\":false,\"initialLocation\":\"LAST_SAVED_LOCATION\",\"fixedLocation\":{\"lat\":0,\"lon\":0,\"zoom\":2},\"browserLocation\":{\"zoom\":2},\"maxZoom\":24,\"minZoom\":0,\"showScaleControl\":false,\"showSpatialFilters\":true,\"showTimesliderToggleButton\":true,\"spatialFiltersAlpa\":0.3,\"spatialFiltersFillColor\":\"#DA8B45\",\"spatialFiltersLineColor\":\"#DA8B45\"}}",
                         "title": "[Zscaler][ZPA] Connector Groups by region",
                         "uiStateJSON": "{\"isLayerTOCOpen\":true,\"openTOCDetails\":[]}"
@@ -1042,14 +1059,14 @@
                     "isLayerTOCOpen": true,
                     "mapBuffer": {
                         "maxLat": 85.05113,
-                        "maxLon": 180,
+                        "maxLon": 360,
                         "minLat": -85.05113,
-                        "minLon": -360
+                        "minLon": -720
                     },
                     "mapCenter": {
-                        "lat": 20.96631,
-                        "lon": -81.88323,
-                        "zoom": 0.69
+                        "lat": 0,
+                        "lon": -130.09157,
+                        "zoom": 0.15
                     },
                     "openTOCDetails": []
                 },
@@ -1063,17 +1080,18 @@
                 "panelIndex": "11b27822-2f89-47bf-9fc0-18bd209bedcf",
                 "title": "Connector Groups by Region [Logs Zscaler ZPA]",
                 "type": "map",
-                "version": "7.16.2"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Zscaler ZPA] App Connector Status Logs",
         "version": 1
     },
-    "coreMigrationVersion": "7.16.2",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:57:37.284Z",
     "id": "zscaler_zpa-893ef040-3a88-11ed-9e41-155bc0d23bc2",
     "migrationVersion": {
-        "dashboard": "7.16.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-a0742450-3a89-11ed-9e41-155bc0d23bc2.json
+++ b/packages/zscaler_zpa/kibana/dashboard/zscaler_zpa-a0742450-3a89-11ed-9e41-155bc0d23bc2.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "This dashboard shows Audit Logs collected by the Zscaler ZPA integration.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -56,7 +57,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "d955d548-c620-418f-addf-a6ed1dfe5510": {
                                             "columnOrder": [
@@ -71,7 +72,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "8a4481ce-ba25-410c-bfb3-ec3e0798ad8a": {
                                                     "customLabel": true,
@@ -113,7 +114,9 @@
                                     }
                                 ],
                                 "layerId": "d955d548-c620-418f-addf-a6ed1dfe5510",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -133,7 +136,7 @@
                 "panelIndex": "ba73376e-4182-4b89-9c8a-aff2bc566165",
                 "title": "Top Users with Most Activities [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -152,7 +155,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0337d250-104e-40b7-9daa-e6fe700c426b": {
                                             "columnOrder": [
@@ -167,7 +170,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "d880e7d2-1014-46df-b6f5-a6d0f5807f35": {
                                                     "customLabel": true,
@@ -203,15 +206,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "d880e7d2-1014-46df-b6f5-a6d0f5807f35"
-                                        ],
                                         "layerId": "0337d250-104e-40b7-9daa-e6fe700c426b",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "7b144756-b7cc-4296-9dd8-2e61838a85e7",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "7b144756-b7cc-4296-9dd8-2e61838a85e7"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "d880e7d2-1014-46df-b6f5-a6d0f5807f35"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -234,7 +240,7 @@
                 "panelIndex": "95dd5419-2d75-4e1a-87c7-ae41953a894d",
                 "title": "Distribution of Audit Events by type of Operation [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -253,7 +259,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "417a4f1a-6348-4b45-9a8e-9e9d63671574": {
                                             "columnOrder": [
@@ -287,7 +293,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -304,15 +310,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "5ed9edc5-85af-4406-a23a-366e90928f45"
-                                        ],
                                         "layerId": "417a4f1a-6348-4b45-9a8e-9e9d63671574",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "c88a9fab-24ce-4bf1-a726-bf6ad4134b81",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "c88a9fab-24ce-4bf1-a726-bf6ad4134b81"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "5ed9edc5-85af-4406-a23a-366e90928f45"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -335,7 +344,7 @@
                 "panelIndex": "4a6702e2-adf1-4535-bbd2-baff2ccc73ce",
                 "title": "Distribution of Audit Events by Object Type [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -354,7 +363,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7412c367-8e4a-4f2c-8f51-a4c51534c7a0": {
                                             "columnOrder": [
@@ -369,7 +378,7 @@
                                                     "label": "Count",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "e99e9844-c523-4416-ae9a-ca2f5dbe362e": {
                                                     "customLabel": true,
@@ -411,7 +420,9 @@
                                     }
                                 ],
                                 "layerId": "7412c367-8e4a-4f2c-8f51-a4c51534c7a0",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "",
@@ -431,7 +442,7 @@
                 "panelIndex": "3e9e7c4d-bdfc-494e-ba7b-9480a70a88fd",
                 "title": "Top 10 Objects on which most operations are performed [Logs Zscaler ZPA]",
                 "type": "lens",
-                "version": "7.16.2"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -449,17 +460,18 @@
                 "panelRefName": "panel_f34abe48-e680-4f67-a089-9338c05898e7",
                 "title": "Audit Operations Details [Logs Zscaler ZPA]",
                 "type": "search",
-                "version": "7.16.2"
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs Zscaler ZPA] Audit Logs",
         "version": 1
     },
-    "coreMigrationVersion": "7.16.2",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:57:45.166Z",
     "id": "zscaler_zpa-a0742450-3a89-11ed-9e41-155bc0d23bc2",
     "migrationVersion": {
-        "dashboard": "7.16.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {

--- a/packages/zscaler_zpa/kibana/search/zscaler_zpa-d9d5e800-537b-11ec-9527-b704eaaa5c53.json
+++ b/packages/zscaler_zpa/kibana/search/zscaler_zpa-d9d5e800-537b-11ec-9527-b704eaaa5c53.json
@@ -28,10 +28,11 @@
         ],
         "title": "[Zscaler][ZPA] Audit Operations Details"
     },
-    "coreMigrationVersion": "7.16.2",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T04:56:41.308Z",
     "id": "zscaler_zpa-d9d5e800-537b-11ec-9527-b704eaaa5c53",
     "migrationVersion": {
-        "search": "7.9.3"
+        "search": "8.0.0"
     },
     "references": [
         {

--- a/packages/zscaler_zpa/manifest.yml
+++ b/packages/zscaler_zpa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: zscaler_zpa
 title: Zscaler Private Access
-version: "1.9.0"
+version: "1.10.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Zscaler Private Access (ZPA) with Elastic Agent.
@@ -11,7 +11,7 @@ categories:
   - network
   - vpn_security
 conditions:
-  kibana.version: ^7.16.2 || ^8.0.0
+  kibana.version: ^8.7.1
   elastic.subscription: basic
 screenshots:
   - src: /img/zscaler-zpa-screenshot.png


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

See title.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #6787

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
