### PR TITLE
[memcached] Add dimension fields to stats datastream

### DIFF
--- a/packages/memcached/changelog.yml
+++ b/packages/memcached/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add dimensions mapping for TSDB enablement.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6926
 - version: "1.0.0"
   changes:
     - description: Make Memcached GA

--- a/packages/memcached/changelog.yml
+++ b/packages/memcached/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Add dimensions mapping for TSDB enablement.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.0.0"
   changes:
     - description: Make Memcached GA

--- a/packages/memcached/data_stream/stats/fields/ecs.yml
+++ b/packages/memcached/data_stream/stats/fields/ecs.yml
@@ -2,7 +2,32 @@
   name: ecs.version
 - external: ecs
   name: service.address
+  dimension: true
 - external: ecs
   name: service.type
 - external: ecs
   name: tags
+- external: ecs
+  name: agent.id
+  dimension: true
+- external: ecs
+  name: cloud.account.id
+  dimension: true
+- external: ecs
+  name: cloud.region
+  dimension: true
+- external: ecs
+  name: cloud.availability_zone
+  dimension: true
+- external: ecs
+  name: cloud.instance.id
+  dimension: true
+- external: ecs
+  name: cloud.provider
+  dimension: true
+- external: ecs
+  name: container.id
+  dimension: true
+- external: ecs
+  name: host.name
+  dimension: true

--- a/packages/memcached/docs/README.md
+++ b/packages/memcached/docs/README.md
@@ -11,6 +11,13 @@ The below metrics are fetched from memcached:
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
 | data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
 | data_stream.type | Data stream type. | constant_keyword |  |  |
@@ -19,6 +26,7 @@ The below metrics are fetched from memcached:
 | event.kind | Event kind | constant_keyword |  |  |
 | event.module | Event module | constant_keyword |  |  |
 | event.type | Event type | constant_keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
 | memcached.stats.cmd.get | Number of "get" commands received since server startup not counting if they were successful or not. | long |  | counter |
 | memcached.stats.cmd.set | Number of "set" commands serviced since server startup. | long |  | counter |
 | memcached.stats.connections.current | Number of open connections to this Memcached server, should be the same value on all servers during normal operation. | long |  | counter |

--- a/packages/memcached/kibana/dashboard/memcached-a36fa0b0-eccf-11ec-b66b-6bfdc9ecc703.json
+++ b/packages/memcached/kibana/dashboard/memcached-a36fa0b0-eccf-11ec-b66b-6bfdc9ecc703.json
@@ -23,16 +23,12 @@
                         "references": [
                             {
                                 "id": "metrics-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-0b4a67e5-9927-450e-b80a-d8e4d960ec81",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "indexpattern": {
                                     "layers": {
@@ -60,7 +56,10 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Hits",
-                                                    "operationType": "median",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
                                                     "scale": "ratio",
                                                     "sourceField": "memcached.stats.get.hits"
                                                 },
@@ -69,8 +68,10 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Misses",
-                                                    "operationType": "median",
-                                                    "params": {},
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
                                                     "scale": "ratio",
                                                     "sourceField": "memcached.stats.get.misses"
                                                 }
@@ -81,6 +82,7 @@
                                 }
                             },
                             "filters": [],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -116,6 +118,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "area_stacked",
@@ -150,7 +153,7 @@
                 "panelIndex": "555d1c56-312e-4267-8eea-95ccb985af39",
                 "title": "Cache Miss/Hits [Metrics Memcached] ",
                 "type": "lens",
-                "version": "8.2.0"
+                "version": "8.5.3"
             },
             {
                 "embeddableConfig": {
@@ -158,16 +161,12 @@
                         "references": [
                             {
                                 "id": "metrics-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-9f7e3c47-6837-4646-b2af-26fa3dd97b1e",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "indexpattern": {
                                     "layers": {
@@ -182,7 +181,10 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Total Connections",
-                                                    "operationType": "median",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
                                                     "scale": "ratio",
                                                     "sourceField": "memcached.stats.connections.total"
                                                 },
@@ -205,6 +207,7 @@
                                 }
                             },
                             "filters": [],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -225,6 +228,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -255,7 +259,7 @@
                 "panelIndex": "3b4ee0c8-717b-4f79-8644-87ee2ca661b1",
                 "title": "Total Connections [Metrics Memcached] ",
                 "type": "lens",
-                "version": "8.2.0"
+                "version": "8.5.3"
             },
             {
                 "embeddableConfig": {
@@ -263,16 +267,12 @@
                         "references": [
                             {
                                 "id": "metrics-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-bed40a09-d5a3-43cf-b5bc-727bdf34f38f",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "indexpattern": {
                                     "layers": {
@@ -299,7 +299,10 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Number of Threads",
-                                                    "operationType": "median",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
                                                     "scale": "ratio",
                                                     "sourceField": "memcached.stats.threads"
                                                 }
@@ -310,6 +313,7 @@
                                 }
                             },
                             "filters": [],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -330,6 +334,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -360,7 +365,7 @@
                 "panelIndex": "d4b70849-800d-4266-a70e-5756b96960f4",
                 "title": "Threads [Metrics Memcached] ",
                 "type": "lens",
-                "version": "8.2.0"
+                "version": "8.5.3"
             },
             {
                 "embeddableConfig": {
@@ -368,16 +373,12 @@
                         "references": [
                             {
                                 "id": "metrics-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-441e4c26-b3fc-406f-ad5f-70335cfcafcf",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "indexpattern": {
                                     "layers": {
@@ -393,7 +394,10 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "cmd_get",
-                                                    "operationType": "median",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
                                                     "scale": "ratio",
                                                     "sourceField": "memcached.stats.cmd.get"
                                                 },
@@ -414,7 +418,10 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "cmd_set",
-                                                    "operationType": "median",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
                                                     "scale": "ratio",
                                                     "sourceField": "memcached.stats.cmd.set"
                                                 }
@@ -425,6 +432,7 @@
                                 }
                             },
                             "filters": [],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -446,6 +454,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "area",
@@ -476,7 +485,7 @@
                 "panelIndex": "86353e77-b7f4-418e-a662-8b1358227016",
                 "title": "Get/Set Commands [Metrics Memcached] ",
                 "type": "lens",
-                "version": "8.2.0"
+                "version": "8.5.3"
             },
             {
                 "embeddableConfig": {
@@ -484,16 +493,12 @@
                         "references": [
                             {
                                 "id": "metrics-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-8b74c71e-904a-4edd-af4b-9c9bc7ebf83e",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "indexpattern": {
                                     "layers": {
@@ -515,7 +520,7 @@
                                                     "label": "Bytes Read (Kb)",
                                                     "operationType": "formula",
                                                     "params": {
-                                                        "formula": "median(memcached.stats.read.bytes)/1000",
+                                                        "formula": "max(memcached.stats.read.bytes)/1000",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
@@ -528,7 +533,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Part of Bytes Read (Kb)",
-                                                    "operationType": "median",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
@@ -548,11 +553,11 @@
                                                                 1000
                                                             ],
                                                             "location": {
-                                                                "max": 39,
+                                                                "max": 36,
                                                                 "min": 0
                                                             },
                                                             "name": "divide",
-                                                            "text": "median(memcached.stats.read.bytes)/1000",
+                                                            "text": "max(memcached.stats.read.bytes)/1000",
                                                             "type": "function"
                                                         }
                                                     },
@@ -568,7 +573,7 @@
                                                     "label": "Bytes Written (Kb)",
                                                     "operationType": "formula",
                                                     "params": {
-                                                        "formula": "median(memcached.stats.written.bytes)/1000",
+                                                        "formula": "max(memcached.stats.written.bytes)/1000",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
@@ -580,8 +585,8 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of Bytes Written",
-                                                    "operationType": "median",
+                                                    "label": "Part of Bytes Written (Kb)",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
@@ -592,7 +597,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of Bytes Written",
+                                                    "label": "Part of Bytes Written (Kb)",
                                                     "operationType": "math",
                                                     "params": {
                                                         "tinymathAst": {
@@ -601,11 +606,11 @@
                                                                 1000
                                                             ],
                                                             "location": {
-                                                                "max": 42,
+                                                                "max": 39,
                                                                 "min": 0
                                                             },
                                                             "name": "divide",
-                                                            "text": "median(memcached.stats.written.bytes)/1000",
+                                                            "text": "max(memcached.stats.written.bytes)/1000",
                                                             "type": "function"
                                                         }
                                                     },
@@ -634,6 +639,7 @@
                                 }
                             },
                             "filters": [],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -655,6 +661,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -679,7 +686,7 @@
                 "panelIndex": "de7c1e7a-a67d-4c71-9acb-d7a45b8fd452",
                 "title": "Bytes Read/Written [Metrics Memcached] ",
                 "type": "lens",
-                "version": "8.2.0"
+                "version": "8.5.3"
             },
             {
                 "embeddableConfig": {
@@ -687,16 +694,12 @@
                         "references": [
                             {
                                 "id": "metrics-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-22fd59e2-9190-4c20-9f62-c5394da65821",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
+                            "adHocDataViews": {},
                             "datasourceStates": {
                                 "indexpattern": {
                                     "layers": {
@@ -717,7 +720,7 @@
                                                     "label": "Hit Ratio",
                                                     "operationType": "formula",
                                                     "params": {
-                                                        "formula": "median(memcached.stats.get.misses)/(median(memcached.stats.get.misses)+median(memcached.stats.get.hits))",
+                                                        "formula": "max(memcached.stats.get.misses)/(max(memcached.stats.get.misses)+max(memcached.stats.get.hits))",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
@@ -729,8 +732,8 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of median(memcached.stats.get.misses)/(median(memcached.stats.get.misses)+median(memcached.stats.get.hits))",
-                                                    "operationType": "median",
+                                                    "label": "Part of Hit Ratio",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
@@ -741,8 +744,8 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of median(memcached.stats.get.misses)/(median(memcached.stats.get.misses)+median(memcached.stats.get.hits))",
-                                                    "operationType": "median",
+                                                    "label": "Part of Hit Ratio",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
@@ -753,8 +756,8 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of median(memcached.stats.get.misses)/(median(memcached.stats.get.misses)+median(memcached.stats.get.hits))",
-                                                    "operationType": "median",
+                                                    "label": "Part of Hit Ratio",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
@@ -765,7 +768,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of median(memcached.stats.get.misses)/(median(memcached.stats.get.misses)+median(memcached.stats.get.hits))",
+                                                    "label": "Part of Hit Ratio",
                                                     "operationType": "math",
                                                     "params": {
                                                         "tinymathAst": {
@@ -777,20 +780,20 @@
                                                                         "254b63dc-089a-42a2-a116-6f61a1e10cf4X2"
                                                                     ],
                                                                     "location": {
-                                                                        "max": 103,
-                                                                        "min": 36
+                                                                        "max": 94,
+                                                                        "min": 33
                                                                     },
                                                                     "name": "add",
-                                                                    "text": "median(memcached.stats.get.misses)+median(memcached.stats.get.hits)",
+                                                                    "text": "max(memcached.stats.get.misses)+max(memcached.stats.get.hits)",
                                                                     "type": "function"
                                                                 }
                                                             ],
                                                             "location": {
-                                                                "max": 104,
+                                                                "max": 95,
                                                                 "min": 0
                                                             },
                                                             "name": "divide",
-                                                            "text": "median(memcached.stats.get.misses)/(median(memcached.stats.get.misses)+median(memcached.stats.get.hits))",
+                                                            "text": "max(memcached.stats.get.misses)/(max(memcached.stats.get.misses)+max(memcached.stats.get.hits))",
                                                             "type": "function"
                                                         }
                                                     },
@@ -821,6 +824,7 @@
                                 }
                             },
                             "filters": [],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -841,6 +845,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -865,7 +870,7 @@
                 "panelIndex": "dfd2fe2c-a1fd-46f9-846f-e17e1338f9c0",
                 "title": "Cache Hit Ratio [Metrics Memcached] ",
                 "type": "lens",
-                "version": "8.2.0"
+                "version": "8.5.3"
             },
             {
                 "embeddableConfig": {
@@ -987,6 +992,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -1011,32 +1017,22 @@
                 "panelIndex": "5061237a-3a71-485a-be3f-5d8e629e579e",
                 "title": "Memory Utilization [Metrics Memcached] ",
                 "type": "lens",
-                "version": "8.2.0"
+                "version": "8.5.3"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics Memcached] Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.2.0",
+    "coreMigrationVersion": "8.5.3",
     "id": "memcached-a36fa0b0-eccf-11ec-b66b-6bfdc9ecc703",
     "migrationVersion": {
-        "dashboard": "8.2.0"
+        "dashboard": "8.5.0"
     },
     "references": [
         {
             "id": "metrics-*",
-            "name": "555d1c56-312e-4267-8eea-95ccb985af39:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "555d1c56-312e-4267-8eea-95ccb985af39:indexpattern-datasource-layer-0b4a67e5-9927-450e-b80a-d8e4d960ec81",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "3b4ee0c8-717b-4f79-8644-87ee2ca661b1:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
@@ -1046,17 +1042,7 @@
         },
         {
             "id": "metrics-*",
-            "name": "d4b70849-800d-4266-a70e-5756b96960f4:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "d4b70849-800d-4266-a70e-5756b96960f4:indexpattern-datasource-layer-bed40a09-d5a3-43cf-b5bc-727bdf34f38f",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "86353e77-b7f4-418e-a662-8b1358227016:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
@@ -1066,17 +1052,7 @@
         },
         {
             "id": "metrics-*",
-            "name": "de7c1e7a-a67d-4c71-9acb-d7a45b8fd452:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "de7c1e7a-a67d-4c71-9acb-d7a45b8fd452:indexpattern-datasource-layer-8b74c71e-904a-4edd-af4b-9c9bc7ebf83e",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "dfd2fe2c-a1fd-46f9-846f-e17e1338f9c0:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {
@@ -1093,6 +1069,16 @@
             "id": "metrics-*",
             "name": "5061237a-3a71-485a-be3f-5d8e629e579e:indexpattern-datasource-layer-09bed68a-54a8-41fe-8e2f-6937efc350b4",
             "type": "index-pattern"
+        },
+        {
+            "id": "memcached-fleet-managed-default",
+            "name": "tag-fleet-managed-default",
+            "type": "tag"
+        },
+        {
+            "id": "memcached-fleet-pkg-memcached-default",
+            "name": "tag-fleet-pkg-memcached-default",
+            "type": "tag"
         }
     ],
     "type": "dashboard"

--- a/packages/memcached/manifest.yml
+++ b/packages/memcached/manifest.yml
@@ -1,6 +1,6 @@
 name: memcached
 title: Memcached
-version: "1.0.0"
+version: "1.1.0"
 description: Memcached Integration
 type: integration
 categories:
@@ -21,7 +21,7 @@ screenshots:
     type: image/png
 conditions:
   kibana:
-    version: ^8.2.0
+    version: ^8.8.0
 format_version: 1.0.0
 license: basic
 policy_templates:


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Add dimension fields for stats datastream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

https://github.com/elastic/integrations/issues/6925

## Screenshots