### PR TITLE
[cisco_ios] Fix grok to be aware of fman_fp_image

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix grok to be aware of fman_fp_image
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6930
 - version: "1.16.0"
   changes:
     - description: Adding Timezone Map advanced configuration option

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.1"
+  changes:
+    - description: Fix grok to be aware of fman_fp_image
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.16.0"
   changes:
     - description: Adding Timezone Map advanced configuration option

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log
@@ -17,7 +17,10 @@ Mar 24 17:37:39 192.168.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_R
 Mar 24 17:37:39 192.168.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (10.50.22.5, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3
 Mar 24 12:09:35 192.168.100.2 1991217: Mar 24 12:09:35.367: %OSPF-4-NOVALIDKEY: No valid authentication send key is available on interface eth0
 Mar 24 12:06:47 192.168.100.2 1991218: Mar 24 12:06:47.099: %CCH323-6-CALL_PRESERVED: cch323_h225_handle_conn_loss: H.323 call preserved due to socket closure or error, Call Id = 6527, fd = 19
-Jul 11 09:34:00 my-router-hostname 1663312: Jul 11 09:34:00.020: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied tcp 172.16.0.26(59144) -> 10.100.8.34(1103), 1 packet
-Jul 11 09:31:03 my-router-hostname 1663410: Jul 11 09:31:03.762: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied tcp 10.100.8.34(59120) -> 172.16.0.26(7774), 1 packet
-Jul 11 09:34:00 my-router-hostname 1663469: Jul 11 09:34:00.334: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied udp 172.16.0.26(1985) -> 10.100.8.34(1985), 327 packets
+Jul 11 09:34:00 my-router-hostname 1663312: Jul 11 09:34:00.020: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 permitted tcp 172.16.0.26(59144) -> 10.100.8.34(1103), 1 packet
+Jul 11 09:31:03 my-router-hostname 1663410: Jul 11 09:31:03.762: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list 110 denied tcp 10.100.8.34(59120) -> 172.16.0.26(7774), 1 packet
+Jul 11 09:34:00 my-router-hostname 1663469: Jul 11 09:34:00.334: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 permitted udp 172.16.0.26(1985) -> 10.100.8.34(1985), 327 packets
 Jul 11 09:34:00 my-router-hostname 1663511: Jul 11 09:34:00.209: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied udp 10.100.8.34(1985) -> 172.16.0.26(1985), 342 packets
+Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:34:58.206: %FMANFP-6-IPACCESSLOGP:  SIP0: fman_fp_image:  list ACL denied udp 10.10.10.10(52361) -> 10.100.8.34(10001), 1 packet
+Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:34:58.206: %FMANFP-6-IPACCESSLOGDP: F0: fman_fp_image:  list ACL_TEST permitted icmp 172.16.0.26 -> 10.100.8.34 (8/0), 2 packets
+Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:35:28.207: %FMANFP-6-IPACCESSLOGDP: F0: fman_fp_image:  list ACL_TEST permitted icmp 10.100.8.34 -> 172.16.0.26 (8/0), 1 packet

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log
@@ -17,3 +17,7 @@ Mar 24 17:37:39 192.168.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_R
 Mar 24 17:37:39 192.168.100.2 1991221: Mar 24 17:37:39 UTC: %PIM-SW1-6-INVALID_RP_JOIN: Received (10.50.22.5, 10.36.2.78) Join from 10.4.5.66 for invalid RP 10.3.66.3
 Mar 24 12:09:35 192.168.100.2 1991217: Mar 24 12:09:35.367: %OSPF-4-NOVALIDKEY: No valid authentication send key is available on interface eth0
 Mar 24 12:06:47 192.168.100.2 1991218: Mar 24 12:06:47.099: %CCH323-6-CALL_PRESERVED: cch323_h225_handle_conn_loss: H.323 call preserved due to socket closure or error, Call Id = 6527, fd = 19
+Jul 11 09:34:00 my-router-hostname 1663312: Jul 11 09:34:00.020: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied tcp 172.16.0.26(59144) -> 10.100.8.34(1103), 1 packet
+Jul 11 09:31:03 my-router-hostname 1663410: Jul 11 09:31:03.762: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied tcp 10.100.8.34(59120) -> 172.16.0.26(7774), 1 packet
+Jul 11 09:34:00 my-router-hostname 1663469: Jul 11 09:34:00.334: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied udp 172.16.0.26(1985) -> 10.100.8.34(1985), 327 packets
+Jul 11 09:34:00 my-router-hostname 1663511: Jul 11 09:34:00.209: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied udp 10.100.8.34(1985) -> 172.16.0.26(1985), 342 packets

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
@@ -1207,6 +1207,274 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2023-07-11T09:34:00.020Z",
+            "cisco": {
+                "ios": {
+                    "access_list": "internet_in_gig0",
+                    "facility": "FMANFP",
+                    "sequence": "1663312"
+                }
+            },
+            "destination": {
+                "address": "10.100.8.34",
+                "ip": "10.100.8.34",
+                "port": 1103
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "deny",
+                "category": [
+                    "network"
+                ],
+                "code": "IPACCESSLOGP",
+                "original": "Jul 11 09:34:00 my-router-hostname 1663312: Jul 11 09:34:00.020: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied tcp 172.16.0.26(59144) -\u003e 10.100.8.34(1103), 1 packet",
+                "provider": "firewall",
+                "sequence": 1663312,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "my-router-hostname"
+                }
+            },
+            "message": "list internet_in_gig0 denied tcp 172.16.0.26(59144) -\u003e 10.100.8.34(1103), 1 packet",
+            "network": {
+                "community_id": "1:KXW3u/74dvvbFZ7Ewo9z4chd5T4=",
+                "packets": 1,
+                "transport": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "172.16.0.26",
+                    "10.100.8.34"
+                ]
+            },
+            "source": {
+                "address": "172.16.0.26",
+                "ip": "172.16.0.26",
+                "packets": 1,
+                "port": 59144
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-07-11T09:31:03.762Z",
+            "cisco": {
+                "ios": {
+                    "access_list": "internet_in_gig0",
+                    "facility": "FMANFP",
+                    "sequence": "1663410"
+                }
+            },
+            "destination": {
+                "address": "172.16.0.26",
+                "ip": "172.16.0.26",
+                "port": 7774
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "deny",
+                "category": [
+                    "network"
+                ],
+                "code": "IPACCESSLOGP",
+                "original": "Jul 11 09:31:03 my-router-hostname 1663410: Jul 11 09:31:03.762: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied tcp 10.100.8.34(59120) -\u003e 172.16.0.26(7774), 1 packet",
+                "provider": "firewall",
+                "sequence": 1663410,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "my-router-hostname"
+                }
+            },
+            "message": "list internet_in_gig0 denied tcp 10.100.8.34(59120) -\u003e 172.16.0.26(7774), 1 packet",
+            "network": {
+                "community_id": "1:e8Y05uGbOy3+E9kG3gX0ri93utw=",
+                "packets": 1,
+                "transport": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "10.100.8.34",
+                    "172.16.0.26"
+                ]
+            },
+            "source": {
+                "address": "10.100.8.34",
+                "ip": "10.100.8.34",
+                "packets": 1,
+                "port": 59120
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-07-11T09:34:00.334Z",
+            "cisco": {
+                "ios": {
+                    "access_list": "internet_in_gig0",
+                    "facility": "FMANFP",
+                    "sequence": "1663469"
+                }
+            },
+            "destination": {
+                "address": "10.100.8.34",
+                "ip": "10.100.8.34",
+                "port": 1985
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "deny",
+                "category": [
+                    "network"
+                ],
+                "code": "IPACCESSLOGP",
+                "original": "Jul 11 09:34:00 my-router-hostname 1663469: Jul 11 09:34:00.334: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied udp 172.16.0.26(1985) -\u003e 10.100.8.34(1985), 327 packets",
+                "provider": "firewall",
+                "sequence": 1663469,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "my-router-hostname"
+                }
+            },
+            "message": "list internet_in_gig0 denied udp 172.16.0.26(1985) -\u003e 10.100.8.34(1985), 327 packets",
+            "network": {
+                "community_id": "1:4IV7i5VTdXeQIUxYQNz2lfhh9eE=",
+                "packets": 327,
+                "transport": "udp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "172.16.0.26",
+                    "10.100.8.34"
+                ]
+            },
+            "source": {
+                "address": "172.16.0.26",
+                "ip": "172.16.0.26",
+                "packets": 327,
+                "port": 1985
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-07-11T09:34:00.209Z",
+            "cisco": {
+                "ios": {
+                    "access_list": "internet_in_gig0",
+                    "facility": "FMANFP",
+                    "sequence": "1663511"
+                }
+            },
+            "destination": {
+                "address": "172.16.0.26",
+                "ip": "172.16.0.26",
+                "port": 1985
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "deny",
+                "category": [
+                    "network"
+                ],
+                "code": "IPACCESSLOGP",
+                "original": "Jul 11 09:34:00 my-router-hostname 1663511: Jul 11 09:34:00.209: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied udp 10.100.8.34(1985) -\u003e 172.16.0.26(1985), 342 packets",
+                "provider": "firewall",
+                "sequence": 1663511,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "my-router-hostname"
+                }
+            },
+            "message": "list internet_in_gig0 denied udp 10.100.8.34(1985) -\u003e 172.16.0.26(1985), 342 packets",
+            "network": {
+                "community_id": "1:4IV7i5VTdXeQIUxYQNz2lfhh9eE=",
+                "packets": 342,
+                "transport": "udp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "10.100.8.34",
+                    "172.16.0.26"
+                ]
+            },
+            "source": {
+                "address": "10.100.8.34",
+                "ip": "10.100.8.34",
+                "packets": 342,
+                "port": 1985
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
@@ -1198,7 +1198,7 @@
                     "hostname": "192.168.100.2"
                 }
             },
-            "message": "cch323_h225_handle_conn_loss: H.323 call preserved due to socket closure or error, Call Id = 6527, fd = 19",
+            "message": "H.323 call preserved due to socket closure or error, Call Id = 6527, fd = 19",
             "observer": {
                 "product": "IOS",
                 "type": "firewall",
@@ -1226,19 +1226,19 @@
                 "version": "8.8.0"
             },
             "event": {
-                "action": "deny",
+                "action": "allow",
                 "category": [
                     "network"
                 ],
                 "code": "IPACCESSLOGP",
-                "original": "Jul 11 09:34:00 my-router-hostname 1663312: Jul 11 09:34:00.020: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied tcp 172.16.0.26(59144) -\u003e 10.100.8.34(1103), 1 packet",
+                "original": "Jul 11 09:34:00 my-router-hostname 1663312: Jul 11 09:34:00.020: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 permitted tcp 172.16.0.26(59144) -\u003e 10.100.8.34(1103), 1 packet",
                 "provider": "firewall",
                 "sequence": 1663312,
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
                     "info",
-                    "denied"
+                    "allowed"
                 ]
             },
             "log": {
@@ -1247,7 +1247,7 @@
                     "hostname": "my-router-hostname"
                 }
             },
-            "message": "list internet_in_gig0 denied tcp 172.16.0.26(59144) -\u003e 10.100.8.34(1103), 1 packet",
+            "message": "list internet_in_gig0 permitted tcp 172.16.0.26(59144) -\u003e 10.100.8.34(1103), 1 packet",
             "network": {
                 "community_id": "1:KXW3u/74dvvbFZ7Ewo9z4chd5T4=",
                 "packets": 1,
@@ -1279,7 +1279,7 @@
             "@timestamp": "2023-07-11T09:31:03.762Z",
             "cisco": {
                 "ios": {
-                    "access_list": "internet_in_gig0",
+                    "access_list": "110",
                     "facility": "FMANFP",
                     "sequence": "1663410"
                 }
@@ -1298,7 +1298,7 @@
                     "network"
                 ],
                 "code": "IPACCESSLOGP",
-                "original": "Jul 11 09:31:03 my-router-hostname 1663410: Jul 11 09:31:03.762: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied tcp 10.100.8.34(59120) -\u003e 172.16.0.26(7774), 1 packet",
+                "original": "Jul 11 09:31:03 my-router-hostname 1663410: Jul 11 09:31:03.762: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list 110 denied tcp 10.100.8.34(59120) -\u003e 172.16.0.26(7774), 1 packet",
                 "provider": "firewall",
                 "sequence": 1663410,
                 "severity": 6,
@@ -1314,7 +1314,7 @@
                     "hostname": "my-router-hostname"
                 }
             },
-            "message": "list internet_in_gig0 denied tcp 10.100.8.34(59120) -\u003e 172.16.0.26(7774), 1 packet",
+            "message": "list 110 denied tcp 10.100.8.34(59120) -\u003e 172.16.0.26(7774), 1 packet",
             "network": {
                 "community_id": "1:e8Y05uGbOy3+E9kG3gX0ri93utw=",
                 "packets": 1,
@@ -1360,19 +1360,19 @@
                 "version": "8.8.0"
             },
             "event": {
-                "action": "deny",
+                "action": "allow",
                 "category": [
                     "network"
                 ],
                 "code": "IPACCESSLOGP",
-                "original": "Jul 11 09:34:00 my-router-hostname 1663469: Jul 11 09:34:00.334: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 denied udp 172.16.0.26(1985) -\u003e 10.100.8.34(1985), 327 packets",
+                "original": "Jul 11 09:34:00 my-router-hostname 1663469: Jul 11 09:34:00.334: %FMANFP-6-IPACCESSLOGP: R0/0: fman_fp_image: list internet_in_gig0 permitted udp 172.16.0.26(1985) -\u003e 10.100.8.34(1985), 327 packets",
                 "provider": "firewall",
                 "sequence": 1663469,
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
                     "info",
-                    "denied"
+                    "allowed"
                 ]
             },
             "log": {
@@ -1381,7 +1381,7 @@
                     "hostname": "my-router-hostname"
                 }
             },
-            "message": "list internet_in_gig0 denied udp 172.16.0.26(1985) -\u003e 10.100.8.34(1985), 327 packets",
+            "message": "list internet_in_gig0 permitted udp 172.16.0.26(1985) -\u003e 10.100.8.34(1985), 327 packets",
             "network": {
                 "community_id": "1:4IV7i5VTdXeQIUxYQNz2lfhh9eE=",
                 "packets": 327,
@@ -1471,6 +1471,211 @@
                 "ip": "10.100.8.34",
                 "packets": 342,
                 "port": 1985
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-06-10T23:34:58.206Z",
+            "cisco": {
+                "ios": {
+                    "access_list": "ACL",
+                    "facility": "FMANFP",
+                    "sequence": "1663511"
+                }
+            },
+            "destination": {
+                "address": "10.100.8.34",
+                "ip": "10.100.8.34",
+                "port": 10001
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "deny",
+                "category": [
+                    "network"
+                ],
+                "code": "IPACCESSLOGP",
+                "original": "Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:34:58.206: %FMANFP-6-IPACCESSLOGP:  SIP0: fman_fp_image:  list ACL denied udp 10.10.10.10(52361) -\u003e 10.100.8.34(10001), 1 packet",
+                "provider": "firewall",
+                "sequence": 1663511,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "10.0.0.1"
+                }
+            },
+            "message": "list ACL denied udp 10.10.10.10(52361) -\u003e 10.100.8.34(10001), 1 packet",
+            "network": {
+                "community_id": "1:7HdATA0Zd7fB8RBwRLEo/zNyyLQ=",
+                "packets": 1,
+                "transport": "udp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "10.10.10.10",
+                    "10.100.8.34"
+                ]
+            },
+            "source": {
+                "address": "10.10.10.10",
+                "ip": "10.10.10.10",
+                "packets": 1,
+                "port": 52361
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-06-10T23:34:58.206Z",
+            "cisco": {
+                "ios": {
+                    "access_list": "ACL_TEST",
+                    "facility": "FMANFP",
+                    "sequence": "1663511"
+                }
+            },
+            "destination": {
+                "address": "10.100.8.34",
+                "ip": "10.100.8.34"
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "allow",
+                "category": [
+                    "network"
+                ],
+                "code": "IPACCESSLOGDP",
+                "original": "Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:34:58.206: %FMANFP-6-IPACCESSLOGDP: F0: fman_fp_image:  list ACL_TEST permitted icmp 172.16.0.26 -\u003e 10.100.8.34 (8/0), 2 packets",
+                "provider": "firewall",
+                "sequence": 1663511,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "allowed"
+                ]
+            },
+            "icmp": {
+                "code": "0",
+                "type": "8"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "10.0.0.1"
+                }
+            },
+            "message": "list ACL_TEST permitted icmp 172.16.0.26 -\u003e 10.100.8.34 (8/0), 2 packets",
+            "network": {
+                "community_id": "1:OvCASybztHusF+Fy8s345w5/IZw=",
+                "packets": 2,
+                "transport": "icmp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "172.16.0.26",
+                    "10.100.8.34"
+                ]
+            },
+            "source": {
+                "address": "172.16.0.26",
+                "ip": "172.16.0.26",
+                "packets": 2
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-06-10T23:35:28.207Z",
+            "cisco": {
+                "ios": {
+                    "access_list": "ACL_TEST",
+                    "facility": "FMANFP",
+                    "sequence": "1663511"
+                }
+            },
+            "destination": {
+                "address": "172.16.0.26",
+                "ip": "172.16.0.26"
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "allow",
+                "category": [
+                    "network"
+                ],
+                "code": "IPACCESSLOGDP",
+                "original": "Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:35:28.207: %FMANFP-6-IPACCESSLOGDP: F0: fman_fp_image:  list ACL_TEST permitted icmp 10.100.8.34 -\u003e 172.16.0.26 (8/0), 1 packet",
+                "provider": "firewall",
+                "sequence": 1663511,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "allowed"
+                ]
+            },
+            "icmp": {
+                "code": "0",
+                "type": "8"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "10.0.0.1"
+                }
+            },
+            "message": "list ACL_TEST permitted icmp 10.100.8.34 -\u003e 172.16.0.26 (8/0), 1 packet",
+            "network": {
+                "community_id": "1:0NC2mwr4V+bYFoMF3BsibI/mn0Y=",
+                "packets": 1,
+                "transport": "icmp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "10.100.8.34",
+                    "172.16.0.26"
+                ]
+            },
+            "source": {
+                "address": "10.100.8.34",
+                "ip": "10.100.8.34",
+                "packets": 1
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -120,7 +120,7 @@ processors:
       field: message
       tag: grok_message
       patterns:
-        - "%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}: %{GREEDYDATA:message}"
+        - "%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}: (\\w+\\d+(\\/\\d+)?\\: fman_fp_image\\: )?%{GREEDYDATA:message}"
   - convert:
       field: event.severity
       type: long

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -120,7 +120,7 @@ processors:
       field: message
       tag: grok_message
       patterns:
-        - "%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}: (\\w+\\d+(\\/\\d+)?\\: fman_fp_image\\: )?%{GREEDYDATA:message}"
+        - "%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}:\\s+(\\w+\\d+(\\/\\d+)?\\:\\s+)?([a-zA-Z0-9_]+\\:\\s+)?%{GREEDYDATA:message}"
   - convert:
       field: event.severity
       type: long

--- a/packages/cisco_ios/data_stream/log/sample_event.json
+++ b/packages/cisco_ios/data_stream/log/sample_event.json
@@ -1,16 +1,16 @@
 {
-    "@timestamp": "2022-01-06T22:11:43.398+11:00",
+    "@timestamp": "2022-01-06T20:52:12.861Z",
     "agent": {
-        "ephemeral_id": "b4eeb540-5cc1-4878-b94d-09d0a0d440dd",
-        "id": "7fcefa24-63f3-457e-b11c-ccf7f1edaad6",
+        "ephemeral_id": "59ad80b9-7543-4614-a909-b2e643890121",
+        "id": "ed9bd903-f38d-43e8-8390-07f50a419d83",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.2"
+        "version": "8.0.0"
     },
     "cisco": {
         "ios": {
-            "facility": "FOO",
-            "message_count": 2361044
+            "facility": "SYS",
+            "message_count": 2360957
         }
     },
     "data_stream": {
@@ -22,42 +22,40 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "7fcefa24-63f3-457e-b11c-ccf7f1edaad6",
+        "id": "ed9bd903-f38d-43e8-8390-07f50a419d83",
         "snapshot": false,
-        "version": "8.6.2"
+        "version": "8.0.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "network"
         ],
-        "code": "BAR",
+        "code": "CONFIG_I",
         "dataset": "cisco_ios.log",
-        "ingested": "2023-06-01T11:59:13Z",
-        "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43.398 AEST: %FOO-6-BAR: Test date format.",
+        "ingested": "2023-07-12T07:38:33Z",
+        "original": "\u003c189\u003e2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
         "provider": "firewall",
-        "sequence": 2361044,
-        "severity": 6,
-        "timezone": "Australia/Sydney",
+        "sequence": 2360957,
+        "severity": 5,
+        "timezone": "+00:00",
         "type": [
             "info"
         ]
     },
     "input": {
-        "type": "log"
+        "type": "tcp"
     },
     "log": {
-        "file": {
-            "path": "/tmp/service_logs/cisco-ios-timezones.log"
+        "level": "notification",
+        "source": {
+            "address": "192.168.32.4:44338"
         },
-        "level": "informational",
-        "offset": 0,
         "syslog": {
-            "hostname": "sw01",
-            "priority": 190
+            "priority": 189
         }
     },
-    "message": "Test date format.",
+    "message": "Configured from console by akroh on vty0 (10.100.11.10)",
     "observer": {
         "product": "IOS",
         "type": "firewall",

--- a/packages/cisco_ios/data_stream/log/sample_event.json
+++ b/packages/cisco_ios/data_stream/log/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2022-01-06T20:52:12.861Z",
     "agent": {
-        "ephemeral_id": "59ad80b9-7543-4614-a909-b2e643890121",
-        "id": "ed9bd903-f38d-43e8-8390-07f50a419d83",
+        "ephemeral_id": "960a0fda-a7b7-4362-9018-34b1d0d119c4",
+        "id": "f00ff835-626e-4a18-a8a2-0bb3ebb7503f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.0.0"
@@ -22,7 +22,7 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "ed9bd903-f38d-43e8-8390-07f50a419d83",
+        "id": "f00ff835-626e-4a18-a8a2-0bb3ebb7503f",
         "snapshot": false,
         "version": "8.0.0"
     },
@@ -33,7 +33,7 @@
         ],
         "code": "CONFIG_I",
         "dataset": "cisco_ios.log",
-        "ingested": "2023-07-12T07:38:33Z",
+        "ingested": "2023-07-13T09:20:48Z",
         "original": "\u003c189\u003e2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
         "provider": "firewall",
         "sequence": 2360957,
@@ -49,7 +49,7 @@
     "log": {
         "level": "notification",
         "source": {
-            "address": "192.168.32.4:44338"
+            "address": "172.25.0.4:46792"
         },
         "syslog": {
             "priority": 189

--- a/packages/cisco_ios/docs/README.md
+++ b/packages/cisco_ios/docs/README.md
@@ -26,8 +26,8 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2022-01-06T20:52:12.861Z",
     "agent": {
-        "ephemeral_id": "59ad80b9-7543-4614-a909-b2e643890121",
-        "id": "ed9bd903-f38d-43e8-8390-07f50a419d83",
+        "ephemeral_id": "960a0fda-a7b7-4362-9018-34b1d0d119c4",
+        "id": "f00ff835-626e-4a18-a8a2-0bb3ebb7503f",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.0.0"
@@ -47,7 +47,7 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "ed9bd903-f38d-43e8-8390-07f50a419d83",
+        "id": "f00ff835-626e-4a18-a8a2-0bb3ebb7503f",
         "snapshot": false,
         "version": "8.0.0"
     },
@@ -58,7 +58,7 @@ An example event for `log` looks as following:
         ],
         "code": "CONFIG_I",
         "dataset": "cisco_ios.log",
-        "ingested": "2023-07-12T07:38:33Z",
+        "ingested": "2023-07-13T09:20:48Z",
         "original": "\u003c189\u003e2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
         "provider": "firewall",
         "sequence": 2360957,
@@ -74,7 +74,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "notification",
         "source": {
-            "address": "192.168.32.4:44338"
+            "address": "172.25.0.4:46792"
         },
         "syslog": {
             "priority": 189

--- a/packages/cisco_ios/docs/README.md
+++ b/packages/cisco_ios/docs/README.md
@@ -24,18 +24,18 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-01-06T22:11:43.398+11:00",
+    "@timestamp": "2022-01-06T20:52:12.861Z",
     "agent": {
-        "ephemeral_id": "b4eeb540-5cc1-4878-b94d-09d0a0d440dd",
-        "id": "7fcefa24-63f3-457e-b11c-ccf7f1edaad6",
+        "ephemeral_id": "59ad80b9-7543-4614-a909-b2e643890121",
+        "id": "ed9bd903-f38d-43e8-8390-07f50a419d83",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.2"
+        "version": "8.0.0"
     },
     "cisco": {
         "ios": {
-            "facility": "FOO",
-            "message_count": 2361044
+            "facility": "SYS",
+            "message_count": 2360957
         }
     },
     "data_stream": {
@@ -47,42 +47,40 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "7fcefa24-63f3-457e-b11c-ccf7f1edaad6",
+        "id": "ed9bd903-f38d-43e8-8390-07f50a419d83",
         "snapshot": false,
-        "version": "8.6.2"
+        "version": "8.0.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "network"
         ],
-        "code": "BAR",
+        "code": "CONFIG_I",
         "dataset": "cisco_ios.log",
-        "ingested": "2023-06-01T11:59:13Z",
-        "original": "\u003c190\u003e2361044: sw01: Jan  6 2022 22:11:43.398 AEST: %FOO-6-BAR: Test date format.",
+        "ingested": "2023-07-12T07:38:33Z",
+        "original": "\u003c189\u003e2360957: Jan  6 2022 20:52:12.861: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)",
         "provider": "firewall",
-        "sequence": 2361044,
-        "severity": 6,
-        "timezone": "Australia/Sydney",
+        "sequence": 2360957,
+        "severity": 5,
+        "timezone": "+00:00",
         "type": [
             "info"
         ]
     },
     "input": {
-        "type": "log"
+        "type": "tcp"
     },
     "log": {
-        "file": {
-            "path": "/tmp/service_logs/cisco-ios-timezones.log"
+        "level": "notification",
+        "source": {
+            "address": "192.168.32.4:44338"
         },
-        "level": "informational",
-        "offset": 0,
         "syslog": {
-            "hostname": "sw01",
-            "priority": 190
+            "priority": 189
         }
     },
-    "message": "Test date format.",
+    "message": "Configured from console by akroh on vty0 (10.100.11.10)",
     "observer": {
         "product": "IOS",
         "type": "firewall",

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: cisco_ios
 title: Cisco IOS
-version: "1.16.0"
+version: "1.16.1"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Fix grok to allow string fman_fp_image to be optionally included.
Added tests.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #6919
- Relates #6680

